### PR TITLE
Adjust review list glow transparency

### DIFF
--- a/src/components/reviews/ReviewList.tsx
+++ b/src/components/reviews/ReviewList.tsx
@@ -64,16 +64,8 @@ export default function ReviewList({
             onClick={() => onSelect(r.id)}
             onKeyDown={onTileKeyDown}
             className={cn(
-              "group/review relative w-full rounded-2xl h-20 px-3 py-2",
-              // constant border to prevent hover jump
-              "border border-[hsl(var(--border)/.22)]",
-              "bg-[hsl(var(--card))]",
-              "transition-[box-shadow,background,border-color] duration-200",
-              // glow only (no transform)
-              "hover:border-[hsl(var(--border)/.45)] hover:shadow-[0_0_0_1px_hsl(var(--accent)/.25)_inset,0_10px_20px_hsl(var(--shadow-color)/.28)]",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
-              active &&
-                "shadow-[0_0_0_1px_hsl(var(--accent)/.35)_inset,0_12px_24px_hsl(var(--shadow-color)/.32)]"
+              "group/review review-tile relative w-full h-20 px-3 py-2",
+              active && "review-tile--active"
             )}
             aria-current={active ? "true" : undefined}
           >

--- a/src/components/reviews/style.css
+++ b/src/components/reviews/style.css
@@ -35,13 +35,13 @@
     0 6px 18px hsl(var(--shadow-color)/.22);
 }
 :where(.reviews-scope, [data-scope="reviews"]) .review-tile:hover::before{ box-shadow: inset 0 0 0 1px hsl(var(--primary)); }
-:where(.reviews-scope, [data-scope="reviews"]) .review-tile:hover::after{ opacity:.55; animation: sheen-rotate 6s linear infinite; }
+:where(.reviews-scope, [data-scope="reviews"]) .review-tile:hover::after{ opacity:.45; animation: sheen-rotate 6s linear infinite; }
 :where(.reviews-scope, [data-scope="reviews"]) .review-tile--active{
   border-color: hsl(var(--primary));
   box-shadow: inset 0 0 0 2px hsl(var(--primary)/.35), 0 10px 22px hsl(var(--shadow-color)/.30);
 }
 :where(.reviews-scope, [data-scope="reviews"]) .review-tile--active::before{ box-shadow: inset 0 0 0 1.5px hsl(var(--primary)); }
-:where(.reviews-scope, [data-scope="reviews"]) .review-tile--active::after{ opacity:.75; }
+:where(.reviews-scope, [data-scope="reviews"]) .review-tile--active::after{ opacity:.6; }
 :where(.reviews-scope, [data-scope="reviews"]) .review-tile:focus-visible{
   outline: none; box-shadow: inset 0 0 0 2px hsl(var(--ring)/.45);
 }
@@ -101,7 +101,7 @@
   box-shadow: inset 0 0 0 1px hsl(var(--primary));
 }
 :where(.reviews-scope, [data-scope="reviews"]) .review-tile:hover::after{
-  opacity:.55;
+  opacity:.45;
   animation: sheen-rotate 6s linear infinite;
 }
 
@@ -116,7 +116,7 @@
   box-shadow: inset 0 0 0 1.5px hsl(var(--primary));
 }
 :where(.reviews-scope, [data-scope="reviews"]) .review-tile--active::after{
-  opacity:.75;
+  opacity:.6;
 }
 
 /* Keyboard focus */


### PR DESCRIPTION
## Summary
- apply shared `review-tile` styles to review list items for consistent glow
- reduce review tile hover/active glow opacity to better match design

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b93c76dbc4832c85e64f85dc9188f6