### PR TITLE
chore: align chrome spacing to 8px grid

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -445,7 +445,7 @@ html.bg-intense body::after {
   }
 
   .btn-like-segmented {
-    @apply inline-flex items-center rounded-2xl border px-3.5 py-2 text-sm transition;
+    @apply inline-flex items-center rounded-2xl border px-4 py-2 text-sm transition;
     position: relative;
     overflow: hidden;
     border-color: hsl(var(--card-hairline));

--- a/src/components/chrome/Header.tsx
+++ b/src/components/chrome/Header.tsx
@@ -32,9 +32,9 @@ export default function Header({
       )}
       style={sticky ? { borderColor: "hsl(var(--border))" } : undefined}
     >
-      <div className="mx-auto max-w-6xl px-3 md:px-4 py-2.5">
+      <div className="mx-auto max-w-6xl px-2 md:px-4 py-2">
         {title || actions ? (
-          <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center justify-between gap-4">
             <div className="font-mono text-sm text-[hsl(var(--muted-foreground))]">
               {title}
             </div>

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -15,10 +15,10 @@ export default function SiteChrome() {
   return (
     <header role="banner" className="sticky-blur top-0 z-50">
       {/* Bar content */}
-      <div className="page-shell h-14 flex items-center justify-between py-3">
-        <div className="flex items-center gap-3">
+      <div className="page-shell h-14 flex items-center justify-between py-2">
+        <div className="flex items-center gap-2">
           <span
-            className="h-3 w-3 rounded-full animate-pulse"
+            className="h-2 w-2 rounded-full animate-pulse"
             style={{ background: "hsl(var(--accent))" }}
             aria-hidden
           />
@@ -27,7 +27,7 @@ export default function SiteChrome() {
           </span>
         </div>
 
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2">
           <NavBar />
           <ThemeToggle />
           <AnimationToggle />


### PR DESCRIPTION
## Summary
- enforce 8px spacing for global top bar
- standardize header padding and gaps on 8/16/24 rhythm
- adjust segmented button padding for 8px system

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9b1247598832caa6fc2abc89b438d