### PR TITLE
style: align goals module with terminal aesthetic

### DIFF
--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -37,14 +37,14 @@ export default function GoalForm({
         onSubmit();
       }}
     >
-      <div className="rounded-2xl p-5 ring-1 ring-[hsl(var(--border)/0.3)] bg-[hsl(var(--card)/0.6)]">
-        <h2 className="mb-4 text-lg font-semibold">Add Goal</h2>
+      <div className="scanlines rounded-2xl bg-card/60 p-5 ring-1 ring-border/30 font-mono">
+        <h2 className="mb-4 text-lg font-semibold uppercase tracking-tight">Add Goal</h2>
         <div className="grid gap-4">
           <label className="grid gap-1">
-            <span className="text-sm text-[hsl(var(--foreground)/0.85)]">Title</span>
+            <span className="text-sm text-foreground/80">Title</span>
             <Input
               tone="default"
-              className="h-12 rounded-2xl border-[hsl(var(--border)/0.3)] bg-[hsl(var(--card)/0.6)] text-sm focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent)/0.6)]"
+              className="h-12 rounded-2xl border-border/30 bg-card/60 text-sm focus-visible:ring-2 focus-visible:ring-accent"
               value={title}
               onChange={(e) => onTitleChange(e.target.value)}
               aria-required="true"
