### PR TITLE
style: cyberpunk segmented buttons

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -456,57 +456,53 @@ html.bg-intense body::after {
   }
 
   .btn-like-segmented {
-    @apply inline-flex items-center rounded-2xl border px-4 py-2 text-sm transition;
+    @apply inline-flex items-center justify-center px-4 py-2 text-sm rounded-full;
     position: relative;
     overflow: hidden;
-    border-color: hsl(var(--card-hairline));
-    background: linear-gradient(
-        90deg,
-        hsl(var(--primary-soft)) 0%,
-        transparent 100%
-      ),
-      hsl(var(--card));
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    text-align: center;
+    border: 1px solid hsl(var(--ring) / 0.6);
+    background: hsl(var(--surface-2) / 0.1);
     color: hsl(var(--muted-foreground));
-    transition: transform var(--dur-quick) var(--ease-out),
-      background var(--dur-quick), color var(--dur-quick);
+    box-shadow: 0 0 4px hsl(var(--ring) / 0.4);
+    transition: color 180ms ease-in-out, background 180ms ease-in-out,
+      box-shadow 180ms ease-in-out;
   }
   .btn-like-segmented:hover {
-    background: linear-gradient(
-        90deg,
-        hsl(var(--primary) / 0.12) 0%,
-        transparent 100%
-      ),
-      hsl(var(--card));
     color: hsl(var(--foreground));
-    text-shadow: 0 0 6px hsl(var(--accent) / 0.25);
+    box-shadow: 0 0 6px hsl(var(--ring) / 0.7);
   }
