### PR TITLE
rename Team Comp to Comps

### DIFF
--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import TeamCompPage from "@/components/team/TeamCompPage";
 
-export const metadata: Metadata = { title: "Team Comp · 13 League Review" };
+export const metadata: Metadata = { title: "Comps · 13 League Review" };
 
 export default function Page() {
   return <TeamCompPage />;

--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -15,7 +15,7 @@ const ITEMS = [
   { href: "/reviews", label: "Reviews" },
   { href: "/planner", label: "Planner" },
   { href: "/goals", label: "Goals" },
-  { href: "/team", label: "Team Comp" },
+  { href: "/team", label: "Comps" },
   { href: "/prompts", label: "Prompts" },
 ];
 

--- a/src/components/team/CheatSheetTabs.tsx
+++ b/src/components/team/CheatSheetTabs.tsx
@@ -30,7 +30,7 @@ export default function CheatSheetTabs() {
   return (
     <div className="w-full">
       <Hero2
-        eyebrow="Team Comp"
+        eyebrow="Comps"
         heading="Cheat Sheet"
         subtitle={tab === "sheet" ? "Archetypes & tips" : "Your saved compositions"}
         tabs={{

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 /**
- * MyComps — CRUD for custom team comps, single-panel version.
+ * MyComps — CRUD for custom comps, single-panel version.
  * - One SectionCard: header + add bar + cards grid inside the same panel
  * - Add comp (title), edit per-role champs (inline chips), notes
  * - Hover-only actions: Copy / Edit / Delete; Save when editing

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -33,7 +33,7 @@ export default function TeamCompPage() {
   return (
     <main className="grid gap-4">
       <Hero
-        eyebrow="Team Comp"
+        eyebrow="Comps"
         heading="Today"
         subtitle="Readable. Fast. On brand."
         icon={<Users2 className="opacity-80" />}
@@ -42,7 +42,7 @@ export default function TeamCompPage() {
             tabs={TABS}
             activeKey={tab}
             onChange={(k: Tab) => setTab(k)}
-            ariaLabel="Team Comp views"
+            ariaLabel="Comps views"
           />
         }
         className="mb-1"


### PR DESCRIPTION
## Summary
- rename navigation/tab text from **Team Comp** to **Comps**
- update metadata and hero labels to reflect new name
- adjust comments referencing team comps

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b99c640d88832c98d8c0230d00d60e