### PR TITLE
Respect reduced motion preference in animation toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Animations
+
+This app respects your operating system's "reduced motion" setting. If reduced motion is enabled, animations will start disabled. You can override this preference at any time using the lightning bolt toggle in the header.

--- a/src/components/ui/AnimationToggle.tsx
+++ b/src/components/ui/AnimationToggle.tsx
@@ -7,22 +7,29 @@ const KEY = "animations-enabled";
 
 export default function AnimationToggle() {
   const [enabled, setEnabled] = React.useState(true);
+  const [showNotice, setShowNotice] = React.useState(false);
 
   React.useEffect(() => {
     let isEnabled = true;
+    let notice = false;
     try {
       const stored = localStorage.getItem(KEY);
       if (stored !== null) {
         isEnabled = stored === "true";
+      } else if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+        isEnabled = false;
+        notice = true;
       }
     } catch {}
     setEnabled(isEnabled);
+    setShowNotice(notice);
     document.documentElement.classList.toggle("no-animations", !isEnabled);
   }, []);
 
   function toggle() {
     const next = !enabled;
     setEnabled(next);
+    setShowNotice(false);
     try {
       localStorage.setItem(KEY, String(next));
     } catch {}
@@ -30,20 +37,27 @@ export default function AnimationToggle() {
   }
 
   return (
-    <button
-      type="button"
-      aria-pressed={enabled}
-      aria-label={enabled ? "Disable animations" : "Enable animations"}
-      onClick={toggle}
-      className={[
-        "inline-flex h-9 w-9 items-center justify-center rounded-full shrink-0",
-        "border border-[hsl(var(--border))] bg-[hsl(var(--card))]",
-        "hover:shadow-[0_0_12px_hsl(var(--ring)/.35)] focus:outline-none",
-        "focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
-      ].join(" ")}
-    >
-      {enabled ? <Zap className="h-4 w-4" /> : <ZapOff className="h-4 w-4" />}
-    </button>
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        aria-pressed={enabled}
+        aria-label={enabled ? "Disable animations" : "Enable animations"}
+        onClick={toggle}
+        className={[
+          "inline-flex h-9 w-9 items-center justify-center rounded-full shrink-0",
+          "border border-[hsl(var(--border))] bg-[hsl(var(--card))]",
+          "hover:shadow-[0_0_12px_hsl(var(--ring)/.35)] focus:outline-none",
+          "focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+        ].join(" ")}
+      >
+        {enabled ? <Zap className="h-4 w-4" /> : <ZapOff className="h-4 w-4" />}
+      </button>
+      {showNotice && (
+        <span className="text-xs text-[hsl(var(--muted-foreground))]">
+          Animations disabled per OS preference
+        </span>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- Detect the user's `prefers-reduced-motion` setting on mount and disable animations by default when requested
- Show a brief notice and allow re-enabling animations via the existing toggle
- Document how to override the OS preference with the header toggle

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b929fcde88832cb254c018106fba34