### PR TITLE
feat: set input corner radius to 16px

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -6,6 +6,7 @@ This project ships with a small design system based on Tailwind CSS and CSS vari
 - Color, radius, shadows and transitions are defined as CSS variables in `tailwind.config.ts` and `src/app/themes.css`.
 - Use semantic classes like `bg-background`, `text-foreground` and `ring` instead of hard-coded values.
 - If you need to introduce a new static color, map it to a token in [`COLOR_MAPPINGS.md`](../COLOR_MAPPINGS.md).
+- Input elements use `--control-radius` (16px) for consistent corner rounding.
 
 ## Global styles
 - `src/app/globals.css` resets layout, sets typography and applies focus and selection styles.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -535,7 +535,7 @@ html.bg-intense body::after {
 
   /* Inputs */
   .input-base {
-    @apply rounded-2xl border text-sm;
+    @apply rounded-xl border text-sm;
     height: var(--control-h);
     padding: 0 var(--control-px);
     font-size: var(--control-fs);

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -46,7 +46,7 @@
   --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
   --ease-snap: cubic-bezier(0.2, 0.8, 0.2, 1);
   --dur-quick: 140ms; --dur-chill: 220ms; --dur-slow: 420ms;
-  --control-h: 42px; --control-radius: var(--radius-2);
+  --control-h: 42px; --control-radius: var(--radius-3);
   --control-fs: 0.9rem; --control-px: 1rem;
 
   --edge-iris: conic-gradient(

--- a/src/components/ui/primitives/input.tsx
+++ b/src/components/ui/primitives/input.tsx
@@ -20,7 +20,7 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
 };
 
 const BASE =
-  "block w-full max-w-[343px] h-[52px] px-4 py-3 text-base rounded-2xl " +
+  "block w-full max-w-[343px] h-[52px] px-4 py-3 text-base rounded-xl " +
   "border border-[hsl(var(--border))] bg-[hsl(var(--card))] " +
   "text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] " +
   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] " +
@@ -29,7 +29,7 @@ const BASE =
 
 /**
  * Input — Lavender-Glitch styled input
- * - Defaults to pill-shaped (`tone="pill"`)
+ * - Defaults to `tone="default"` (16px corners)
  * - Accepts className overrides and passes all standard <input> props
  * - Auto-generates stable `id` and `name` if not provided
  */


### PR DESCRIPTION
## Summary
- increase `--control-radius` token to use 16px
- update Input primitive and global styles to apply new radius
- document input radius in design system

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ba71865bd8832ca15f0575114e4955