### PR TITLE
fix: align search bar icons

### DIFF
--- a/src/components/ui/primitives/searchbar.tsx
+++ b/src/components/ui/primitives/searchbar.tsx
@@ -119,7 +119,7 @@ export default function SearchBar({
             circleSize={btnCircleMap[size]}
             iconSize={btnIconMap[size]}
             // Position clear button inside the input without overlapping text
-            className="absolute right-2 top-1/2 -translate-y-1/2"
+            className="!absolute right-2 top-1/2 -translate-y-1/2"
             onClick={() => {
               setQuery("");
               onValueChange?.("");


### PR DESCRIPTION
## Summary
- ensure search bar's clear button uses absolute positioning to align icons
- restore tsconfig build info

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b910a81ff4832ca3d287cbd4d4426a