### PR TITLE
Refine planner layout and empty states

### DIFF
--- a/src/components/planner/DayCard.tsx
+++ b/src/components/planner/DayCard.tsx
@@ -32,6 +32,8 @@ export default function DayCard({ iso, isToday }: Props) {
   const [draftTask, setDraftTask] = React.useState("");
   const [editingProjectId, setEditingProjectId] = React.useState<string | null>(null);
   const [editingProjectName, setEditingProjectName] = React.useState("");
+  const projectInputRef = React.useRef<HTMLInputElement>(null);
+  const taskInputRef = React.useRef<HTMLInputElement>(null);
 
   // If the selected project goes away, clear selection
   React.useEffect(() => {
@@ -72,35 +74,23 @@ export default function DayCard({ iso, isToday }: Props) {
   return (
     <section
       className={cn(
-        "daycard relative overflow-hidden card-neo-soft rounded-2xl border card-pad",
-        "grid gap-4 lg:gap-6",
+        "daycard relative rounded-2xl border p-4",
+        "grid gap-6",
         "grid-cols-1 lg:grid-cols-[340px_1px_1fr]",
-        isToday && "ring-1 ring-[hsl(var(--ring)/0.65)] title-glow",
-        "before:pointer-events-none before:absolute before:inset-x-4 before:top-0 before:h-px before:bg-gradient-to-r",
-        "before:from-transparent before:via-[hsl(var(--ring)/.45)] before:to-transparent",
-        "after:pointer-events-none after:absolute after:-inset-px after:rounded-2xl after:bg-[radial-gradient(60%_40%_at_100%_0%,hsl(var(--ring)/.12),transparent_60%)]"
+        isToday && "ring-1 ring-[hsl(var(--ring)/0.65)]"
       )}
       aria-label={`Planner for ${iso}`}
     >
       {/* Header */}
-      <div className="col-span-1 lg:col-span-3 flex items-center gap-3 min-w-0">
-        <span className="glitch glitch-label text-sm font-semibold tracking-wide shrink-0" data-text={headerText}>
-          {headerText}
-        </span>
+      <div className="col-span-1 lg:col-span-3 flex items-center gap-4 min-w-0">
+        <span className="text-sm font-semibold shrink-0">{headerText}</span>
 
-        <div className="flex-1 min-w-0">
-          <div
-            className={cn("glitch-track", pctNum === 100 && "is-complete")}
-            role="progressbar"
-            aria-valuemin={0} aria-valuemax={100} aria-valuenow={pctNum}
-          >
-            <div className="glitch-fill transition-[width] duration-500 ease-out" style={{ width: `${pctNum}%` }} />
-            <div className="glitch-scan" />
-          </div>
+        <div className="flex-1 h-1.5 rounded-full bg-muted" role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={pctNum}>
+          <div className="h-full rounded-full bg-primary transition-[width] duration-500" style={{ width: `${pctNum}%` }} />
         </div>
 
-        <div className="shrink-0 flex items-baseline gap-3 text-xs text-[hsl(var(--muted-foreground))]">
-          <span className="tabular-nums font-medium text-[hsl(var(--foreground))]">{pctNum}%</span>
+        <div className="shrink-0 flex items-baseline gap-3 text-xs text-muted-foreground">
+          <span className="tabular-nums font-medium text-foreground">{pctNum}%</span>
           <span className="hidden sm:inline">·</span>
           <span className="whitespace-nowrap"><span className="tabular-nums">{projects.length}</span> projects</span>
           <span className="hidden sm:inline">·</span>
@@ -114,6 +104,7 @@ export default function DayCard({ iso, isToday }: Props) {
         onSubmit={e => { e.preventDefault(); addProjectCommit(); }}
       >
         <Input
+          ref={projectInputRef}
           className="task-input w-full"
           placeholder="> new project…"
           value={draftProject}
@@ -126,7 +117,18 @@ export default function DayCard({ iso, isToday }: Props) {
       <div className="flex flex-col gap-3 min-w-0">
         <div className={cn("mt-1 px-0 py-2 w-full", projectsScrollable ? "max-h-[260px] overflow-y-auto" : "overflow-visible")}>
           {projects.length === 0 ? (
-            <EmptyRow text="No projects yet." />
+            <div className="border border-dashed rounded-lg p-6 text-center text-sm text-muted-foreground">
+              No projects yet.
+              <div className="mt-2">
+                <button
+                  type="button"
+                  className="rounded-md border px-2 py-1 text-xs"
+                  onClick={() => projectInputRef.current?.focus()}
+                >
+                  Add project
+                </button>
+              </div>
+            </div>
           ) : (
             <ul className="w-full space-y-2 [&>li:first-child]:mt-1.5 [&>li:last-child]:mb-1.5" role="radiogroup" aria-label="Projects">
               {projects.map((p, idx) => {
@@ -216,6 +218,7 @@ export default function DayCard({ iso, isToday }: Props) {
       <div className="flex flex-col gap-3 min-w-0">
         {selectedProjectId && (
           <Input
+            ref={taskInputRef}
             className="task-input w-full"
             placeholder="> add task…"
             value={draftTask}
@@ -226,9 +229,25 @@ export default function DayCard({ iso, isToday }: Props) {
         )}
         <div className="min-h-[120px] max-h-[320px] overflow-y-auto px-2 py-2">
           {!selectedProjectId ? (
-            <EmptyRow text="No task selected." />
+            <div className="border border-dashed rounded-lg p-6 text-center text-sm text-muted-foreground">
+              No task selected.
+              <div className="mt-2">
+                <button type="button" className="rounded-md border px-2 py-1 text-xs">Select project</button>
+              </div>
+            </div>
           ) : tasksForSelected.length === 0 ? (
-            <EmptyRow text="No tasks selected." />
+            <div className="border border-dashed rounded-lg p-6 text-center text-sm text-muted-foreground">
+              No tasks yet.
+              <div className="mt-2">
+                <button
+                  type="button"
+                  className="rounded-md border px-2 py-1 text-xs"
+                  onClick={() => taskInputRef.current?.focus()}
+                >
+                  Add task
+                </button>
+              </div>
+            </div>
           ) : (
             <ul className="space-y-2 [&>li:first-child]:mt-1.5 [&>li:last-child]:mb-1.5" aria-label="Tasks">
               {tasksForSelected.map(t => (
@@ -247,10 +266,6 @@ export default function DayCard({ iso, isToday }: Props) {
       </div>
     </section>
   );
-}
-
-function EmptyRow({ text }: { text: string }) {
-  return <div className="tasks-placeholder text-xs">{text}</div>;
 }
 
 function TaskRow({

--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -112,7 +112,7 @@ function Inner() {
       </section>
 
       {/* Week list (Mon→Sun) — anchors used by WeekPicker’s selectAndScroll */}
-      <section role="list" aria-label="Week days (Monday to Sunday)" className="flex flex-col gap-4">
+      <section role="list" aria-label="Week days (Monday to Sunday)" className="grid grid-cols-1 gap-6 md:grid-cols-2">
         {dayItems.map(item => (
           <DayRow key={item.iso} iso={item.iso} isToday={item.isToday} />
         ))}

--- a/src/components/planner/TodayHero.tsx
+++ b/src/components/planner/TodayHero.tsx
@@ -59,48 +59,37 @@ export default function TodayHero({ iso }: Props) {
   const openPicker = () => { const el = dateRef.current as DateInputWithPicker | null; if (el?.showPicker) el.showPicker(); else dateRef.current?.focus(); };
 
   return (
-    <section className="bg-hero-soft rounded-card card-pad-lg anim-in">
-      {/* Header */}
-      <div className="mb-4 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-        <div className="flex items-center gap-3">
-          <h2 className="glitch text-lg font-semibold tracking-tight" data-text={isToday ? "Today" : viewIso}>
-            {isToday ? "Today" : viewIso}
-          </h2>
+    <section className="rounded-2xl border p-4 space-y-4">
+      {/* Header with inline progress */}
+      <div className="flex items-center gap-4">
+        <h2 className="text-lg font-semibold">{isToday ? "Today" : viewIso}</h2>
+        <div className="flex-1 h-1.5 rounded-full bg-muted" role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={pct}>
+          <div className="h-full rounded-full bg-primary transition-[width] duration-500" style={{ width: `${pct}%` }} />
         </div>
-
-        <div className="flex items-center gap-2">
-          <input
-            ref={dateRef}
-            type="date"
-            value={viewIso || nowISO}
-            onChange={e => setIso(e.target.value)}
-            aria-label="Change focused date"
-            className="sr-only"
-          />
-          <IconButton
-            aria-label="Open calendar"
-            title={viewIso}
-            onClick={openPicker}
-            circleSize="md"
-            variant="ring"
-            iconSize="md"
-          >
-            <Calendar />
-          </IconButton>
-        </div>
-      </div>
-
-      {/* Animated Progress of selected project */}
-      <div className="mb-4 flex items-center gap-3">
-        <div className={cn("glitch-track w-full", pct === 100 && "is-complete")} role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={pct}>
-          <div className="glitch-fill transition-[width] duration-500 ease-out" style={{ width: `${pct}%` }} />
-          <div className="glitch-scan" />
-        </div>
-        <span className="glitch-percent w-12 text-right text-sm" aria-live="polite">{pct}%</span>
+        <span className="w-12 text-right text-sm" aria-live="polite">{pct}%</span>
+        <input
+          ref={dateRef}
+          type="date"
+          value={viewIso || nowISO}
+          onChange={e => setIso(e.target.value)}
+          aria-label="Change focused date"
+          className="sr-only"
+        />
+        <IconButton
+          aria-label="Open calendar"
+          title={viewIso}
+          onClick={openPicker}
+          circleSize="sm"
+          variant="ring"
+          fx={false}
+          iconSize="sm"
+        >
+          <Calendar />
+        </IconButton>
       </div>
 
       {/* Projects */}
-      <div className="mt-4 space-y-4">
+      <div className="space-y-4">
         <form
           onSubmit={e => {
             e.preventDefault();
@@ -176,9 +165,11 @@ export default function TodayHero({ iso }: Props) {
 
       {/* Tasks (only when a project is selected) */}
       {!selProjectId ? (
-        <div className="mt-4 text-[13px] text-[hsl(var(--muted-foreground))]">Select a project to add and view tasks.</div>
+        <div className="border border-dashed rounded-lg p-6 text-center text-sm text-muted-foreground">
+          Select a project to add tasks.
+        </div>
       ) : (
-        <div className="mt-4 space-y-4">
+        <div className="space-y-4">
           <form
             onSubmit={e => {
               e.preventDefault();
@@ -198,7 +189,9 @@ export default function TodayHero({ iso }: Props) {
           </form>
 
           {scopedTasks.length === 0 ? (
-            <div className="tasks-placeholder">No tasks yet.</div>
+            <div className="border border-dashed rounded-lg p-6 text-center text-sm text-muted-foreground">
+              No tasks yet.
+            </div>
           ) : (
             <ul className="space-y-2" role="list" aria-label="Tasks">
               {scopedTasks.slice(0, 12).map(t => {

--- a/src/components/planner/WeekNotes.tsx
+++ b/src/components/planner/WeekNotes.tsx
@@ -8,7 +8,6 @@ import "./style.css";
  */
 
 import * as React from "react";
-import SectionCard from "@/components/ui/layout/SectionCard";
 import Textarea from "@/components/ui/primitives/textarea";
 import { usePlanner, type ISODate } from "./usePlanner";
 
@@ -27,19 +26,17 @@ export default function WeekNotes({ iso }: Props) {
   }, [day.notes]);
 
   return (
-    <SectionCard className="card-neo-soft">
-      <SectionCard.Header title="Notes" />
-      <SectionCard.Body>
-        <Textarea
-          placeholder="Jot down anything related to this day…"
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          name={`notes-${iso}`}
-          className="planner-textarea"
-          onBlur={() => setNotes(value)}
-        />
-        <p className="mt-2 text-xs text-[hsl(var(--muted-foreground))]">Autosaves on blur.</p>
-      </SectionCard.Body>
-    </SectionCard>
+    <section className="rounded-2xl border p-4 space-y-2">
+      <h2 className="text-base font-semibold">Notes</h2>
+      <Textarea
+        placeholder="Jot anything for this day…"
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        name={`notes-${iso}`}
+        className="min-h-[80px] rounded-lg border p-2 text-sm"
+        onBlur={() => setNotes(value)}
+      />
+      <p className="text-xs text-muted-foreground">Autosaves on blur</p>
+    </section>
   );
 }

--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -9,7 +9,6 @@
  */
 
 import * as React from "react";
-import Hero2 from "@/components/ui/layout/Hero2";
 import Button from "@/components/ui/primitives/button";
 import { useFocusDate, useDay, type ISODate } from "./usePlanner";
 import { cn } from "@/lib/utils";
@@ -97,38 +96,27 @@ function DayChip({
       aria-label={`Select ${iso}. Completed ${done} of ${total}. ${selected ? "Double-click to jump." : ""}`}
       title={selected ? "Double-click to jump" : "Click to focus"}
       className={cn(
-        "chip relative w-full rounded-2xl border text-left px-3 py-2 transition",
-        // default border is NOT white; use card hairline tint
-        "border-[hsl(var(--card-hairline))] bg-[hsl(var(--card)/0.75)]",
+        "relative w-full rounded-2xl border px-3 py-2 text-left",
+        "border-[hsl(var(--border)/0.6)] bg-[hsl(var(--card)/0.6)]",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
-        today && "chip--today",
-        selected
-          ? cn(
-              // “armed” personality: dashed, tinted border + subtle glow
-              "border-dashed border-[hsl(var(--primary)/.75)] shadow-[0_8px_22px_hsl(var(--shadow-color)/.22)]",
-              "ring-1 ring-[hsl(var(--primary)/.45)]"
-            )
-          : "hover:border-[hsl(var(--primary)/.4)] hover:shadow-[0_6px_18px_hsl(var(--shadow-color)/.18)]"
+        today && "ring-1 ring-[hsl(var(--ring)/0.6)]",
+        selected && "border-dashed border-[hsl(var(--primary))]"
       )}
       data-today={today || undefined}
       data-active={selected || undefined}
     >
       <div
         className={cn(
-          "chip__date",
+          "text-xs",
           today ? "text-[hsl(var(--accent))]" : "text-[hsl(var(--muted-foreground))]"
         )}
-        data-text={iso}
       >
         {iso}
       </div>
-      <div className="chip__counts">
+      <div className="mt-1 text-sm">
         <span className="tabular-nums text-[hsl(var(--foreground))]">{done}</span>
         <span className="text-[hsl(var(--muted-foreground))]"> / {total}</span>
       </div>
-      {/* decorative layers */}
-      <span aria-hidden className="chip__scan" />
-      <span aria-hidden className="chip__edge" />
     </button>
   );
 }
@@ -191,111 +179,47 @@ export default function WeekPicker() {
     }
   };
 
-  /* Top-right controls go in Hero2.right */
-  const right = (
-    <div className="flex items-center gap-2">
-      <Button
-        variant="ghost"
-        size="sm"
-        vibe="lift"
-        pill
-        aria-label="Previous week"
-        leftIcon={<ChevronLeft className="btn-icon" />}
-        onClick={prevWeek}
-      >
-        Prev
-      </Button>
-      <Button
-        variant="secondary"
-        size="sm"
-        vibe="glitch"
-        pill
-        aria-label="Jump to today"
-        onClick={jumpToday}
-      >
-        Today
-      </Button>
-      <Button
-        variant="ghost"
-        size="sm"
-        vibe="lift"
-        pill
-        aria-label="Next week"
-        rightIcon={<ChevronRight className="btn-icon" />}
-        onClick={nextWeek}
-      >
-        Next
-      </Button>
-
-      {showTop && (
-        <Button
-          variant="destructive"
-          size="sm"
-          vibe="lift"
-          pill
-          aria-label="Jump to top"
-          leftIcon={<ArrowUpToLine className="btn-icon" />}
-          onClick={jumpToTop}
-          title="Jump to top"
-        >
-          Top
-        </Button>
-      )}
-    </div>
-  );
-
   return (
-    <Hero2
-      heading={
-        <span className="hero2-title" data-text={heading}>
-          {heading}
-        </span>
-      }
-      subtitle={`${isoStart} → ${isoEnd}`}
-      right={right}
-      rail
-      sticky
-      dividerTint="primary"
-      bottom={
-        <div className="grid gap-3 flex-1">
-          {/* Range + totals */}
-          <div className="flex items-center justify-between gap-3">
-            <span
-              className={cn(
-                "inline-flex items-center gap-2 rounded-2xl px-3 py-1.5 text-sm",
-                "bg-[hsl(var(--card)/0.72)] ring-1 ring-[hsl(var(--border)/0.55)] backdrop-blur"
-              )}
-              aria-label={`Week range ${rangeLabel}`}
-            >
-              <CalendarDays className="size-4 opacity-80" />
-              <span className="opacity-90">{rangeLabel}</span>
-            </span>
-
-            <span className="text-sm text-[hsl(var(--muted-foreground))]">
-              <span className="opacity-70">Total tasks: </span>
-              <span className="font-medium tabular-nums text-[hsl(var(--foreground))]">
-                {weekDone} / {weekTotal}
-              </span>
-            </span>
-          </div>
-
-          {/* Day chips */}
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3 lg:grid-cols-7">
-            {days.map((d, i) => (
-              <DayChip
-                key={d}
-                iso={d}
-                selected={d === iso}
-                today={d === today}
-                done={per[i]?.done ?? 0}
-                total={per[i]?.total ?? 0}
-                onClick={selectOnly}
-                onDoubleClick={jumpToDay}
-              />
-            ))}
-          </div>
+    <section className="space-y-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-xl font-semibold">{heading}</h1>
+          <p className="text-sm text-muted-foreground">
+            {isoStart} — {isoEnd}
+          </p>
         </div>
-      }
-    />
+        <div className="flex items-center gap-2">
+          <Button size="sm" variant="ghost" onClick={prevWeek} leftIcon={<ChevronLeft className="h-4 w-4" />}>Prev</Button>
+          <Button size="sm" variant="ghost" onClick={jumpToday}>Today</Button>
+          <Button size="sm" variant="ghost" onClick={nextWeek} rightIcon={<ChevronRight className="h-4 w-4" />}>Next</Button>
+          {showTop && (
+            <Button size="sm" variant="ghost" onClick={jumpToTop} leftIcon={<ArrowUpToLine className="h-4 w-4" />}>Top</Button>
+          )}
+        </div>
+      </div>
+      <div className="flex items-center justify-between text-sm text-muted-foreground">
+        <span className="inline-flex items-center gap-2">
+          <CalendarDays className="h-4 w-4" />
+          {rangeLabel}
+        </span>
+        <span>
+          {weekDone} / {weekTotal}
+        </span>
+      </div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3 lg:grid-cols-7">
+        {days.map((d, i) => (
+          <DayChip
+            key={d}
+            iso={d}
+            selected={d === iso}
+            today={d === today}
+            done={per[i]?.done ?? 0}
+            total={per[i]?.total ?? 0}
+            onClick={selectOnly}
+            onDoubleClick={jumpToDay}
+          />
+        ))}
+      </div>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary
- Simplify week header with inline range and grouped navigation controls
- Streamline today and day cards with inline progress and dashed placeholders
- Replace nested notes card with single-surface textarea and hint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9a4471c14832c8a77800217b72c25