### PR TITLE
feat: default buttons use neon scanlines

### DIFF
--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -30,6 +30,12 @@
   --glow-active: color-mix(in oklab, hsl(var(--glow)) 50%, transparent);
   --text-on-accent: color-contrast(var(--accent-overlay) vs hsl(var(--foreground)), hsl(var(--background)));
 
+  /* Default button tones */
+  --neon: var(--glow);
+  --neon-soft: color-mix(in oklab, hsl(var(--neon)) 50%, transparent);
+  --btn-bg: transparent;
+  --btn-fg: hsl(var(--foreground));
+
   /* Hairlines, radii, motion, control geometry, gradients */
   /* Fallback (works everywhere) */
   --card-hairline: hsl(var(--border));

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -48,10 +48,14 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
         ref={ref}
         type="button"
         className={cn(
-          "btn-glitch inline-flex items-center justify-center select-none rounded-full transition",
+          "glitch-scanlines inline-flex items-center justify-center select-none rounded-full transition",
           "focus-visible:outline-none",
+          "bg-[var(--btn-bg)] text-[var(--btn-fg)]",
+          "hover:shadow-[0_0_8px_var(--neon),0_0_16px_var(--neon-soft)]",
+          "focus-visible:shadow-[0_0_8px_var(--neon),0_0_16px_var(--neon-soft)]",
+          "active:shadow-[0_0_8px_var(--neon),0_0_16px_var(--neon-soft)] active:scale-95",
           "[&>svg]:transition",
-          "active:scale-95 disabled:opacity-50 disabled:pointer-events-none",
+          "disabled:opacity-50 disabled:pointer-events-none",
           circleMap[circleSize],
           iconMap[iconSize],
           className

--- a/src/components/ui/primitives/button.tsx
+++ b/src/components/ui/primitives/button.tsx
@@ -55,7 +55,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={isDisabled}
         aria-busy={loading || undefined}
         className={cn(
-          "inline-flex items-center justify-center select-none font-medium transition",
+          "glitch-scanlines inline-flex items-center justify-center select-none font-medium transition",
           "focus-visible:outline-none",
           "bg-[var(--btn-bg)] text-[var(--btn-fg)]",
           "hover:shadow-[0_0_8px_var(--neon),0_0_16px_var(--neon-soft)]",

--- a/src/components/ui/primitives/glitch-segmented.tsx
+++ b/src/components/ui/primitives/glitch-segmented.tsx
@@ -100,7 +100,7 @@ export const GlitchSegmentedButton = React.forwardRef<
       data-selected={selected ? "true" : undefined}
       onClick={onSelect}
       className={cn(
-        "flex-1 h-9 px-3 inline-flex items-center justify-center gap-2 text-sm font-medium select-none",
+        "glitch-scanlines flex-1 h-9 px-3 inline-flex items-center justify-center gap-2 text-sm font-medium select-none",
         "rounded-full transition focus-visible:outline-none",
         "bg-[var(--btn-bg)] text-[var(--btn-fg)]",
         "hover:shadow-[0_0_8px_var(--neon),0_0_16px_var(--neon-soft)]",


### PR DESCRIPTION
## Summary
- add default button CSS variables for neon scanlines and transparent backgrounds
- apply `glitch-scanlines` class to button primitives so all buttons get neon scanline glow

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ba26120554832c84aa4ff6d1eb389a