### PR TITLE
Persist role selection and streamline review editing

### DIFF
--- a/src/components/reviews/ReviewList.tsx
+++ b/src/components/reviews/ReviewList.tsx
@@ -70,10 +70,10 @@ export default function ReviewList({
               "bg-[hsl(var(--card))]",
               "transition-[box-shadow,background,border-color] duration-200",
               // glow only (no transform)
-              "hover:border-[hsl(var(--border)/.45)] hover:shadow-[0_0_0_1px_hsl(var(--accent)/.25)_inset,0_10px_28px_hsl(var(--shadow-color)/.28)]",
+              "hover:border-[hsl(var(--border)/.45)] hover:shadow-[0_0_0_1px_hsl(var(--accent)/.25)_inset,0_10px_20px_hsl(var(--shadow-color)/.28)]",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
               active &&
-                "shadow-[0_0_0_1px_hsl(var(--accent)/.35)_inset,0_12px_32px_hsl(var(--shadow-color)/.32)]"
+                "shadow-[0_0_0_1px_hsl(var(--accent)/.35)_inset,0_12px_24px_hsl(var(--shadow-color)/.32)]"
             )}
             aria-current={active ? "true" : undefined}
           >


### PR DESCRIPTION
## Summary
- remember the last lane/role selected and use it for new reviews
- tighten the glow under review list cards
- remove redundant save icon and auto-save when clicking outside the editor

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b92baca6ec832caa2fd0951379ef31