### PR TITLE
refactor: use canonical role literals

### DIFF
--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -5,7 +5,7 @@ import "../reviews/style.css";
 import RoleSelector from "@/components/reviews/RoleSelector";
 
 import * as React from "react";
-import type { Review, Pillar } from "@/lib/types";
+import type { Review, Pillar, Role } from "@/lib/types";
 import Input from "@/components/ui/primitives/input";
 import Textarea from "@/components/ui/primitives/textarea";
 import IconButton from "@/components/ui/primitives/IconButton";
@@ -31,8 +31,7 @@ import {
   FOCUS_POOLS,
   pickIndex,
   scoreIcon,
-  type Role,
-} from "@/components/reviews/reviewData"; // <-- corrected import path
+} from "@/components/reviews/reviewData";
 
 /** Faint section label + rule used throughout the form. */
 function SectionLabel({ children }: { children: React.ReactNode }) {

--- a/src/components/reviews/RoleSelector.tsx
+++ b/src/components/reviews/RoleSelector.tsx
@@ -2,7 +2,8 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
-import { ROLE_OPTIONS, type Role } from "@/components/reviews/reviewData";
+import { ROLE_OPTIONS } from "@/components/reviews/reviewData";
+import type { Role } from "@/lib/types";
 
 type Props = {
   value: Role;

--- a/src/components/reviews/reviewData.ts
+++ b/src/components/reviews/reviewData.ts
@@ -1,6 +1,5 @@
-// src/lib/reviewData.ts
-import * as React from "react";
-import type { Pillar } from "../../lib/types";
+import type { ComponentType } from "react";
+import type { Pillar, Role } from "@/lib/types";
 import {
   Flag,
   MapPin,
@@ -16,9 +15,6 @@ import {
 /** Persisted key for role memory */
 export const LAST_ROLE_KEY = "last_role";
 
-/** Role type used across editor/summary */
-export type Role = "TOP" | "JGL" | "MID" | "ADC" | "SUP";
-
 /** Lane/pillar enums used in UI */
 export const ALL_PILLARS: Pillar[] = [
   "Wave",
@@ -33,13 +29,13 @@ export const ALL_PILLARS: Pillar[] = [
 export const ROLE_OPTIONS: Array<{
   value: Role;
   label: string;
-  Icon: React.ComponentType<{ className?: string }>;
+  Icon: ComponentType<{ className?: string }>;
 }> = [
   { value: "TOP", label: "Top", Icon: Flag },
-  { value: "JGL", label: "Jungle", Icon: MapPin },
+  { value: "JUNGLE", label: "Jungle", Icon: MapPin },
   { value: "MID", label: "Mid", Icon: Target },
   { value: "ADC", label: "ADC", Icon: Crosshair },
-  { value: "SUP", label: "Support", Icon: Shield },
+  { value: "SUPPORT", label: "Support", Icon: Shield },
 ];
 
 /** Deterministic index selector (cheap string hash) */
@@ -54,7 +50,7 @@ export function pickIndex(seed: string, modulo: number): number {
 
 /** Icon + color class for a score bucket */
 export function scoreIcon(score: number): {
-  Icon: React.ComponentType<{ className?: string }>;
+  Icon: ComponentType<{ className?: string }>;
   cls: string;
 } {
   if (score <= 3) return { Icon: Skull, cls: "text-rose-400" };


### PR DESCRIPTION
## Summary
- import `Role` from `@/lib/types` and use `JUNGLE`/`SUPPORT` role values
- update ReviewEditor and RoleSelector to rely on canonical role literals
- narrow React type imports to `ComponentType` for role icons

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f1f2091c832ca51f7cfd1f219004