### PR TITLE
tweak IconButton hover and active ring colors

### DIFF
--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -141,8 +141,13 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
               transition: border-color 150ms ease;
             }
             /* Let the neon take over the border area */
-            .ib2-root.ib2--ring:hover,
+            .ib2-root.ib2--ring:hover {
+              --ib-ring: var(--ib-ring-hover);
+              border-color: transparent;
+            }
+            .ib2-root.ib2--ring:active,
             .ib2-root.ib2--ring[aria-pressed="true"] {
+              --ib-ring: var(--ib-ring-active);
               border-color: transparent;
             }
 


### PR DESCRIPTION
## Summary
- ensure IconButton's ring variant updates CSS ring color variables on hover and active states to match new neon styling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b94169a19c832cb096ed81c1b0a5c0