### PR TITLE
feat: neon glass segmented buttons

### DIFF
--- a/src/components/reviews/style.css
+++ b/src/components/reviews/style.css
@@ -112,9 +112,10 @@
   position: relative;
   padding: .25rem;                 /* p-1 */
   border-radius: 1rem;             /* rounded-2xl */
-  border: 1px solid hsl(var(--border));
-  background: hsl(var(--card));
-  box-shadow: 0 8px 22px hsl(var(--shadow-color)/.25);
+  background: hsl(var(--surface-2) / .05);
+  backdrop-filter: blur(4px);
+  border: 1px solid hsl(var(--accent) / .4);
+  box-shadow: inset 0 1px rgba(255,255,255,.06), 0 0 8px hsl(var(--accent) / .15);
   overflow: hidden;                /* <-- keep the pill inside the border */
 }
 
@@ -138,7 +139,7 @@
   transition: color .18s ease;
 }
 .seg__btn--idle { color: hsl(var(--muted-foreground)); }
-.seg__btn--active { color: white; text-shadow: 0 0 10px hsl(200 100% 60% / .25); }
+.seg__btn--active { color: hsl(var(--foreground)); text-shadow: 0 0 8px hsl(var(--accent) / .5); }
 
 /* Sliding pill — width accounts for the gaps; translate includes gap each step */
 .seg__rail {
@@ -152,8 +153,10 @@
   );
   transform: translateX(calc(var(--seg-idx) * (100% + .25rem)));
   transition: transform .22s cubic-bezier(.22,1,.36,1);
-  background: linear-gradient(90deg, hsla(260,90%,72%,.18), hsla(200,90%,60%,.14));
-  box-shadow: 0 10px 30px hsl(var(--shadow-color)/.25);
+  background: hsl(var(--surface-2) / .15);
+  backdrop-filter: blur(4px);
+  border: 1px solid hsl(var(--accent) / .5);
+  box-shadow: inset 0 1px rgba(255,255,255,.15), 0 0 8px hsl(var(--accent) / .4);
 }
 
 /* Optional subtle inner glow like the reference GIF */

--- a/src/components/ui/primitives/glitch-segmented.tsx
+++ b/src/components/ui/primitives/glitch-segmented.tsx
@@ -68,7 +68,10 @@ export const GlitchSegmentedGroup = ({
       role="tablist"
       aria-label={ariaLabel}
       className={cn(
-        "inline-flex rounded-full bg-[hsl(var(--surface-2))] p-0.5",
+        "inline-flex rounded-full p-0.5 backdrop-blur-sm",
+        "bg-[hsl(var(--surface-2)/0.1)]",
+        "ring-1 ring-[hsl(var(--accent)/0.4)]",
+        "shadow-[0_0_8px_hsl(var(--accent)/0.15)]",
         className
       )}
       onKeyDown={onKeyDown}
@@ -126,14 +129,17 @@ export const GlitchSegmentedButton = React.forwardRef<
       onMouseEnter={trigger}
       className={cn(
         "relative flex-1 h-9 select-none whitespace-nowrap px-3 inline-flex items-center justify-center gap-2 text-sm font-medium",
-        "rounded-none first:rounded-l-full last:rounded-r-full",
-        "bg-[hsl(var(--surface-2))] text-[hsl(var(--muted))] shadow-[inset_0_0_0_1px_color-mix(in_oklab,hsl(var(--ring))_16%,transparent)]",
+        "rounded-full first:rounded-l-full last:rounded-r-full",
+        "bg-[hsl(var(--surface-2)/0.15)] backdrop-blur-sm text-[hsl(var(--muted))]",
+        "ring-1 ring-[hsl(var(--accent)/0.4)]",
+        "shadow-[inset_0_1px_rgba(255,255,255,0.15)]",
         "motion-safe:transition-[background-color,color,box-shadow,transform] motion-safe:ease-[cubic-bezier(.2,.8,.2,1)] motion-safe:duration-[160ms]",
-        "hover:-translate-y-px hover:shadow-[0_0_0_1px_hsl(var(--accent)/.25),0_0_8px_hsl(var(--accent)/.15)]",
-        "active:scale-[0.98] motion-safe:active:duration-[80ms] active:shadow-[0_0_0_1px_hsl(var(--accent)),0_0_10px_hsl(var(--accent)/.6)]",
-        "data-[selected=true]:bg-[color-mix(in_oklab,hsl(var(--accent))_18%,hsl(var(--surface-2)))] data-[selected=true]:text-[hsl(var(--on-accent))] data-[selected=true]:shadow-[0_0_0_1px_hsl(var(--accent)),0_0_8px_hsl(var(--glow))]",
+        "hover:-translate-y-px hover:shadow-[0_0_6px_hsl(var(--accent)/0.3)]",
+        "active:scale-[0.98] motion-safe:active:duration-[80ms] active:shadow-[0_0_6px_hsl(var(--accent)/0.5)]",
+        "data-[selected=true]:bg-[hsl(var(--surface-2)/0.25)] data-[selected=true]:text-[hsl(var(--foreground))]",
+        "data-[selected=true]:ring-[hsl(var(--accent))] data-[selected=true]:shadow-[0_0_8px_hsl(var(--accent)/0.6)]",
         "disabled:opacity-40 disabled:shadow-none",
-        "data-[selected=true]:focus-visible:ring-2 data-[selected=true]:focus-visible:ring-[hsl(var(--ring))] data-[selected=true]:focus-visible:ring-offset-2 data-[selected=true]:focus-visible:ring-offset-[color-mix(in_oklab,hsl(var(--accent))_18%,hsl(var(--surface-2)))]",
+        "data-[selected=true]:focus-visible:ring-2 data-[selected=true]:focus-visible:ring-[hsl(var(--ring))] data-[selected=true]:focus-visible:ring-offset-2 data-[selected=true]:focus-visible:ring-offset-[hsl(var(--surface-2)/0.25)]",
         "motion-reduce:transition-none motion-reduce:hover:translate-y-0 motion-reduce:active:scale-100",
         className
       )}


### PR DESCRIPTION
## Summary
- restyle segmented button group with glassy neon surface and blur
- refresh review role selector to share neon glass pill aesthetic

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9e9a871b0832c9ea070b89886cf14