### PR TITLE
Fix champ badge editing to use inputs

### DIFF
--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -370,28 +370,23 @@ function ChampPillsEdit({
       {(list.length ? list : [""]).map((c, i) => (
         <span key={i} className="champ-badge text-xs">
           <i className="dot" />
-          <span
-            contentEditable
+          <input
+            type="text"
             dir="ltr"
-            suppressContentEditableWarning
-            className="outline-none"
-            onInput={(e) => setAt(i, (e.currentTarget.textContent ?? "").trim())}
+            value={c}
+            onChange={(e) => setAt(i, e.currentTarget.value)}
             onKeyDown={(e) => {
               if (e.key === "Enter" || e.key === ",") {
                 e.preventDefault();
                 insertAfter(i);
               }
-              if (e.key === "Backspace") {
-                const text = (e.currentTarget.textContent ?? "").trim();
-                if (!text) {
-                  e.preventDefault();
-                  removeAt(i);
-                }
+              if (e.key === "Backspace" && !e.currentTarget.value) {
+                e.preventDefault();
+                removeAt(i);
               }
             }}
-          >
-            {c}
-          </span>
+            className="bg-transparent outline-none border-none w-24"
+          />
         </span>
       ))}
     </div>

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -188,28 +188,23 @@ function ChampChips({
       {(champs.length ? champs : [""]).map((c, i) => (
         <span key={i} className="champ-badge glitch-pill text-xs">
           <i className="dot" />
-          <span
-            contentEditable
+          <input
+            type="text"
             dir="ltr"
-            suppressContentEditableWarning
-            className="outline-none"
-            onInput={e => setAt(i, (e.currentTarget.textContent ?? "").trim())}
+            value={c}
+            onChange={e => setAt(i, e.currentTarget.value)}
             onKeyDown={e => {
               if (e.key === "Enter" || e.key === ",") {
                 e.preventDefault();
                 insertAfter(i);
               }
-              if (e.key === "Backspace") {
-                const text = (e.currentTarget.textContent ?? "").trim();
-                if (!text) {
-                  e.preventDefault();
-                  removeAt(i);
-                }
+              if (e.key === "Backspace" && !e.currentTarget.value) {
+                e.preventDefault();
+                removeAt(i);
               }
             }}
-          >
-            {c}
-          </span>
+            className="bg-transparent outline-none border-none w-24"
+          />
         </span>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- replace contentEditable champion chips with text inputs in MyComps
- use input fields for CheatSheet champion examples as well

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b91cbcb238832cbd101fdfa9716880