### PR TITLE
Refactor Goals layout to match Comps style

### DIFF
--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -38,7 +38,7 @@ export default function GoalForm({
         onSubmit();
       }}
     >
-      <SectionCard>
+      <SectionCard className="card-neo-soft">
         <SectionCard.Header
           className="flex items-center justify-between"
           title={<h2 className="text-lg font-semibold">Add Goal</h2>}

--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -28,15 +28,15 @@ export default function GoalQueue({ items, onAdd, onRemove, onPromote }: GoalQue
   }
 
   return (
-    <SectionCard>
+    <SectionCard className="card-neo-soft">
       <SectionCard.Header title={<h2 className="text-lg font-semibold">Goal Queue</h2>} />
       <SectionCard.Body className="grid gap-6">
-        <ul className="divide-y divide-white/7">
+        <ul className="divide-y divide-white/10">
           {items.length === 0 ? (
-            <li className="py-2 text-sm text-white/60">No queued goals</li>
+            <li className="py-3 text-sm text-white/60">No queued goals</li>
           ) : (
             items.map((it) => (
-              <li key={it.id} className="group flex items-center gap-2 py-2">
+              <li key={it.id} className="group flex items-center gap-2 py-3">
                 <span className="h-1.5 w-1.5 rounded-full bg-white/40" aria-hidden />
                 <p className="flex-1 truncate text-sm">{it.text}</p>
                 <time
@@ -74,7 +74,7 @@ export default function GoalQueue({ items, onAdd, onRemove, onPromote }: GoalQue
           )}
         </ul>
 
-        <form onSubmit={submit} className="flex items-center gap-2 pt-2">
+        <form onSubmit={submit} className="flex items-center gap-2 pt-3">
           <span className="h-1.5 w-1.5 rounded-full bg-white/40" aria-hidden />
           <Input
             tone="default"

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -163,7 +163,7 @@ export default function GoalsPage() {
     setWaitlist((prev) => prev.filter((w) => w.id !== item.id));
   }
 
-  const heroSubtitle =
+  const summary =
     tab === "goals"
       ? `Cap: ${ACTIVE_CAP} active · Remaining: ${remaining} · ${pctDone}% done · ${totalCount} total`
       : tab === "reminders"
@@ -171,14 +171,20 @@ export default function GoalsPage() {
       : "Pick a duration and focus.";
 
   return (
-    <main className="page-shell grid gap-6 py-6">
+    <main className="page-shell grid gap-4 py-6">
       {/* ======= HERO ======= */}
       <Hero
-        eyebrow="GOALS"
-        heading="Today"
-        subtitle={heroSubtitle}
+        eyebrow="Goals"
+        heading={
+          <>
+            <span className="sm:mr-2">Today</span>
+            <span className="block text-xs text-[hsl(var(--muted-foreground))] sm:inline">
+              {summary}
+            </span>
+          </>
+        }
         sticky
-        barClassName="gap-2 items-baseline"
+        barClassName="flex-col items-start justify-start gap-2 sm:flex-row sm:items-center sm:justify-between"
         right={
           <GlitchSegmentedGroup
             value={tab}
@@ -194,7 +200,7 @@ export default function GoalsPage() {
         }
       />
 
-      <section className="grid gap-6">
+      <section className="grid gap-4">
         <div
           role="tabpanel"
           id="goals-panel"
@@ -212,7 +218,7 @@ export default function GoalsPage() {
                   }
                 />
               ) : (
-                <SectionCard>
+                <SectionCard className="card-neo-soft">
                   <SectionCard.Header sticky className="flex items-center justify-between">
                     <div className="flex items-center gap-2 sm:gap-3">
                       <h2 className="text-lg font-semibold">Your Goals</h2>


### PR DESCRIPTION
## Summary
- Use compact header with inline stats and responsive nav
- Style Add Goal and Goal Queue as cards with consistent spacing
- Add subtle dividers for queue list entries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba3fc0d620832cbd399e09987c100b