### PR TITLE
style: apply glitch styling to icon buttons

### DIFF
--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -48,18 +48,10 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
         ref={ref}
         type="button"
         className={cn(
-          "inline-flex items-center justify-center select-none rounded-full transition",
+          "btn-glitch inline-flex items-center justify-center select-none rounded-full transition",
           "focus-visible:outline-none",
-          "bg-[var(--btn-bg)] text-[var(--btn-fg)]",
           "[&>svg]:transition",
-          "hover:text-[hsl(var(--neon))] focus-visible:text-[hsl(var(--neon))] active:text-[hsl(var(--neon))]",
-          "hover:[&>svg]:drop-shadow-[0_0_6px_hsl(var(--neon))]",
-          "focus-visible:[&>svg]:drop-shadow-[0_0_6px_hsl(var(--neon))]",
-          "active:[&>svg]:drop-shadow-[0_0_6px_hsl(var(--neon))]",
-          "hover:shadow-[0_0_8px_var(--neon),0_0_16px_var(--neon-soft)]",
-          "focus-visible:shadow-[0_0_8px_var(--neon),0_0_16px_var(--neon-soft)]",
-          "active:shadow-[0_0_8px_var(--neon),0_0_16px_var(--neon-soft)] active:scale-95",
-          "disabled:opacity-50 disabled:pointer-events-none",
+          "active:scale-95 disabled:opacity-50 disabled:pointer-events-none",
           circleMap[circleSize],
           iconMap[iconSize],
           className


### PR DESCRIPTION
## Summary
- use global `btn-glitch` styling for `IconButton`
- simplify icon button state classes

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ba14b50950832c8c2d7e1bb008e5ed