### PR TITLE
feat: add goal management components

### DIFF
--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import * as React from "react";
+import SectionCard from "@/components/ui/layout/SectionCard";
+import Input from "@/components/ui/primitives/input";
+import Textarea from "@/components/ui/primitives/textarea";
+import Button from "@/components/ui/primitives/button";
+
+interface GoalFormProps {
+  title: string;
+  metric: string;
+  notes: string;
+  onTitleChange: (v: string) => void;
+  onMetricChange: (v: string) => void;
+  onNotesChange: (v: string) => void;
+  onSubmit: () => void;
+  activeCount: number;
+  activeCap: number;
+  err?: string | null;
+}
+
+export default function GoalForm({
+  title,
+  metric,
+  notes,
+  onTitleChange,
+  onMetricChange,
+  onNotesChange,
+  onSubmit,
+  activeCount,
+  activeCap,
+  err,
+}: GoalFormProps) {
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit();
+      }}
+    >
+      <SectionCard>
+        <SectionCard.Header
+          className="flex items-center justify-between"
+          title={<h2 className="text-lg font-semibold">Add Goal</h2>}
+          actions={
+            <Button type="submit" size="sm" disabled={!title.trim()}>
+              Add Goal
+            </Button>
+          }
+        />
+        <SectionCard.Body className="grid gap-6">
+          <label className="grid gap-1">
+            <span className="text-xs text-white/60">Title</span>
+            <Input
+              tone="default"
+              className="h-9 text-sm focus:ring-2 focus:ring-purple-400/60"
+              value={title}
+              onChange={(e) => onTitleChange(e.target.value)}
+              aria-required="true"
+            />
+          </label>
+
+          <label className="grid gap-1">
+            <span className="text-xs text-white/60">Metric (optional)</span>
+            <Input
+              tone="default"
+              className="h-9 text-sm focus:ring-2 focus:ring-purple-400/60 tabular-nums"
+              value={metric}
+              onChange={(e) => onMetricChange(e.target.value)}
+            />
+          </label>
+
+          <label className="grid gap-1">
+            <span className="text-xs text-white/60">Notes (optional)</span>
+            <Textarea
+              tone="default"
+              className="min-h-[96px] text-sm focus:ring-2 focus:ring-purple-400/60"
+              value={notes}
+              onChange={(e) => onNotesChange(e.target.value)}
+            />
+          </label>
+
+          <div className="text-xs text-white/60">
+            {activeCount >= activeCap ? (
+              <span className="text-[hsl(var(--accent))]">
+                Cap reached. Finish one to add more.
+              </span>
+            ) : (
+              <span>
+                {activeCap - activeCount} active slot
+                {activeCap - activeCount === 1 ? "" : "s"} left
+              </span>
+            )}
+          </div>
+
+          {err ? (
+            <p role="status" aria-live="polite" className="text-xs text-[hsl(var(--accent))]">
+              {err}
+            </p>
+          ) : null}
+        </SectionCard.Body>
+      </SectionCard>
+    </form>
+  );
+}
+

