### PR TITLE
feat: add search filtering to team pages

### DIFF
--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -33,6 +33,7 @@ export type CheatSheetProps = {
   className?: string;
   dense?: boolean;
   data?: Archetype[];
+  query?: string;
 };
 
 /* ───────────── seeds ───────────── */
@@ -399,9 +400,28 @@ export default function CheatSheet({
   className = "",
   dense = false,
   data = DEFAULT_SHEET,
+  query = "",
 }: CheatSheetProps) {
   const [sheet, setSheet] = useLocalDB<Archetype[]>("team:cheatsheet.v2", data);
   const [editingId, setEditingId] = React.useState<string | null>(null);
+
+  const filtered = React.useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return sheet;
+    return sheet.filter((a) => {
+      const hay = [
+        a.title,
+        a.description,
+        ...(a.wins ?? []),
+        ...(a.struggles ?? []),
+        ...(a.tips ?? []),
+        ...Object.values(a.examples).flat(),
+      ]
+        .join(" ")
+        .toLowerCase();
+      return hay.includes(q);
+    });
+  }, [sheet, query]);
 
   const patchArc = React.useCallback(
     (id: string, partial: Partial<Archetype>) => {
@@ -415,7 +435,7 @@ export default function CheatSheet({
       data-scope="team"
       className={["grid gap-4 sm:gap-5 md:grid-cols-2 xl:grid-cols-3", className].join(" ")}
     >
-      {sheet.map((a) => {
+      {filtered.map((a) => {
         const isEditing = editingId === a.id;
 
         return (

--- a/src/components/team/CheatSheetTabs.tsx
+++ b/src/components/team/CheatSheetTabs.tsx
@@ -45,11 +45,10 @@ export default function CheatSheetTabs() {
           placeholder: "Search…",
           size: "md",
           round: true,
-          // No "New Comp" button here; creation lives inside <MyComps />
         }}
       />
       <div className="mt-6">
-        {tab === "sheet" ? <CheatSheet dense /> : <MyComps />}
+        {tab === "sheet" ? <CheatSheet dense query={query} /> : <MyComps query={query} />}
       </div>
     </div>
   );

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -213,10 +213,26 @@ function ChampChips({
 
 /* ───────────── Component ───────────── */
 
-export default function MyComps() {
+export type MyCompsProps = { query?: string };
+
+export default function MyComps({ query = "" }: MyCompsProps) {
   // Load and normalize so old/bad records don't break the UI.
   const [raw, setRaw] = useLocalDB<TeamComp[]>(DB_KEY, SEEDS);
   const items = React.useMemo(() => normalize(raw as unknown[]), [raw]);
+  const filtered = React.useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((c) => {
+      const hay = [
+        c.title,
+        c.notes ?? "",
+        ...ROLES.flatMap((r) => c.roles[r] ?? []),
+      ]
+        .join(" ")
+        .toLowerCase();
+      return hay.includes(q);
+    });
+  }, [items, query]);
 
   const [copiedId, setCopiedId] = React.useState<string | null>(null);
   const [editingId, setEditingId] = React.useState<string | null>(null);
@@ -291,16 +307,20 @@ export default function MyComps() {
             </IconButton>
           </form>
 
-          {/* Empty state */}
+          {/* Empty states */}
           {items.length === 0 ? (
             <div className="rounded-2xl p-6 text-sm text-[hsl(var(--muted-foreground))] border border-[hsl(var(--border))]">
               No comps yet. Type a title above and press Enter.
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="rounded-2xl p-6 text-sm text-[hsl(var(--muted-foreground))] border border-[hsl(var(--border))]">
+              Nothing matches your search.
             </div>
           ) : null}
 
           {/* Cards grid */}
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-            {items.map(c => {
+            {filtered.map(c => {
               const editing = editingId === c.id;
 
               return (


### PR DESCRIPTION
## Summary
- filter cheat sheet by query across title, text, and examples
- pass header search to My Comps and filter results
- wire CheatSheetTabs search state into child components

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9b165bd60832cab0fbd64e781a461