### PR TITLE
feat: add light background variant

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -61,7 +61,7 @@ const noFlash = `
       try { localStorage.setItem(VAR_KEY, variant); } catch (_) {}
     }
     var bg = parseInt(localStorage.getItem(BG_KEY) || '0', 10);
-    if (bg !== 1 && bg !== 2) {
+    if (bg !== 1 && bg !== 2 && bg !== 3) {
       bg = 0;
       try { localStorage.setItem(BG_KEY, String(bg)); } catch (_) {}
     }
@@ -71,8 +71,10 @@ const noFlash = `
       if (name.indexOf('theme-') === 0) cl.remove(name);
     });
     cl.add('theme-' + variant);
-    ['bg-alt1','bg-alt2'].forEach(function (c) { cl.remove(c); });
-    if (bg === 1) cl.add('bg-alt1'); else if (bg === 2) cl.add('bg-alt2');
+    ['bg-alt1','bg-alt2','bg-light'].forEach(function (c) { cl.remove(c); });
+    if (bg === 1) cl.add('bg-alt1');
+    else if (bg === 2) cl.add('bg-alt2');
+    else if (bg === 3) cl.add('bg-light');
 
     // ---- light only matters for the base LG theme ----
     if (variant === 'lg') {

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -353,6 +353,18 @@ html.bg-alt2 body::after {
   content: none;
 }
 
+html.bg-light body {
+  background-image:
+    radial-gradient(1200px 700px at 50% -10%, hsl(var(--foreground) / 0.08), transparent 60%),
+    radial-gradient(1000px 600px at 50% 120%, hsl(var(--accent) / 0.06), transparent 60%),
+    linear-gradient(180deg, hsl(var(--card)), hsl(var(--background)));
+  background-attachment: fixed, fixed, fixed;
+}
+html.bg-light body::before,
+html.bg-light body::after {
+  content: none;
+}
+
 /* ---------- Shared backdrop animations ---------- */
 @keyframes lg-grid-drift { 0%{transform:translate3d(0,0,0)} 100%{transform:translate3d(26px,26px,0)} }
 @keyframes lg-aurora-pan {

--- a/src/components/ui/theme/ThemeToggle.tsx
+++ b/src/components/ui/theme/ThemeToggle.tsx
@@ -7,7 +7,7 @@ import AnimatedSelect, { DropItem } from "@/components/ui/selects/AnimatedSelect
 
 type Mode = "dark" | "light";
 type Variant = "lg" | "citrus" | "noir" | "ocean" | "rose";
-type Background = 0 | 1 | 2;
+type Background = 0 | 1 | 2 | 3;
 
 type ThemeToggleProps = {
   className?: string;
@@ -21,7 +21,7 @@ const MODE_KEY  = "lg-mode";
 const VAR_KEY   = "lg-variant";
 const BG_KEY    = "lg-bg";
 
-const BG_CLASSES = ["", "bg-alt1", "bg-alt2"] as const;
+const BG_CLASSES = ["", "bg-alt1", "bg-alt2", "bg-light"] as const;
 
 const VARIANTS: { id: Variant; label: string }[] = [
   { id: "lg",     label: "Glitch" },
@@ -59,13 +59,13 @@ function readStorage(): { variant: Variant; mode: Mode; bg: Background } {
     if (t) {
       const { variant, mode } = parseTheme(t);
       const b = parseInt(localStorage.getItem(BG_KEY) || "0", 10);
-      const bg: Background = b === 1 || b === 2 ? b : 0;
+      const bg: Background = b === 1 || b === 2 || b === 3 ? b : 0;
       return { variant, mode, bg };
     }
     const m = localStorage.getItem(MODE_KEY) as Mode | null;
     const v = localStorage.getItem(VAR_KEY) as Variant | null;
     const b = parseInt(localStorage.getItem(BG_KEY) || "0", 10);
-    const bg: Background = b === 1 || b === 2 ? b : 0;
+    const bg: Background = b === 1 || b === 2 || b === 3 ? b : 0;
     if ((m === "dark" || m === "light") && v && VARIANTS.some(x => x.id === v)) return { variant: v, mode: m, bg };
   } catch {}
   const { variant, mode } = parseTheme(null);
@@ -141,7 +141,7 @@ export default function ThemeToggle({
   }
 
   function cycleBg() {
-    const next: Background = ((bg + 1) % 3) as Background;
+    const next: Background = ((bg + 1) % 4) as Background;
     const s = { variant, mode, bg: next };
     setState(s);
     writeStorage(s.variant, s.mode, s.bg);


### PR DESCRIPTION
## Summary
- add optional `bg-light` backdrop using subtle theme colors
- allow cycling through new background in ThemeToggle
- update no-flash script to recognize extra background class

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b942be0de8832c94274247ecaf992b