### PR TITLE
Simplify goal slots with TV-style cards

### DIFF
--- a/src/components/goals/GoalSlot.tsx
+++ b/src/components/goals/GoalSlot.tsx
@@ -1,61 +1,52 @@
 "use client";
 
 import * as React from "react";
+import { Check, Pencil } from "lucide-react";
 import type { Goal } from "@/lib/types";
 
 interface GoalSlotProps {
   goal?: Goal | null;
-  idx: number;
+  onToggleDone?: (id: string) => void;
+  onEdit?: (id: string, title: string) => void;
 }
 
-export default function GoalSlot({ goal, idx }: GoalSlotProps) {
-  const num = String(idx + 1).padStart(2, "0");
-  const file = `GoalSlot_${num}.exe`;
-  const code = `HQ0${num}`;
+export default function GoalSlot({ goal, onToggleDone, onEdit }: GoalSlotProps) {
+  function handleEdit() {
+    if (!goal || !onEdit) return;
+    const t = window.prompt("Edit goal title", goal.title);
+    if (t !== null) {
+      const clean = t.trim();
+      if (clean) onEdit(goal.id, clean);
+    }
+  }
+
   return (
-    <div
-      className="goal-card group shadow-neoSoft hover:-translate-y-px hover:ring-1 hover:ring-[hsl(var(--accent))] focus-within:ring-2 focus-within:ring-[hsl(var(--accent))]"
-    >
-      <header className="flex items-center justify-between border-b border-[hsl(var(--border))] px-3 py-2 text-xs font-mono">
-        <div className="flex items-center gap-2 truncate">
-          <span className="h-2 w-2 rounded-sm bg-[hsl(var(--accent))]" aria-hidden />
-          <span className="truncate">{file}</span>
-        </div>
-        <span>{code}</span>
-      </header>
-      <div className="p-4 font-mono text-xs text-[hsl(var(--fg-muted))]">
+    <div className="goal-tv group shadow-neoSoft">
+      <div className="goal-tv__screen">
         {goal ? (
           <>
-            <span className="text-[hsl(var(--fg))]">{`function goal_${num}() {`}</span>
-            <br />
-            <span className="pl-4 text-[hsl(var(--fg))]">{`return "${goal.title}";`}</span>
-            <br />
-            {goal.notes ? (
-              <>
-                <span className="pl-4 text-[hsl(var(--fg-muted))]">{`// ${goal.notes}`}</span>
-                <br />
-              </>
-            ) : null}
-            <span className="text-[hsl(var(--fg))]">{`}`}</span>
+            <span className="block">{goal.title}</span>
+            <button
+              type="button"
+              className="goal-tv__check"
+              aria-label="Mark goal done"
+              onClick={() => onToggleDone?.(goal.id)}
+            >
+              <Check className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              className="goal-tv__edit"
+              aria-label="Edit goal"
+              onClick={handleEdit}
+            >
+              <Pencil className="h-4 w-4" />
+            </button>
           </>
         ) : (
-          <>
-            <span>{`// ERROR: NO_GOALS_FOUND`}</span>
-            <br />
-            <span>{`// Add goals to fill slots`}</span>
-          </>
+          <span className="goal-tv__empty">NO SIGNAL</span>
         )}
       </div>
-      <footer className="relative h-2 overflow-hidden rounded-b-2xl bg-[hsl(var(--surface))]">
-        <div className="absolute inset-0 bg-[repeating-linear-gradient(-45deg,hsl(var(--accent)/0.4)_0_8px,transparent_8px_16px)] animate-[slot-stripes_1s_linear_infinite] motion-reduce:animate-none" />
-      </footer>
-      <style jsx>{`
-        @keyframes slot-stripes {
-          from { background-position: 0 0; }
-          to { background-position: 40px 0; }
-        }
-      `}</style>
-      <div className="pointer-events-none absolute inset-0 rounded-2xl before:absolute before:top-1 before:left-1 before:h-2 before:w-2 before:border-t before:border-l before:border-[hsl(var(--border))] after:absolute after:bottom-1 after:right-1 after:h-2 after:w-2 after:border-b after:border-r after:border-[hsl(var(--border))]" aria-hidden />
     </div>
   );
 }

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -116,7 +116,6 @@ export default function GoalsPage() {
     resetForm();
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   function toggleDone(id: string) {
     setErr(null);
     setGoals((prev) => {
@@ -145,6 +144,10 @@ export default function GoalsPage() {
     setLastDeleted(g);
     if (undoTimer.current) window.clearTimeout(undoTimer.current);
     undoTimer.current = window.setTimeout(() => setLastDeleted(null), 5000);
+  }
+
+  function editGoal(id: string, title: string) {
+    setGoals((prev) => prev.map((g) => (g.id === id ? { ...g, title } : g)));
   }
 
   // waitlist ops
@@ -211,7 +214,12 @@ export default function GoalsPage() {
                   <div className="grid gap-6">
                     <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
                       {Array.from({ length: 3 }).map((_, i) => (
-                        <GoalSlot key={i} idx={i} goal={filtered[i]} />
+                        <GoalSlot
+                          key={i}
+                          goal={filtered[i]}
+                          onToggleDone={toggleDone}
+                          onEdit={editGoal}
+                        />
                       ))}
                     </div>
                     <div className="grid gap-6 lg:grid-cols-2">

--- a/src/components/goals/style.css
+++ b/src/components/goals/style.css
@@ -154,3 +154,50 @@
   );
   mix-blend-mode: overlay;
 }
+
+/* Simple pixelated TV slot */
+.goal-tv {
+  position: relative;
+  border: 4px solid hsl(var(--border));
+  border-radius: 8px;
+  background: hsl(var(--surface));
+  padding: 0.25rem;
+}
+.goal-tv__screen {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  background: hsl(var(--surface-2));
+  border-radius: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.875rem;
+  text-align: center;
+  color: hsl(var(--foreground));
+}
+.goal-tv__empty {
+  color: hsl(var(--muted-foreground));
+}
+.goal-tv__check,
+.goal-tv__edit {
+  position: absolute;
+  bottom: 0.25rem;
+  padding: 0.15rem;
+  border-radius: 4px;
+  background: hsl(var(--surface));
+  color: hsl(var(--foreground));
+  display: flex;
+}
+.goal-tv__check {
+  right: 0.25rem;
+}
+.goal-tv__edit {
+  left: 0.25rem;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.goal-tv:hover .goal-tv__edit {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- Redesign goal slots as pixelated TV screens with done and edit controls
- Add goal editing function and wire goal slot callbacks
- Introduce TV-style CSS helpers for simplified layout

## Testing
- `npx vitest run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ba88a82c28832cbb4da9f3f0edbd93