### PR TITLE
fix: ensure unique ids for form fields

### DIFF
--- a/src/components/ui/primitives/input.tsx
+++ b/src/components/ui/primitives/input.tsx
@@ -4,7 +4,7 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-/** Small helper to generate a stable id/name from aria-label if missing. */
+/** Small helper to generate a stable name from aria-label if missing. */
 function slug(s?: string) {
   return (s ?? "")
     .toLowerCase()
@@ -46,7 +46,9 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
 ) {
   const auto = React.useId();
   const fromAria = slug(ariaLabel as string | undefined);
-  const finalId = id || fromAria || auto;
+  // Always derive a unique id from React to avoid duplicates when the same
+  // aria-label is used for multiple fields.
+  const finalId = id || auto;
   const finalName = name || fromAria || finalId;
 
   return (

--- a/src/components/ui/primitives/textarea.tsx
+++ b/src/components/ui/primitives/textarea.tsx
@@ -31,7 +31,9 @@ export default React.forwardRef<HTMLTextAreaElement, TextareaProps>(function Tex
 ) {
   const auto = React.useId();
   const fromAria = slug(ariaLabel as string | undefined);
-  const finalId = id || fromAria || auto;
+  // Use React-generated id by default so multiple fields sharing an aria-label
+  // do not end up with duplicate ids.
+  const finalId = id || auto;
   const finalName = name || fromAria || finalId;
 
   return (


### PR DESCRIPTION
## Summary
- generate input and textarea IDs using React's `useId` to avoid duplicate IDs when aria-labels repeat

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9413a8f98832c83462d7064eb3ab2