### PR TITLE
style: match task input styling in TodayHero

### DIFF
--- a/src/components/planner/TodayHero.tsx
+++ b/src/components/planner/TodayHero.tsx
@@ -190,7 +190,12 @@ export default function TodayHero({ iso }: Props) {
               if (id) setSelTaskId(id);
             }}
           >
-            <Input name={`new-task-${selProjectId}`} placeholder={`> task for "${projects.find(p => p.id === selProjectId)?.name ?? "Project"}"`} aria-label="New task" className="mt-1" />
+              <Input
+                name={`new-task-${selProjectId}`}
+                placeholder={`> task for "${projects.find(p => p.id === selProjectId)?.name ?? "Project"}"`}
+                aria-label="New task"
+                className="mt-1 task-input"
+              />
             <IconButton type="submit" aria-label="Add task" title="Add task" circleSize="sm" variant="ring" iconSize="sm">
               <CirclePlus />
             </IconButton>


### PR DESCRIPTION
## Summary
- style TodayHero task input with `task-input` class for consistency

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9360e960c832c885ffc97fd7e605b