### PR TITLE
fix: validate ISO dates

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { cn } from './utils.ts';
+import { cn, fromISODate } from './utils.ts';
 
 // Unit tests for the `cn` class name utility
 
@@ -36,4 +36,11 @@ test('handles mixed inputs', () => {
     0
   );
   assert.equal(result, 'foo 1 bar baz qux corge');
+});
+
+test('fromISODate returns null for invalid dates', () => {
+  const valid = fromISODate('2024-02-29');
+  assert(valid && valid.getFullYear() === 2024 && valid.getMonth() === 1 && valid.getDate() === 29);
+  assert.equal(fromISODate('2024-02-30'), null);
+  assert.equal(fromISODate('not-a-date'), null);
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -66,7 +66,11 @@ export function fromISODate(iso: string): Date | null {
   if (!isISODate(iso)) return null;
   const [y, m, d] = iso.split("-").map((x) => parseInt(x, 10));
   const dt = new Date(y, m - 1, d, 0, 0, 0, 0);
-  return Number.isFinite(dt.getTime()) ? dt : null;
+  if (!Number.isFinite(dt.getTime())) return null;
+  // Guard against JS Date rolling over invalid dates like "2023-02-31" -> Mar 3
+  return dt.getFullYear() === y && dt.getMonth() === m - 1 && dt.getDate() === d
+    ? dt
+    : null;
 }
 
 /** Predicate for "YYYY-MM-DD". */


### PR DESCRIPTION
## Summary
- ensure fromISODate rejects invalid dates instead of rolling over
- add tests verifying fromISODate behavior

## Testing
- `npm run lint`
- `npm run typecheck`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b92a379950832cbf19cc77c54ebca0