### PR TITLE
test: add cn utility tests

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { cn } from './utils.ts';
+
+// Unit tests for the `cn` class name utility
+
+test('handles strings', () => {
+  assert.equal(cn('foo', 'bar', 'baz'), 'foo bar baz');
+  assert.equal(cn('foo', '', 'bar', undefined, null, false, 'baz'), 'foo bar baz');
+});
+
+test('handles numbers', () => {
+  assert.equal(cn(1, 2, 3), '1 2 3');
+  assert.equal(cn(0, 1, 2, 0), '1 2');
+});
+
+test('handles nested arrays', () => {
+  assert.equal(cn(['foo', ['bar', null], undefined, ['baz', ['', ['qux']]]]), 'foo bar baz qux');
+});
+
+test('handles objects with truthy and falsy values', () => {
+  assert.equal(
+    cn({ foo: true, bar: false, baz: 0, qux: 1, quux: '', corge: 'yes' }),
+    'foo qux corge'
+  );
+});
+
+test('handles mixed inputs', () => {
+  const result = cn(
+    'foo',
+    1,
+    ['bar', ['baz', { qux: true, quux: 0 }]],
+    { corge: true, grault: false },
+    null,
+    undefined,
+    0
+  );
+  assert.equal(result, 'foo 1 bar baz qux corge');
+});


### PR DESCRIPTION
## Summary
- add comprehensive test coverage for `cn` utility
- validate class merging across strings, numbers, arrays, objects and mixed inputs
- document test suite with inline comments

## Testing
- `node --experimental-strip-types --test src/lib/utils.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aef85ac1fc832cbe530fac5b87974d