### PR TITLE
Use glitch segmented controls in Goals and Comps headers

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -15,10 +15,14 @@ import "./style.css"; // scoped: .goals-cap, .goal-row, and terminal waitlist he
 import * as React from "react";
 import { Flag, ListChecks, Timer as TimerIcon, Trash2 } from "lucide-react";
 
-import Hero, { HeroTabs } from "@/components/ui/layout/Hero";
+import Hero from "@/components/ui/layout/Hero";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import IconButton from "@/components/ui/primitives/IconButton";
 import CheckCircle from "@/components/ui/toggles/CheckCircle";
+import {
+  GlitchSegmentedGroup,
+  GlitchSegmentedButton,
+} from "@/components/ui";
 import GoalsTabs, { FilterKey } from "./GoalsTabs";
 import GoalsProgress from "./GoalsProgress";
 import GoalForm from "./GoalForm";
@@ -36,9 +40,9 @@ import TimerTab from "./TimerTab";
 type Tab = "goals" | "reminders" | "timer";
 
 const TABS: Array<{ key: Tab; label: string; icon: React.ReactNode; hint?: string }> = [
-  { key: "goals", label: "Goals", icon: <Flag className="mr-1" />, hint: "Cap 3 active" },
-  { key: "reminders", label: "Reminders", icon: <ListChecks className="mr-1" />, hint: "Quick cues" },
-  { key: "timer", label: "Timer", icon: <TimerIcon className="mr-1" />, hint: "Focus sprints" },
+  { key: "goals", label: "Goals", icon: <Flag className="mr-1 h-4 w-4" />, hint: "Cap 3 active" },
+  { key: "reminders", label: "Reminders", icon: <ListChecks className="mr-1 h-4 w-4" />, hint: "Quick cues" },
+  { key: "timer", label: "Timer", icon: <TimerIcon className="mr-1 h-4 w-4" />, hint: "Focus sprints" },
 ];
 
 const ACTIVE_CAP = 3;
