### PR TITLE
style: unify add icon buttons and card layers

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -244,7 +244,7 @@ export default function GoalsPage() {
                       key={g.id}
                       className={[
                         "relative rounded-2xl p-5",
-                        "card-neo-soft transition",
+                        "card-neo transition",
                         "hover:shadow-[0_0_0_1px_hsl(var(--primary)/.25),0_12px_40px_rgba(0,0,0,.35)]",
                         "min-h-[152px] flex flex-col",
                       ].join(" ")}
@@ -316,7 +316,7 @@ export default function GoalsPage() {
           </SectionCard>
 
           {/* Add Goal + Waiting List */}
-          <SectionCard className="card-neo">
+          <SectionCard className="card-neo-soft">
             <SectionCard.Header title={<span className="text-base font-semibold">Add Goal</span>} />
             <SectionCard.Body>
               <div className="grid gap-6 lg:grid-cols-[1fr_minmax(320px,420px)]">
@@ -519,7 +519,7 @@ function WaitlistPanel({
           aria-label="New waitlist item"
         />
         <span className="waitlist-terminal__caret" aria-hidden />
-        <IconButton title="Add" aria-label="Add" type="submit" circleSize="md">
+        <IconButton title="Add" aria-label="Add" type="submit" circleSize="md" variant="solid">
           <Plus />
         </IconButton>
       </form>

--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -164,7 +164,7 @@ export default function Reminders() {
 
   return (
     <div className="grid gap-4">
-      <SectionCard className="card-neo">
+      <SectionCard className="card-neo-soft">
         <SectionCard.Header sticky>
           {/* header row (no Quick Add here anymore) */}
           <div className="flex flex-wrap items-center gap-2 sm:gap-3 w-full">
@@ -223,7 +223,7 @@ export default function Reminders() {
               onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); addQuick(); } }}
               className="h-10 flex-1"
             />
-            <IconButton title="Add quick" aria-label="Add quick" onClick={addQuick} circleSize="md">
+            <IconButton title="Add quick" aria-label="Add quick" onClick={addQuick} circleSize="md" variant="solid">
               <Plus />
             </IconButton>
             <p className="text-xs sm:text-sm italic text-[hsl(var(--muted-foreground))]">
@@ -232,7 +232,7 @@ export default function Reminders() {
           </div>
 
           {/* Cards grid */}
-          <div className="grid card-neo gap-3 sm:gap-4 md:grid-cols-2">
+          <div className="grid card-neo-soft gap-3 sm:gap-4 md:grid-cols-2">
             {filtered.map((r) => (
               <ReminderCard
                 key={r.id}

--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -274,7 +274,7 @@ export default function RemindersTab() {
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => setQuickAdd(e.currentTarget.value)}
                 className="h-10 flex-1"
               />
-              <IconButton title="Add quick" aria-label="Add quick" type="submit" circleSize="md">
+              <IconButton title="Add quick" aria-label="Add quick" type="submit" circleSize="md" variant="solid">
                 <svg width="16" height="16" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round"/></svg>
               </IconButton>
               <div className={neonClass}>

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -937,7 +937,7 @@ export default function ReviewEditor({
               disabled={!canAddMarker}
               circleSize="md"
               iconSize="sm"
-              variant="ring"
+              variant="solid"
               onClick={addMarker}
             >
               <Plus />
@@ -1006,7 +1006,7 @@ export default function ReviewEditor({
               title="Add tag"
               circleSize="md"
               iconSize="sm"
-              variant="ring"
+              variant="solid"
               onClick={() => {
                 addTag(draftTag);
                 setDraftTag("");

--- a/src/components/team/JungleClears.tsx
+++ b/src/components/team/JungleClears.tsx
@@ -200,7 +200,7 @@ export default function JungleClears() {
                 </div>
 
                 <div className="mb-2 flex justify-end">
-                  <IconButton circleSize="sm" iconSize="xs" aria-label="Add row" onClick={() => addRow(bucket)}>
+                  <IconButton circleSize="sm" iconSize="xs" aria-label="Add row" onClick={() => addRow(bucket)} variant="solid">
                     <Plus />
                   </IconButton>
                 </div>

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -285,6 +285,7 @@ export default function MyComps() {
               aria-label="Add comp"
               circleSize="md"
               className="shrink-0"
+              variant="solid"
             >
               <Plus />
             </IconButton>

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 type Circle = "sm" | "md" | "lg";
 type Icon = "xs" | "sm" | "md" | "lg";
 type Tone = "primary" | "accent" | "info" | "danger";
-type Variant = "ring" | "glow"; // ring = flat outline w/ neon on hover, glow = original FX
+type Variant = "ring" | "glow" | "solid"; // ring = flat outline, glow = original FX, solid = filled
 
 export type IconButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   circleSize?: Circle;
@@ -14,7 +14,7 @@ export type IconButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   tone?: Tone;
   active?: boolean;
   fx?: boolean;      // kept for backwards-compat in "glow" mode
-  variant?: Variant; // "ring" (default) | "glow"
+  variant?: Variant; // "ring" (default) | "glow" | "solid"
 };
 
 const circleMap: Record<Circle, string> = {
@@ -86,6 +86,35 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
       "--ib-ring-hover": "hsl(var(--foreground) / 0.28)",
       "--ib-ring-active": "hsl(var(--foreground) / 0.36)",
     };
+
+    // ─────────────────────────────────────────────────────────────
+    // VARIANT: SOLID button matching primary "Add" styling
+    // ─────────────────────────────────────────────────────────────
+    if (variant === "solid") {
+      return (
+        <button
+          ref={ref}
+          type="button"
+          data-active={active ? "true" : undefined}
+          aria-pressed={active || undefined}
+          className={cn(
+            "inline-flex items-center justify-center select-none rounded-full",
+            "text-[hsl(var(--primary-foreground))]",
+            "bg-[var(--seg-active-grad)]",
+            "shadow-[0_0_0_1px_hsl(var(--ring)/.22),0_12px_28px_hsl(var(--shadow-color)/.28)]",
+            "transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+            "hover:brightness-[1.05] active:brightness-[0.95] active:scale-[0.97]",
+            "disabled:opacity-50 disabled:pointer-events-none",
+            circleMap[circleSize],
+            iconMap[iconSize],
+            className
+          )}
+          {...rest}
+        >
+          {withIcon(children)}
+        </button>
+      );
+    }
 
     // ─────────────────────────────────────────────────────────────
     // VARIANT: FLAT RING with NEON that COVERS the gray border on hover


### PR DESCRIPTION
## Summary
- add solid IconButton variant mirroring primary add button
- use solid IconButton for all add actions and nest solid cards on softer containers

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9986d4618832c923c83acdf0b00d1