### PR TITLE
feat: add hero gif to week picker

### DIFF
--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -257,44 +257,52 @@ export default function WeekPicker() {
       sticky
       dividerTint="primary"
       bottom={
-        <div className="grid gap-3">
-          {/* Range + totals */}
-          <div className="flex items-center justify-between gap-3">
-            <span
-              className={cn(
-                "inline-flex items-center gap-2 rounded-2xl px-3 py-1.5 text-sm",
-                "bg-[hsl(var(--card)/0.72)] ring-1 ring-[hsl(var(--border)/0.55)] backdrop-blur"
-              )}
-              aria-label={`Week range ${rangeLabel}`}
-            >
-              <CalendarDays className="size-4 opacity-80" />
-              <span className="opacity-90">{rangeLabel}</span>
-            </span>
-
-            <span className="text-sm text-[hsl(var(--muted-foreground))]">
-              <span className="opacity-70">Total tasks: </span>
-              <span className="font-medium tabular-nums text-[hsl(var(--foreground))]">
-                {weekDone} / {weekTotal}
+        <>
+          <div className="grid gap-3 flex-1">
+            {/* Range + totals */}
+            <div className="flex items-center justify-between gap-3">
+              <span
+                className={cn(
+                  "inline-flex items-center gap-2 rounded-2xl px-3 py-1.5 text-sm",
+                  "bg-[hsl(var(--card)/0.72)] ring-1 ring-[hsl(var(--border)/0.55)] backdrop-blur"
+                )}
+                aria-label={`Week range ${rangeLabel}`}
+              >
+                <CalendarDays className="size-4 opacity-80" />
+                <span className="opacity-90">{rangeLabel}</span>
               </span>
-            </span>
-          </div>
 
-          {/* Day chips */}
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3 lg:grid-cols-7">
-            {days.map((d, i) => (
-              <DayChip
-                key={d}
-                iso={d}
-                selected={d === iso}
-                today={d === today}
-                done={per[i]?.done ?? 0}
-                total={per[i]?.total ?? 0}
-                onClick={selectOnly}
-                onDoubleClick={jumpToDay}
-              />
-            ))}
+              <span className="text-sm text-[hsl(var(--muted-foreground))]">
+                <span className="opacity-70">Total tasks: </span>
+                <span className="font-medium tabular-nums text-[hsl(var(--foreground))]">
+                  {weekDone} / {weekTotal}
+                </span>
+              </span>
+            </div>
+
+            {/* Day chips */}
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3 lg:grid-cols-7">
+              {days.map((d, i) => (
+                <DayChip
+                  key={d}
+                  iso={d}
+                  selected={d === iso}
+                  today={d === today}
+                  done={per[i]?.done ?? 0}
+                  total={per[i]?.total ?? 0}
+                  onClick={selectOnly}
+                  onDoubleClick={jumpToDay}
+                />
+              ))}
+            </div>
           </div>
-        </div>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src="https://pin.it/6abRvOq6C"
+            alt="Weekly highlight"
+            className="h-16 w-16 rounded-full object-cover"
+          />
+        </>
       }
     />
   );


### PR DESCRIPTION
## Summary
- add animated circle gif under navigation buttons on planner page

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b93d1ba1c8832c931901a71d1ec57c