### PR TITLE
fix: preserve last selected role

### DIFF
--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -412,8 +412,10 @@ export default function ReviewEditor({
 
     const r = ext.role ?? lastRole ?? "MID";
     setRole(r);
-    setLastRole(r);
 
+    // Default new reviews to the previously selected role without
+    // overwriting the remembered role when opening existing reviews.
+    // Persisting happens only when the user explicitly selects a role.
     if (ext.role == null) {
       onChangeMeta?.({ role: r });
     }


### PR DESCRIPTION
## Summary
- avoid overwriting remembered lane when opening existing reviews
- new reviews now default to previously chosen role

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b93bf0a398832c946d80e150e8b531