### PR TITLE
Add static glitch backgrounds to theme toggle

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -60,21 +60,23 @@ const noFlash = `
       variant = 'lg';
       try { localStorage.setItem(VAR_KEY, variant); } catch (_) {}
     }
-    var bg = parseInt(localStorage.getItem(BG_KEY) || '0', 10);
-    if (bg !== 1 && bg !== 2 && bg !== 3) {
-      bg = 0;
-      try { localStorage.setItem(BG_KEY, String(bg)); } catch (_) {}
-    }
+      var bg = parseInt(localStorage.getItem(BG_KEY) || '0', 10);
+      if (bg !== 1 && bg !== 2 && bg !== 3 && bg !== 4 && bg !== 5) {
+        bg = 0;
+        try { localStorage.setItem(BG_KEY, String(bg)); } catch (_) {}
+      }
 
     // ---- apply one theme-* class ----
     Array.from(cl).forEach(function (name) {
       if (name.indexOf('theme-') === 0) cl.remove(name);
     });
     cl.add('theme-' + variant);
-    ['bg-alt1','bg-alt2','bg-light'].forEach(function (c) { cl.remove(c); });
-    if (bg === 1) cl.add('bg-alt1');
-    else if (bg === 2) cl.add('bg-alt2');
-    else if (bg === 3) cl.add('bg-light');
+      ['bg-alt1','bg-alt2','bg-light','bg-vhs','bg-streak'].forEach(function (c) { cl.remove(c); });
+      if (bg === 1) cl.add('bg-alt1');
+      else if (bg === 2) cl.add('bg-alt2');
+      else if (bg === 3) cl.add('bg-light');
+      else if (bg === 4) cl.add('bg-vhs');
+      else if (bg === 5) cl.add('bg-streak');
 
     // ---- light only matters for the base LG theme ----
     if (variant === 'lg') {

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -365,6 +365,42 @@ html.bg-light body::after {
   content: none;
 }
 
+html.bg-vhs body {
+  background-color: #0b0f13;
+  background-image:
+    radial-gradient(circle at 20% 30%, rgba(70, 230, 255, 0.15), transparent 60%),
+    repeating-linear-gradient(
+      to bottom,
+      rgba(150, 210, 225, 0.15),
+      rgba(150, 210, 225, 0.15) 1px,
+      transparent 1px,
+      transparent 3px
+    );
+  background-blend-mode: screen;
+}
+html.bg-vhs body::before,
+html.bg-vhs body::after {
+  content: none;
+}
+
+html.bg-streak body {
+  background-color: #1a1a24;
+  background-image:
+    radial-gradient(circle at 70% 40%, rgba(180, 100, 255, 0.25), transparent 40%),
+    repeating-linear-gradient(
+      to right,
+      rgba(160, 60, 255, 0.2),
+      rgba(160, 60, 255, 0.2) 6px,
+      transparent 6px,
+      transparent 20px
+    );
+  background-blend-mode: lighten;
+}
+html.bg-streak body::before,
+html.bg-streak body::after {
+  content: none;
+}
+
 /* ---------- Shared backdrop animations ---------- */
 @keyframes lg-grid-drift { 0%{transform:translate3d(0,0,0)} 100%{transform:translate3d(26px,26px,0)} }
 @keyframes lg-aurora-pan {

--- a/src/components/ui/theme/ThemeToggle.tsx
+++ b/src/components/ui/theme/ThemeToggle.tsx
@@ -7,7 +7,7 @@ import AnimatedSelect, { DropItem } from "@/components/ui/selects/AnimatedSelect
 
 type Mode = "dark" | "light";
 type Variant = "lg" | "citrus" | "noir" | "ocean" | "rose";
-type Background = 0 | 1 | 2 | 3;
+type Background = 0 | 1 | 2 | 3 | 4 | 5;
 
 type ThemeToggleProps = {
   className?: string;
@@ -21,7 +21,7 @@ const MODE_KEY  = "lg-mode";
 const VAR_KEY   = "lg-variant";
 const BG_KEY    = "lg-bg";
 
-const BG_CLASSES = ["", "bg-alt1", "bg-alt2", "bg-light"] as const;
+const BG_CLASSES = ["", "bg-alt1", "bg-alt2", "bg-light", "bg-vhs", "bg-streak"] as const;
 
 const VARIANTS: { id: Variant; label: string }[] = [
   { id: "lg",     label: "Glitch" },
@@ -59,13 +59,13 @@ function readStorage(): { variant: Variant; mode: Mode; bg: Background } {
     if (t) {
       const { variant, mode } = parseTheme(t);
       const b = parseInt(localStorage.getItem(BG_KEY) || "0", 10);
-      const bg: Background = b === 1 || b === 2 || b === 3 ? b : 0;
+      const bg: Background = b >= 1 && b <= 5 ? (b as Background) : 0;
       return { variant, mode, bg };
     }
     const m = localStorage.getItem(MODE_KEY) as Mode | null;
     const v = localStorage.getItem(VAR_KEY) as Variant | null;
-    const b = parseInt(localStorage.getItem(BG_KEY) || "0", 10);
-    const bg: Background = b === 1 || b === 2 || b === 3 ? b : 0;
+      const b = parseInt(localStorage.getItem(BG_KEY) || "0", 10);
+      const bg: Background = b >= 1 && b <= 5 ? (b as Background) : 0;
     if ((m === "dark" || m === "light") && v && VARIANTS.some(x => x.id === v)) return { variant: v, mode: m, bg };
   } catch {}
   const { variant, mode } = parseTheme(null);
@@ -141,7 +141,7 @@ export default function ThemeToggle({
   }
 
   function cycleBg() {
-    const next: Background = ((bg + 1) % 4) as Background;
+      const next: Background = ((bg + 1) % BG_CLASSES.length) as Background;
     const s = { variant, mode, bg: next };
     setState(s);
     writeStorage(s.variant, s.mode, s.bg);


### PR DESCRIPTION
## Summary
- add VHS scanline and purple streak background styles
- extend ThemeToggle to cycle through new backgrounds
- update no-flash bootstrap to honor additional backgrounds

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b947bcd908832c92f5a3d789b5f589