### PR TITLE
chore: remove debug logging from Hero2 layout

### DIFF
--- a/src/components/ui/layout/Hero2.tsx
+++ b/src/components/ui/layout/Hero2.tsx
@@ -17,13 +17,6 @@ function cx(...p: Array<string | false | null | undefined>) {
   return p.filter(Boolean).join(" ");
 }
 
-const devLog = (...args: unknown[]) => {
-  if (process.env.NODE_ENV !== "production") {
-    // eslint-disable-next-line no-console
-    console.log("[Hero2]", ...args);
-  }
-};
-
 export interface Hero2Props
   extends Omit<React.HTMLAttributes<HTMLElement>, "title"> {
   eyebrow?: React.ReactNode;
@@ -82,13 +75,6 @@ export default function Hero2({
   ...rest
 }: Hero2Props) {
   const headingStr = typeof heading === "string" ? heading : undefined;
-
-  React.useEffect(() => {
-    devLog("mounted Hero2", { heading: headingStr, sticky, rail });
-    return () => devLog("unmounted Hero2");
-  }, [headingStr, sticky, rail]);
-
-  devLog("render Hero2", { heading: headingStr, subtitle, sticky, rail });
 
   // Compose right area: prefer built-in tabs if provided.
   const rightNode = tabs ? (


### PR DESCRIPTION
## Summary
- remove development logging utility from `Hero2` layout

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(fails: process stuck creating optimized build)*

------
https://chatgpt.com/codex/tasks/task_e_68ba24304b94832ca8fae51acdffae1a