### PR TITLE
Add border to planner dropdown trigger

### DIFF
--- a/src/components/ui/selects/AnimatedSelect.tsx
+++ b/src/components/ui/selects/AnimatedSelect.tsx
@@ -223,6 +223,7 @@ export default function AnimatedSelect({
   const triggerCls = [
     "group glitch-trigger relative inline-flex items-center gap-2 rounded-2xl px-3 overflow-hidden",
     "bg-[hsl(var(--muted)/.12)] hover:bg-[hsl(var(--muted)/.18)]",
+    "border border-[hsl(var(--ring)/.22)] data-[lit=true]:border-[hsl(var(--ring)/.38)] data-[open=true]:border-[hsl(var(--ring)/.38)]",
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
     "transition",
     buttonClassName,


### PR DESCRIPTION
## Summary
- make planner dropdown trigger show a subtle border that brightens when opened or a value is chosen

## Testing
- `npx eslint src/components/ui/selects/AnimatedSelect.tsx`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aefae87cf8832c8ad852ff3068c871