### PR TITLE
fix: prevent prototype pollution in cn

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -26,8 +26,10 @@ export function cn(...inputs: ClassValue[]): string {
     }
     if (v && typeof v === "object" && !Array.isArray(v)) {
       const dict = v as Record<string, unknown>;
-      for (const k in dict) {
-        if (dict[k]) out.push(k);
+      // Only iterate over an object's own enumerable properties to avoid
+      // leaking prototype keys into the class list.
+      for (const [k, val] of Object.entries(dict)) {
+        if (val) out.push(k);
       }
       return;
     }


### PR DESCRIPTION
## Summary
- avoid iterating prototype keys in `cn` helper
- restore tsbuildinfo

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: If you set up ESLint yourself, we recommend adding the Next.js ESLint plugin. See https://nextjs.org/docs/basic-features/eslint#migrating-existing-config)*

------
https://chatgpt.com/codex/tasks/task_e_68aef61451c8832cb514e6a9853dfbf1