### PR TITLE
Refine Today card layout and styling

### DIFF
--- a/src/components/planner/TodayHero.tsx
+++ b/src/components/planner/TodayHero.tsx
@@ -13,7 +13,7 @@ import CheckCircle from "@/components/ui/toggles/CheckCircle";
 import AnimatedSelect from "@/components/ui/selects/AnimatedSelect";
 import Input from "@/components/ui/primitives/input";
 import IconButton from "@/components/ui/primitives/IconButton";
-import { Pencil, Trash2, Calendar, Plus } from "lucide-react";
+import { Pencil, Trash2, Calendar, CirclePlus } from "lucide-react";
 import type React from "react";
 
 type DateInputWithPicker = HTMLInputElement & { showPicker?: () => void };
@@ -69,27 +69,23 @@ export default function TodayHero({ iso }: Props) {
           </h2>
         </div>
 
-        <div className="flex items-center">
+        <div className="flex items-center gap-2">
+          <div className="w-[240px]">
+            <AnimatedSelect
+              items={projects.length ? projects.map(p => ({ value: p.id, label: p.name || "Untitled" })) : [{ value: "", label: "No projects" }]}
+              value={selProjectId}
+              onChange={v => { setSelProjectId(v); /* clears task selection via hook */ }}
+              label="Project"
+              hideLabel
+              buttonClassName="h-10 rounded-full"
+              dropdownClassName="rounded-2xl"
+              placeholder="Select a project"
+            />
+          </div>
           <input ref={dateRef} type="date" value={viewIso || nowISO} onChange={e => setIso(e.target.value)} aria-label="Change focused date" className="sr-only" />
           <IconButton aria-label="Open calendar" title={viewIso} onClick={openPicker} circleSize="md" variant="ring" iconSize="md">
             <Calendar />
           </IconButton>
-        </div>
-      </div>
-
-      {/* Project dropdown */}
-      <div className="mb-4">
-        <div className="w-[240px]">
-          <AnimatedSelect
-            items={projects.length ? projects.map(p => ({ value: p.id, label: p.name || "Untitled" })) : [{ value: "", label: "No projects" }]}
-            value={selProjectId}
-            onChange={v => { setSelProjectId(v); /* clears task selection via hook */ }}
-            label="Project"
-            hideLabel
-            buttonClassName="h-10 rounded-full"
-            dropdownClassName="rounded-2xl"
-            placeholder="Select a project"
-          />
         </div>
       </div>
 
@@ -104,8 +100,6 @@ export default function TodayHero({ iso }: Props) {
 
       {/* Projects */}
       <div className="mt-1">
-        <div className="mb-2 text-[11px] text-[hsl(var(--muted-foreground))]">{`// projects`}</div>
-
         <form
           className="flex items-center gap-2"
           onSubmit={e => {
@@ -118,7 +112,7 @@ export default function TodayHero({ iso }: Props) {
         >
           <Input name="new-project" placeholder="> new project…" value={projectName} onChange={e => setProjectName(e.target.value)} aria-label="New project" className="mt-1" />
           <IconButton type="submit" aria-label="Add project" title="Add project" circleSize="sm" variant="ring" iconSize="sm">
-            <Plus />
+            <CirclePlus />
           </IconButton>
         </form>
 
@@ -131,7 +125,7 @@ export default function TodayHero({ iso }: Props) {
                 <li
                   key={p.id}
                   className={cn(
-                    "group flex select-none items-center justify-between rounded-md border px-3 py-2 text-sm transition",
+                    "group flex select-none items-center justify-between rounded-[24px] border px-3 py-2 text-sm transition",
                     "border-[hsl(var(--border))] bg-[hsl(var(--card)/0.55)] hover:bg-[hsl(var(--card)/0.7)]",
                     isSelected && "ring-1 ring-[hsl(var(--ring))]"
                   )}
@@ -180,8 +174,6 @@ export default function TodayHero({ iso }: Props) {
         <div className="mt-4 text-[13px] text-[hsl(var(--muted-foreground))]">Select a project to add and view tasks.</div>
       ) : (
         <>
-          <div className="mt-4 text-[11px] text-[hsl(var(--muted-foreground))]">{`// tasks`}</div>
-
           <form
             className="flex items-center gap-2"
             onSubmit={e => {
@@ -195,7 +187,7 @@ export default function TodayHero({ iso }: Props) {
           >
             <Input name={`new-task-${selProjectId}`} placeholder={`> task for "${projects.find(p => p.id === selProjectId)?.name ?? "Project"}"`} aria-label="New task" className="mt-1" />
             <IconButton type="submit" aria-label="Add task" title="Add task" circleSize="sm" variant="ring" iconSize="sm">
-              <Plus />
+              <CirclePlus />
             </IconButton>
           </form>
 
@@ -209,7 +201,7 @@ export default function TodayHero({ iso }: Props) {
                   <li
                     key={t.id}
                     className={cn(
-                      "task-tile flex items-center justify-between rounded-md border px-3 py-2",
+                      "task-tile flex items-center justify-between rounded-[24px] border px-3 py-2",
                       "border-[hsl(var(--border))] bg-[hsl(var(--card)/0.55)] hover:bg-[hsl(var(--card)/0.7)]"
                     )}
                     role="listitem"


### PR DESCRIPTION
## Summary
- move project dropdown next to calendar button in Today card header
- remove redundant `// projects` and `// tasks` labels
- give project and task tiles a 24px radius and use an add-icon button

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b91e0b49d4832c910a69801dd63fe2