### PR TITLE
feat: enhance planner task selection

### DIFF
--- a/src/components/planner/DayCard.tsx
+++ b/src/components/planner/DayCard.tsx
@@ -67,8 +67,22 @@ export default function DayCard({ iso, isToday }: Props) {
 
   const projectsScrollable = projects.length > 3;
 
+  const cardRef = React.useRef<HTMLElement>(null);
+
+  React.useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (cardRef.current && !cardRef.current.contains(e.target as Node)) {
+        setSelectedProjectId("");
+        setSelectedTaskId("");
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [setSelectedProjectId, setSelectedTaskId]);
+
   return (
     <section
+      ref={cardRef}
       className={cn(
         "daycard relative overflow-hidden card-neo-soft rounded-2xl border card-pad",
         "grid gap-4 lg:gap-6",
@@ -106,28 +120,16 @@ export default function DayCard({ iso, isToday }: Props) {
         </div>
       </div>
 
-      {/* Add row */}
+      {/* Add project */}
       <div className="col-span-1 lg:col-span-3">
-        <div className="flex flex-col gap-2 sm:flex-row">
-          <Input
-            className="planner-input w-full"
-            placeholder="New project…"
-            value={draftProject}
-            onChange={e => setDraftProject(e.target.value)}
-            onKeyDown={e => e.key === "Enter" && addProjectCommit()}
-            aria-label="Add project"
-          />
-          {selectedProjectId ? (
-            <Input
-              className="planner-input w-full"
-              placeholder="Add task…"
-              value={draftTask}
-              onChange={e => setDraftTask(e.target.value)}
-              onKeyDown={e => e.key === "Enter" && addTaskCommit()}
-              aria-label="Add task"
-            />
-          ) : null}
-        </div>
+        <Input
+          className="w-full"
+          placeholder="> new project..."
+          value={draftProject}
+          onChange={e => setDraftProject(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && addProjectCommit()}
+          aria-label="Add project"
+        />
       </div>
 
       {/* Left: projects */}
@@ -192,11 +194,21 @@ export default function DayCard({ iso, isToday }: Props) {
 
       {/* Right: tasks */}
       <div className="flex flex-col gap-3 min-w-0">
+        {selectedProjectId && (
+          <Input
+            className="task-input w-full"
+            placeholder="> add task..."
+            value={draftTask}
+            onChange={e => setDraftTask(e.target.value)}
+            onKeyDown={e => e.key === "Enter" && addTaskCommit()}
+            aria-label="Add task"
+          />
+        )}
         <div className="min-h-[120px] max-h-[320px] overflow-y-auto px-2 py-2">
           {!selectedProjectId ? (
-            <EmptyRow text="No project selected." />
+            <EmptyRow text="No task selected." />
           ) : tasksForSelected.length === 0 ? (
-            <EmptyRow text="No tasks yet." />
+            <EmptyRow text="No tasks selected." />
           ) : (
             <ul className="space-y-2 [&>li:first-child]:mt-1.5 [&>li:last-child]:mb-1.5" aria-label="Tasks">
               {tasksForSelected.map(t => (

--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -118,6 +118,32 @@
   background: linear-gradient(180deg, hsl(var(--card) / .65), hsl(var(--card) / .45));
 }
 
+/* Dark task input with subtle glitch lines */
+.task-input {
+  height: var(--control-h);
+  border-radius: var(--radius-2, 12px);
+  padding-inline: var(--control-px);
+  font-size: var(--control-fs);
+  background: repeating-linear-gradient(
+    to bottom,
+    hsl(var(--card) / .55) 0,
+    hsl(var(--card) / .55) 1px,
+    hsl(var(--card) / .50) 1px,
+    hsl(var(--card) / .50) 2px
+  );
+  border: 1px solid hsl(var(--card-hairline));
+  color: hsl(var(--foreground));
+  transition: box-shadow var(--dur-quick), border-color var(--dur-quick);
+}
+.task-input::placeholder {
+  color: hsl(var(--muted-foreground) / 0.8);
+}
+.task-input:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px hsl(var(--ring) / 0.35);
+  border-color: hsl(var(--ring));
+}
+
 /* ============ Week chips: hover flicker + active glitch ============ */
 @keyframes chip-flicker {
   0%, 22%, 24%, 55%, 57%, 100% { opacity: 1; filter: none; }


### PR DESCRIPTION
## Summary
- style new project field like TodayHero and expand to full width
- move task input above task list with glitchy styling and adjusted empty messages
- clear selected project when clicking outside the planner card

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b91f6f1028832c8ee3b1de4558b10f