### PR TITLE
Style timer duration chips as pill buttons

### DIFF
--- a/src/components/goals/DurationSelector.tsx
+++ b/src/components/goals/DurationSelector.tsx
@@ -1,0 +1,50 @@
+// src/components/goals/DurationSelector.tsx
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type DurationSelectorProps = {
+  options?: number[];
+  value?: number;
+  onChange?: (value: number) => void;
+  disabled?: boolean;
+  className?: string;
+};
+
+const DEFAULT_OPTIONS = [10, 15, 20, 25, 30, 45, 60];
+
+export default function DurationSelector({
+  options = DEFAULT_OPTIONS,
+  value,
+  onChange,
+  disabled = false,
+  className,
+}: DurationSelectorProps) {
+  return (
+    <div className={cn("flex flex-row gap-3", className)}>
+      {options.map((m) => {
+        const active = value === m;
+        return (
+          <button
+            key={m}
+            type="button"
+            disabled={disabled}
+            onClick={() => !disabled && onChange?.(m)}
+            className={cn(
+              "inline-flex items-center justify-center h-9 px-3 rounded-full text-center text-sm",
+              "border transition-colors",
+              "border-white/10 bg-white/5 text-white/80",
+              "hover:bg-white/10 hover:text-white",
+              "focus:outline-none focus:ring-2 focus:ring-purple-400/70",
+              active &&
+                "border-purple-400/60 bg-purple-500/20 text-white font-semibold"
+            )}
+          >
+            {m}m
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -19,6 +19,7 @@ import {
   BookOpen, Brush, Code2, User,
 } from "lucide-react";
 import { useLocalDB } from "@/lib/db";
+import DurationSelector from "./DurationSelector";
 
 /* profiles */
 type ProfileKey = "study" | "clean" | "code" | "personal";
@@ -30,7 +31,6 @@ const PROFILES: Profile[] = [
   { key: "personal", label: "Personal", icon: <User className="mr-1" />,     defaultMin: 25 },
 ];
 
-const QUICK = [10, 15, 20, 25, 30, 45, 60];
 
 /* helpers */
 const clamp = (n: number, a: number, b: number) => Math.min(b, Math.max(a, n));
@@ -134,29 +134,18 @@ export default function TimerTab() {
     []
   );
 
-  // Right slot content for Personal: glitchy quick presets + custom time field
+  // Right slot content for Personal: quick duration chips + custom time field
   const rightSlot = isPersonal ? (
     <div className="flex items-center flex-wrap gap-2">
-      {QUICK.map((m) => (
-        <button
-          key={`q-${m}`}
-          className={[
-            "btn-like-segmented btn-glitch",
-            minutes === m && "is-active",
-          ]
-            .filter(Boolean)
-            .join(" ")}
-          onClick={() => {
-            if (running) return;
-            setPersonalMinutes(m);
-            setRemaining(m * 60_000);
-          }}
-          type="button"
-          title={`Set ${m} minutes`}
-        >
-          {m}m
-        </button>
-      ))}
+      <DurationSelector
+        value={minutes}
+        onChange={(m) => {
+          if (running) return;
+          setPersonalMinutes(m);
+          setRemaining(m * 60_000);
+        }}
+        disabled={running}
+      />
       <input
         aria-label="Custom minutes and seconds"
         value={timeEdit}


### PR DESCRIPTION
## Summary
- add DurationSelector component for timer quick presets
- style duration chips with pill layout, hover and active states
- integrate DurationSelector into timer's personal profile

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9a83e114c832c9962fd5554ebc8b0