### PR TITLE
fix: remove invalid size prop

### DIFF
--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -244,7 +244,6 @@ export default function RemindersTab() {
             value={query}
             onValueChange={setQuery}
             placeholder="Search title, text, tags…"
-            size="md"
             debounceMs={80}
             right={
               <div className="flex items-center gap-2">

--- a/src/components/team/CheatSheetTabs.tsx
+++ b/src/components/team/CheatSheetTabs.tsx
@@ -43,7 +43,6 @@ export default function CheatSheetTabs() {
           value: query,
           onValueChange: setQuery,
           placeholder: "Search…",
-          size: "md",
           round: true,
         }}
       />


### PR DESCRIPTION
## Summary
- fix RemindersTab search bar wrong `size` prop type
- fix CheatSheetTabs search bar `size` prop type

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ba6803c440832cac128d9a82c48b5c