-  .btn-like-segmented::after {
+  .btn-like-segmented::before {
     content: "";
     position: absolute;
-    top: 0;
-    bottom: 0;
-    width: 24%;
-    left: -30%;
-    background: linear-gradient(
-      90deg,
-      transparent,
-      hsl(var(--foreground) / 0.18),
-      transparent
+    top: -24px;
+    left: 50%;
+    width: 70%;
+    height: 24px;
+    transform: translateX(-50%);
+    background: radial-gradient(
+      ellipse at bottom,
+      hsl(var(--accent)),
+      transparent 70%
     );
-    transform: skewX(-20deg);
     opacity: 0;
+    clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+    transition: opacity 180ms ease-in-out;
+    pointer-events: none;
   }
-  .btn-like-segmented:hover::after {
-    animation: sheenSweep var(--dur-slow) var(--ease-out) 1 forwards;
-    opacity: 1;
-  }
-  .btn-like-segmented[aria-current="page"],
-  .btn-like-segmented.is-active {
+  .btn-like-segmented.is-active,
+  .btn-like-segmented[aria-current="page"] {
     color: hsl(var(--foreground));
-    background: color-mix(in oklab, hsl(var(--card)) 75%, transparent);
+    background: hsl(var(--accent) / 0.15);
     border-color: hsl(var(--ring));
-    box-shadow: 0 0 0 2px hsl(var(--ring) / 0.35),
-      0 12px 28px hsl(var(--ring) / 0.25);
+    box-shadow: inset 0 0 8px hsl(var(--accent) / 0.6),
+      0 0 8px hsl(var(--ring) / 0.8),
+      0 0 12px hsl(var(--accent) / 0.5);
+  }
+  .btn-like-segmented.is-active::before,
+  .btn-like-segmented[aria-current="page"]::before {
+    opacity: 1;
   }
 
   .btn-glitch {

--- a/src/components/chrome/PageTabs.tsx
+++ b/src/components/chrome/PageTabs.tsx
@@ -54,8 +54,8 @@ export default function PageTabs({
           {tabs.map((t) => {
             const active = t.id === value;
             const classNames = [
-              "btn-like-segmented rounded-xl px-4 py-2 font-mono text-sm border relative",
-              active ? "is-active btn-glitch" : "",
+              "btn-like-segmented font-mono text-sm",
+              active ? "is-active" : "",
             ]
               .filter(Boolean)
               .join(" ");

--- a/src/components/ui/primitives/glitch-segmented.tsx
+++ b/src/components/ui/primitives/glitch-segmented.tsx
@@ -68,7 +68,7 @@ export const GlitchSegmentedGroup = ({
       role="tablist"
       aria-label={ariaLabel}
       className={cn(
-        "inline-flex rounded-full p-0.5 backdrop-blur-sm",
+        "inline-flex gap-1 rounded-full p-1 backdrop-blur-sm",
         "bg-[hsl(var(--surface-2)/0.1)]",
         "ring-1 ring-[var(--ring-contrast)]",
         "shadow-[0_0_8px_var(--glow-active)]",
@@ -128,20 +128,7 @@ export const GlitchSegmentedButton = React.forwardRef<
       onClick={onSelect}
       onMouseEnter={trigger}
       className={cn(
-        "relative flex-1 h-9 select-none whitespace-nowrap px-3 inline-flex items-center justify-center gap-2 text-sm font-medium",
-        "rounded-full first:rounded-l-full last:rounded-r-full",
-        "bg-[hsl(var(--surface-2)/0.15)] backdrop-blur-sm text-[hsl(var(--muted))]",
-        "ring-1 ring-[var(--ring-contrast)]",
-        "shadow-[inset_0_1px_rgba(255,255,255,0.15)]",
-        "motion-safe:transition-[background-color,color,box-shadow,transform] motion-safe:ease-[cubic-bezier(.2,.8,.2,1)] motion-safe:duration-[160ms]",
-        "hover:-translate-y-px hover:shadow-[0_0_6px_var(--glow-active)]",
-        "active:scale-[0.98] motion-safe:active:duration-[80ms] active:shadow-[0_0_6px_var(--glow-active)]",
-        "data-[selected=true]:bg-[hsl(var(--surface-2)/0.25)] data-[selected=true]:text-[var(--text-on-accent)]",
-        "data-[selected=true]:ring-[var(--ring-contrast)] data-[selected=true]:shadow-[0_0_8px_var(--glow-active)]",
-        "disabled:opacity-40 disabled:shadow-none",
-        "data-[selected=true]:focus-visible:ring-2 data-[selected=true]:focus-visible:ring-[var(--ring-contrast)] data-[selected=true]:focus-visible:ring-offset-2 data-[selected=true]:focus-visible:ring-offset-[hsl(var(--surface-2)/0.25)]",
-        "motion-reduce:transition-none motion-reduce:hover:translate-y-0 motion-reduce:active:scale-100",
-        "glitch-scanlines",
+        "seg-btn relative flex-1 h-9 select-none whitespace-nowrap px-4 inline-flex items-center justify-center gap-2 text-sm font-medium rounded-full",
         className
       )}
       {...rest}
@@ -151,8 +138,42 @@ export const GlitchSegmentedButton = React.forwardRef<
           {icon}
         </span>
       ) : null}
-      <span className="seg-label truncate">{children}</span>
+      <span className="seg-label truncate text-center">{children}</span>
       <style jsx>{`
+        .seg-btn {
+          overflow: hidden;
+          color: hsl(var(--muted));
+          background: hsl(var(--surface-2)/0.1);
+          border: 1px solid hsl(var(--ring-contrast));
+          box-shadow: 0 0 4px hsl(var(--ring-contrast)/0.4);
+          transition: color 180ms ease-in-out, background 180ms ease-in-out, box-shadow 180ms ease-in-out;
+        }
+        .seg-btn:hover {
+          color: hsl(var(--foreground));
+          box-shadow: 0 0 6px hsl(var(--ring-contrast));
+        }
+        .seg-btn::before {
+          content: "";
+          position: absolute;
+          top: -24px;
+          left: 50%;
+          width: 70%;
+          height: 24px;
+          transform: translateX(-50%);
+          background: radial-gradient(ellipse at bottom, var(--accent-overlay), transparent 70%);
+          opacity: 0;
+          clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+          transition: opacity 180ms ease-in-out;
+          pointer-events: none;
+        }
+        .seg-btn[data-selected="true"] {
+          color: var(--text-on-accent);
+          background: color-mix(in oklab, hsl(var(--accent)) 25%, transparent);
+          box-shadow: inset 0 0 8px var(--accent-overlay), 0 0 8px var(--glow-active), 0 0 6px var(--ring-contrast);
+        }
+        .seg-btn[data-selected="true"]::before {
+          opacity: 1;
+        }
         button[data-glitch="true"] .seg-label {
           animation: seg-jitter 150ms steps(2, end);
         }


### PR DESCRIPTION
## Summary
- restyle segmented buttons with neon rim, spotlight, and smooth transitions
- clean up PageTabs to use new segments without glitch styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ba0048fb44832cb291ea27aa1fdda8