### PR TITLE
fix: remove glitch style from champ inputs

### DIFF
--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -368,7 +368,7 @@ function ChampPillsEdit({
   return (
     <div className="champ-badges mt-1 flex flex-wrap gap-1.5">
       {(list.length ? list : [""]).map((c, i) => (
-        <span key={i} className="champ-badge glitch-pill text-xs">
+        <span key={i} className="champ-badge text-xs">
           <i className="dot" />
           <span
             contentEditable


### PR DESCRIPTION
## Summary
- remove glitch style from champ example editing pills

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b90bbf2964832c9de2880c7eda0dbb