@@ -174,152 +178,176 @@ export default function GoalsPage() {
         heading="Today"
         subtitle={heroSubtitle}
         sticky
+        barClassName="gap-2 items-baseline"
         right={
-          <HeroTabs
-            tabs={TABS}
-            activeKey={tab}
-            onChange={(k) => setTab(k)}
-            ariaLabel="Today sections"
-          />
+          <GlitchSegmentedGroup
+            value={tab}
+            onChange={(v) => setTab(v as Tab)}
+            ariaLabel="Goals header mode"
+            intensity="default"
+          >
+            {TABS.map((t) => (
+              <GlitchSegmentedButton key={t.key} value={t.key} icon={t.icon}>
+                {t.label}
+              </GlitchSegmentedButton>
+            ))}
+          </GlitchSegmentedGroup>
         }
       />
 
-      {/* -------------------------- GOALS TAB -------------------------- */}
-      {tab === "goals" && (
-        <>
-          {totalCount === 0 ? (
-            <GoalsProgress
-              total={totalCount}
-              pct={pctDone}
-              onAddFirst={() =>
-                formRef.current?.scrollIntoView({ behavior: "smooth" })
-              }
-            />
-          ) : (
-            <SectionCard>
-              <SectionCard.Header sticky className="flex items-center justify-between">
-                <div className="flex items-center gap-2 sm:gap-3">
-                  <h2 className="text-lg font-semibold">Your Goals</h2>
-                  <GoalsProgress total={totalCount} pct={pctDone} />
-                </div>
-                <GoalsTabs value={filter} onChange={setFilter} />
-              </SectionCard.Header>
-              <SectionCard.Body>
-                <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 [grid-auto-rows:1fr]">
-                  {filtered.length === 0 ? (
-                    <p className="text-sm text-white/60">
-                      No goals here. Add one simple, finishable thing.
-                    </p>
-                  ) : (
-                    filtered.map((g) => (
-                      <article
-                        key={g.id}
-                        className={["relative rounded-2xl p-6","card-neo transition","hover:shadow-[0_0_0_1px_hsl(var(--primary)/.25),0_12px_40px_rgba(0,0,0,.35)]","min-h-[152px] flex flex-col"].join(" ")}
-                      >
-                        <span
-                          aria-hidden
-                          className="absolute inset-y-4 left-0 w-[2px] rounded-full bg-gradient-to-b from-[hsl(var(--primary))] via-[hsl(var(--accent))] to-transparent opacity-60"
-                        />
-                        <header className="flex items-start justify-between gap-2">
-                          <h3 className="font-semibold leading-tight pr-6 line-clamp-2">
-                            {g.title}
-                          </h3>
-                          <div className="flex items-center gap-1">
-                            <CheckCircle
-                              aria-label={g.done ? "Mark active" : "Mark done"}
-                              checked={g.done}
-                              onChange={() => toggleDone(g.id)}
-                              size="lg"
-                            />
-                            <IconButton
-                              title="Delete"
-                              aria-label="Delete goal"
-                              onClick={() => removeGoal(g.id)}
-                              circleSize="sm"
-                            >
-                              <Trash2 />
-                            </IconButton>
-                          </div>
-                        </header>
-                        <div className="mt-3 text-sm text-white/60 space-y-2">
-                          {g.metric ? (
-                            <div className="tabular-nums">
-                              <span className="opacity-70">Metric:</span> {g.metric}
-                            </div>
-                          ) : null}
-                          {g.notes ? <p className="leading-relaxed">{g.notes}</p> : null}
-                        </div>
-                        <footer className="mt-auto pt-3 flex items-center justify-between text-xs text-white/60">
-                          <span className="inline-flex items-center gap-2">
+      <section className="grid gap-6">
+        <div
+          role="tabpanel"
+          id="goals-panel"
+          aria-labelledby="goals-tab"
+          hidden={tab !== "goals"}
+        >
+          {tab === "goals" && (
+            <>
+              {totalCount === 0 ? (
+                <GoalsProgress
+                  total={totalCount}
+                  pct={pctDone}
+                  onAddFirst={() =>
+                    formRef.current?.scrollIntoView({ behavior: "smooth" })
+                  }
+                />
+              ) : (
+                <SectionCard>
+                  <SectionCard.Header sticky className="flex items-center justify-between">
+                    <div className="flex items-center gap-2 sm:gap-3">
+                      <h2 className="text-lg font-semibold">Your Goals</h2>
+                      <GoalsProgress total={totalCount} pct={pctDone} />
+                    </div>
+                    <GoalsTabs value={filter} onChange={setFilter} />
+                  </SectionCard.Header>
+                  <SectionCard.Body>
+                    <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 [grid-auto-rows:1fr]">
+                      {filtered.length === 0 ? (
+                        <p className="text-sm text-white/60">
+                          No goals here. Add one simple, finishable thing.
+                        </p>
+                      ) : (
+                        filtered.map((g) => (
+                          <article
+                            key={g.id}
+                            className={["relative rounded-2xl p-6","card-neo transition","hover:shadow-[0_0_0_1px_hsl(var(--primary)/.25),0_12px_40px_rgba(0,0,0,.35)]","min-h-[152px] flex flex-col"].join(" ")}
+                          >
                             <span
                               aria-hidden
-                              className={[
-                                "h-2 w-2 rounded-full",
-                                g.done
-                                  ? "bg-[hsl(var(--accent))]"
-                                  : "bg-[hsl(var(--primary))]",
-                              ].join(" ")}
+                              className="absolute inset-y-4 left-0 w-[2px] rounded-full bg-gradient-to-b from-[hsl(var(--primary))] via-[hsl(var(--accent))] to-transparent opacity-60"
                             />
-                            <time className="tabular-nums" dateTime={new Date(g.createdAt).toISOString()}>
-                              {new Date(g.createdAt).toLocaleDateString(LOCALE)}
-                            </time>
-                          </span>
-                          <span className={g.done ? "text-[hsl(var(--accent))]" : ""}>
-                            {g.done ? "Done" : "Active"}
-                          </span>
-                        </footer>
-                      </article>
-                    ))
-                  )}
+                            <header className="flex items-start justify-between gap-2">
+                              <h3 className="font-semibold leading-tight pr-6 line-clamp-2">
+                                {g.title}
+                              </h3>
+                              <div className="flex items-center gap-1">
+                                <CheckCircle
+                                  aria-label={g.done ? "Mark active" : "Mark done"}
+                                  checked={g.done}
+                                  onChange={() => toggleDone(g.id)}
+                                  size="lg"
+                                />
+                                <IconButton
+                                  title="Delete"
+                                  aria-label="Delete goal"
+                                  onClick={() => removeGoal(g.id)}
+                                  circleSize="sm"
+                                >
+                                  <Trash2 />
+                                </IconButton>
+                              </div>
+                            </header>
+                            <div className="mt-3 text-sm text-white/60 space-y-2">
+                              {g.metric ? (
+                                <div className="tabular-nums">
+                                  <span className="opacity-70">Metric:</span> {g.metric}
+                                </div>
+                              ) : null}
+                              {g.notes ? <p className="leading-relaxed">{g.notes}</p> : null}
+                            </div>
+                            <footer className="mt-auto pt-3 flex items-center justify-between text-xs text-white/60">
+                              <span className="inline-flex items-center gap-2">
+                                <span
+                                  aria-hidden
+                                  className={["h-2 w-2 rounded-full", g.done ? "bg-[hsl(var(--accent))]" : "bg-[hsl(var(--primary))]"].join(" ")}
+                                />
+                                <time className="tabular-nums" dateTime={new Date(g.createdAt).toISOString()}>
+                                  {new Date(g.createdAt).toLocaleDateString(LOCALE)}
+                                </time>
+                              </span>
+                              <span className={g.done ? "text-[hsl(var(--accent))]" : ""}>
+                                {g.done ? "Done" : "Active"}
+                              </span>
+                            </footer>
+                          </article>
+                        ))
+                      )}
+                    </div>
+                  </SectionCard.Body>
+                </SectionCard>
+              )}
+
+              <div ref={formRef}>
+                <GoalForm
+                  title={title}
+                  metric={metric}
+                  notes={notes}
+                  onTitleChange={setTitle}
+                  onMetricChange={setMetric}
+                  onNotesChange={setNotes}
+                  onSubmit={addGoal}
+                  activeCount={activeCount}
+                  activeCap={ACTIVE_CAP}
+                  err={err}
+                />
+              </div>
+
+              <GoalQueue
+                items={waitlist}
+                onAdd={addWait}
+                onRemove={removeWait}
+                onPromote={promoteWait}
+              />
+
+              {lastDeleted && (
+                <div className="mx-auto w-fit rounded-full px-4 py-2 text-sm bg-[hsl(var(--card))] border border-[hsl(var(--card-hairline))] shadow-sm">
+                  Deleted “{lastDeleted.title}”.{" "}
+                  <button
+                    type="button"
+                    className="underline underline-offset-2"
+                    onClick={() => {
+                      if (!lastDeleted) return;
+                      setGoals((prev) => [lastDeleted, ...prev]);
+                      setLastDeleted(null);
+                    }}
+                  >
+                    Undo
+                  </button>
                 </div>
-              </SectionCard.Body>
-            </SectionCard>
+              )}
+            </>
           )}
+        </div>
 
-          <div ref={formRef}>
-            <GoalForm
-              title={title}
-              metric={metric}
-              notes={notes}
-              onTitleChange={setTitle}
-              onMetricChange={setMetric}
-              onNotesChange={setNotes}
-              onSubmit={addGoal}
-              activeCount={activeCount}
-              activeCap={ACTIVE_CAP}
-              err={err}
-            />
-          </div>
+        <div
+          role="tabpanel"
+          id="reminders-panel"
+          aria-labelledby="reminders-tab"
+          hidden={tab !== "reminders"}
+        >
+          {tab === "reminders" && <RemindersTab />}
+        </div>
 
-          <GoalQueue
-            items={waitlist}
-            onAdd={addWait}
-            onRemove={removeWait}
-            onPromote={promoteWait}
-          />
-
-          {lastDeleted && (
-            <div className="mx-auto w-fit rounded-full px-4 py-2 text-sm bg-[hsl(var(--card))] border border-[hsl(var(--card-hairline))] shadow-sm">
-              Deleted “{lastDeleted.title}”.{" "}
-              <button
-                type="button"
-                className="underline underline-offset-2"
-                onClick={() => {
-                  if (!lastDeleted) return;
-                  setGoals((prev) => [lastDeleted, ...prev]);
-                  setLastDeleted(null);
-                }}
-              >
-                Undo
-              </button>
-            </div>
-          )}
-        </>
-      )}
-
-      {/* ----------------------- OTHER TABS ----------------------- */}
-      {tab === "reminders" && <RemindersTab />}
-      {tab === "timer" && <TimerTab />}
+        <div
+          role="tabpanel"
+          id="timer-panel"
+          aria-labelledby="timer-tab"
+          hidden={tab !== "timer"}
+        >
+          {tab === "timer" && <TimerTab />}
+        </div>
+      </section>
 
       <style jsx>{`
         .tabular-nums {

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -14,17 +14,21 @@ import "../team/style.css";
 
 import { useState } from "react";
 import { Users2, BookOpenText, Hammer, Timer } from "lucide-react";
-import Hero, { HeroTabs, type HeroTab } from "@/components/ui/layout/Hero";
+import Hero from "@/components/ui/layout/Hero";
+import {
+  GlitchSegmentedGroup,
+  GlitchSegmentedButton,
+} from "@/components/ui";
 import Builder from "./Builder";
 import JungleClears from "./JungleClears";
 import CheatSheetTabs from "./CheatSheetTabs";
 
 type Tab = "cheat" | "builder" | "clears";
 
-const TABS: HeroTab<Tab>[] = [
-  { key: "cheat",   label: "Cheat Sheet",   hint: "Archetypes, counters, examples", icon: <BookOpenText className="mr-1" /> },
-  { key: "builder", label: "Builder",       hint: "Fill allies vs enemies",         icon: <Hammer className="mr-1" /> },
-  { key: "clears",  label: "Jungle Clears", hint: "Relative buckets by speed",      icon: <Timer className="mr-1" /> },
+const TABS = [
+  { key: "cheat", label: "Cheat Sheet", hint: "Archetypes, counters, examples", icon: <BookOpenText className="mr-1 h-4 w-4" /> },
+  { key: "builder", label: "Builder", hint: "Fill allies vs enemies", icon: <Hammer className="mr-1 h-4 w-4" /> },
+  { key: "clears", label: "Jungle Clears", hint: "Relative buckets by speed", icon: <Timer className="mr-1 h-4 w-4" /> },
 ] as const;
 
 export default function TeamCompPage() {
@@ -38,21 +42,29 @@ export default function TeamCompPage() {
         subtitle="Readable. Fast. On brand."
         icon={<Users2 className="opacity-80" />}
         right={
-          <HeroTabs<Tab>
-            tabs={TABS}
-            activeKey={tab}
-            onChange={(k: Tab) => setTab(k)}
-            ariaLabel="Comps views"
-          />
+          <GlitchSegmentedGroup
+            value={tab}
+            onChange={(v) => setTab(v as Tab)}
+            ariaLabel="Comps header mode"
+            className="px-2"
+            intensity="default"
+          >
+            {TABS.map((t) => (
+              <GlitchSegmentedButton key={t.key} value={t.key} icon={t.icon}>
+                {t.label}
+              </GlitchSegmentedButton>
+            ))}
+          </GlitchSegmentedGroup>
         }
         className="mb-1"
+        barClassName="gap-2 items-baseline"
       />
 
       <section className="grid gap-4">
         <div
           role="tabpanel"
-          id="hero-cheat-panel"
-          aria-labelledby="hero-cheat-tab"
+          id="cheat-panel"
+          aria-labelledby="cheat-tab"
           hidden={tab !== "cheat"}
         >
           {tab === "cheat" && <CheatSheetTabs />}
@@ -60,8 +72,8 @@ export default function TeamCompPage() {
 
         <div
           role="tabpanel"
-          id="hero-builder-panel"
-          aria-labelledby="hero-builder-tab"
+          id="builder-panel"
+          aria-labelledby="builder-tab"
           hidden={tab !== "builder"}
         >
           {tab === "builder" && <Builder />}
@@ -69,8 +81,8 @@ export default function TeamCompPage() {
 
         <div
           role="tabpanel"
-          id="hero-clears-panel"
-          aria-labelledby="hero-clears-tab"
+          id="clears-panel"
+          aria-labelledby="clears-tab"
           hidden={tab !== "clears"}
         >
           {tab === "clears" && <JungleClears />}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -12,6 +12,8 @@ export { default as Textarea } from "./primitives/textarea";
 export { default as Badge } from "./primitives/badge";
 export { default as Pill } from "./primitives/pill";
 export { default as SearchBar } from "./primitives/searchbar";
+export { SegmentedGroup, SegmentedButton } from "./primitives/segmented";
+export { GlitchSegmentedGroup, GlitchSegmentedButton } from "./primitives/glitch-segmented";
 //
 // Feedback
 //

--- a/src/components/ui/primitives/glitch-segmented.tsx
+++ b/src/components/ui/primitives/glitch-segmented.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface GlitchSegmentedGroupProps {
+  value: string;
+  onChange: (v: string) => void;
+  ariaLabel?: string;
+  intensity?: "calm" | "default" | "feral";
+  children: React.ReactNode;
+  className?: string;
+}
+
+export interface GlitchSegmentedButtonProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "onChange"> {
+  value: string;
+  icon?: React.ReactNode;
+  selected?: boolean;
+  onSelect?: () => void;
+  intensity?: "calm" | "default" | "feral";
+}
+
+export const GlitchSegmentedGroup = ({
+  value,
+  onChange,
+  ariaLabel,
+  children,
+  className,
+  intensity = "default",
+}: GlitchSegmentedGroupProps) => {
+  const btnRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
+  const setBtnRef = (index: number) => (el: HTMLButtonElement | null) => {
+    btnRefs.current[index] = el;
+  };
+
+  const values = React.Children.toArray(children).map((child) =>
+    React.isValidElement(child) ? (child.props as GlitchSegmentedButtonProps).value : ""
+  );
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    const idx = values.findIndex((v) => v === value);
+    if (idx < 0) return;
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+      const next = (idx + 1) % values.length;
+      onChange(values[next]);
+      btnRefs.current[next]?.focus();
+      e.preventDefault();
+    } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+      const prev = (idx - 1 + values.length) % values.length;
+      onChange(values[prev]);
+      btnRefs.current[prev]?.focus();
+      e.preventDefault();
+    } else if (e.key === "Home") {
+      onChange(values[0]);
+      btnRefs.current[0]?.focus();
+      e.preventDefault();
+    } else if (e.key === "End") {
+      const last = values.length - 1;
+      onChange(values[last]);
+      btnRefs.current[last]?.focus();
+      e.preventDefault();
+    }
+  };
+
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      className={cn(
+        "inline-flex rounded-full bg-[hsl(var(--surface-2))] p-0.5",
+        className
+      )}
+      onKeyDown={onKeyDown}
+    >
+      {React.Children.map(children, (child, i) => {
+        if (!React.isValidElement<GlitchSegmentedButtonProps>(child)) return child;
+        const selected = child.props.value === value;
+        const buttonChild = child as React.ReactElement<GlitchSegmentedButtonProps>;
+        return React.cloneElement(
+          buttonChild,
+          {
+            ref: setBtnRef(i),
+            tabIndex: selected ? 0 : -1,
+            selected,
+            intensity,
+            onSelect: () => onChange(child.props.value),
+            id: child.props.id ?? `${child.props.value}-tab`,
+            "aria-controls":
+              child.props["aria-controls"] ?? `${child.props.value}-panel`,
+          } as Partial<GlitchSegmentedButtonProps> &
+            React.RefAttributes<HTMLButtonElement>
+        );
+      })}
+    </div>
+  );
+};
+
+export const GlitchSegmentedButton = React.forwardRef<
+  HTMLButtonElement,
+  GlitchSegmentedButtonProps
+>(({ icon, children, className, selected, onSelect, intensity = "default", ...rest }, ref) => {
+  const [glitch, setGlitch] = React.useState(false);
+  const lastRef = React.useRef(0);
+  const trigger = () => {
+    const now = Date.now();
+    if (now - lastRef.current < 300) return;
+    lastRef.current = now;
+    setGlitch(true);
+    window.setTimeout(() => setGlitch(false), 160);
+  };
+  React.useEffect(() => {
+    if (selected) trigger();
+  }, [selected]);
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      role="tab"
+      aria-selected={selected}
+      data-selected={selected ? "true" : undefined}
+      data-glitch={glitch ? "true" : undefined}
+      data-intensity={intensity}
+      onClick={onSelect}
+      onMouseEnter={trigger}
+      className={cn(
+        "relative flex-1 h-9 select-none whitespace-nowrap px-3 inline-flex items-center justify-center gap-2 text-sm font-medium",
+        "rounded-none first:rounded-l-full last:rounded-r-full",
+        "bg-[hsl(var(--surface-2))] text-[hsl(var(--muted))] shadow-[inset_0_0_0_1px_color-mix(in_oklab,hsl(var(--ring))_16%,transparent)]",
+        "motion-safe:transition-[background-color,color,box-shadow,transform] motion-safe:ease-[cubic-bezier(.2,.8,.2,1)] motion-safe:duration-[160ms]",
+        "hover:-translate-y-px hover:shadow-[0_0_0_1px_hsl(var(--accent)/.25),0_0_8px_hsl(var(--accent)/.15)]",
+        "active:scale-[0.98] motion-safe:active:duration-[80ms] active:shadow-[0_0_0_1px_hsl(var(--accent)),0_0_10px_hsl(var(--accent)/.6)]",
+        "data-[selected=true]:bg-[color-mix(in_oklab,hsl(var(--accent))_18%,hsl(var(--surface-2)))] data-[selected=true]:text-[hsl(var(--on-accent))] data-[selected=true]:shadow-[0_0_0_1px_hsl(var(--accent)),0_0_8px_hsl(var(--glow))]",
+        "disabled:opacity-40 disabled:shadow-none",
+        "data-[selected=true]:focus-visible:ring-2 data-[selected=true]:focus-visible:ring-[hsl(var(--ring))] data-[selected=true]:focus-visible:ring-offset-2 data-[selected=true]:focus-visible:ring-offset-[color-mix(in_oklab,hsl(var(--accent))_18%,hsl(var(--surface-2)))]",
+        "motion-reduce:transition-none motion-reduce:hover:translate-y-0 motion-reduce:active:scale-100",
+        className
+      )}
+      {...rest}
+    >
+      {icon ? (
+        <span className="inline-flex h-4 w-4 items-center justify-center">
+          {icon}
+        </span>
+      ) : null}
+      <span className="seg-label truncate">{children}</span>
+      <span aria-hidden className="glitch-scanline" />
+      <style jsx>{`
+        button[data-glitch="true"] .seg-label {
+          animation: seg-jitter 150ms steps(2, end);
+        }
+        button[data-glitch="true"] .seg-label::before,
+        button[data-glitch="true"] .seg-label::after {
+          opacity: 0.12;
+        }
+        .seg-label {
+          position: relative;
+        }
+        .seg-label::before,
+        .seg-label::after {
+          content: "";
+          position: absolute;
+          inset: 0;
+          background: hsl(var(--accent));
+          mix-blend-mode: screen;
+          opacity: 0;
+          pointer-events: none;
+          transition: opacity 160ms;
+        }
+        button[data-glitch="true"] .seg-label::before {
+          transform: translate(calc(1px * var(--gi)), 0);
+        }
+        button[data-glitch="true"] .seg-label::after {
+          transform: translate(calc(-1px * var(--gi)), 0);
+        }
+        .glitch-scanline {
+          position: absolute;
+          inset: 0;
+          background: linear-gradient(to right, transparent 0%, hsl(var(--accent)) 50%, transparent 100%);
+          opacity: 0;
+          transform: translateX(-100%);
+          pointer-events: none;
+        }
+        button[data-glitch="true"] .glitch-scanline {
+          opacity: 0.08;
+          animation: scanline 140ms linear;
+        }
+        button[data-intensity="calm"] {
+          --gi: 0.5;
+        }
+        button[data-intensity="default"] {
+          --gi: 1;
+        }
+        button[data-intensity="feral"] {
+          --gi: 1.5;
+        }
+        @keyframes seg-jitter {
+          0% { transform: translate(0,0); }
+          25% { transform: translate(calc(1px * var(--gi)), 0); }
+          50% { transform: translate(calc(-1px * var(--gi)), 0); }
+          75% { transform: translate(calc(1px * var(--gi)), 0); }
+          100% { transform: translate(0,0); }
+        }
+        @keyframes scanline {
+          from { transform: translateX(-100%); }
+          to { transform: translateX(100%); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          button[data-glitch="true"] .seg-label {
+            animation: none;
+          }
+          .glitch-scanline {
+            animation: none;
+            transform: none;
+            opacity: 0;
+          }
+        }
+      `}</style>
+    </button>
+  );
+});
+GlitchSegmentedButton.displayName = "GlitchSegmentedButton";
+
+export default GlitchSegmentedGroup;

--- a/src/components/ui/primitives/segmented.tsx
+++ b/src/components/ui/primitives/segmented.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface SegmentedGroupProps {
+  /** Current value */
+  value: string;
+  /** Called when a new value is selected */
+  onChange: (v: string) => void;
+  /** Accessible label for the group */
+  ariaLabel?: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export interface SegmentedButtonProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "onChange"> {
+  /** The unique value for this segment */
+  value: string;
+  /** Optional icon placed to the left */
+  icon?: React.ReactNode;
+  /** Internal: set by the group */
+  selected?: boolean;
+  /** Internal: select handler */
+  onSelect?: () => void;
+}
+
+export const SegmentedGroup = ({
+  value,
+  onChange,
+  ariaLabel,
+  children,
+  className,
+}: SegmentedGroupProps) => {
+  const btnRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
+  const setBtnRef = (index: number) => (el: HTMLButtonElement | null) => {
+    btnRefs.current[index] = el;
+  };
+
+  const values = React.Children.toArray(children).map((child) =>
+    React.isValidElement(child) ? (child.props as SegmentedButtonProps).value : ""
+  );
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    const idx = values.findIndex((v) => v === value);
+    if (idx < 0) return;
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+      const next = (idx + 1) % values.length;
+      onChange(values[next]);
+      btnRefs.current[next]?.focus();
+      e.preventDefault();
+    } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+      const prev = (idx - 1 + values.length) % values.length;
+      onChange(values[prev]);
+      btnRefs.current[prev]?.focus();
+      e.preventDefault();
+    } else if (e.key === "Home") {
+      onChange(values[0]);
+      btnRefs.current[0]?.focus();
+      e.preventDefault();
+    } else if (e.key === "End") {
+      const last = values.length - 1;
+      onChange(values[last]);
+      btnRefs.current[last]?.focus();
+      e.preventDefault();
+    }
+  };
+
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      className={cn(
+        "inline-flex rounded-full bg-[hsl(var(--surface-1))] p-0.5",
+        className
+      )}
+      onKeyDown={onKeyDown}
+    >
+      {React.Children.map(children, (child, i) => {
+        if (!React.isValidElement<SegmentedButtonProps>(child)) return child;
+        const selected = child.props.value === value;
+        const buttonChild = child as React.ReactElement<SegmentedButtonProps>;
+        return React.cloneElement(
+          buttonChild,
+          {
+            ref: setBtnRef(i),
+            tabIndex: selected ? 0 : -1,
+            selected,
+            onSelect: () => onChange(child.props.value),
+            id: child.props.id ?? `${child.props.value}-tab`,
+            "aria-controls":
+              child.props["aria-controls"] ?? `${child.props.value}-panel`,
+          } as Partial<SegmentedButtonProps> &
+            React.RefAttributes<HTMLButtonElement>
+        );
+      })}
+    </div>
+  );
+};
+
+export const SegmentedButton = React.forwardRef<
+  HTMLButtonElement,
+  SegmentedButtonProps
+>(
+  ({ icon, children, className, selected, onSelect, ...rest }, ref) => {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        role="tab"
+        aria-selected={selected}
+        data-selected={selected ? "true" : undefined}
+        onClick={onSelect}
+        className={cn(
+          "flex-1 select-none whitespace-nowrap rounded-full px-3 h-9 inline-flex items-center justify-center gap-1 text-sm",
+          "bg-[hsl(var(--surface-2))] text-[hsl(var(--muted-foreground))] shadow-[inset_0_0_0_1px_hsl(var(--surface-3))]",
+          "motion-safe:transition-[color,box-shadow,transform] motion-safe:ease-[cubic-bezier(.2,.8,.2,1)] motion-safe:duration-[120ms]",
+          "hover:shadow-[0_0_0_1px_hsl(var(--accent)/.25),0_0_8px_hsl(var(--accent)/.15)] hover:text-[hsl(var(--foreground))]",
+          "active:scale-[0.98] motion-safe:active:duration-[80ms] active:shadow-[0_0_0_1px_hsl(var(--accent)),0_0_10px_hsl(var(--accent)/.6)]",
+          "data-[selected=true]:bg-[hsl(var(--accent))] data-[selected=true]:text-[hsl(var(--accent-foreground))] data-[selected=true]:shadow-[0_0_0_1px_hsl(var(--accent)),0_0_8px_hsl(var(--accent)/.5)] data-[selected=true]:motion-safe:duration-[160ms]",
+          "focus-visible:outline-none data-[selected=true]:focus-visible:ring-2 data-[selected=true]:focus-visible:ring-[hsl(var(--ring))] data-[selected=true]:focus-visible:ring-offset-2 data-[selected=true]:focus-visible:ring-offset-[hsl(var(--accent))]",
+          "motion-reduce:transition-none motion-reduce:transform-none",
+          className
+        )}
+        {...rest}
+      >
+        {icon ? <span className="mr-1 inline-flex h-4 w-4 items-center justify-center">{icon}</span> : null}
+        <span className="truncate">{children}</span>
+      </button>
+    );
+  }
+);
+SegmentedButton.displayName = "SegmentedButton";
+
+export default SegmentedGroup;


### PR DESCRIPTION
## Summary
- replace Goals header tabs with GlitchSegmentedGroup
- update Comps header to glitch segmented control
- add GlitchSegmentedGroup/GlitchSegmentedButton primitives with glitch animations and intensity variants

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9c594f444832c89a3e15be2e09125