### PR TITLE
Refactor Goals page layout

### DIFF
--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import * as React from "react";
-import SectionCard from "@/components/ui/layout/SectionCard";
 import Input from "@/components/ui/primitives/input";
 import Textarea from "@/components/ui/primitives/textarea";
 import Button from "@/components/ui/primitives/button";
@@ -38,22 +37,14 @@ export default function GoalForm({
         onSubmit();
       }}
     >
-      <SectionCard className="card-neo-soft">
-        <SectionCard.Header
-          className="flex items-center justify-between"
-          title={<h2 className="text-lg font-semibold">Add Goal</h2>}
-          actions={
-            <Button type="submit" size="sm" disabled={!title.trim()}>
-              Add Goal
-            </Button>
-          }
-        />
-        <SectionCard.Body className="grid gap-6">
+      <div className="rounded-2xl p-5 ring-1 ring-[hsl(var(--border)/0.3)] bg-[hsl(var(--card)/0.6)]">
+        <h2 className="mb-4 text-lg font-semibold">Add Goal</h2>
+        <div className="grid gap-4">
           <label className="grid gap-1">
-            <span className="text-xs text-white/60">Title</span>
+            <span className="text-sm text-[hsl(var(--foreground)/0.85)]">Title</span>
             <Input
               tone="default"
-              className="h-9 text-sm focus:ring-2 focus:ring-purple-400/60"
+              className="h-12 rounded-2xl border-[hsl(var(--border)/0.3)] bg-[hsl(var(--card)/0.6)] text-sm focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent)/0.6)]"
               value={title}
               onChange={(e) => onTitleChange(e.target.value)}
               aria-required="true"
@@ -61,45 +52,52 @@ export default function GoalForm({
           </label>
 
           <label className="grid gap-1">
-            <span className="text-xs text-white/60">Metric (optional)</span>
+            <span className="text-sm text-[hsl(var(--foreground)/0.85)]">Metric (optional)</span>
             <Input
               tone="default"
-              className="h-9 text-sm focus:ring-2 focus:ring-purple-400/60 tabular-nums"
+              className="h-10 rounded-2xl border-[hsl(var(--border)/0.3)] bg-[hsl(var(--card)/0.6)] text-sm focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent)/0.6)] tabular-nums"
               value={metric}
               onChange={(e) => onMetricChange(e.target.value)}
             />
           </label>
 
           <label className="grid gap-1">
-            <span className="text-xs text-white/60">Notes (optional)</span>
+            <span className="text-sm text-[hsl(var(--foreground)/0.85)]">Notes (optional)</span>
             <Textarea
               tone="default"
-              className="min-h-[96px] text-sm focus:ring-2 focus:ring-purple-400/60"
+              className="h-24 rounded-2xl border-[hsl(var(--border)/0.3)] bg-[hsl(var(--card)/0.6)] text-sm focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent)/0.6)]"
               value={notes}
               onChange={(e) => onNotesChange(e.target.value)}
             />
           </label>
 
-          <div className="text-xs text-white/60">
-            {activeCount >= activeCap ? (
-              <span className="text-[hsl(var(--accent))]">
-                Cap reached. Finish one to add more.
-              </span>
-            ) : (
-              <span>
-                {activeCap - activeCount} active slot
-                {activeCap - activeCount === 1 ? "" : "s"} left
-              </span>
-            )}
+          <div className="flex justify-end">
+            <Button
+              type="submit"
+              size="lg"
+              className="h-12"
+              disabled={!title.trim()}
+              aria-label="Add Goal"
+            >
+              Add Goal
+            </Button>
           </div>
-
+          <p className="text-xs text-[hsl(var(--foreground)/0.65)]">
+            {activeCount >= activeCap
+              ? "Cap reached. Finish one to add more."
+              : `${activeCap - activeCount} active slot${activeCap - activeCount === 1 ? "" : "s"} left`}
+          </p>
           {err ? (
-            <p role="status" aria-live="polite" className="text-xs text-[hsl(var(--accent))]">
+            <p
+              role="status"
+              aria-live="polite"
+              className="text-xs text-[hsl(var(--accent))]"
+            >
               {err}
             </p>
           ) : null}
-        </SectionCard.Body>
-      </SectionCard>
+        </div>
+      </div>
     </form>
   );
 }

--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -1,11 +1,9 @@
 "use client";
 
 import * as React from "react";
-import SectionCard from "@/components/ui/layout/SectionCard";
 import Input from "@/components/ui/primitives/input";
 import IconButton from "@/components/ui/primitives/IconButton";
