### PR TITLE
Restyle goals page cards

### DIFF
--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -28,21 +28,21 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
     <div className="font-mono">
       <h2 className="mb-4 text-lg font-semibold uppercase tracking-tight">Goal Queue</h2>
       {items.length === 0 ? (
-        <div className="scanlines rounded-2xl border-2 border-dashed border-border/30 bg-card/60 p-8 text-center text-sm text-foreground/65">
+        <div className="scanlines rounded-2xl border border-border/30 bg-card/60 p-8 text-center text-sm text-foreground/65">
           No queued goals
         </div>
       ) : (
-        <ul className="divide-y divide-border/15">
+        <ul className="divide-y divide-border/15 border-t border-border/15">
           {items.map((it) => (
             <li
               key={it.id}
-              className="flex h-12 items-center justify-between"
+              className="group flex h-12 items-center justify-between"
             >
               <div className="flex min-w-0 items-center gap-2">
                 <span className="h-2 w-2 rounded-full bg-foreground/65" aria-hidden />
                 <p className="truncate text-sm text-foreground/85">{it.text}</p>
               </div>
-              <div className="flex items-center gap-1">
+              <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
                 <IconButton
                   title="Drag"
                   aria-label="Drag"

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -204,7 +204,7 @@ export default function GoalsPage() {
         >
           {tab === "goals" && (
             <>
-              <div className="mx-auto mt-6 mb-6 max-w-screen-2xl">
+              <div className="mx-auto my-6 max-w-screen-2xl px-4">
                 {totalCount === 0 ? (
                   <GoalsProgress
                     total={totalCount}
@@ -216,7 +216,7 @@ export default function GoalsPage() {
                 ) : null}
                 <div className="grid gap-y-6 md:grid-cols-2 md:gap-x-6">
                   <section>
-                    <div className="mb-4 flex items-center justify-between">
+                    <div className="mb-6 flex items-center justify-between">
                       <div className="flex items-center gap-2 sm:gap-3">
                         <h2 className="text-lg font-semibold uppercase tracking-tight">Your Goals</h2>
                         <GoalsProgress total={totalCount} pct={pctDone} />
@@ -225,14 +225,14 @@ export default function GoalsPage() {
                     </div>
                     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                       {filtered.length === 0 ? (
-                        <p className="text-sm text-foreground/65">
+                        <div className="scanlines rounded-2xl border-2 border-dashed border-border/30 p-6 text-center text-sm text-foreground/65">
                           No goals here. Add one simple, finishable thing.
-                        </p>
+                        </div>
                       ) : (
                         filtered.map((g) => (
                           <article
                             key={g.id}
-                            className="group scanlines rounded-2xl bg-card/60 p-4 ring-1 ring-accent/20 shadow-neoSoft transition hover:-translate-y-px hover:ring-2 hover:ring-accent focus-within:ring-2 focus-within:ring-accent"
+                            className="group scanlines rounded-2xl border border-border bg-card/60 p-4 ring-1 ring-border/40 shadow-neoSoft transition hover:-translate-y-px hover:ring-2 hover:ring-accent focus-within:ring-2 focus-within:ring-accent"
                           >
                             <header className="flex items-center justify-between gap-2">
                               <h3 className="min-w-0 font-semibold leading-tight line-clamp-2">{g.title}</h3>
@@ -263,20 +263,23 @@ export default function GoalsPage() {
                               ) : null}
                               {g.notes ? <p className="leading-relaxed line-clamp-2">{g.notes}</p> : null}
                             </div>
-                            <footer className="mt-4 flex items-baseline justify-between text-xs text-foreground/65">
+                            <footer className="mt-4 flex items-center justify-between text-xs text-foreground/65">
+                              <div className="flex items-center gap-1">
+                                <time dateTime={new Date(g.createdAt).toISOString()}>
+                                  {new Date(g.createdAt).toLocaleDateString(LOCALE)}
+                                </time>
+                                <span className="h-1 w-1 rounded-full bg-foreground/65" aria-hidden />
+                              </div>
                               <span
                                 className={cn(
                                   "rounded-full border px-2 py-0.5",
                                   g.done
                                     ? "border-accent/40 text-accent"
-                                    : "border-border/40"
+                                    : "border-border/40",
                                 )}
                               >
                                 {g.done ? "Done" : "Active"}
                               </span>
-                              <time dateTime={new Date(g.createdAt).toISOString()}>
-                                {new Date(g.createdAt).toLocaleDateString(LOCALE)}
-                              </time>
                             </footer>
                           </article>
                         ))


### PR DESCRIPTION
## Summary
- center goals content in a padded container
- add dashed empty state and bordered cards with date metadata
- simplify queue rows and hide actions until hover

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba57dfb5e8832ca47e24d8a1a521b8