### PR TITLE
docs: add design system usage guidelines

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,23 @@
+# Design System Usage
+
+This project ships with a small design system based on Tailwind CSS and CSS variables. This guide summarizes how to use it when building new features.
+
+## Tokens
+- Color, radius, shadows and transitions are defined as CSS variables in `tailwind.config.ts` and `src/app/themes.css`.
+- Use semantic classes like `bg-background`, `text-foreground` and `ring` instead of hard-coded values.
+- If you need to introduce a new static color, map it to a token in [`COLOR_MAPPINGS.md`](../COLOR_MAPPINGS.md).
+
+## Global styles
+- `src/app/globals.css` resets layout, sets typography and applies focus and selection styles.
+- Respect the `no-animations` class for reduced motion users. Avoid forcing animations when it is present.
+
+## Primitive components
+- Reusable building blocks live under `src/components/ui/primitives` (e.g. `button`, `badge`, `input`).
+- Prefer composing these primitives rather than creating bespoke styles.
+- Variant props are provided for sizing and icon placement where appropriate.
+
+## Theme system
+- `ThemeToggle` (in `src/components/ui/theme`) lets users switch among preset themes and backgrounds while persisting preferences in local storage.
+- Apply the provided classes (`bg-intense`, variant names, etc.) to opt into specific theme behavior.
+
+Following these guidelines keeps the interface consistent and lets theme updates propagate automatically.


### PR DESCRIPTION
## Summary
- document design tokens, global styles, primitives and theming in a new guide

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ba2c9beee0832c960b9f59e8b1b47c