### PR TITLE
docs: add button and theme examples

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -16,8 +16,30 @@ This project ships with a small design system based on Tailwind CSS and CSS vari
 - Prefer composing these primitives rather than creating bespoke styles.
 - Variant props are provided for sizing and icon placement where appropriate.
 
+```tsx
+import { Button } from "@/components/ui/primitives/button";
+
+export function Submit() {
+  return (
+    <Button className="bg-primary text-primary-foreground">Save</Button>
+  );
+}
+```
+
 ## Theme system
 - `ThemeToggle` (in `src/components/ui/theme`) lets users switch among preset themes and backgrounds while persisting preferences in local storage.
 - Apply the provided classes (`bg-intense`, variant names, etc.) to opt into specific theme behavior.
+
+```tsx
+import ThemeToggle from "@/components/ui/theme/ThemeToggle";
+
+export function Header() {
+  return (
+    <header className="flex justify-end p-4">
+      <ThemeToggle />
+    </header>
+  );
+}
+```
 
 Following these guidelines keeps the interface consistent and lets theme updates propagate automatically.


### PR DESCRIPTION
## Summary
- document importing Button with semantic classes
- document ThemeToggle usage for switching themes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ba30636688832cb5f91185806e3c8b