### PR TITLE
Make review list sidebar semi-transparent

### DIFF
--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -150,7 +150,7 @@ export default function ReviewsPage({
         )}
       >
         <aside>
-          <SectionCard className="overflow-hidden">
+          <SectionCard className="overflow-hidden bg-card/50">
             <SectionCard.Body>
               <div className="mb-2 text-sm text-muted-foreground">{filtered.length} shown</div>
               <ReviewList


### PR DESCRIPTION
## Summary
- make review list sidebar card semi-transparent

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ba34b764c0832c8e54f520dcc48dab