-import { ArrowUpRight, Trash2 } from "lucide-react";
-import { LOCALE } from "@/lib/utils";
+import { GripVertical, Trash2 } from "lucide-react";
 
 export type WaitItem = { id: string; text: string; createdAt: number };
 
@@ -13,10 +11,9 @@ interface GoalQueueProps {
   items: WaitItem[];
   onAdd: (text: string) => void;
   onRemove: (id: string) => void;
-  onPromote: (item: WaitItem) => void;
 }
 
-export default function GoalQueue({ items, onAdd, onRemove, onPromote }: GoalQueueProps) {
+export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
   const [val, setVal] = React.useState("");
 
   function submit(e: React.FormEvent) {
@@ -28,64 +25,59 @@ export default function GoalQueue({ items, onAdd, onRemove, onPromote }: GoalQue
   }
 
   return (
-    <SectionCard className="card-neo-soft">
-      <SectionCard.Header title={<h2 className="text-lg font-semibold">Goal Queue</h2>} />
-      <SectionCard.Body className="grid gap-6">
-        <ul className="divide-y divide-white/10">
-          {items.length === 0 ? (
-            <li className="py-3 text-sm text-white/60">No queued goals</li>
-          ) : (
-            items.map((it) => (
-              <li key={it.id} className="group flex items-center gap-2 py-3">
-                <span className="h-1.5 w-1.5 rounded-full bg-white/40" aria-hidden />
-                <p className="flex-1 truncate text-sm">{it.text}</p>
-                <time
-                  className="text-xs text-white/60 opacity-0 group-hover:opacity-100"
-                  dateTime={new Date(it.createdAt).toISOString()}
+    <div>
+      <h2 className="mb-4 text-lg font-semibold">Goal Queue</h2>
+      {items.length === 0 ? (
+        <div className="rounded-2xl border-2 border-dashed border-[hsl(var(--border)/0.3)] bg-[hsl(var(--card)/0.6)] p-8 text-center text-sm text-[hsl(var(--foreground)/0.65)]">
+          No queued goals
+        </div>
+      ) : (
+        <ul>
+          {items.map((it) => (
+            <li
+              key={it.id}
+              className="flex items-center justify-between py-3 border-t border-[hsl(var(--border)/0.15)]"
+            >
+              <div className="flex min-w-0 items-center gap-2">
+                <span className="h-2 w-2 rounded-full bg-[hsl(var(--foreground)/0.65)]" aria-hidden />
+                <p className="truncate text-sm text-[hsl(var(--foreground)/0.85)]">{it.text}</p>
+              </div>
+              <div className="flex items-center gap-1">
+                <IconButton
+                  title="Drag"
+                  aria-label="Drag"
+                  circleSize="sm"
+                  iconSize="sm"
+                  className="focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent)/0.6)]"
                 >
-                  {new Date(it.createdAt).toLocaleDateString(LOCALE)}
-                </time>
-                <div className="flex items-center gap-1 ml-2">
-                  <IconButton
-                    title="Promote"
-                    aria-label="Promote"
-                    onClick={() => onPromote(it)}
-                    circleSize="sm"
-                    iconSize="sm"
-                    variant="ring"
-                    className="opacity-0 group-hover:opacity-100"
-                  >
-                    <ArrowUpRight />
-                  </IconButton>
-                  <IconButton
-                    title="Delete"
-                    aria-label="Delete"
-                    onClick={() => onRemove(it.id)}
-                    circleSize="sm"
-                    iconSize="sm"
-                    variant="ring"
-                    className="opacity-0 group-hover:opacity-100"
-                  >
-                    <Trash2 />
-                  </IconButton>
-                </div>
-              </li>
-            ))
-          )}
+                  <GripVertical />
+                </IconButton>
+                <IconButton
+                  title="Delete"
+                  aria-label="Delete"
+                  onClick={() => onRemove(it.id)}
+                  circleSize="sm"
+                  iconSize="sm"
+                  className="focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent)/0.6)]"
+                >
+                  <Trash2 />
+                </IconButton>
+              </div>
+            </li>
+          ))}
         </ul>
+      )}
 
-        <form onSubmit={submit} className="flex items-center gap-2 pt-3">
-          <span className="h-1.5 w-1.5 rounded-full bg-white/40" aria-hidden />
-          <Input
-            tone="default"
-            className="flex-1 h-9 text-sm focus:ring-2 focus:ring-purple-400/60"
-            value={val}
-            onChange={(e) => setVal(e.currentTarget.value)}
-            placeholder="Add to queue and press Enter"
-          />
-        </form>
-      </SectionCard.Body>
-    </SectionCard>
+      <form onSubmit={submit} className="mt-4">
+        <Input
+          tone="default"
+          className="h-12 rounded-2xl border border-[hsl(var(--border)/0.3)] bg-[hsl(var(--card)/0.6)] focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent)/0.6)]"
+          value={val}
+          onChange={(e) => setVal(e.currentTarget.value)}
+          placeholder="Add to queue…"
+        />
+      </form>
+    </div>
   );
 }
 

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -16,7 +16,6 @@ import * as React from "react";
 import { Flag, ListChecks, Timer as TimerIcon, Trash2 } from "lucide-react";
 
 import Hero from "@/components/ui/layout/Hero";
-import SectionCard from "@/components/ui/layout/SectionCard";
 import IconButton from "@/components/ui/primitives/IconButton";
 import CheckCircle from "@/components/ui/toggles/CheckCircle";
 import {
@@ -158,10 +157,6 @@ export default function GoalsPage() {
   function removeWait(id: string) {
     setWaitlist((prev) => prev.filter((w) => w.id !== id));
   }
-  function promoteWait(item: WaitItem) {
-    setTitle(item.text);
-    setWaitlist((prev) => prev.filter((w) => w.id !== item.id));
-  }
 
   const summary =
     tab === "goals"
@@ -209,80 +204,75 @@ export default function GoalsPage() {
         >
           {tab === "goals" && (
             <>
-              {totalCount === 0 ? (
-                <GoalsProgress
-                  total={totalCount}
-                  pct={pctDone}
-                  onAddFirst={() =>
-                    formRef.current?.scrollIntoView({ behavior: "smooth" })
-                  }
-                />
-              ) : (
-                <SectionCard className="card-neo-soft">
-                  <SectionCard.Header sticky className="flex items-center justify-between">
-                    <div className="flex items-center gap-2 sm:gap-3">
-                      <h2 className="text-lg font-semibold">Your Goals</h2>
-                      <GoalsProgress total={totalCount} pct={pctDone} />
+              <div className="mx-auto mt-6 mb-6 max-w-screen-2xl">
+                {totalCount === 0 ? (
+                  <GoalsProgress
+                    total={totalCount}
+                    pct={pctDone}
+                    onAddFirst={() =>
+                      formRef.current?.scrollIntoView({ behavior: "smooth" })
+                    }
+                  />
+                ) : null}
+                <div className="grid gap-y-6 md:grid-cols-2 md:gap-x-6">
+                  <section>
+                    <div className="mb-4 flex items-center justify-between">
+                      <div className="flex items-center gap-2 sm:gap-3">
+                        <h2 className="text-lg font-semibold">Your Goals</h2>
+                        <GoalsProgress total={totalCount} pct={pctDone} />
+                      </div>
+                      <GoalsTabs value={filter} onChange={setFilter} />
                     </div>
-                    <GoalsTabs value={filter} onChange={setFilter} />
-                  </SectionCard.Header>
-                  <SectionCard.Body>
-                    <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 [grid-auto-rows:1fr]">
+                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                       {filtered.length === 0 ? (
-                        <p className="text-sm text-white/60">
+                        <p className="text-sm text-[hsl(var(--foreground)/0.65)]">
                           No goals here. Add one simple, finishable thing.
                         </p>
                       ) : (
                         filtered.map((g) => (
                           <article
                             key={g.id}
-                            className={["relative rounded-2xl p-6","card-neo transition","hover:shadow-[0_0_0_1px_hsl(var(--primary)/.25),0_12px_40px_rgba(0,0,0,.35)]","min-h-[152px] flex flex-col"].join(" ")}
+                            className="group rounded-2xl p-4 ring-1 ring-[hsl(var(--border)/0.3)] bg-[hsl(var(--card)/0.6)] transition hover:-translate-y-[1px] hover:shadow-md focus-within:ring-2 focus-within:ring-[hsl(var(--accent)/0.6)]"
                           >
-                            <span
-                              aria-hidden
-                              className="absolute inset-y-4 left-0 w-[2px] rounded-full bg-gradient-to-b from-[hsl(var(--primary))] via-[hsl(var(--accent))] to-transparent opacity-60"
-                            />
-                            <header className="flex items-start justify-between gap-2">
-                              <h3 className="font-semibold leading-tight pr-6 line-clamp-2">
-                                {g.title}
-                              </h3>
+                            <header className="flex items-center justify-between gap-2">
+                              <div className="min-w-0">
+                                <h3 className="font-semibold leading-tight line-clamp-2">{g.title}</h3>
+                                <time
+                                  className="mt-1 block text-xs text-[hsl(var(--foreground)/0.65)]"
+                                  dateTime={new Date(g.createdAt).toISOString()}
+                                >
+                                  {new Date(g.createdAt).toLocaleDateString(LOCALE)}
+                                </time>
+                              </div>
                               <div className="flex items-center gap-1">
                                 <CheckCircle
                                   aria-label={g.done ? "Mark active" : "Mark done"}
                                   checked={g.done}
                                   onChange={() => toggleDone(g.id)}
                                   size="lg"
+                                  className="focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent)/0.6)]"
                                 />
                                 <IconButton
                                   title="Delete"
                                   aria-label="Delete goal"
                                   onClick={() => removeGoal(g.id)}
                                   circleSize="sm"
+                                  className="focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent)/0.6)]"
                                 >
                                   <Trash2 />
                                 </IconButton>
                               </div>
                             </header>
-                            <div className="mt-3 text-sm text-white/60 space-y-2">
+                            <div className="mt-4 space-y-2 text-sm text-[hsl(var(--foreground)/0.65)]">
                               {g.metric ? (
                                 <div className="tabular-nums">
                                   <span className="opacity-70">Metric:</span> {g.metric}
                                 </div>
                               ) : null}
-                              {g.notes ? <p className="leading-relaxed">{g.notes}</p> : null}
+                              {g.notes ? <p className="leading-relaxed line-clamp-2">{g.notes}</p> : null}
                             </div>
-                            <footer className="mt-auto pt-3 flex items-center justify-between text-xs text-white/60">
-                              <span className="inline-flex items-center gap-2">
-                                <span
-                                  aria-hidden
-                                  className={["h-2 w-2 rounded-full", g.done ? "" : "bg-[hsl(var(--primary))]"].join(" ")}
-                                  style={g.done ? { background: "var(--accent-overlay)" } : undefined}
-                                />
-                                <time className="tabular-nums" dateTime={new Date(g.createdAt).toISOString()}>
-                                  {new Date(g.createdAt).toLocaleDateString(LOCALE)}
-                                </time>
-                              </span>
-                              <span className={g.done ? "text-[hsl(var(--accent))]" : ""}>
+                            <footer className="mt-4 flex justify-end text-xs">
+                              <span className={g.done ? "text-[hsl(var(--accent))]" : "text-[hsl(var(--foreground)/0.65)]"}>
                                 {g.done ? "Done" : "Active"}
                               </span>
                             </footer>
@@ -290,31 +280,26 @@ export default function GoalsPage() {
                         ))
                       )}
                     </div>
-                  </SectionCard.Body>
-                </SectionCard>
-              )}
-
-              <div ref={formRef}>
-                <GoalForm
-                  title={title}
-                  metric={metric}
-                  notes={notes}
-                  onTitleChange={setTitle}
-                  onMetricChange={setMetric}
-                  onNotesChange={setNotes}
-                  onSubmit={addGoal}
-                  activeCount={activeCount}
-                  activeCap={ACTIVE_CAP}
-                  err={err}
-                />
+                  </section>
+                  <section className="md:sticky md:top-16" ref={formRef}>
+                    <GoalForm
+                      title={title}
+                      metric={metric}
+                      notes={notes}
+                      onTitleChange={setTitle}
+                      onMetricChange={setMetric}
+                      onNotesChange={setNotes}
+                      onSubmit={addGoal}
+                      activeCount={activeCount}
+                      activeCap={ACTIVE_CAP}
+                      err={err}
+                    />
+                  </section>
+                  <section className="md:col-span-2">
+                    <GoalQueue items={waitlist} onAdd={addWait} onRemove={removeWait} />
+                  </section>
+                </div>
               </div>
-
-              <GoalQueue
-                items={waitlist}
-                onAdd={addWait}
-                onRemove={removeWait}
-                onPromote={promoteWait}
-              />
 
               {lastDeleted && (
                 <div className="mx-auto w-fit rounded-full px-4 py-2 text-sm bg-[hsl(var(--card))] border border-[hsl(var(--card-hairline))] shadow-sm">


### PR DESCRIPTION
## Summary
- Rebuild Goals body into a centered max-w-screen-2xl grid with responsive columns and sticky Add Goal form
- Restyle goal cards, form, and queue using rings and panel tokens for consistent spacing and alignment
- Simplify goal queue into dividable list with drag/delete actions and queue input

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba41dbfe14832c8c5252022a9c7251