### PR TITLE
Refactor Goals page layout with design tokens

### DIFF
--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -37,58 +37,66 @@ export default function GoalForm({
         onSubmit();
       }}
     >
-      <div className="scanlines rounded-2xl bg-card/60 p-5 ring-1 ring-border/30 font-mono">
+      <div className="scanlines rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] p-4 shadow-neoSoft">
         <h2 className="mb-4 text-lg font-semibold uppercase tracking-tight">Add Goal</h2>
-        <div className="grid gap-2.5">
-          <label className="grid gap-3">
-            <span className="text-xs text-foreground/80">Title</span>
+        <div className="grid gap-4">
+          <label htmlFor="goal-title" className="grid gap-2">
+            <span className="text-xs text-[hsl(var(--fg-muted))]">Title</span>
             <Input
-              className="rounded-2xl border-border/30 bg-card/60 focus-visible:ring-2 focus-visible:ring-accent"
+              id="goal-title"
+              className="h-12 rounded-xl border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))]"
               value={title}
               onChange={(e) => onTitleChange(e.target.value)}
               aria-required="true"
+              aria-describedby="goal-form-help goal-form-error"
             />
           </label>
 
-          <label className="grid gap-3">
-            <span className="text-xs text-foreground/80">Metric (optional)</span>
+          <label htmlFor="goal-metric" className="grid gap-2">
+            <span className="text-xs text-[hsl(var(--fg-muted))]">Metric (optional)</span>
             <Input
-              className="rounded-2xl border-border/30 bg-card/60 tabular-nums focus-visible:ring-2 focus-visible:ring-accent"
+              id="goal-metric"
+              className="h-10 rounded-xl border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] tabular-nums focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))]"
               value={metric}
               onChange={(e) => onMetricChange(e.target.value)}
+              aria-describedby="goal-form-help goal-form-error"
             />
           </label>
 
-          <label className="grid gap-3">
-            <span className="text-xs text-foreground/80">Notes (optional)</span>
+          <label htmlFor="goal-notes" className="grid gap-2">
+            <span className="text-xs text-[hsl(var(--fg-muted))]">Notes (optional)</span>
             <Textarea
-              className="h-24 rounded-2xl border-border/30 bg-card/60 focus-visible:ring-2 focus-visible:ring-accent"
+              id="goal-notes"
+              className="min-h-24 rounded-xl border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))]"
               value={notes}
               onChange={(e) => onNotesChange(e.target.value)}
+              aria-describedby="goal-form-help goal-form-error"
             />
           </label>
-        
+
           <div className="flex justify-end">
             <Button
               type="submit"
               size="lg"
-              className="h-12"
+              pill={false}
+              className="h-12 rounded-xl"
               disabled={!title.trim()}
               aria-label="Add Goal"
             >
               Add Goal
             </Button>
           </div>
