### PR TITLE
Ensure CheckCircle deactivates on external uncheck

### DIFF
--- a/src/components/ui/toggles/CheckCircle.tsx
+++ b/src/components/ui/toggles/CheckCircle.tsx
@@ -66,6 +66,19 @@ export default function CheckCircle({
     return () => clearTimeout(t);
   }, []);
 
+  // If our checked state flips off from an external source while hovered or
+  // focused, ensure we still run the "just cleared" power-down sequence so the
+  // neon rim doesn't remain lit.
+  const prevChecked = React.useRef(checked);
+  React.useEffect(() => {
+    let cleanup: (() => void) | undefined;
+    if (prevChecked.current && !checked && !justCleared) {
+      cleanup = markJustCleared();
+    }
+    prevChecked.current = checked;
+    return cleanup;
+  }, [checked, markJustCleared, justCleared]);
+
   // Theme-driven tones
   const pink = "hsl(var(--success,316 92% 70%))";
   const glow = "hsl(var(--success-glow,316 92% 52% / 0.6))";


### PR DESCRIPTION
## Summary
- ensure CheckCircle button powers down when unchecked externally

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b942865e50832c8892458158396960