### PR TITLE
feat: add neon accent hover to icons

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2094,3 +2094,20 @@ html.light .btn-cta {
     animation: none;
   }
 }
+
+/* ---------- Icon styling ---------- */
+.lucide {
+  color: hsl(var(--muted-foreground));
+  transition: color var(--dur-quick) var(--ease-out),
+    filter var(--dur-quick) var(--ease-out);
+}
+
+.lucide:hover,
+.lucide:active,
+button:hover .lucide,
+button:active .lucide,
+a:hover .lucide,
+a:active .lucide {
+  color: hsl(var(--accent));
+  filter: drop-shadow(0 0 6px hsl(var(--accent) / 0.8));
+}


### PR DESCRIPTION
## Summary
- make lucide icons muted by default
- highlight icons with accent-colored neon glow on hover or active

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba30b5fe60832c831f73a2d769c524