### PR TITLE
feat: add glass segmented controls

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -181,6 +181,7 @@ export default function GoalsPage() {
             value={tab}
             onChange={(v) => setTab(v as Tab)}
             ariaLabel="Goals header mode"
+            variant="glass"
           >
             {TABS.map((t) => (
               <SegmentedButton key={t.key} value={t.key} icon={t.icon}>

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -44,6 +44,7 @@ export default function TeamCompPage() {
             onChange={(v) => setTab(v as Tab)}
             ariaLabel="Comps header mode"
             className="px-2"
+            variant="glass"
           >
             {TABS.map((t) => (
               <SegmentedButton key={t.key} value={t.key} icon={t.icon}>

--- a/src/components/ui/primitives/segmented.tsx
+++ b/src/components/ui/primitives/segmented.tsx
@@ -12,6 +12,8 @@ export interface SegmentedGroupProps {
   ariaLabel?: string;
   children: React.ReactNode;
   className?: string;
+  /** Visual style */
+  variant?: "default" | "glass";
 }
 
 export interface SegmentedButtonProps
@@ -24,6 +26,8 @@ export interface SegmentedButtonProps
   selected?: boolean;
   /** Internal: select handler */
   onSelect?: () => void;
+  /** Visual style */
+  variant?: "default" | "glass";
 }
 
 export const SegmentedGroup = ({
@@ -32,6 +36,7 @@ export const SegmentedGroup = ({
   ariaLabel,
   children,
   className,
+  variant = "default",
 }: SegmentedGroupProps) => {
   const btnRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
   const setBtnRef = (index: number) => (el: HTMLButtonElement | null) => {
@@ -72,7 +77,10 @@ export const SegmentedGroup = ({
       role="tablist"
       aria-label={ariaLabel}
       className={cn(
-        "inline-flex rounded-full bg-[hsl(var(--surface-1))] p-0.5",
+        "inline-flex",
+        variant === "default"
+          ? "rounded-full bg-[hsl(var(--surface-1))] p-0.5"
+          : "h-9 overflow-hidden rounded-full divide-x divide-[color-mix(in_oklab,var(--ring)_20%,transparent)]",
         className
       )}
       onKeyDown={onKeyDown}
@@ -81,7 +89,7 @@ export const SegmentedGroup = ({
         if (!React.isValidElement<SegmentedButtonProps>(child)) return child;
         const selected = child.props.value === value;
         return React.cloneElement(
-          child as React.ReactElement<any>,
+          child as React.ReactElement<SegmentedButtonProps>,
           {
             ref: setBtnRef(i),
             tabIndex: selected ? 0 : -1,
@@ -89,7 +97,8 @@ export const SegmentedGroup = ({
             onSelect: () => onChange(child.props.value),
             id: child.props.id ?? `${child.props.value}-tab`,
             "aria-controls": child.props["aria-controls"] ?? `${child.props.value}-panel`,
-          } as any
+            variant: child.props.variant ?? variant,
+          } as Partial<SegmentedButtonProps>
         );
       })}
     </div>
@@ -100,7 +109,10 @@ export const SegmentedButton = React.forwardRef<
   HTMLButtonElement,
   SegmentedButtonProps
 >(
-  ({ icon, children, className, selected, onSelect, ...rest }, ref) => {
+  (
+    { icon, children, className, selected, onSelect, variant = "default", ...rest },
+    ref
+  ) => {
     return (
       <button
         ref={ref}
@@ -110,19 +122,17 @@ export const SegmentedButton = React.forwardRef<
         data-selected={selected ? "true" : undefined}
         onClick={onSelect}
         className={cn(
-          "flex-1 select-none whitespace-nowrap rounded-full px-3 h-9 inline-flex items-center justify-center gap-1 text-sm",
-          "bg-[hsl(var(--surface-2))] text-[hsl(var(--muted-foreground))] shadow-[inset_0_0_0_1px_hsl(var(--surface-3))]",
-          "motion-safe:transition-[color,box-shadow,transform] motion-safe:ease-[cubic-bezier(.2,.8,.2,1)] motion-safe:duration-[120ms]",
-          "hover:shadow-[0_0_0_1px_hsl(var(--accent)/.25),0_0_8px_hsl(var(--accent)/.15)] hover:text-[hsl(var(--foreground))]",
-          "active:scale-[0.98] motion-safe:active:duration-[80ms] active:shadow-[0_0_0_1px_hsl(var(--accent)),0_0_10px_hsl(var(--accent)/.6)]",
-          "data-[selected=true]:bg-[hsl(var(--accent))] data-[selected=true]:text-[hsl(var(--accent-foreground))] data-[selected=true]:shadow-[0_0_0_1px_hsl(var(--accent)),0_0_8px_hsl(var(--accent)/.5)] data-[selected=true]:motion-safe:duration-[160ms]",
-          "focus-visible:outline-none data-[selected=true]:focus-visible:ring-2 data-[selected=true]:focus-visible:ring-[hsl(var(--ring))] data-[selected=true]:focus-visible:ring-offset-2 data-[selected=true]:focus-visible:ring-offset-[hsl(var(--accent))]",
-          "motion-reduce:transition-none motion-reduce:transform-none",
+          "flex-1 select-none whitespace-nowrap px-3 h-9 inline-flex items-center justify-center text-sm gap-1",
+          variant === "glass" && "gap-2",
+          variant === "default" &&
+            "rounded-full bg-[hsl(var(--surface-2))] text-[hsl(var(--muted-foreground))] shadow-[inset_0_0_0_1px_hsl(var(--surface-3))] motion-safe:transition-[color,box-shadow,transform] motion-safe:ease-[cubic-bezier(.2,.8,.2,1)] motion-safe:duration-[120ms] hover:shadow-[0_0_0_1px_hsl(var(--accent)/.25),0_0_8px_hsl(var(--accent)/.15)] hover:text-[hsl(var(--foreground))] active:scale-[0.98] motion-safe:active:duration-[80ms] active:shadow-[0_0_0_1px_hsl(var(--accent)),0_0_10px_hsl(var(--accent)/.6)] data-[selected=true]:bg-[hsl(var(--accent))] data-[selected=true]:text-[hsl(var(--accent-foreground))] data-[selected=true]:shadow-[0_0_0_1px_hsl(var(--accent)),0_0_8px_hsl(var(--accent)/.5)] data-[selected=true]:motion-safe:duration-[160ms] focus-visible:outline-none data-[selected=true]:focus-visible:ring-2 data-[selected=true]:focus-visible:ring-[hsl(var(--ring))] data-[selected=true]:focus-visible:ring-offset-2 data-[selected=true]:focus-visible:ring-offset-[hsl(var(--accent))] motion-reduce:transition-none motion-reduce:transform-none",
+          variant === "glass" &&
+            "relative first:rounded-l-full last:rounded-r-full bg-[color-mix(in_oklab,var(--surface-2)_92%,transparent)] text-[hsl(var(--muted))] shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--ring)_20%,transparent)] backdrop-blur-[6px] before:absolute before:inset-0 before:rounded-[inherit] before:pointer-events-none before:bg-[linear-gradient(to_bottom,rgba(255,255,255,.06),transparent_40%)] motion-safe:transition-[background-color,color,box-shadow,transform] motion-safe:duration-[160ms] motion-safe:ease-[cubic-bezier(.2,.8,.2,1)] hover:text-[hsl(var(--text))] hover:shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--accent)_45%,transparent),0_0_4px_hsl(var(--glow)/.3)] data-[selected=true]:bg-[color-mix(in_oklab,var(--accent)_16%,var(--surface-2))] data-[selected=true]:text-[hsl(var(--on-accent))] data-[selected=true]:shadow-[inset_0_0_0_1px_hsl(var(--accent)),0_0_6px_hsl(var(--glow)/.6)] active:translate-y-px active:before:opacity-[0.7] active:shadow-[inset_0_0_0_1px_hsl(var(--accent)),0_0_6px_hsl(var(--glow)/.7)] disabled:opacity-40 disabled:shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--ring)_20%,transparent)] disabled:text-[hsl(var(--muted))] disabled:pointer-events-none after:absolute after:inset-y-0 after:w-px after:bg-[hsl(var(--accent)/0.08)] after:opacity-0 hover:after:opacity-100 hover:after:animate-shimmer data-[selected=true]:after:opacity-100 data-[selected=true]:after:animate-shimmer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] motion-reduce:transition-none motion-reduce:transform-none motion-reduce:after:hidden",
           className
         )}
         {...rest}
       >
-        {icon ? <span className="mr-1 inline-flex h-4 w-4 items-center justify-center">{icon}</span> : null}
+        {icon ? <span className="inline-flex h-4 w-4 items-center justify-center">{icon}</span> : null}
         <span className="truncate">{children}</span>
       </button>
     );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -32,7 +32,16 @@ const config: Config = {
         out: "cubic-bezier(0.16, 1, 0.3, 1)",
         snap: "cubic-bezier(0.22, 1, 0.36, 1)"
       },
-      transitionDuration: { 150: "150ms", 200: "200ms", 220: "220ms" }
+      transitionDuration: { 150: "150ms", 200: "200ms", 220: "220ms" },
+      keyframes: {
+        shimmer: {
+          "0%": { transform: "translateX(-100%)" },
+          "100%": { transform: "translateX(100%)" }
+        }
+      },
+      animation: {
+        shimmer: "shimmer 120ms linear"
+      }
     }
   },
   plugins: []


### PR DESCRIPTION
## Summary
- add optional "glass" variant for segmented controls with neon edge, shimmer, and glass-like styling
- update Goals and TeamComp sticky headers to use new glass segmented buttons
- define shimmer animation in Tailwind config

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9d2998e74832c988bab83452a3621