### PR TITLE
feat: add goal edit dialog

### DIFF
--- a/src/components/goals/EditGoalDialog.tsx
+++ b/src/components/goals/EditGoalDialog.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import * as React from "react";
+import Input from "@/components/ui/primitives/input";
+import Textarea from "@/components/ui/primitives/textarea";
+import Button from "@/components/ui/primitives/button";
+import type { Goal } from "@/lib/types";
+
+interface EditGoalDialogProps {
+  goal: Goal;
+  open: boolean;
+  onConfirm: (g: Goal) => void;
+  onCancel: () => void;
+}
+
+export default function EditGoalDialog({
+  goal,
+  open,
+  onConfirm,
+  onCancel,
+}: EditGoalDialogProps) {
+  const [title, setTitle] = React.useState(goal.title);
+  const [metric, setMetric] = React.useState(goal.metric || "");
+  const [notes, setNotes] = React.useState(goal.notes || "");
+  const titleRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    if (open) {
+      setTitle(goal.title);
+      setMetric(goal.metric || "");
+      setNotes(goal.notes || "");
+      // Ensure focus after render
+      setTimeout(() => titleRef.current?.focus(), 0);
+    }
+  }, [open, goal]);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const updated: Goal = {
+      ...goal,
+      title: title.trim(),
+      metric: metric.trim() || undefined,
+      notes: notes.trim() || undefined,
+    };
+    onConfirm(updated);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onCancel();
+    }
+  }
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="edit-goal-heading"
+      className="fixed inset-0 z-50 grid place-items-center bg-black/50 p-4"
+      onKeyDown={handleKeyDown}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="goal-card w-full max-w-sm rounded-xl bg-[hsl(var(--card))] p-4 shadow-neoSoft"
+      >
+        <h2
+          id="edit-goal-heading"
+          className="mb-4 text-lg font-semibold uppercase tracking-tight"
+        >
+          Edit Goal
+        </h2>
+        <div className="grid gap-4">
+          <label htmlFor="edit-goal-title" className="grid gap-2">
+            <span className="text-xs text-[hsl(var(--fg-muted))]">Title</span>
+            <Input
+              id="edit-goal-title"
+              ref={titleRef}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              aria-required="true"
+            />
+          </label>
+          <label htmlFor="edit-goal-metric" className="grid gap-2">
+            <span className="text-xs text-[hsl(var(--fg-muted))]">Metric (optional)</span>
+            <Input
+              id="edit-goal-metric"
+              value={metric}
+              onChange={(e) => setMetric(e.target.value)}
+            />
+          </label>
+          <label htmlFor="edit-goal-notes" className="grid gap-2">
+            <span className="text-xs text-[hsl(var(--fg-muted))]">Notes (optional)</span>
+            <Textarea
+              id="edit-goal-notes"
+              className="min-h-24"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+            />
+          </label>
+        </div>
+        <div className="mt-6 flex justify-end gap-2">
+          <Button type="button" onClick={onCancel} aria-label="Cancel editing">
+            Cancel
+          </Button>
+          <Button type="submit" aria-label="Save goal">
+            Save
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+

--- a/src/components/goals/GoalSlot.tsx
+++ b/src/components/goals/GoalSlot.tsx
@@ -3,21 +3,32 @@
 import * as React from "react";
 import { Check, Pencil } from "lucide-react";
 import type { Goal } from "@/lib/types";
+import EditGoalDialog from "./EditGoalDialog";
 
 interface GoalSlotProps {
   goal?: Goal | null;
   onToggleDone?: (id: string) => void;
-  onEdit?: (id: string, title: string) => void;
+  onEdit?: (g: Goal) => void;
 }
 
 export default function GoalSlot({ goal, onToggleDone, onEdit }: GoalSlotProps) {
+  const [isEditing, setIsEditing] = React.useState(false);
+  const editBtnRef = React.useRef<HTMLButtonElement>(null);
+
   function handleEdit() {
-    if (!goal || !onEdit) return;
-    const t = window.prompt("Edit goal title", goal.title);
-    if (t !== null) {
-      const clean = t.trim();
-      if (clean) onEdit(goal.id, clean);
-    }
+    if (!goal) return;
+    setIsEditing(true);
+  }
+
+  function handleCancel() {
+    setIsEditing(false);
+    editBtnRef.current?.focus();
+  }
+
+  function handleConfirm(updated: Goal) {
+    onEdit?.(updated);
+    setIsEditing(false);
+    editBtnRef.current?.focus();
   }
 
   return (
@@ -39,9 +50,18 @@ export default function GoalSlot({ goal, onToggleDone, onEdit }: GoalSlotProps) 
               className="goal-tv__edit"
               aria-label="Edit goal"
               onClick={handleEdit}
+              ref={editBtnRef}
             >
               <Pencil className="h-4 w-4" />
             </button>
+            {goal && (
+              <EditGoalDialog
+                goal={goal}
+                open={isEditing}
+                onConfirm={handleConfirm}
+                onCancel={handleCancel}
+              />
+            )}
           </>
         ) : (
           <span className="goal-tv__empty">NO SIGNAL</span>

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -146,8 +146,14 @@ export default function GoalsPage() {
     undoTimer.current = window.setTimeout(() => setLastDeleted(null), 5000);
   }
 
-  function editGoal(id: string, title: string) {
-    setGoals((prev) => prev.map((g) => (g.id === id ? { ...g, title } : g)));
+  function editGoal(updated: Goal) {
+    setGoals((prev) =>
+      prev.map((g) =>
+        g.id === updated.id
+          ? { ...g, title: updated.title, metric: updated.metric, notes: updated.notes }
+          : g
+      )
+    );
   }
 
   // waitlist ops


### PR DESCRIPTION
## Summary
- add `EditGoalDialog` component for editing goal title, metric, and notes with focus management
- swap GoalSlot prompt edit for dialog and wire updates through
- update GoalsPage edit handler to accept updated goal data

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ba8de038b8832cb664361a75cf83a0