### PR TITLE
feat: add shared button sizing system

### DIFF
--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -551,9 +551,9 @@ function RemTile({
             </div>
 
             <div className="flex gap-2">
-              <Button className="h-8" onClick={save}>Save</Button>
+              <Button size="sm" onClick={save}>Save</Button>
               <Button
-                className="h-8"
+                size="sm"
                 variant="ghost"
                 onClick={() => {
                   setEditing(false);

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -2,26 +2,22 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
+import { buttonSizes, type ButtonSize } from "./button";
 
-type Circle = "sm" | "md" | "lg";
 type Icon = "xs" | "sm" | "md" | "lg";
 
 type Tone = "primary" | "accent" | "info" | "danger";
 type Variant = "ring" | "glow" | "solid";
 
 export type IconButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  circleSize?: Circle;
+  size?: ButtonSize;
   iconSize?: Icon;
   tone?: Tone;
   active?: boolean;
   fx?: boolean;
   variant?: Variant;
-};
-
-const circleMap: Record<Circle, string> = {
-  sm: "h-9 w-9",
-  md: "h-10 w-10",
-  lg: "h-11 w-11",
+  /** @deprecated use size */
+  circleSize?: ButtonSize;
 };
 
 const iconMap: Record<Icon, string> = {
@@ -33,16 +29,14 @@ const iconMap: Record<Icon, string> = {
 
 const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
   (
-    {
-      circleSize = "md",
-      iconSize = "md",
-      className,
-      ...rest
-    },
+    { size = "md", circleSize, iconSize = size, className, ...rest },
     ref
   ) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { tone: _tone, active: _active, fx: _fx, variant: _variant, ...props } = rest;
+    const finalSize = circleSize ?? size;
+    const h = buttonSizes[finalSize].height;
+    const sizeClass = `${h} ${h.replace("h-", "w-")}`;
     return (
       <button
         ref={ref}
@@ -56,7 +50,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
           "active:shadow-[0_0_8px_var(--neon),0_0_16px_var(--neon-soft)] active:scale-95",
           "[&>svg]:transition",
           "disabled:opacity-50 disabled:pointer-events-none",
-          circleMap[circleSize],
+          sizeClass,
           iconMap[iconSize],
           className
         )}

--- a/src/components/ui/primitives/button.tsx
+++ b/src/components/ui/primitives/button.tsx
@@ -3,27 +3,38 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
+export const buttonSizes = {
+  sm: {
+    height: "h-8",
+    padding: "px-3",
+    text: "text-xs",
+    gap: "gap-1.5",
+  },
+  md: {
+    height: "h-10",
+    padding: "px-4",
+    text: "text-sm",
+    gap: "gap-2",
+  },
+  lg: {
+    height: "h-12",
+    padding: "px-6",
+    text: "text-base",
+    gap: "gap-2.5",
+  },
+} as const;
+
+export type ButtonSize = keyof typeof buttonSizes;
+
 export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: "primary" | "secondary" | "ghost" | "destructive";
-  size?: "sm" | "md" | "lg";
+  size?: ButtonSize;
   vibe?: "glitch" | "lift" | "none";
   loading?: boolean;
   block?: boolean;
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;
   pill?: boolean;
-};
-
-const sizeMap: Record<NonNullable<ButtonProps["size"]>, string> = {
-  sm: "h-9 px-3 text-sm",
-  md: "h-10 px-4 text-sm",
-  lg: "h-11 px-5 text-base",
-};
-
-const gapMap: Record<NonNullable<ButtonProps["size"]>, string> = {
-  sm: "gap-1.5",
-  md: "gap-2",
-  lg: "gap-2.5",
 };
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
@@ -47,6 +58,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const { variant: _variant, vibe: _vibe, ...props } = rest;
     const isDisabled = disabled || loading;
     const rounded = pill ? "rounded-full" : "rounded-md";
+    const s = buttonSizes[size];
 
     return (
       <button
@@ -62,8 +74,10 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           "focus-visible:shadow-[0_0_8px_var(--neon),0_0_16px_var(--neon-soft)]",
           "active:shadow-[0_0_8px_var(--neon),0_0_16px_var(--neon-soft)] active:scale-95",
           "disabled:opacity-50 disabled:pointer-events-none",
-          sizeMap[size],
-          gapMap[size],
+          s.height,
+          s.padding,
+          s.text,
+          s.gap,
           rounded,
           block && "w-full",
           className


### PR DESCRIPTION
## Summary
- centralize button heights, padding, and font size in a shared `buttonSizes` map
- allow `Button` and `IconButton` to accept a `size` prop that applies these size classes
- replace hardcoded sizing in Reminders tab with the new size prop

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6ddcc668832c8c65558f204926a3