### PR TITLE
Style goals page cards with retro vibe

### DIFF
--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -37,7 +37,7 @@ export default function GoalForm({
         onSubmit();
       }}
     >
-      <div className="scanlines rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] p-4 shadow-neoSoft">
+      <div className="goal-card p-4 shadow-neoSoft">
         <h2 className="mb-4 text-lg font-semibold uppercase tracking-tight">Add Goal</h2>
         <div className="grid gap-4">
           <label htmlFor="goal-title" className="grid gap-2">

--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -25,7 +25,7 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
   }
 
   return (
-    <div className="scanlines rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] p-4 shadow-neoSoft font-mono">
+    <div className="goal-card p-4 shadow-neoSoft font-mono">
       <header className="mb-4 flex items-center justify-between text-xs text-[hsl(var(--fg-muted))]">
         <span>project file detected</span>
         <button

--- a/src/components/goals/GoalSlot.tsx
+++ b/src/components/goals/GoalSlot.tsx
@@ -14,7 +14,7 @@ export default function GoalSlot({ goal, idx }: GoalSlotProps) {
   const code = `HQ0${num}`;
   return (
     <div
-      className="scanlines group relative rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] shadow-neoSoft hover:-translate-y-px hover:ring-1 hover:ring-[hsl(var(--accent))] focus-within:ring-2 focus-within:ring-[hsl(var(--accent))]"
+      className="goal-card group shadow-neoSoft hover:-translate-y-px hover:ring-1 hover:ring-[hsl(var(--accent))] focus-within:ring-2 focus-within:ring-[hsl(var(--accent))]"
     >
       <header className="flex items-center justify-between border-b border-[hsl(var(--border))] px-3 py-2 text-xs font-mono">
         <div className="flex items-center gap-2 truncate">

--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -255,7 +255,7 @@ export default function RemindersTab() {
         }
       />
 
-      <SectionCard className="card-neo-soft">
+      <SectionCard className="goal-card">
         <SectionCard.Body>
           <div className="grid gap-2.5">
             {/* Quick Add row — now INSIDE the same panel as the cards */}
@@ -384,7 +384,7 @@ export default function RemindersTab() {
 
 function EmptyState() {
   return (
-    <div className="card-neo-soft rounded-card ds-card-pad text-sm text-muted-foreground grid place-items-center">
+    <div className="goal-card rounded-card ds-card-pad text-sm text-muted-foreground grid place-items-center">
       <p>Nothing here. Add one clear sentence you’ll read in champ select.</p>
     </div>
   );

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -161,7 +161,7 @@ export default function TimerTab() {
   ) : null;
 
   return (
-    <SectionCard className="card-neo-soft no-hover">
+    <SectionCard className="goal-card no-hover">
       <SectionCard.Header sticky>
         <TabBar
           items={tabItems}
@@ -177,7 +177,7 @@ export default function TimerTab() {
 
       <SectionCard.Body>
         {/* Stage row with side buttons and centered digits */}
-        <div className="relative rounded-2xl card-neo-soft p-5 sm:p-6 overflow-hidden">
+        <div className="goal-card p-5 sm:p-6 overflow-hidden">
           <div className="relative grid grid-cols-[auto_1fr_auto] items-center gap-3 sm:gap-4">
             {/* minus */}
             <IconButton
@@ -289,13 +289,13 @@ export default function TimerTab() {
       {/* Local styles for neon pills, glitch loader, and complete state */}
       <style jsx>{`
         /* Disable card hover bloom */
-        .no-hover.card-neo-soft:hover {
+        .no-hover.goal-card:hover {
           box-shadow: 0 0 0 var(--hairline-w) hsl(var(--card-hairline)) inset,
             inset 0 1px 0 hsl(var(--foreground) / 0.05),
             0 30px 60px hsl(250 30% 2% / 0.35);
         }
-        .no-hover.card-neo-soft:hover::before { opacity: 0.45; }
-        .no-hover.card-neo-soft:hover::after { opacity: 0; }
+        .no-hover.goal-card:hover::before { opacity: 0.45; }
+        .no-hover.goal-card:hover::after { opacity: 0; }
 
         /* Emphasize active tab text glow (works with TabBar) */
         [role="tab"][data-active="true"] { text-shadow: 0 0 10px hsl(var(--ring)); }

--- a/src/components/goals/style.css
+++ b/src/components/goals/style.css
@@ -125,3 +125,32 @@
     text-shadow: -0.5px 0 hsl(var(--accent)), 0.5px 0 hsl(var(--accent-2));
   }
 }
+
+/* Retro-inspired section card */
+.goal-card {
+  position: relative;
+  border-radius: 14px;
+  border: 1px solid hsl(var(--border));
+  background: linear-gradient(
+    135deg,
+    hsl(var(--surface-2)),
+    hsl(var(--surface))
+  );
+  box-shadow:
+    0 0 0 1px hsl(var(--border)) inset,
+    0 0 30px hsl(var(--accent) / 0.15);
+  overflow: hidden;
+}
+.goal-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  background: repeating-linear-gradient(
+    to bottom,
+    hsl(var(--foreground) / 0.06) 0 1px,
+    transparent 1px 3px
+  );
+  mix-blend-mode: overlay;
+}


### PR DESCRIPTION
## Summary
- add goal-card style with scanlines and gradient
- apply retro card styling to goal slots, form, queue and reminders/timer sections

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ba7e429218832c879f6c2a3905e7f3