--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import * as React from "react";
+import SectionCard from "@/components/ui/layout/SectionCard";
+import Input from "@/components/ui/primitives/input";
+import IconButton from "@/components/ui/primitives/IconButton";
+import { ArrowUpRight, Trash2 } from "lucide-react";
+
+export type WaitItem = { id: string; text: string; createdAt: number };
+
+interface GoalQueueProps {
+  items: WaitItem[];
+  onAdd: (text: string) => void;
+  onRemove: (id: string) => void;
+  onPromote: (item: WaitItem) => void;
+}
+
+export default function GoalQueue({ items, onAdd, onRemove, onPromote }: GoalQueueProps) {
+  const [val, setVal] = React.useState("");
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    const t = val.trim();
+    if (!t) return;
+    onAdd(t);
+    setVal("");
+  }
+
+  return (
+    <SectionCard>
+      <SectionCard.Header title={<h2 className="text-lg font-semibold">Goal Queue</h2>} />
+      <SectionCard.Body className="grid gap-6">
+        <ul className="divide-y divide-white/7">
+          {items.length === 0 ? (
+            <li className="py-2 text-sm text-white/60">No queued goals</li>
+          ) : (
+            items.map((it) => (
+              <li key={it.id} className="group flex items-center gap-2 py-2">
+                <span className="h-1.5 w-1.5 rounded-full bg-white/40" aria-hidden />
+                <p className="flex-1 truncate text-sm">{it.text}</p>
+                <time
+                  className="text-xs text-white/60 opacity-0 group-hover:opacity-100"
+                  dateTime={new Date(it.createdAt).toISOString()}
+                >
+                  {new Date(it.createdAt).toLocaleDateString()}
+                </time>
+                <div className="flex items-center gap-1 ml-2">
+                  <IconButton
+                    title="Promote"
+                    aria-label="Promote"
+                    onClick={() => onPromote(it)}
+                    circleSize="sm"
+                    iconSize="sm"
+                    variant="ring"
+                    className="opacity-0 group-hover:opacity-100"
+                  >
+                    <ArrowUpRight />
+                  </IconButton>
+                  <IconButton
+                    title="Delete"
+                    aria-label="Delete"
+                    onClick={() => onRemove(it.id)}
+                    circleSize="sm"
+                    iconSize="sm"
+                    variant="ring"
+                    className="opacity-0 group-hover:opacity-100"
+                  >
+                    <Trash2 />
+                  </IconButton>
+                </div>
+              </li>
+            ))
+          )}
+        </ul>
+
+        <form onSubmit={submit} className="flex items-center gap-2 pt-2">
+          <span className="h-1.5 w-1.5 rounded-full bg-white/40" aria-hidden />
+          <Input
+            tone="default"
+            className="flex-1 h-9 text-sm focus:ring-2 focus:ring-purple-400/60"
+            value={val}
+            onChange={(e) => setVal(e.currentTarget.value)}
+            placeholder="Add to queue and press Enter"
+          />
+        </form>
+      </SectionCard.Body>
+    </SectionCard>
+  );
+}
+

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -13,23 +13,16 @@
 import "./style.css"; // scoped: .goals-cap, .goal-row, and terminal waitlist helpers
 
 import * as React from "react";
-import {
-  Flag,
-  ListChecks,
-  Timer as TimerIcon,
-  Trash2,
-  Plus,
-  ArrowUpRight,
-} from "lucide-react";
+import { Flag, ListChecks, Timer as TimerIcon, Trash2 } from "lucide-react";
 
 import Hero, { HeroTabs } from "@/components/ui/layout/Hero";
 import SectionCard from "@/components/ui/layout/SectionCard";
-import Input from "@/components/ui/primitives/input";
-import Textarea from "@/components/ui/primitives/textarea";
-import Button from "@/components/ui/primitives/button";
 import IconButton from "@/components/ui/primitives/IconButton";
-import Progress from "@/components/ui/feedback/Progress";
 import CheckCircle from "@/components/ui/toggles/CheckCircle";
+import GoalsTabs, { FilterKey } from "./GoalsTabs";
+import GoalsProgress from "./GoalsProgress";
+import GoalForm from "./GoalForm";
+import GoalQueue, { WaitItem } from "./GoalQueue";
 
 import { useLocalDB, uid } from "@/lib/db";
 import type { Goal } from "@/lib/types";
@@ -40,7 +33,6 @@ import TimerTab from "./TimerTab";
 
 /* ---------- Types & constants ---------- */
 type Tab = "goals" | "reminders" | "timer";
