### PR TITLE
Fix hydration date mismatch

### DIFF
--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -5,6 +5,7 @@ import SectionCard from "@/components/ui/layout/SectionCard";
 import Input from "@/components/ui/primitives/input";
 import IconButton from "@/components/ui/primitives/IconButton";
 import { ArrowUpRight, Trash2 } from "lucide-react";
+import { LOCALE } from "@/lib/utils";
 
 export type WaitItem = { id: string; text: string; createdAt: number };
 
@@ -42,7 +43,7 @@ export default function GoalQueue({ items, onAdd, onRemove, onPromote }: GoalQue
                   className="text-xs text-white/60 opacity-0 group-hover:opacity-100"
                   dateTime={new Date(it.createdAt).toISOString()}
                 >
-                  {new Date(it.createdAt).toLocaleDateString()}
+                  {new Date(it.createdAt).toLocaleDateString(LOCALE)}
                 </time>
                 <div className="flex items-center gap-1 ml-2">
                   <IconButton

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -26,6 +26,7 @@ import GoalQueue, { WaitItem } from "./GoalQueue";
 
 import { useLocalDB, uid } from "@/lib/db";
 import type { Goal } from "@/lib/types";
+import { LOCALE } from "@/lib/utils";
 
 /* Tabs */
 import RemindersTab from "./RemindersTab";
@@ -260,7 +261,7 @@ export default function GoalsPage() {
                               ].join(" ")}
                             />
                             <time className="tabular-nums" dateTime={new Date(g.createdAt).toISOString()}>
-                              {new Date(g.createdAt).toLocaleDateString()}
+                              {new Date(g.createdAt).toLocaleDateString(LOCALE)}
                             </time>
                           </span>
                           <span className={g.done ? "text-[hsl(var(--accent))]" : ""}>

--- a/src/components/planner/WeekSummary.tsx
+++ b/src/components/planner/WeekSummary.tsx
@@ -5,7 +5,7 @@ import "./style.css";
 import * as React from "react";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import { useWeek, usePlanner, type ISODate } from "./usePlanner";
-import { cn } from "@/lib/utils";
+import { cn, LOCALE } from "@/lib/utils";
 
 /**
  * WeekSummary
@@ -146,7 +146,7 @@ function fmtDay(iso: string) {
   try {
     const [y, m, d] = iso.split("-").map(Number);
     const dt = new Date(Date.UTC(y, m - 1, d));
-    return dt.toLocaleDateString(undefined, { day: "2-digit", month: "short" });
+    return dt.toLocaleDateString(LOCALE, { day: "2-digit", month: "short" });
   } catch {
     return iso;
   }

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -12,6 +12,7 @@ import Textarea from "@/components/ui/primitives/textarea";
 import Button from "@/components/ui/primitives/button";
 import Input from "@/components/ui/primitives/input";
 import { useLocalDB, uid } from "@/lib/db";
+import { LOCALE } from "@/lib/utils";
 
 type Prompt = {
   id: string;
@@ -117,7 +118,7 @@ export default function PromptsPage() {
               <header className="flex items-center justify-between">
                 <h3 className="font-semibold">{deriveTitle(p)}</h3>
                 <time className="text-xs text-muted-foreground">
-                  {new Date(p.createdAt).toLocaleString()}
+                  {new Date(p.createdAt).toLocaleString(LOCALE)}
                 </time>
               </header>
               {p.text ? (

--- a/src/components/reviews/ReviewCard.tsx
+++ b/src/components/reviews/ReviewCard.tsx
@@ -2,7 +2,7 @@
 import "../reviews/style.css";
 
 import type { Review } from "@/lib/types";
-import { cn } from "@/lib/utils";
+import { cn, LOCALE } from "@/lib/utils";
 import Pill from "@/components/ui/primitives/pill";
 import IconButton from "@/components/ui/primitives/IconButton";
 import { Pencil } from "lucide-react";
@@ -44,7 +44,7 @@ export default function ReviewCard({
             <span>Side: {review.side || "—"}</span>
             <span>Patch: {review.patch || "—"}</span>
             <span>Duration: {review.duration || "—"}</span>
-            <span>{created ? created.toLocaleDateString() : "—"}</span>
+            <span>{created ? created.toLocaleDateString(LOCALE) : "—"}</span>
           </div>
 
           {Array.isArray(review.tags) && review.tags.length > 0 && (

--- a/src/components/reviews/ReviewList.tsx
+++ b/src/components/reviews/ReviewList.tsx
@@ -4,7 +4,7 @@ import "../reviews/style.css";
 
 import * as React from "react";
 import type { Review } from "@/lib/types";
-import { cn } from "@/lib/utils";
+import { cn, LOCALE } from "@/lib/utils";
 import { Ghost, Trash2 } from "lucide-react";
 import IconButton from "@/components/ui/IconButton";
 
@@ -54,7 +54,7 @@ export default function ReviewList({
 
         const dateStr =
           typeof r.createdAt === "number"
-            ? new Date(r.createdAt).toLocaleDateString()
+            ? new Date(r.createdAt).toLocaleDateString(LOCALE)
             : "";
 
         const dotColor =

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,9 @@
 // src/lib/utils.ts
 // Tiny helpers. Keep dependencies minimal and SSR-safe.
 
+// Default locale for consistent date/time formatting.
+export const LOCALE = "en-US";
+
 export type ClassValue =
   | string
   | number


### PR DESCRIPTION
## Summary
- add shared LOCALE constant for consistent date/time formatting
- use LOCALE when rendering dates across goals, prompts, reviews, and week summary to avoid hydration mismatch

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9c0990afc832cb27ebe9d3312cf17