### PR TITLE
feat: add glitch scanline overlay to buttons

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2008,3 +2008,91 @@ html.light .btn-cta {
   box-shadow: 0 0 0 1px hsl(var(--ring) / 0.25),
     0 8px 20px hsl(var(--shadow-color) / 0.22);
 }
+
+/* === Glitch neon scanline effect for buttons === */
+.glitch-scanlines {
+  position: relative;
+  overflow: hidden;
+}
+.glitch-scanlines::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    to bottom,
+    hsl(var(--accent) / 0.08) 0 1px,
+    transparent 1px 3px
+  );
+  opacity: 0.12;
+  mix-blend-mode: overlay;
+  transition: opacity 200ms, filter 200ms;
+}
+.glitch-scanlines:hover::after {
+  opacity: 0.28;
+  filter: drop-shadow(0 0 6px hsl(var(--glow) / 0.5));
+  animation: crt-scan 4s linear infinite;
+}
+.glitch-scanlines:active::after,
+.glitch-scanlines[aria-pressed="true"]::after,
+.glitch-scanlines[data-selected="true"]::after {
+  opacity: 0.45;
+  filter: drop-shadow(0 0 8px hsl(var(--glow)));
+  animation: crt-scan 1s linear infinite, crt-jitter 200ms steps(2, end) infinite;
+}
+.glitch-scanlines::before {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  pointer-events: none;
+  background: radial-gradient(50% 50% at 50% 50%, hsl(var(--glow) / 0.35), transparent 70%);
+  opacity: 0;
+  transition: opacity 200ms;
+}
+.glitch-scanlines:hover::before {
+  opacity: 0.25;
+  animation: crt-glow 2.4s ease-in-out infinite alternate;
+}
+.glitch-scanlines:active::before,
+.glitch-scanlines[aria-pressed="true"]::before,
+.glitch-scanlines[data-selected="true"]::before {
+  opacity: 0.45;
+}
+@keyframes crt-scan {
+  0% {
+    background-position-y: 0;
+  }
+  100% {
+    background-position-y: 100%;
+  }
+}
+@keyframes crt-glow {
+  0% {
+    opacity: 0.2;
+  }
+  100% {
+    opacity: 0.4;
+  }
+}
+@keyframes crt-jitter {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(1px);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .glitch-scanlines:hover::after,
+  .glitch-scanlines:active::after,
+  .glitch-scanlines[aria-pressed="true"]::after,
+  .glitch-scanlines[data-selected="true"]::after,
+  .glitch-scanlines:hover::before,
+  .glitch-scanlines:active::before,
+  .glitch-scanlines[aria-pressed="true"]::before,
+  .glitch-scanlines[data-selected="true"]::before {
+    animation: none;
+  }
+}

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -99,6 +99,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
           aria-pressed={active || undefined}
           className={cn(
             "inline-flex items-center justify-center select-none rounded-full",
+            "relative overflow-hidden glitch-scanlines",
             "text-[hsl(var(--primary-foreground))]",
             "bg-[var(--seg-active-grad)]",
             "shadow-[0_0_0_1px_hsl(var(--ring)/.22),0_12px_28px_hsl(var(--shadow-color)/.28)]",
@@ -130,6 +131,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
             className={cn(
               "group ib2-root ib2--ring relative inline-flex items-center justify-center select-none",
               "rounded-full border-2 bg-transparent",
+              "overflow-hidden glitch-scanlines",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
               "disabled:opacity-50 disabled:pointer-events-none",
               circleMap[circleSize],
@@ -268,7 +270,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
           aria-pressed={active || undefined}
           className={cn(
             "group ib-root relative inline-flex items-center justify-center select-none",
-            "overflow-hidden rounded-full border border-[hsl(var(--border))]",
+            "overflow-hidden glitch-scanlines rounded-full border border-[hsl(var(--border))]",
             "bg-[hsl(var(--card)/.60)] backdrop-blur-md",
             "transition-transform duration-150 ease-out",
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",

--- a/src/components/ui/primitives/button.tsx
+++ b/src/components/ui/primitives/button.tsx
@@ -170,6 +170,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             rounded,
             baseByVariant[variant],
             vibeMap[vibe],
+            (variant === "primary" || variant === "ghost") && "glitch-scanlines",
             "overflow-hidden active:scale-[.995]",
             block && "w-full",
             className

--- a/src/components/ui/primitives/glitch-segmented.tsx
+++ b/src/components/ui/primitives/glitch-segmented.tsx
@@ -141,6 +141,7 @@ export const GlitchSegmentedButton = React.forwardRef<
         "disabled:opacity-40 disabled:shadow-none",
         "data-[selected=true]:focus-visible:ring-2 data-[selected=true]:focus-visible:ring-[var(--ring-contrast)] data-[selected=true]:focus-visible:ring-offset-2 data-[selected=true]:focus-visible:ring-offset-[hsl(var(--surface-2)/0.25)]",
         "motion-reduce:transition-none motion-reduce:hover:translate-y-0 motion-reduce:active:scale-100",
+        "glitch-scanlines",
         className
       )}
       {...rest}
@@ -151,7 +152,6 @@ export const GlitchSegmentedButton = React.forwardRef<
         </span>
       ) : null}
       <span className="seg-label truncate">{children}</span>
-      <span aria-hidden className="glitch-scanline" />
       <style jsx>{`
         button[data-glitch="true"] .seg-label {
           animation: seg-jitter 150ms steps(2, end);
@@ -180,18 +180,6 @@ export const GlitchSegmentedButton = React.forwardRef<
         button[data-glitch="true"] .seg-label::after {
           transform: translate(calc(-1px * var(--gi)), 0);
         }
-        .glitch-scanline {
-          position: absolute;
-          inset: 0;
-          background: linear-gradient(to right, transparent 0%, var(--accent-overlay) 50%, transparent 100%);
-          opacity: 0;
-          transform: translateX(-100%);
-          pointer-events: none;
-        }
-        button[data-glitch="true"] .glitch-scanline {
-          opacity: 0.08;
-          animation: scanline 140ms linear;
-        }
         button[data-intensity="calm"] {
           --gi: 0.5;
         }
@@ -208,18 +196,9 @@ export const GlitchSegmentedButton = React.forwardRef<
           75% { transform: translate(calc(1px * var(--gi)), 0); }
           100% { transform: translate(0,0); }
         }
-        @keyframes scanline {
-          from { transform: translateX(-100%); }
-          to { transform: translateX(100%); }
-        }
         @media (prefers-reduced-motion: reduce) {
           button[data-glitch="true"] .seg-label {
             animation: none;
-          }
-          .glitch-scanline {
-            animation: none;
-            transform: none;
-            opacity: 0;
           }
         }
       `}</style>


### PR DESCRIPTION
## Summary
- implement reusable `glitch-scanlines` effect using theme accent/glow tokens
- apply scanline/glow overlay to Primary & Ghost button variants
- layer scanline effect on IconButton variants and segmented controls

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9f7ec6cb4832c98e6ec100989f568