-type FilterKey = "All" | "Active" | "Done";
 
 const TABS: Array<{ key: Tab; label: string; icon: React.ReactNode; hint?: string }> = [
   { key: "goals", label: "Goals", icon: <Flag className="mr-1" />, hint: "Cap 3 active" },
@@ -48,11 +40,9 @@ const TABS: Array<{ key: Tab; label: string; icon: React.ReactNode; hint?: strin
   { key: "timer", label: "Timer", icon: <TimerIcon className="mr-1" />, hint: "Focus sprints" },
 ];
 
-const FILTERS: FilterKey[] = ["All", "Active", "Done"];
 const ACTIVE_CAP = 3;
 
 /* ---------- Waitlist ---------- */
-type WaitItem = { id: string; text: string; createdAt: number };
 const WAITLIST_SEEDS: WaitItem[] = [
   { id: uid("wl"), text: "Fix wave-3 crash timing", createdAt: Date.now() - 86400000 },
   { id: uid("wl"), text: "Early ward @2:30 then shove", createdAt: Date.now() - 860000 },
@@ -78,6 +68,7 @@ export default function GoalsPage() {
   // undo
   const [lastDeleted, setLastDeleted] = React.useState<Goal | null>(null);
   const undoTimer = React.useRef<number | null>(null);
+  const formRef = React.useRef<HTMLDivElement | null>(null);
 
   // stats
   const totalCount = goals.length;
@@ -175,7 +166,7 @@ export default function GoalsPage() {
       : "Pick a duration and focus.";
 
   return (
-    <main className="grid gap-4">
+    <main className="grid gap-6">
       {/* ======= HERO ======= */}
       <Hero
         eyebrow="GOALS"
@@ -195,212 +186,117 @@ export default function GoalsPage() {
       {/* -------------------------- GOALS TAB -------------------------- */}
       {tab === "goals" && (
         <>
-          <SectionCard className="card-neo-soft">
-            <SectionCard.Header sticky className="flex items-center justify-between">
-              <div className="flex items-center gap-2 sm:gap-3">
-                <h2 className="text-base font-semibold">Your Goals</h2>
-
-                {/* progress, stable width */}
-                <div className="flex items-center gap-2 min-w-[120px]" aria-label="Progress">
-                  <div className="w-28">
-                    <Progress value={pctDone} />
-                  </div>
-                  <span className="text-xs text-muted-foreground tabular-nums">{pctDone}%</span>
+          {totalCount === 0 ? (
+            <GoalsProgress
+              total={totalCount}
+              pct={pctDone}
+              onAddFirst={() =>
+                formRef.current?.scrollIntoView({ behavior: "smooth" })
+              }
+            />
+          ) : (
+            <SectionCard>
+              <SectionCard.Header sticky className="flex items-center justify-between">
+                <div className="flex items-center gap-2 sm:gap-3">
+                  <h2 className="text-lg font-semibold">Your Goals</h2>
+                  <GoalsProgress total={totalCount} pct={pctDone} />
                 </div>
-              </div>
-
-              {/* right side filter chips */}
-              <div className="flex items-center gap-4" role="tablist" aria-label="Filter">
-                {FILTERS.map((f) => {
-                  const active = filter === f;
-                  return (
-                    <button
-                      key={f}
-                      type="button"
-                      role="tab"
-                      aria-selected={active}
-                      className={["btn-like-segmented", active && "is-active"]
-                        .filter(Boolean)
-                        .join(" ")}
-                      onClick={() => setFilter(f)}
-                    >
-                      {f}
-                    </button>
-                  );
-                })}
-              </div>
-            </SectionCard.Header>
-
-            {/* Grid — fixed-ish card min height to reduce jumpiness */}
-            <SectionCard.Body>
-              <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3 [grid-auto-rows:1fr]">
-                {filtered.length === 0 ? (
-                  <p className="text-sm text-muted-foreground">
-                    No goals here. Add one simple, finishable thing.
-                  </p>
-                ) : (
-                  filtered.map((g) => (
-                    <article
-                      key={g.id}
-                      className={[
-                        "relative rounded-2xl p-5",
-                        "card-neo transition",
-                        "hover:shadow-[0_0_0_1px_hsl(var(--primary)/.25),0_12px_40px_rgba(0,0,0,.35)]",
-                        "min-h-[152px] flex flex-col",
-                      ].join(" ")}
-                    >
-                      {/* decorative rail */}
-                      <span
-                        aria-hidden
-                        className="absolute inset-y-4 left-0 w-[2px] rounded-full bg-gradient-to-b from-[hsl(var(--primary))] via-[hsl(var(--accent))] to-transparent opacity-60"
-                      />
-
-                      {/* header row */}
-                      <header className="flex items-start justify-between gap-2">
-                        <h3 className="font-semibold leading-tight pr-6 line-clamp-2">
-                          {g.title}
-                        </h3>
-                        <div className="flex items-center gap-1">
-                          <CheckCircle
-                            aria-label={g.done ? "Mark active" : "Mark done"}
-                            checked={g.done}
-                            onChange={() => toggleDone(g.id)}
-                            size="lg"
-                          />
-                          <IconButton
-                            title="Delete"
-                            aria-label="Delete goal"
-                            onClick={() => removeGoal(g.id)}
-                            circleSize="sm"
-                          >
-                            <Trash2 />
-                          </IconButton>
-                        </div>
-                      </header>
-
-                      {/* body */}
-                      <div className="mt-3 text-sm text-muted-foreground space-y-2">
-                        {g.metric ? (
-                          <div className="tabular-nums">
-                            <span className="opacity-70">Metric:</span> {g.metric}
-                          </div>
-                        ) : null}
-                        {g.notes ? <p className="leading-relaxed">{g.notes}</p> : null}
-                      </div>
-
-                      {/* footer sticks to bottom */}
-                      <footer className="mt-auto pt-3 flex items-center justify-between text-xs text-muted-foreground">
-                        <span className="inline-flex items-center gap-2">
-                          <span
-                            aria-hidden
-                            className={[
-                              "h-2 w-2 rounded-full",
-                              g.done
-                                ? "bg-[hsl(var(--accent))]"
-                                : "bg-[hsl(var(--primary))]",
-                            ].join(" ")}
-                          />
-                          <time className="tabular-nums" dateTime={new Date(g.createdAt).toISOString()}>
-                            {new Date(g.createdAt).toLocaleDateString()}
-                          </time>
-                        </span>
-                        <span className={g.done ? "text-[hsl(var(--accent))]" : ""}>
-                          {g.done ? "Done" : "Active"}
-                        </span>
-                      </footer>
-                    </article>
-                  ))
-                )}
-              </div>
-            </SectionCard.Body>
-          </SectionCard>
-
-          {/* Add Goal + Waiting List */}
-          <SectionCard className="card-neo-soft">
-            <SectionCard.Header title={<span className="text-base font-semibold">Add Goal</span>} />
-            <SectionCard.Body>
-              <div className="grid gap-6 lg:grid-cols-[1fr_minmax(320px,420px)]">
-                {/* left: form */}
-                <form
-                  className="grid gap-3 max-w-xl"
-                  onSubmit={(e) => {
-                    e.preventDefault();
-                    addGoal();
-                  }}
-                >
-                  <label className="grid gap-2">
-                    <span className="text-xs text-muted-foreground">Title</span>
-                    <Input
-                      className="h-10 w-full"
-                      value={title}
-                      onChange={(e) => setTitle(e.target.value)}
-                      placeholder="Clear wave 3 faster…"
-                      aria-required="true"
-                    />
-                  </label>
-
-                  <label className="grid gap-2">
-                    <span className="text-xs text-muted-foreground">Metric (optional)</span>
-                    <Input
-                      className="h-10 w-full tabular-nums"
-                      value={metric}
-                      onChange={(e) => setMetric(e.target.value)}
-                      placeholder="Win lane by 10 CS at 10"
-                    />
-                  </label>
-
-                  <label className="grid gap-2">
-                    <span className="text-xs text-muted-foreground">Notes (optional)</span>
-                    <Textarea
-                      className="w-full min-h-[120px]"
-                      rows={6}
-                      value={notes}
-                      onChange={(e) => setNotes(e.target.value)}
-                      placeholder="Constraints, reminders, champion pool notes…"
-                    />
-                  </label>
-
-                  <div className="flex items-center justify-between gap-3 pt-1">
-                    <div className="text-xs text-muted-foreground">
-                      {activeCount >= ACTIVE_CAP ? (
-                        <span className="text-[hsl(var(--accent))]">
-                          Cap reached. Finish one to add more.
-                        </span>
-                      ) : (
-                        <span>
-                          {Math.max(0, ACTIVE_CAP - activeCount)} active slot
-                          {ACTIVE_CAP - activeCount === 1 ? "" : "s"} left
-                        </span>
-                      )}
-                    </div>
-                    <Button
-                      type="submit"
-                      disabled={activeCount >= ACTIVE_CAP || !title.trim()}
-                      className="h-10"
-                    >
-                      Add Goal
-                    </Button>
-                  </div>
-
-                  {err ? (
-                    <p role="status" aria-live="polite" className="text-xs text-[hsl(var(--accent))]">
-                      {err}
+                <GoalsTabs value={filter} onChange={setFilter} />
+              </SectionCard.Header>
+              <SectionCard.Body>
+                <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 [grid-auto-rows:1fr]">
+                  {filtered.length === 0 ? (
+                    <p className="text-sm text-white/60">
+                      No goals here. Add one simple, finishable thing.
                     </p>
-                  ) : null}
-                </form>
+                  ) : (
+                    filtered.map((g) => (
+                      <article
+                        key={g.id}
+                        className={["relative rounded-2xl p-6","card-neo transition","hover:shadow-[0_0_0_1px_hsl(var(--primary)/.25),0_12px_40px_rgba(0,0,0,.35)]","min-h-[152px] flex flex-col"].join(" ")}
+                      >
+                        <span
+                          aria-hidden
+                          className="absolute inset-y-4 left-0 w-[2px] rounded-full bg-gradient-to-b from-[hsl(var(--primary))] via-[hsl(var(--accent))] to-transparent opacity-60"
+                        />
+                        <header className="flex items-start justify-between gap-2">
+                          <h3 className="font-semibold leading-tight pr-6 line-clamp-2">
+                            {g.title}
+                          </h3>
+                          <div className="flex items-center gap-1">
+                            <CheckCircle
+                              aria-label={g.done ? "Mark active" : "Mark done"}
+                              checked={g.done}
+                              onChange={() => toggleDone(g.id)}
+                              size="lg"
+                            />
+                            <IconButton
+                              title="Delete"
+                              aria-label="Delete goal"
+                              onClick={() => removeGoal(g.id)}
+                              circleSize="sm"
+                            >
+                              <Trash2 />
+                            </IconButton>
+                          </div>
+                        </header>
+                        <div className="mt-3 text-sm text-white/60 space-y-2">
+                          {g.metric ? (
+                            <div className="tabular-nums">
+                              <span className="opacity-70">Metric:</span> {g.metric}
+                            </div>
+                          ) : null}
+                          {g.notes ? <p className="leading-relaxed">{g.notes}</p> : null}
+                        </div>
+                        <footer className="mt-auto pt-3 flex items-center justify-between text-xs text-white/60">
+                          <span className="inline-flex items-center gap-2">
+                            <span
+                              aria-hidden
+                              className={[
+                                "h-2 w-2 rounded-full",
+                                g.done
+                                  ? "bg-[hsl(var(--accent))]"
+                                  : "bg-[hsl(var(--primary))]",
+                              ].join(" ")}
+                            />
+                            <time className="tabular-nums" dateTime={new Date(g.createdAt).toISOString()}>
+                              {new Date(g.createdAt).toLocaleDateString()}
+                            </time>
+                          </span>
+                          <span className={g.done ? "text-[hsl(var(--accent))]" : ""}>
+                            {g.done ? "Done" : "Active"}
+                          </span>
+                        </footer>
+                      </article>
+                    ))
+                  )}
+                </div>
+              </SectionCard.Body>
+            </SectionCard>
+          )}
 
-                {/* right: waitlist (terminal style) */}
-                <WaitlistPanel
-                  items={waitlist}
-                  onAdd={(t) => addWait(t)}
-                  onRemove={(id) => removeWait(id)}
-                  onPromote={(it) => promoteWait(it)}
-                />
-              </div>
-            </SectionCard.Body>
-          </SectionCard>
+          <div ref={formRef}>
+            <GoalForm
+              title={title}
+              metric={metric}
+              notes={notes}
+              onTitleChange={setTitle}
+              onMetricChange={setMetric}
+              onNotesChange={setNotes}
+              onSubmit={addGoal}
+              activeCount={activeCount}
+              activeCap={ACTIVE_CAP}
+              err={err}
+            />
+          </div>
 
-          {/* Undo snackbar */}
+          <GoalQueue
+            items={waitlist}
+            onAdd={addWait}
+            onRemove={removeWait}
+            onPromote={promoteWait}
+          />
+
           {lastDeleted && (
             <div className="mx-auto w-fit rounded-full px-4 py-2 text-sm bg-[hsl(var(--card))] border border-[hsl(var(--card-hairline))] shadow-sm">
               Deleted “{lastDeleted.title}”.{" "}
@@ -433,96 +329,3 @@ export default function GoalsPage() {
   );
 }
 
-/* ----------------------- Waitlist UI (terminal style) ----------------------- */
-
-function WaitlistPanel({
-  items,
-  onAdd,
-  onRemove,
-  onPromote,
-}: {
-  items: WaitItem[];
-  onAdd: (text: string) => void;
-  onRemove: (id: string) => void;
-  onPromote: (item: WaitItem) => void;
-}) {
-  const [val, setVal] = React.useState("");
-  const feedRef = React.useRef<HTMLDivElement | null>(null);
-
-  // Auto-scroll to bottom when items change
-  React.useEffect(() => {
-    const el = feedRef.current;
-    if (!el) return;
-    el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
-  }, [items]);
-
-  const count = items.length;
-
-  return (
-    <div className="waitlist-terminal">
-      <div className="waitlist-terminal__header">
-        <h3 className="font-semibold">Goal Waiting List</h3>
-        <span className="text-xs text-muted-foreground tabular-nums">
-          {count} item{count === 1 ? "" : "s"}
-        </span>
-      </div>
-
-      <div ref={feedRef} className="waitlist-terminal__feed">
-        {items.length === 0 ? (
-          <div className="waitlist-terminal__line text-sm"># no items — add one below</div>
-        ) : (
-          items.map((it) => (
-            <div key={it.id} className="waitlist-terminal__line">
-              <span className="waitlist-terminal__dot" aria-hidden />
-              <p className="truncate text-sm">{it.text}</p>
-              <div className="flex items-center gap-1 shrink-0">
-                <IconButton
-                  title="Promote to form"
-                  aria-label="Promote to form"
-                  onClick={() => onPromote(it)}
-                  circleSize="sm"
-                  iconSize="sm"
-                >
-                  <ArrowUpRight />
-                </IconButton>
-                <IconButton
-                  title="Remove"
-                  aria-label="Remove"
-                  onClick={() => onRemove(it.id)}
-                  circleSize="sm"
-                  iconSize="sm"
-                  variant="ring"
-                >
-                  <Trash2 />
-                </IconButton>
-              </div>
-            </div>
-          ))
-        )}
-      </div>
-
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          const t = val.trim();
-          if (!t) return;
-          onAdd(t);
-          setVal("");
-        }}
-        className="waitlist-terminal__input"
-      >
-        <Input
-          value={val}
-          onChange={(e) => setVal(e.currentTarget.value)}
-          placeholder="> type and press Enter"
-          className="flex-1 h-10 font-mono"
-          aria-label="New waitlist item"
-        />
-        <span className="waitlist-terminal__caret" aria-hidden />
-        <IconButton title="Add" aria-label="Add" type="submit" circleSize="md" variant="solid">
-          <Plus />
-        </IconButton>
-      </form>
-    </div>
-  );
-}

--- a/src/components/goals/GoalsProgress.tsx
+++ b/src/components/goals/GoalsProgress.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import * as React from "react";
+import Button from "@/components/ui/primitives/button";
+
+interface GoalsProgressProps {
+  total: number;
+  pct: number; // 0..100
+  onAddFirst?: () => void;
+}
+
+export default function GoalsProgress({ total, pct, onAddFirst }: GoalsProgressProps) {
+  if (total === 0) {
+    return (
+      <div className="border border-dashed border-white/20 rounded-2xl p-6 text-center">
+        <p className="text-sm text-white/60 mb-4">No goals yet.</p>
+        {onAddFirst && (
+          <Button onClick={onAddFirst} className="mx-auto" size="sm">
+            Add a first goal
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  const v = Math.max(0, Math.min(100, Math.round(pct)));
+  return (
+    <div className="flex items-center gap-2 min-w-[120px]" aria-label="Progress">
+      <div className="w-28 h-1.5 rounded-full bg-white/10 overflow-hidden">
+        <div
+          className="h-1.5 rounded-full bg-[hsl(var(--primary))] transition-[width]"
+          style={{ width: `${v}%` }}
+        />
+      </div>
+      <span className="text-xs text-white/60 tabular-nums">{v}%</span>
+    </div>
+  );
+}
+

--- a/src/components/goals/GoalsTabs.tsx
+++ b/src/components/goals/GoalsTabs.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type FilterKey = "All" | "Active" | "Done";
+const FILTERS: FilterKey[] = ["All", "Active", "Done"];
+
+interface GoalsTabsProps {
+  value: FilterKey;
+  onChange: (val: FilterKey) => void;
+}
+
+export default function GoalsTabs({ value, onChange }: GoalsTabsProps) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Filter goals"
+      className="flex gap-2"
+    >
+      {FILTERS.map((f) => {
+        const active = value === f;
+        return (
+          <button
+            key={f}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(f)}
+            className={cn(
+              "h-8 px-3 rounded-full text-sm flex items-center", // equal height
+              "focus:ring-2 focus:ring-purple-400/60", // focus ring
+              active
+                ? "bg-white/10 ring-1 ring-white/20"
+                : "hover:bg-white/5"
+            )}
+          >
+            {f}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- build tabbed filter chips for goal statuses
- add compact progress bar with empty state CTA
- create standalone goal form and queue components

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9a6c43468832c8dd5d94be4fd8552