@@ -52,20 +52,20 @@ export default function GoalForm({
           </label>
 
           <label className="grid gap-1">
-            <span className="text-sm text-[hsl(var(--foreground)/0.85)]">Metric (optional)</span>
+            <span className="text-sm text-foreground/80">Metric (optional)</span>
             <Input
               tone="default"
-              className="h-10 rounded-2xl border-[hsl(var(--border)/0.3)] bg-[hsl(var(--card)/0.6)] text-sm focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent)/0.6)] tabular-nums"
+              className="h-10 rounded-2xl border-border/30 bg-card/60 text-sm tabular-nums focus-visible:ring-2 focus-visible:ring-accent"
               value={metric}
               onChange={(e) => onMetricChange(e.target.value)}
             />
           </label>
 
           <label className="grid gap-1">
-            <span className="text-sm text-[hsl(var(--foreground)/0.85)]">Notes (optional)</span>
+            <span className="text-sm text-foreground/80">Notes (optional)</span>
             <Textarea
               tone="default"
-              className="h-24 rounded-2xl border-[hsl(var(--border)/0.3)] bg-[hsl(var(--card)/0.6)] text-sm focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent)/0.6)]"
+              className="h-24 rounded-2xl border-border/30 bg-card/60 text-sm focus-visible:ring-2 focus-visible:ring-accent"
               value={notes}
               onChange={(e) => onNotesChange(e.target.value)}
             />
@@ -82,7 +82,7 @@ export default function GoalForm({
               Add Goal
             </Button>
           </div>
-          <p className="text-xs text-[hsl(var(--foreground)/0.65)]">
+          <p className="glitch-text text-xs text-foreground/65">
             {activeCount >= activeCap
               ? "Cap reached. Finish one to add more."
               : `${activeCap - activeCount} active slot${activeCap - activeCount === 1 ? "" : "s"} left`}
@@ -91,7 +91,7 @@ export default function GoalForm({
             <p
               role="status"
               aria-live="polite"
-              className="text-xs text-[hsl(var(--accent))]"
+              className="glitch-text text-xs text-accent"
             >
               {err}
             </p>

--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -25,22 +25,22 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
   }
 
   return (
-    <div>
-      <h2 className="mb-4 text-lg font-semibold">Goal Queue</h2>
+    <div className="font-mono">
+      <h2 className="mb-4 text-lg font-semibold uppercase tracking-tight">Goal Queue</h2>
       {items.length === 0 ? (
-        <div className="rounded-2xl border-2 border-dashed border-[hsl(var(--border)/0.3)] bg-[hsl(var(--card)/0.6)] p-8 text-center text-sm text-[hsl(var(--foreground)/0.65)]">
+        <div className="scanlines rounded-2xl border-2 border-dashed border-border/30 bg-card/60 p-8 text-center text-sm text-foreground/65">
           No queued goals
         </div>
       ) : (
-        <ul>
+        <ul className="divide-y divide-border/15">
           {items.map((it) => (
             <li
               key={it.id}
-              className="flex items-center justify-between py-3 border-t border-[hsl(var(--border)/0.15)]"
+              className="flex h-12 items-center justify-between"
             >
               <div className="flex min-w-0 items-center gap-2">
-                <span className="h-2 w-2 rounded-full bg-[hsl(var(--foreground)/0.65)]" aria-hidden />
-                <p className="truncate text-sm text-[hsl(var(--foreground)/0.85)]">{it.text}</p>
+                <span className="h-2 w-2 rounded-full bg-foreground/65" aria-hidden />
+                <p className="truncate text-sm text-foreground/85">{it.text}</p>
               </div>
               <div className="flex items-center gap-1">
                 <IconButton
@@ -48,7 +48,7 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
                   aria-label="Drag"
                   circleSize="sm"
                   iconSize="sm"
-                  className="focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent)/0.6)]"
+                  className="focus-visible:ring-2 focus-visible:ring-accent"
                 >
                   <GripVertical />
                 </IconButton>
@@ -58,7 +58,7 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
                   onClick={() => onRemove(it.id)}
                   circleSize="sm"
                   iconSize="sm"
-                  className="focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent)/0.6)]"
+                  className="focus-visible:ring-2 focus-visible:ring-accent"
                 >
                   <Trash2 />
                 </IconButton>
@@ -71,7 +71,7 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
       <form onSubmit={submit} className="mt-4">
         <Input
           tone="default"
-          className="h-12 rounded-2xl border border-[hsl(var(--border)/0.3)] bg-[hsl(var(--card)/0.6)] focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent)/0.6)]"
+          className="h-12 rounded-2xl border border-border/30 bg-card/60 focus-visible:ring-2 focus-visible:ring-accent"
           value={val}
           onChange={(e) => setVal(e.currentTarget.value)}
           placeholder="Add to queue…"

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -29,7 +29,7 @@ import GoalQueue, { WaitItem } from "./GoalQueue";
 
 import { useLocalDB, uid } from "@/lib/db";
 import type { Goal } from "@/lib/types";
-import { LOCALE } from "@/lib/utils";
+import { LOCALE, cn } from "@/lib/utils";
 
 /* Tabs */
 import RemindersTab from "./RemindersTab";
@@ -218,52 +218,44 @@ export default function GoalsPage() {
                   <section>
                     <div className="mb-4 flex items-center justify-between">
                       <div className="flex items-center gap-2 sm:gap-3">
-                        <h2 className="text-lg font-semibold">Your Goals</h2>
+                        <h2 className="text-lg font-semibold uppercase tracking-tight">Your Goals</h2>
                         <GoalsProgress total={totalCount} pct={pctDone} />
                       </div>
                       <GoalsTabs value={filter} onChange={setFilter} />
                     </div>
                     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                       {filtered.length === 0 ? (
-                        <p className="text-sm text-[hsl(var(--foreground)/0.65)]">
+                        <p className="text-sm text-foreground/65">
                           No goals here. Add one simple, finishable thing.
                         </p>
                       ) : (
                         filtered.map((g) => (
                           <article
                             key={g.id}
-                            className="group rounded-2xl p-4 ring-1 ring-[hsl(var(--border)/0.3)] bg-[hsl(var(--card)/0.6)] transition hover:-translate-y-[1px] hover:shadow-md focus-within:ring-2 focus-within:ring-[hsl(var(--accent)/0.6)]"
+                            className="group scanlines rounded-2xl bg-card/60 p-4 ring-1 ring-accent/20 shadow-neoSoft transition hover:-translate-y-px hover:ring-2 hover:ring-accent focus-within:ring-2 focus-within:ring-accent"
                           >
                             <header className="flex items-center justify-between gap-2">
-                              <div className="min-w-0">
-                                <h3 className="font-semibold leading-tight line-clamp-2">{g.title}</h3>
-                                <time
-                                  className="mt-1 block text-xs text-[hsl(var(--foreground)/0.65)]"
-                                  dateTime={new Date(g.createdAt).toISOString()}
-                                >
-                                  {new Date(g.createdAt).toLocaleDateString(LOCALE)}
-                                </time>
-                              </div>
+                              <h3 className="min-w-0 font-semibold leading-tight line-clamp-2">{g.title}</h3>
                               <div className="flex items-center gap-1">
                                 <CheckCircle
                                   aria-label={g.done ? "Mark active" : "Mark done"}
                                   checked={g.done}
                                   onChange={() => toggleDone(g.id)}
                                   size="lg"
-                                  className="focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent)/0.6)]"
+                                  className="focus-visible:ring-2 focus-visible:ring-accent"
                                 />
                                 <IconButton
                                   title="Delete"
                                   aria-label="Delete goal"
                                   onClick={() => removeGoal(g.id)}
                                   circleSize="sm"
-                                  className="focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent)/0.6)]"
+                                  className="focus-visible:ring-2 focus-visible:ring-accent"
                                 >
                                   <Trash2 />
                                 </IconButton>
                               </div>
                             </header>
-                            <div className="mt-4 space-y-2 text-sm text-[hsl(var(--foreground)/0.65)]">
+                            <div className="mt-4 space-y-2 text-sm text-foreground/65">
                               {g.metric ? (
                                 <div className="tabular-nums">
                                   <span className="opacity-70">Metric:</span> {g.metric}
@@ -271,17 +263,27 @@ export default function GoalsPage() {
                               ) : null}
                               {g.notes ? <p className="leading-relaxed line-clamp-2">{g.notes}</p> : null}
                             </div>
-                            <footer className="mt-4 flex justify-end text-xs">
-                              <span className={g.done ? "text-[hsl(var(--accent))]" : "text-[hsl(var(--foreground)/0.65)]"}>
+                            <footer className="mt-4 flex items-baseline justify-between text-xs text-foreground/65">
+                              <span
+                                className={cn(
+                                  "rounded-full border px-2 py-0.5",
+                                  g.done
+                                    ? "border-accent/40 text-accent"
+                                    : "border-border/40"
+                                )}
+                              >
                                 {g.done ? "Done" : "Active"}
                               </span>
+                              <time dateTime={new Date(g.createdAt).toISOString()}>
+                                {new Date(g.createdAt).toLocaleDateString(LOCALE)}
+                              </time>
                             </footer>
                           </article>
                         ))
                       )}
                     </div>
                   </section>
-                  <section className="md:sticky md:top-16" ref={formRef}>
+                  <section className="md:sticky md:top-4" ref={formRef}>
                     <GoalForm
                       title={title}
                       metric={metric}
@@ -302,7 +304,7 @@ export default function GoalsPage() {
               </div>
 
               {lastDeleted && (
-                <div className="mx-auto w-fit rounded-full px-4 py-2 text-sm bg-[hsl(var(--card))] border border-[hsl(var(--card-hairline))] shadow-sm">
+                <div className="mx-auto w-fit rounded-full border border-border bg-card px-4 py-2 text-sm shadow-sm">
                   Deleted “{lastDeleted.title}”.{" "}
                   <button
                     type="button"

--- a/src/components/goals/GoalsProgress.tsx
+++ b/src/components/goals/GoalsProgress.tsx
@@ -12,8 +12,8 @@ interface GoalsProgressProps {
 export default function GoalsProgress({ total, pct, onAddFirst }: GoalsProgressProps) {
   if (total === 0) {
     return (
-      <div className="border border-dashed border-white/20 rounded-2xl p-6 text-center">
-        <p className="text-sm text-white/60 mb-4">No goals yet.</p>
+      <div className="border border-dashed border-foreground/20 rounded-2xl p-6 text-center">
+        <p className="mb-4 text-sm text-foreground/60">No goals yet.</p>
         {onAddFirst && (
           <Button onClick={onAddFirst} className="mx-auto" size="sm">
             Add a first goal
@@ -25,14 +25,14 @@ export default function GoalsProgress({ total, pct, onAddFirst }: GoalsProgressP
 
   const v = Math.max(0, Math.min(100, Math.round(pct)));
   return (
-    <div className="flex items-center gap-2 min-w-[120px]" aria-label="Progress">
-      <div className="w-28 h-1.5 rounded-full bg-white/10 overflow-hidden">
+    <div className="flex min-w-[120px] items-center gap-2" aria-label="Progress">
+      <div className="h-1.5 w-28 overflow-hidden rounded-full bg-foreground/10">
         <div
-          className="h-1.5 rounded-full bg-[hsl(var(--primary))] transition-[width]"
+          className="h-1.5 rounded-full bg-accent transition-[width]"
           style={{ width: `${v}%` }}
         />
       </div>
-      <span className="text-xs text-white/60 tabular-nums">{v}%</span>
+      <span className="tabular-nums text-xs text-foreground/60">{v}%</span>
     </div>
   );
 }

--- a/src/components/goals/GoalsTabs.tsx
+++ b/src/components/goals/GoalsTabs.tsx
@@ -28,13 +28,14 @@ export default function GoalsTabs({ value, onChange }: GoalsTabsProps) {
             aria-selected={active}
             onClick={() => onChange(f)}
             className={cn(
-              "h-8 px-3 rounded-full text-sm flex items-center", // equal height
-              "focus:ring-2 focus:ring-purple-400/60", // focus ring
+              "relative inline-flex items-center gap-1 px-2 py-1 text-xs font-mono uppercase tracking-tight transition",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
               active
-                ? "bg-white/10 ring-1 ring-white/20"
-                : "hover:bg-white/5"
+                ? "after:absolute after:inset-x-0 after:-bottom-[2px] after:h-[2px] after:bg-accent"
+                : "hover:translate-x-1"
             )}
           >
+            <span aria-hidden>&gt;</span>
             {f}
           </button>
         );

--- a/src/components/goals/style.css
+++ b/src/components/goals/style.css
@@ -93,3 +93,35 @@
 }
 
 @keyframes wl-blink { 50% { opacity: 0; } }
+
+/* Scanline overlay for cards */
+.scanlines {
+  position: relative;
+}
+.scanlines::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  background:
+    repeating-linear-gradient(
+      to bottom,
+      hsl(var(--foreground) / 0.06) 0 1px,
+      transparent 1px 3px
+    );
+  mix-blend-mode: overlay;
+}
+
+/* Subtle glitch text utility */
+.glitch-text {
+  animation: glitch-text 2.8s steps(2, end) infinite;
+}
+@keyframes glitch-text {
+  0%, 100% {
+    text-shadow: 0.5px 0 hsl(var(--accent)), -0.5px 0 hsl(var(--accent-2));
+  }
+  50% {
+    text-shadow: -0.5px 0 hsl(var(--accent)), 0.5px 0 hsl(var(--accent-2));
+  }
+}


### PR DESCRIPTION
## Summary
- restyle Goals UI with monospaced layout, accent tokens, and scanlines
- add reusable scanline and glitch-text utilities
- refine filter tabs, queue rows, and progress bar to use theme tokens

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba4bd88e1c832cab0facf39d404d65