### PR TITLE
refactor: remove unused intensity prop

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -184,7 +184,6 @@ export default function GoalsPage() {
             value={tab}
             onChange={(v) => setTab(v as Tab)}
             ariaLabel="Goals header mode"
-            intensity="default"
           >
             {TABS.map((t) => (
               <GlitchSegmentedButton key={t.key} value={t.key} icon={t.icon}>

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -47,7 +47,6 @@ export default function TeamCompPage() {
             onChange={(v) => setTab(v as Tab)}
             ariaLabel="Comps header mode"
             className="px-2"
-            intensity="default"
           >
             {TABS.map((t) => (
               <GlitchSegmentedButton key={t.key} value={t.key} icon={t.icon}>

--- a/src/components/ui/primitives/glitch-segmented.tsx
+++ b/src/components/ui/primitives/glitch-segmented.tsx
@@ -9,7 +9,6 @@ export interface GlitchSegmentedGroupProps {
   ariaLabel?: string;
   children: React.ReactNode;
   className?: string;
-  intensity?: "calm" | "default" | "feral";
 }
 
 export interface GlitchSegmentedButtonProps
@@ -18,7 +17,6 @@ export interface GlitchSegmentedButtonProps
   icon?: React.ReactNode;
   selected?: boolean;
   onSelect?: () => void;
-  intensity?: "calm" | "default" | "feral";
 }
 
 export const GlitchSegmentedGroup = ({
@@ -27,7 +25,6 @@ export const GlitchSegmentedGroup = ({
   ariaLabel,
   children,
   className,
-  intensity,
 }: GlitchSegmentedGroupProps) => {
   const btnRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
   const setBtnRef = (index: number) => (el: HTMLButtonElement | null) => {
@@ -80,7 +77,6 @@ export const GlitchSegmentedGroup = ({
             ref: setBtnRef(i),
             tabIndex: selected ? 0 : -1,
             selected,
-            intensity,
             onSelect: () => onChange(child.props.value),
             id: child.props.id ?? `${child.props.value}-tab`,
             "aria-controls": child.props["aria-controls"] ?? `${child.props.value}-panel`,
@@ -94,9 +90,8 @@ export const GlitchSegmentedGroup = ({
 export const GlitchSegmentedButton = React.forwardRef<
   HTMLButtonElement,
   GlitchSegmentedButtonProps
->(({ icon, children, className, selected, onSelect, intensity, ...rest }, ref) => {
+>(({ icon, children, className, selected, onSelect, ...rest }, ref) => {
   return (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     <button
       ref={ref}
       type="button"


### PR DESCRIPTION
## Summary
- remove unused intensity property from GlitchSegmented components
- clean up callers now that intensity is unused

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba0107d3e4832c8c60cda49e7f20a5