### PR TITLE
style: right-align dropdown caret

### DIFF
--- a/src/components/planner/TodayHero.tsx
+++ b/src/components/planner/TodayHero.tsx
@@ -86,7 +86,7 @@ export default function TodayHero({ iso }: Props) {
             onChange={v => { setSelProjectId(v); /* clears task selection via hook */ }}
             label="Project"
             hideLabel
-            buttonClassName="h-10 rounded-2xl"
+            buttonClassName="h-10 rounded-full"
             dropdownClassName="rounded-2xl"
             placeholder="Select a project"
           />

--- a/src/components/ui/selects/AnimatedSelect.tsx
+++ b/src/components/ui/selects/AnimatedSelect.tsx
@@ -221,7 +221,7 @@ export default function AnimatedSelect({
 
   // ── Trigger (glitch chrome + stays lit on selection) ──
   const triggerCls = [
-    "group glitch-trigger relative inline-flex items-center gap-2 rounded-2xl px-3 overflow-hidden",
+    "group glitch-trigger relative flex items-center rounded-full px-3 overflow-hidden",
     "bg-[hsl(var(--muted)/.12)] hover:bg-[hsl(var(--muted)/.18)]",
     "border border-[hsl(var(--ring)/.22)] data-[lit=true]:border-[hsl(var(--ring)/.38)] data-[open=true]:border-[hsl(var(--ring)/.38)]",
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
@@ -229,7 +229,7 @@ export default function AnimatedSelect({
     buttonClassName,
   ].join(" ");
 
-  const caretCls = `caret ml-1 size-4 opacity-75 ${open ? "caret-open" : ""}`;
+  const caretCls = `caret ml-auto size-4 shrink-0 opacity-75 ${open ? "caret-open" : ""}`;
 
   return (
     <div id={id} className={["glitch-wrap", className].join(" ")}>

--- a/src/components/ui/theme/ThemeToggle.tsx
+++ b/src/components/ui/theme/ThemeToggle.tsx
@@ -157,7 +157,7 @@ export default function ThemeToggle({
         items={items}
         value={variant}
         onChange={(v) => setVariantPersist(v as Variant)}
-        buttonClassName="!h-9 !px-3 !rounded-[9999px] !text-sm"
+        buttonClassName="!h-9 !px-3 !rounded-full !text-sm !w-auto"
         matchTriggerWidth={false}
         align="right"
         className="shrink-0"


### PR DESCRIPTION
## Summary
- place dropdown caret on the far right and use pill-shaped trigger buttons
- ensure project picker uses fully rounded trigger
- keep theme toggle compact with explicit full rounding

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b91a2da418832cb7d4c09e89c69dd6