### PR TITLE
feat: derive accessible accent tints

### DIFF
--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -25,6 +25,10 @@
   --lav-deep: 320 85% 60%;
   --success: 316 92% 70%;
   --success-glow: 316 92% 52% / 0.6;
+  --accent-overlay: color-mix(in oklab, hsl(var(--accent)) 60%, transparent);
+  --ring-contrast: color-mix(in oklab, hsl(var(--ring)) 70%, hsl(var(--background)) 30%);
+  --glow-active: color-mix(in oklab, hsl(var(--glow)) 50%, transparent);
+  --text-on-accent: color-contrast(var(--accent-overlay) vs hsl(var(--foreground)), hsl(var(--background)));
 
   /* Hairlines, radii, motion, control geometry, gradients */
   /* Fallback (works everywhere) */

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -19,7 +19,10 @@ export default function SiteChrome() {
         <div className="flex items-center gap-2">
           <span
             className="h-2 w-2 rounded-full animate-pulse"
-            style={{ background: "hsl(var(--accent))" }}
+            style={{
+              background: "var(--accent-overlay)",
+              boxShadow: "0 0 6px var(--glow-active)",
+            }}
             aria-hidden
           />
           <span className="font-mono tracking-wide text-[hsl(var(--muted-foreground))]">

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -270,7 +270,8 @@ export default function GoalsPage() {
                               <span className="inline-flex items-center gap-2">
                                 <span
                                   aria-hidden
-                                  className={["h-2 w-2 rounded-full", g.done ? "bg-[hsl(var(--accent))]" : "bg-[hsl(var(--primary))]"].join(" ")}
+                                  className={["h-2 w-2 rounded-full", g.done ? "" : "bg-[hsl(var(--primary))]"].join(" ")}
+                                  style={g.done ? { background: "var(--accent-overlay)" } : undefined}
                                 />
                                 <time className="tabular-nums" dateTime={new Date(g.createdAt).toISOString()}>
                                   {new Date(g.createdAt).toLocaleDateString(LOCALE)}

--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -576,7 +576,10 @@ function RemTile({
 
             <div className="mt-1 flex items-center justify-between text-sm">
               <div className="flex items-center gap-2">
-                <span className="inline-block h-2 w-2 rounded-full bg-[hsl(var(--accent))]" />
+                <span
+                  className="inline-block h-2 w-2 rounded-full"
+                  style={{ background: "var(--accent-overlay)" }}
+                />
                 <span className="text-xs">{fmtDate(value.createdAt)}</span>
               </div>
 

--- a/src/components/ui/league/pillars/PillarSelector.tsx
+++ b/src/components/ui/league/pillars/PillarSelector.tsx
@@ -54,8 +54,9 @@ export default function PillarSelector({
                 aria-hidden
                 className={cn(
                   "h-2 w-2 rounded-full",
-                  active ? "bg-[hsl(var(--accent))]" : "bg-[hsl(var(--muted-foreground))]"
+                  active ? "" : "bg-[hsl(var(--muted-foreground))]"
                 )}
+                style={active ? { background: "var(--accent-overlay)" } : undefined}
               />
               {p}
             </button>

--- a/src/components/ui/primitives/badge.tsx
+++ b/src/components/ui/primitives/badge.tsx
@@ -32,7 +32,7 @@ const sizeMap: Record<Size, string> = {
 const toneBorder: Record<Tone, string> = {
   neutral: "border-[hsl(var(--card-hairline))]",
   primary: "border-[hsl(var(--ring))]",
-  accent: "border-[hsl(var(--accent))]",
+  accent: "border-[var(--accent-overlay)]",
   top: "border-[hsl(var(--tone-top))]",
   jungle: "border-[hsl(var(--tone-jg))]",
   mid: "border-[hsl(var(--tone-mid))]",
@@ -63,12 +63,12 @@ export default function Badge({
         "transition-[background,box-shadow,transform] duration-150 ease-out",
         sizeMap[size],
         toneBorder[tone],
-        interactive && "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] cursor-pointer",
+        interactive && "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring-contrast)] cursor-pointer",
         interactive && "hover:bg-[color-mix(in_oklab,hsl(var(--muted))_28%,transparent)]",
         selected &&
-          "bg-[color-mix(in_oklab,hsl(var(--primary-soft))_36%,transparent)] border-[hsl(var(--ring))] shadow-[0_0_0_1px_hsl(var(--ring)/.6)_inset,0_8px_22px_hsl(var(--shadow-color)/.6)]",
+          "bg-[color-mix(in_oklab,hsl(var(--primary-soft))_36%,transparent)] border-[var(--ring-contrast)] shadow-[0_0_0_1px_var(--ring-contrast)_inset,0_8px_22px_var(--glow-active)] text-[var(--text-on-accent)]",
         glitch &&
-          "shadow-[0_0_0_1px_hsl(var(--card-hairline))_inset,0_0_16px_hsl(var(--accent)/.25)] hover:shadow-[0_0_0_1px_hsl(var(--ring))_inset,0_0_20px_hsl(var(--accent)/.35)]",
+          "shadow-[0_0_0_1px_hsl(var(--card-hairline))_inset,0_0_16px_var(--glow-active)] hover:shadow-[0_0_0_1px_var(--ring-contrast)_inset,0_0_20px_var(--glow-active)]",
         className
       )}
       {...rest}

--- a/src/components/ui/primitives/glitch-segmented.tsx
+++ b/src/components/ui/primitives/glitch-segmented.tsx
@@ -70,8 +70,8 @@ export const GlitchSegmentedGroup = ({
       className={cn(
         "inline-flex rounded-full p-0.5 backdrop-blur-sm",
         "bg-[hsl(var(--surface-2)/0.1)]",
-        "ring-1 ring-[hsl(var(--accent)/0.4)]",
-        "shadow-[0_0_8px_hsl(var(--accent)/0.15)]",
+        "ring-1 ring-[var(--ring-contrast)]",
+        "shadow-[0_0_8px_var(--glow-active)]",
         className
       )}
       onKeyDown={onKeyDown}
@@ -131,15 +131,15 @@ export const GlitchSegmentedButton = React.forwardRef<
         "relative flex-1 h-9 select-none whitespace-nowrap px-3 inline-flex items-center justify-center gap-2 text-sm font-medium",
         "rounded-full first:rounded-l-full last:rounded-r-full",
         "bg-[hsl(var(--surface-2)/0.15)] backdrop-blur-sm text-[hsl(var(--muted))]",
-        "ring-1 ring-[hsl(var(--accent)/0.4)]",
+        "ring-1 ring-[var(--ring-contrast)]",
         "shadow-[inset_0_1px_rgba(255,255,255,0.15)]",
         "motion-safe:transition-[background-color,color,box-shadow,transform] motion-safe:ease-[cubic-bezier(.2,.8,.2,1)] motion-safe:duration-[160ms]",
-        "hover:-translate-y-px hover:shadow-[0_0_6px_hsl(var(--accent)/0.3)]",
-        "active:scale-[0.98] motion-safe:active:duration-[80ms] active:shadow-[0_0_6px_hsl(var(--accent)/0.5)]",
-        "data-[selected=true]:bg-[hsl(var(--surface-2)/0.25)] data-[selected=true]:text-[hsl(var(--foreground))]",
-        "data-[selected=true]:ring-[hsl(var(--accent))] data-[selected=true]:shadow-[0_0_8px_hsl(var(--accent)/0.6)]",
+        "hover:-translate-y-px hover:shadow-[0_0_6px_var(--glow-active)]",
+        "active:scale-[0.98] motion-safe:active:duration-[80ms] active:shadow-[0_0_6px_var(--glow-active)]",
+        "data-[selected=true]:bg-[hsl(var(--surface-2)/0.25)] data-[selected=true]:text-[var(--text-on-accent)]",
+        "data-[selected=true]:ring-[var(--ring-contrast)] data-[selected=true]:shadow-[0_0_8px_var(--glow-active)]",
         "disabled:opacity-40 disabled:shadow-none",
-        "data-[selected=true]:focus-visible:ring-2 data-[selected=true]:focus-visible:ring-[hsl(var(--ring))] data-[selected=true]:focus-visible:ring-offset-2 data-[selected=true]:focus-visible:ring-offset-[hsl(var(--surface-2)/0.25)]",
+        "data-[selected=true]:focus-visible:ring-2 data-[selected=true]:focus-visible:ring-[var(--ring-contrast)] data-[selected=true]:focus-visible:ring-offset-2 data-[selected=true]:focus-visible:ring-offset-[hsl(var(--surface-2)/0.25)]",
         "motion-reduce:transition-none motion-reduce:hover:translate-y-0 motion-reduce:active:scale-100",
         className
       )}
@@ -168,7 +168,7 @@ export const GlitchSegmentedButton = React.forwardRef<
           content: "";
           position: absolute;
           inset: 0;
-          background: hsl(var(--accent));
+          background: var(--accent-overlay);
           mix-blend-mode: screen;
           opacity: 0;
           pointer-events: none;
@@ -183,7 +183,7 @@ export const GlitchSegmentedButton = React.forwardRef<
         .glitch-scanline {
           position: absolute;
           inset: 0;
-          background: linear-gradient(to right, transparent 0%, hsl(var(--accent)) 50%, transparent 100%);
+          background: linear-gradient(to right, transparent 0%, var(--accent-overlay) 50%, transparent 100%);
           opacity: 0;
           transform: translateX(-100%);
           pointer-events: none;


### PR DESCRIPTION
## Summary
- add derived tokens for accent overlay, ring contrast, glow and readable text
- replace solid accent fills with transparent tints and apply glow on active states
- ensure interactive elements use contrast-aware ring and text colors

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9f6327f38832cbf93c8857b862afb