### PR TITLE
Ensure heroes use page-shell wrapper

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -96,7 +96,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body className="min-h-screen bg-[hsl(var(--background))] text-[hsl(var(--foreground))] glitch-root">
         <SiteChrome />
-        <main className="relative z-10 mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-6">
+        <main className="relative z-10">
           {children}
         </main>
       </body>

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -171,7 +171,7 @@ export default function GoalsPage() {
       : "Pick a duration and focus.";
 
   return (
-    <main className="grid gap-6">
+    <main className="page-shell grid gap-6 py-6">
       {/* ======= HERO ======= */}
       <Hero
         eyebrow="GOALS"

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -92,7 +92,7 @@ export default function ReviewsPage({
   const active = base.find((r) => r.id === selectedId) || null;
 
   return (
-    <div className="space-y-6">
+    <main className="page-shell space-y-6 py-6">
       <Hero2
         heading={
           <div className="flex items-center gap-2">
@@ -194,6 +194,6 @@ export default function ReviewsPage({
           )}
         </SectionCard>
       </div>
-    </div>
+    </main>
   );
 }

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -35,7 +35,7 @@ export default function TeamCompPage() {
   const [tab, setTab] = useState<Tab>("cheat");
 
   return (
-    <main className="grid gap-4">
+    <main className="page-shell grid gap-4 py-6">
       <Hero
         eyebrow="Comps"
         heading="Today"


### PR DESCRIPTION
## Summary
- Remove hardcoded layout container and let pages handle their own width
- Wrap Goals, Team, and Reviews pages in `page-shell` so hero sections align

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ba35977188832ca6d4365900773e58