### PR TITLE
Fix planner highlight media

### DIFF
--- a/public/weekly-highlight.svg
+++ b/public/weekly-highlight.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#ddd"/>
+  <text x="32" y="32" dominant-baseline="middle" text-anchor="middle" font-size="8" fill="#555">Week</text>
+</svg>

--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -9,6 +9,7 @@
  */
 
 import * as React from "react";
+import Image from "next/image";
 import Hero2 from "@/components/ui/layout/Hero2";
 import Button from "@/components/ui/primitives/button";
 import { useFocusDate, useDay, type ISODate } from "./usePlanner";
@@ -296,10 +297,11 @@ export default function WeekPicker() {
               ))}
             </div>
           </div>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src="https://pin.it/6abRvOq6C"
+          <Image
+            src="/weekly-highlight.svg"
             alt="Weekly highlight"
+            width={64}
+            height={64}
             className="h-16 w-16 rounded-full object-cover"
           />
         </>


### PR DESCRIPTION
## Summary
- show local weekly highlight image in WeekPicker
- import Next.js Image component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b941ef1544832ca61dc8fdf8bbbfe8