### PR TITLE
feat: add selectable backgrounds

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,6 +24,7 @@ const noFlash = `
   try {
     var MODE_KEY = 'lg-mode';
     var VAR_KEY  = 'lg-variant';
+    var BG_KEY   = 'lg-bg';
     var LEGACY   = 'lg-theme';
     var cl = document.documentElement.classList;
 
@@ -59,12 +60,19 @@ const noFlash = `
       variant = 'lg';
       try { localStorage.setItem(VAR_KEY, variant); } catch (_) {}
     }
+    var bg = parseInt(localStorage.getItem(BG_KEY) || '0', 10);
+    if (bg !== 1 && bg !== 2) {
+      bg = 0;
+      try { localStorage.setItem(BG_KEY, String(bg)); } catch (_) {}
+    }
 
     // ---- apply one theme-* class ----
     Array.from(cl).forEach(function (name) {
       if (name.indexOf('theme-') === 0) cl.remove(name);
     });
     cl.add('theme-' + variant);
+    ['bg-alt1','bg-alt2'].forEach(function (c) { cl.remove(c); });
+    if (bg === 1) cl.add('bg-alt1'); else if (bg === 2) cl.add('bg-alt2');
 
     // ---- light only matters for the base LG theme ----
     if (variant === 'lg') {

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -328,6 +328,31 @@ html.theme-rose body::after {
 }
 @keyframes rose-pan { 0% { transform: translate3d(-1%,-1%,0) } 100% { transform: translate3d(1%,1%,0) } }
 
+/* Additional background options */
+html.bg-alt1 body {
+  background-image:
+    radial-gradient(1000px 600px at 10% -10%, hsl(var(--accent) / 0.20), transparent 60%),
+    radial-gradient(900px 500px at 110% 20%, hsl(var(--accent-2) / 0.18), transparent 60%),
+    linear-gradient(180deg, hsl(var(--card)), hsl(var(--background)));
+  background-attachment: fixed, fixed, fixed;
+}
+html.bg-alt1 body::before,
+html.bg-alt1 body::after {
+  content: none;
+}
+
+html.bg-alt2 body {
+  background-image:
+    radial-gradient(1000px 600px at 50% 0%, hsl(var(--primary) / 0.18), transparent 60%),
+    radial-gradient(900px 500px at 50% 120%, hsl(var(--accent) / 0.16), transparent 60%),
+    linear-gradient(180deg, hsl(var(--card)), hsl(var(--background)));
+  background-attachment: fixed, fixed, fixed;
+}
+html.bg-alt2 body::before,
+html.bg-alt2 body::after {
+  content: none;
+}
+
 /* ---------- Shared backdrop animations ---------- */
 @keyframes lg-grid-drift { 0%{transform:translate3d(0,0,0)} 100%{transform:translate3d(26px,26px,0)} }
 @keyframes lg-aurora-pan {


### PR DESCRIPTION
## Summary
- add storage and button to cycle through alternate backgrounds
- define two new background styles and persist selection
- ensure no-flash script applies chosen background on load

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b93b65d988832ca7cd478f2c030a16