### PR TITLE
Tone down white elements to 70% opacity

### DIFF
--- a/src/components/goals/DurationSelector.tsx
+++ b/src/components/goals/DurationSelector.tsx
@@ -34,11 +34,11 @@ export default function DurationSelector({
             className={cn(
               "inline-flex items-center justify-center h-9 px-3 rounded-full text-center text-sm",
               "border transition-colors",
-              "border-white/10 bg-white/5 text-white/80",
-              "hover:bg-white/10 hover:text-white",
+              "border-white/10 bg-white/5 text-white/70",
+              "hover:bg-white/10 hover:text-white/70",
               "focus:outline-none focus:ring-2 focus:ring-purple-400/70",
               active &&
-                "border-purple-400/60 bg-purple-500/20 text-white font-semibold"
+                "border-purple-400/60 bg-purple-500/20 text-white/70 font-semibold"
             )}
           >
             {m}m

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -673,7 +673,7 @@ export default function ReviewEditor({
               <div
                 className={cn(
                   "py-2 text-center",
-                  result === "Win" ? "text-white" : "text-[hsl(var(--muted-foreground))]"
+                  result === "Win" ? "text-white/70" : "text-[hsl(var(--muted-foreground))]"
                 )}
               >
                 Win
@@ -681,7 +681,7 @@ export default function ReviewEditor({
               <div
                 className={cn(
                   "py-2 text-center",
-                  result === "Loss" ? "text-white" : "text-[hsl(var(--muted-foreground))]"
+                  result === "Loss" ? "text-white/70" : "text-[hsl(var(--muted-foreground))]"
                 )}
               >
                 Loss
@@ -908,7 +908,7 @@ export default function ReviewEditor({
               />
             ) : (
               <span
-                className="inline-flex h-10 items-center justify-center gap-2 rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 text-sm text-white/80"
+                className="inline-flex h-10 items-center justify-center gap-2 rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 text-sm text-white/70"
                 style={{ width: "calc(5ch + 1.5rem)" }}
                 title="Timestamp disabled"
               >

--- a/src/components/reviews/ReviewSummary.tsx
+++ b/src/components/reviews/ReviewSummary.tsx
@@ -298,7 +298,7 @@ export default function ReviewSummary({ review, onEdit, className }: Props) {
           {/* Left: Title */}
           <div className="min-w-0">
             <div className="mb-0.5 text-xs text-white/25">Title</div>
-            <div className="truncate text-lg font-medium leading-7 text-white/90">
+            <div className="truncate text-lg font-medium leading-7 text-white/70">
               {laneTitle || "Untitled review"}
             </div>
           </div>
@@ -475,7 +475,7 @@ export default function ReviewSummary({ review, onEdit, className }: Props) {
         {review.notes ? (
           <div>
             <SectionLabel>Notes</SectionLabel>
-            <div className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-3 text-sm leading-6 text-white/80">
+            <div className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-3 text-sm leading-6 text-white/70">
               {review.notes}
             </div>
           </div>

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -3,7 +3,7 @@
 
 /**
  * TabBar — Lavender-Glitch borderless tabs with neon text and sliding indicator
- * - Text-only buttons (white/75 default, full white active) with neon glow.
+ * - Text-only buttons (white/70 default and active) with neon glow.
  * - Smooth indicator; keyboard: ← → Home End; role="tablist".
  */
 
@@ -155,7 +155,7 @@ export default function TabBar({
                   "relative inline-flex items-center select-none rounded-full transition-[color,opacity,text-shadow] duration-200",
                   "bg-transparent border-0 outline-none",
                   s.h, s.px, s.text, size === "lg" ? "font-medium" : "font-normal",
-                  "text-white/75 hover:text-white data-[active=true]:text-white",
+                  "text-white/70 hover:text-white/70 data-[active=true]:text-white/70",
                   "focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] focus-visible:ring-offset-0",
                   item.disabled && "opacity-40 pointer-events-none",
                   item.className
@@ -166,7 +166,7 @@ export default function TabBar({
                 {item.icon && <span className={cn("mr-2 grid place-items-center", size !== "lg" ? "[&>svg]:h-4 [&>svg]:w-4" : "[&>svg]:h-5 [&>svg]:w-5")}>{item.icon}</span>}
                 <span className="truncate">{item.label}</span>
                 {item.badge != null && (
-                  <span className="ml-2 inline-flex items-center justify-center rounded-full text-[10px] leading-none px-2 py-1 bg-[hsl(var(--primary-soft))] text-white/90">
+                  <span className="ml-2 inline-flex items-center justify-center rounded-full text-[10px] leading-none px-2 py-1 bg-[hsl(var(--primary-soft))] text-white/70">
                     {item.badge}
                   </span>
                 )}

--- a/src/components/ui/league/SideSelector.tsx
+++ b/src/components/ui/league/SideSelector.tsx
@@ -92,7 +92,7 @@ export default function SideSelector({
         <div
           className={cn(
             "py-2 text-center transition-colors",
-            !isRight ? "text-white" : "text-[hsl(var(--muted-foreground))]"
+            !isRight ? "text-white/70" : "text-[hsl(var(--muted-foreground))]"
           )}
           style={{ textShadow: !isRight ? "0 0 10px hsl(200 100% 60% / .35)" : undefined }}
         >
@@ -101,7 +101,7 @@ export default function SideSelector({
         <div
           className={cn(
             "py-2 text-center transition-colors",
-            isRight ? "text-white" : "text-[hsl(var(--muted-foreground))]"
+            isRight ? "text-white/70" : "text-[hsl(var(--muted-foreground))]"
           )}
           style={{ textShadow: isRight ? "0 0 10px hsl(0 85% 60% / .35)" : undefined }}
         >

--- a/src/components/ui/toggles/toggle.tsx
+++ b/src/components/ui/toggles/toggle.tsx
@@ -65,7 +65,7 @@ export default function Toggle({
       <span
         className={cn(
           "relative z-10 flex-1 text-center font-mono text-sm transition-colors",
-          !isRight ? "text-white" : "text-[hsl(var(--muted-foreground))]"
+          !isRight ? "text-white/70" : "text-[hsl(var(--muted-foreground))]"
         )}
         style={{ textShadow: !isRight ? "0 0 10px hsl(200 100% 60% / .35)" : undefined }}
       >
@@ -74,7 +74,7 @@ export default function Toggle({
       <span
         className={cn(
           "relative z-10 flex-1 text-center font-mono text-sm transition-colors",
-          isRight ? "text-white" : "text-[hsl(var(--muted-foreground))]"
+          isRight ? "text-white/70" : "text-[hsl(var(--muted-foreground))]"
         )}
         style={{ textShadow: isRight ? "0 0 10px hsl(0 85% 60% / .35)" : undefined }}
       >


### PR DESCRIPTION
## Summary
- render win/loss toggles and disabled timestamp labels with white at 70% opacity
- use semi-transparent white for review summary text and notes
- update tab, toggle, side selector, and duration selector components to use white/70 for text and hover states

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba353a06c8832cbbf971edb792f768