### PR TITLE
Refactor goal cards and header layout

### DIFF
--- a/src/components/goals/GoalCard.tsx
+++ b/src/components/goals/GoalCard.tsx
@@ -1,0 +1,70 @@
+"use client";
+import "./style.css";
+
+import * as React from "react";
+import { Goal } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import CheckCircle from "@/components/ui/toggles/CheckCircle";
+import IconButton from "@/components/ui/primitives/IconButton";
+import Pill from "@/components/ui/primitives/pill";
+import { Trash2 } from "lucide-react";
+
+export default function GoalCard({ goal, onToggle, onDelete }: {
+  goal: Goal;
+  onToggle: () => void;
+  onDelete: () => void;
+}) {
+  const date = React.useMemo(() => new Date(goal.createdAt), [goal.createdAt]);
+  return (
+    <article className="p-4 rounded-xl border bg-[hsl(var(--card)/0.6)] flex flex-col gap-4">
+      <header className="flex items-start justify-between gap-2">
+        <h3 className="text-base font-semibold leading-tight flex-1 min-w-0 line-clamp-2">
+          {goal.title}
+        </h3>
+        <div className="flex items-center gap-1 shrink-0">
+          <CheckCircle
+            aria-label={goal.done ? "Mark active" : "Mark done"}
+            checked={goal.done}
+            onChange={onToggle}
+            size="lg"
+          />
+          <IconButton
+            title="Delete"
+            aria-label="Delete goal"
+            onClick={onDelete}
+            circleSize="sm"
+          >
+            <Trash2 />
+          </IconButton>
+        </div>
+      </header>
+
+      <div className="flex flex-col gap-1 min-h-[28px]">
+        {goal.metric && (
+          <p className="text-sm text-white/70 tabular-nums">{goal.metric}</p>
+        )}
+        {goal.notes && (
+          <p className="text-sm text-muted-foreground line-clamp-2">{goal.notes}</p>
+        )}
+      </div>
+
+      <footer className="flex items-center justify-between text-xs text-muted-foreground mt-auto">
+        <span className="inline-flex items-center gap-2">
+          <span
+            aria-hidden
+            className={cn(
+              "h-2 w-2 rounded-full",
+              goal.done ? "bg-[hsl(var(--accent))]" : "bg-[hsl(var(--primary))]"
+            )}
+          />
+          <time className="tabular-nums" dateTime={date.toISOString()}>
+            {date.toLocaleDateString()}
+          </time>
+        </span>
+        <Pill className={goal.done ? "text-[hsl(var(--accent))]" : ""}>
+          {goal.done ? "Done" : "Active"}
+        </Pill>
+      </footer>
+    </article>
+  );
+}

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -29,7 +29,6 @@ import Textarea from "@/components/ui/primitives/textarea";
 import Button from "@/components/ui/primitives/button";
 import IconButton from "@/components/ui/primitives/IconButton";
 import Progress from "@/components/ui/feedback/Progress";
-import CheckCircle from "@/components/ui/toggles/CheckCircle";
 
 import { useLocalDB, uid } from "@/lib/db";
 import type { Goal } from "@/lib/types";
@@ -37,6 +36,7 @@ import type { Goal } from "@/lib/types";
 /* Tabs */
 import RemindersTab from "./RemindersTab";
 import TimerTab from "./TimerTab";
+import GoalCard from "./GoalCard";
 
 /* ---------- Types & constants ---------- */
 type Tab = "goals" | "reminders" | "timer";
