### PR TITLE
Add pillar selection to goals

### DIFF
--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -4,12 +4,17 @@ import * as React from "react";
 import Input from "@/components/ui/primitives/input";
 import Textarea from "@/components/ui/primitives/textarea";
 import Button from "@/components/ui/primitives/button";
+import type { Pillar } from "@/lib/types";
+
+const PILLARS: Pillar[] = ["Wave", "Trading", "Vision", "Tempo", "Positioning", "Comms"];
 
 interface GoalFormProps {
   title: string;
+  pillar: Pillar | "";
   metric: string;
   notes: string;
   onTitleChange: (v: string) => void;
+  onPillarChange: (v: Pillar | "") => void;
   onMetricChange: (v: string) => void;
   onNotesChange: (v: string) => void;
   onSubmit: () => void;
@@ -20,9 +25,11 @@ interface GoalFormProps {
 
 export default function GoalForm({
   title,
+  pillar,
   metric,
   notes,
   onTitleChange,
+  onPillarChange,
   onMetricChange,
   onNotesChange,
   onSubmit,
@@ -50,6 +57,24 @@ export default function GoalForm({
               aria-required="true"
               aria-describedby="goal-form-help goal-form-error"
             />
+          </label>
+
+          <label htmlFor="goal-pillar" className="grid gap-2">
+            <span className="text-xs text-[hsl(var(--fg-muted))]">Pillar (optional)</span>
+            <select
+              id="goal-pillar"
+              className="h-10 rounded-2xl border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))]"
+              value={pillar}
+              onChange={(e) => onPillarChange(e.target.value as Pillar | "")}
+              aria-describedby="goal-form-help goal-form-error"
+            >
+              <option value="">None</option>
+              {PILLARS.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
           </label>
 
           <label htmlFor="goal-metric" className="grid gap-2">

--- a/src/components/goals/GoalSlot.tsx
+++ b/src/components/goals/GoalSlot.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { Check, Pencil } from "lucide-react";
 import type { Goal } from "@/lib/types";
+import { PillarBadge } from "@/components/ui";
 
 interface GoalSlotProps {
   goal?: Goal | null;
@@ -25,7 +26,12 @@ export default function GoalSlot({ goal, onToggleDone, onEdit }: GoalSlotProps) 
       <div className="goal-tv__screen">
         {goal ? (
           <>
-            <span className="block">{goal.title}</span>
+            <div className="flex flex-col items-center">
+              <span className="block">{goal.title}</span>
+              {goal.pillar && (
+                <PillarBadge pillar={goal.pillar} size="sm" className="mt-1" as="span" />
+              )}
+            </div>
             <button
               type="button"
               className="goal-tv__check"

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -26,7 +26,7 @@ import GoalQueue, { WaitItem } from "./GoalQueue";
 import GoalSlot from "./GoalSlot";
 
 import { useLocalDB, uid } from "@/lib/db";
-import type { Goal } from "@/lib/types";
+import type { Goal, Pillar } from "@/lib/types";
 
 /* Tabs */
 import RemindersTab from "./RemindersTab";
@@ -64,6 +64,7 @@ export default function GoalsPage() {
   const [title, setTitle] = React.useState("");
   const [metric, setMetric] = React.useState("");
   const [notes, setNotes] = React.useState("");
+  const [pillar, setPillar] = React.useState<Pillar | "">("");
   const [err, setErr] = React.useState<string | null>(null);
 
   // undo
@@ -95,6 +96,7 @@ export default function GoalsPage() {
     setTitle("");
     setMetric("");
     setNotes("");
+    setPillar("");
   }
 
   function addGoal() {
@@ -106,7 +108,7 @@ export default function GoalsPage() {
     const g: Goal = {
       id: uid("goal"),
       title: title.trim(),
-      pillar: "",
+      ...(pillar ? { pillar } : {}),
       metric: metric.trim() || undefined,
       notes: notes.trim() || undefined,
       done: false,
@@ -226,9 +228,11 @@ export default function GoalsPage() {
                       <section ref={formRef}>
                         <GoalForm
                           title={title}
+                          pillar={pillar}
                           metric={metric}
                           notes={notes}
                           onTitleChange={setTitle}
+                          onPillarChange={setPillar}
                           onMetricChange={setMetric}
                           onNotesChange={setNotes}
                           onSubmit={addGoal}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,7 +45,7 @@ export type Review = {
 export type Goal = {
   id: string;
   title: string;
-  pillar: Pillar | "";
+  pillar?: Pillar;
   metric?: string;
   notes?: string;
   done: boolean;


### PR DESCRIPTION
## Summary
- allow Goal model to omit pillar and use Pillar enum directly
- add pillar dropdown to goal form and track state on goals page
- show a Pillar badge on goal slots when selected

## Testing
- `npm run typecheck`
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68ba8dde7ca0832ca1d59a561264ae6a