-          <p className="glitch-text text-xs text-foreground/65">
+          <p id="goal-form-help" className="glitch-text text-xs text-[hsl(var(--fg-muted))]">
             {activeCount >= activeCap
               ? "Cap reached. Finish one to add more."
               : `${activeCap - activeCount} active slot${activeCap - activeCount === 1 ? "" : "s"} left`}
           </p>
           {err ? (
             <p
+              id="goal-form-error"
               role="status"
               aria-live="polite"
-              className="glitch-text text-xs text-accent"
+              className="glitch-text text-xs text-[hsl(var(--accent))]"
             >
               {err}
             </p>

--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -28,19 +28,19 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
     <div className="font-mono">
       <h2 className="mb-4 text-lg font-semibold uppercase tracking-tight">Goal Queue</h2>
       {items.length === 0 ? (
-        <div className="scanlines rounded-2xl border border-border/30 bg-card/60 p-8 text-center text-sm text-foreground/65">
+        <div className="scanlines rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] p-8 text-center text-sm text-[hsl(var(--fg-muted))]">
           No queued goals
         </div>
       ) : (
-        <ul className="divide-y divide-border/15 border-t border-border/15">
+        <ul className="divide-y divide-[hsl(var(--border)/0.15)] border-t border-[hsl(var(--border)/0.15)]">
           {items.map((it) => (
             <li
               key={it.id}
-              className="group flex h-12 items-center justify-between"
+              className="group flex h-12 items-center justify-between px-4"
             >
               <div className="flex min-w-0 items-center gap-2">
-                <span className="h-2 w-2 rounded-full bg-foreground/65" aria-hidden />
-                <p className="truncate text-sm text-foreground/85">{it.text}</p>
+                <span className="h-2 w-2 rounded-full bg-[hsl(var(--fg)/0.65)]" aria-hidden />
+                <p className="truncate text-sm text-[hsl(var(--fg)/0.85)]">{it.text}</p>
               </div>
               <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
                 <IconButton
@@ -48,7 +48,7 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
                   aria-label="Drag"
                   circleSize="sm"
                   iconSize="sm"
-                  className="focus-visible:ring-2 focus-visible:ring-accent"
+                  className="rounded-xl focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))]"
                 >
                   <GripVertical />
                 </IconButton>
@@ -58,7 +58,7 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
                   onClick={() => onRemove(it.id)}
                   circleSize="sm"
                   iconSize="sm"
-                  className="focus-visible:ring-2 focus-visible:ring-accent"
+                  className="rounded-xl focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))]"
                 >
                   <Trash2 />
                 </IconButton>
@@ -68,9 +68,9 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
         </ul>
       )}
 
-      <form onSubmit={submit} className="mt-4">
+      <form onSubmit={submit} className="mt-6">
         <Input
-          className="rounded-2xl border-border/30 bg-card/60 focus-visible:ring-2 focus-visible:ring-accent"
+          className="h-12 rounded-xl border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))] placeholder:text-[hsl(var(--fg-muted))]"
           value={val}
           onChange={(e) => setVal(e.currentTarget.value)}
           placeholder="Add to queue…"

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -166,7 +166,7 @@ export default function GoalsPage() {
       : "Pick a duration and focus.";
 
   return (
-    <main className="page-shell grid gap-4 py-6">
+    <main id="goals-main" role="main" className="page-shell grid gap-6 py-6">
       {/* ======= HERO ======= */}
       <Hero
         eyebrow="Goals"
@@ -195,7 +195,7 @@ export default function GoalsPage() {
         }
       />
 
-      <section className="grid gap-4">
+      <section className="grid gap-6">
         <div
           role="tabpanel"
           id="goals-panel"
@@ -214,8 +214,8 @@ export default function GoalsPage() {
                     }
                   />
                 ) : null}
-                <div className="grid gap-y-6 md:grid-cols-2 md:gap-x-6">
-                  <section>
+                <div className="grid gap-6 md:grid-cols-2">
+                  <section className="order-2 md:order-1">
                     <div className="mb-6 flex items-center justify-between">
                       <div className="flex items-center gap-2 sm:gap-3">
                         <h2 className="text-lg font-semibold uppercase tracking-tight">Your Goals</h2>
@@ -225,14 +225,14 @@ export default function GoalsPage() {
                     </div>
                     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                       {filtered.length === 0 ? (
-                        <div className="scanlines rounded-2xl border-2 border-dashed border-border/30 p-6 text-center text-sm text-foreground/65">
+                        <div className="scanlines rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] p-6 text-center text-sm text-[hsl(var(--fg-muted))]">
                           No goals here. Add one simple, finishable thing.
                         </div>
                       ) : (
                         filtered.map((g) => (
                           <article
                             key={g.id}
-                            className="group scanlines rounded-2xl border border-border bg-card/60 p-4 ring-1 ring-border/40 shadow-neoSoft transition hover:-translate-y-px hover:ring-2 hover:ring-accent focus-within:ring-2 focus-within:ring-accent"
+                            className="group scanlines rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] p-4 shadow-neoSoft transition hover:-translate-y-px hover:ring-1 hover:ring-[hsl(var(--ring))] focus-within:ring-2 focus-within:ring-[hsl(var(--accent))]"
                           >
                             <header className="flex items-center justify-between gap-2">
                               <h3 className="min-w-0 font-semibold leading-tight line-clamp-2">{g.title}</h3>
@@ -242,40 +242,40 @@ export default function GoalsPage() {
                                   checked={g.done}
                                   onChange={() => toggleDone(g.id)}
                                   size="lg"
-                                  className="focus-visible:ring-2 focus-visible:ring-accent"
+                                  className="focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))]"
                                 />
                                 <IconButton
                                   title="Delete"
                                   aria-label="Delete goal"
                                   onClick={() => removeGoal(g.id)}
                                   circleSize="sm"
-                                  className="focus-visible:ring-2 focus-visible:ring-accent"
+                                  className="rounded-xl focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))]"
                                 >
                                   <Trash2 />
                                 </IconButton>
                               </div>
                             </header>
-                            <div className="mt-4 space-y-2 text-sm text-foreground/65">
+                            <div className="mt-4 space-y-2 text-sm text-[hsl(var(--fg-muted))]">
                               {g.metric ? (
                                 <div className="tabular-nums">
-                                  <span className="opacity-70">Metric:</span> {g.metric}
+                                  <span className="text-[hsl(var(--fg)/0.7)]">Metric:</span> {g.metric}
                                 </div>
                               ) : null}
                               {g.notes ? <p className="leading-relaxed line-clamp-2">{g.notes}</p> : null}
                             </div>
-                            <footer className="mt-4 flex items-center justify-between text-xs text-foreground/65">
+                            <footer className="mt-4 flex items-center justify-between text-xs text-[hsl(var(--fg-muted))]">
                               <div className="flex items-center gap-1">
                                 <time dateTime={new Date(g.createdAt).toISOString()}>
                                   {new Date(g.createdAt).toLocaleDateString(LOCALE)}
                                 </time>
-                                <span className="h-1 w-1 rounded-full bg-foreground/65" aria-hidden />
+                                <span className="h-1 w-1 rounded-full bg-[hsl(var(--fg)/0.65)]" aria-hidden />
                               </div>
                               <span
                                 className={cn(
-                                  "rounded-full border px-2 py-0.5",
+                                  "rounded-xl border px-2 py-0.5",
                                   g.done
-                                    ? "border-accent/40 text-accent"
-                                    : "border-border/40",
+                                    ? "border-[hsl(var(--accent)/0.4)] text-[hsl(var(--accent))]"
+                                    : "border-[hsl(var(--border)/0.4)] text-[hsl(var(--fg))]",
                                 )}
                               >
                                 {g.done ? "Done" : "Active"}
@@ -286,7 +286,7 @@ export default function GoalsPage() {
                       )}
                     </div>
                   </section>
-                  <section className="md:sticky md:top-4" ref={formRef}>
+                  <section className="order-1 md:order-2 md:sticky md:top-4" ref={formRef}>
                     <GoalForm
                       title={title}
                       metric={metric}
@@ -300,14 +300,14 @@ export default function GoalsPage() {
                       err={err}
                     />
                   </section>
-                  <section className="md:col-span-2">
+                  <section className="order-3 md:col-span-2">
                     <GoalQueue items={waitlist} onAdd={addWait} onRemove={removeWait} />
                   </section>
                 </div>
               </div>
 
               {lastDeleted && (
-                <div className="mx-auto w-fit rounded-full border border-border bg-card px-4 py-2 text-sm shadow-sm">
+                <div className="mx-auto w-fit rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] px-4 py-2 text-sm shadow-sm">
                   Deleted “{lastDeleted.title}”.{" "}
                   <button
                     type="button"

--- a/src/components/goals/GoalsProgress.tsx
+++ b/src/components/goals/GoalsProgress.tsx
@@ -12,10 +12,10 @@ interface GoalsProgressProps {
 export default function GoalsProgress({ total, pct, onAddFirst }: GoalsProgressProps) {
   if (total === 0) {
     return (
-      <div className="border border-dashed border-foreground/20 rounded-2xl p-6 text-center">
-        <p className="mb-4 text-sm text-foreground/60">No goals yet.</p>
+      <div className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] p-6 text-center">
+        <p className="mb-4 text-sm text-[hsl(var(--fg-muted))]">No goals yet.</p>
         {onAddFirst && (
-          <Button onClick={onAddFirst} className="mx-auto" size="sm">
+          <Button onClick={onAddFirst} size="sm" pill={false} className="mx-auto rounded-xl">
             Add a first goal
           </Button>
         )}
@@ -26,13 +26,13 @@ export default function GoalsProgress({ total, pct, onAddFirst }: GoalsProgressP
   const v = Math.max(0, Math.min(100, Math.round(pct)));
   return (
     <div className="flex min-w-[120px] items-center gap-2" aria-label="Progress">
-      <div className="h-1.5 w-28 overflow-hidden rounded-full bg-foreground/10">
+      <div className="h-1.5 w-28 overflow-hidden rounded-full bg-[hsl(var(--fg)/0.1)]">
         <div
-          className="h-1.5 rounded-full bg-accent transition-[width]"
+          className="h-1.5 rounded-full bg-[hsl(var(--accent))] transition-[width]"
           style={{ width: `${v}%` }}
         />
       </div>
-      <span className="tabular-nums text-xs text-foreground/60">{v}%</span>
+      <span className="tabular-nums text-xs text-[hsl(var(--fg)/0.6)]">{v}%</span>
     </div>
   );
 }

--- a/src/components/goals/GoalsTabs.tsx
+++ b/src/components/goals/GoalsTabs.tsx
@@ -13,11 +13,7 @@ interface GoalsTabsProps {
 
 export default function GoalsTabs({ value, onChange }: GoalsTabsProps) {
   return (
-    <div
-      role="tablist"
-      aria-label="Filter goals"
-      className="flex gap-2"
-    >
+    <div role="tablist" aria-label="Filter goals" className="flex gap-2">
       {FILTERS.map((f) => {
         const active = value === f;
         return (
@@ -28,11 +24,12 @@ export default function GoalsTabs({ value, onChange }: GoalsTabsProps) {
             aria-selected={active}
             onClick={() => onChange(f)}
             className={cn(
-              "relative inline-flex items-center gap-1 px-2 py-1 text-xs font-mono uppercase tracking-tight transition",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+              "relative inline-flex items-center gap-1 px-3 py-1 text-xs font-mono uppercase tracking-tight transition",
+              "rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))]",
+              "hover:-translate-y-px hover:ring-1 hover:ring-[hsl(var(--ring))]",
               active
-                ? "after:absolute after:inset-x-0 after:-bottom-[2px] after:h-[2px] after:bg-accent"
-                : "hover:translate-x-1"
+                ? "after:absolute after:inset-x-0 after:-bottom-[2px] after:h-[2px] after:bg-[hsl(var(--accent))]"
+                : undefined,
             )}
           >
             <span aria-hidden>&gt;</span>


### PR DESCRIPTION
## Summary
- restructure goals page with main landmark and two-column layout
- restyle goal filters, cards, and forms using design system tokens
- tidy goal queue and progress components with consistent 16px corners

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba72fb463c832c80c670917ce19e13