@@ -196,39 +196,33 @@ export default function GoalsPage() {
       {tab === "goals" && (
         <>
           <SectionCard className="card-neo-soft">
-            <SectionCard.Header sticky className="flex items-center justify-between">
-              <div className="flex items-center gap-2 sm:gap-3">
+            <SectionCard.Header sticky className="space-y-3">
+              <div className="flex items-center justify-between">
                 <h2 className="text-base font-semibold">Your Goals</h2>
 
-                {/* progress, stable width */}
-                <div className="flex items-center gap-2 min-w-[120px]" aria-label="Progress">
-                  <div className="w-28">
-                    <Progress value={pctDone} />
-                  </div>
-                  <span className="text-xs text-muted-foreground tabular-nums">{pctDone}%</span>
+                {/* right side filter chips */}
+                <div className="flex items-center gap-4" role="tablist" aria-label="Filter">
+                  {FILTERS.map((f) => {
+                    const active = filter === f;
+                    return (
+                      <button
+                        key={f}
+                        type="button"
+                        role="tab"
+                        aria-selected={active}
+                        className={["btn-like-segmented", active && "is-active"]
+                          .filter(Boolean)
+                          .join(" ")}
+                        onClick={() => setFilter(f)}
+                      >
+                        {f}
+                      </button>
+                    );
+                  })}
                 </div>
               </div>
 
-              {/* right side filter chips */}
-              <div className="flex items-center gap-4" role="tablist" aria-label="Filter">
-                {FILTERS.map((f) => {
-                  const active = filter === f;
-                  return (
-                    <button
-                      key={f}
-                      type="button"
-                      role="tab"
-                      aria-selected={active}
-                      className={["btn-like-segmented", active && "is-active"]
-                        .filter(Boolean)
-                        .join(" ")}
-                      onClick={() => setFilter(f)}
-                    >
-                      {f}
-                    </button>
-                  );
-                })}
-              </div>
+              <Progress value={pctDone} className="h-[6px]" />
             </SectionCard.Header>
 
             {/* Grid — fixed-ish card min height to reduce jumpiness */}
@@ -240,75 +234,12 @@ export default function GoalsPage() {
                   </p>
                 ) : (
                   filtered.map((g) => (
-                    <article
+                    <GoalCard
                       key={g.id}
-                      className={[
-                        "relative rounded-2xl p-5",
-                        "card-neo transition",
-                        "hover:shadow-[0_0_0_1px_hsl(var(--primary)/.25),0_12px_40px_rgba(0,0,0,.35)]",
-                        "min-h-[152px] flex flex-col",
-                      ].join(" ")}
-                    >
-                      {/* decorative rail */}
-                      <span
-                        aria-hidden
-                        className="absolute inset-y-4 left-0 w-[2px] rounded-full bg-gradient-to-b from-[hsl(var(--primary))] via-[hsl(var(--accent))] to-transparent opacity-60"
-                      />
-
-                      {/* header row */}
-                      <header className="flex items-start justify-between gap-2">
-                        <h3 className="font-semibold leading-tight pr-6 line-clamp-2">
-                          {g.title}
-                        </h3>
-                        <div className="flex items-center gap-1">
-                          <CheckCircle
-                            aria-label={g.done ? "Mark active" : "Mark done"}
-                            checked={g.done}
-                            onChange={() => toggleDone(g.id)}
-                            size="lg"
-                          />
-                          <IconButton
-                            title="Delete"
-                            aria-label="Delete goal"
-                            onClick={() => removeGoal(g.id)}
-                            circleSize="sm"
-                          >
-                            <Trash2 />
-                          </IconButton>
-                        </div>
-                      </header>
-
-                      {/* body */}
-                      <div className="mt-3 text-sm text-muted-foreground space-y-2">
-                        {g.metric ? (
-                          <div className="tabular-nums">
-                            <span className="opacity-70">Metric:</span> {g.metric}
-                          </div>
-                        ) : null}
-                        {g.notes ? <p className="leading-relaxed">{g.notes}</p> : null}
-                      </div>
-
-                      {/* footer sticks to bottom */}
-                      <footer className="mt-auto pt-3 flex items-center justify-between text-xs text-muted-foreground">
-                        <span className="inline-flex items-center gap-2">
-                          <span
-                            aria-hidden
-                            className={[
-                              "h-2 w-2 rounded-full",
-                              g.done
-                                ? "bg-[hsl(var(--accent))]"
-                                : "bg-[hsl(var(--primary))]",
-                            ].join(" ")}
-                          />
-                          <time className="tabular-nums" dateTime={new Date(g.createdAt).toISOString()}>
-                            {new Date(g.createdAt).toLocaleDateString()}
-                          </time>
-                        </span>
-                        <span className={g.done ? "text-[hsl(var(--accent))]" : ""}>
-                          {g.done ? "Done" : "Active"}
-                        </span>
-                      </footer>
-                    </article>
+                      goal={g}
+                      onToggle={() => toggleDone(g.id)}
+                      onDelete={() => removeGoal(g.id)}
+                    />
                   ))
                 )}
               </div>

--- a/src/components/ui/feedback/Progress.tsx
+++ b/src/components/ui/feedback/Progress.tsx
@@ -1,13 +1,23 @@
 // src/components/ui/Progress.tsx
 "use client";
 
+import { cn } from "@/lib/utils";
+
 /** Simple progress bar (0..100), with SR label */
-export default function Progress({ value, label }: { value: number; label?: string }) {
+export default function Progress({
+  value,
+  label,
+  className,
+}: {
+  value: number;
+  label?: string;
+  className?: string;
+}) {
   const v = Math.max(0, Math.min(100, Math.round(value)));
   return (
-    <div className="h-2 w-full rounded-full bg-muted" aria-label={label}>
+    <div className={cn("h-2 w-full rounded-full bg-muted", className)} aria-label={label}>
       <div
-        className="h-2 rounded-full bg-[hsl(var(--primary))] transition-[width]"
+        className="h-full rounded-full bg-[hsl(var(--primary))] transition-[width]"
         style={{ width: `${v}%` }}
         aria-valuemin={0}
         aria-valuemax={100}

--- a/src/components/ui/feedback/Progress.tsx
+++ b/src/components/ui/feedback/Progress.tsx
@@ -1,4 +1,4 @@
-// src/components/ui/Progress.tsx
+// src/components/ui/feedback/Progress.tsx
 "use client";
 
 import { cn } from "@/lib/utils";
@@ -15,7 +15,7 @@ export default function Progress({
 }) {
   const v = Math.max(0, Math.min(100, Math.round(value)));
   return (
-    <div className={cn("h-2 w-full rounded-full bg-muted", className)} aria-label={label}>
+    <div className={cn("h-2 w-full rounded-full bg-muted", className)}>
       <div
         className="h-full rounded-full bg-[hsl(var(--primary))] transition-[width]"
         style={{ width: `${v}%` }}
@@ -23,6 +23,7 @@ export default function Progress({
         aria-valuemax={100}
         aria-valuenow={v}
         role="progressbar"
+        aria-label={label}
       >
         <span className="sr-only">{v}%</span>
       </div>


### PR DESCRIPTION
## Summary
- introduce reusable `GoalCard` with compact layout and inline actions
- place goal filters in header and show slim progress bar under title
- allow progress component height override via `className`

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9a6f6c824832c9ddb92c1c7b38d24