### PR TITLE
feat: add goal deletion and re-enable lint

### DIFF
--- a/src/components/goals/GoalSlot.tsx
+++ b/src/components/goals/GoalSlot.tsx
@@ -1,16 +1,17 @@
 "use client";
 
 import * as React from "react";
-import { Check, Pencil } from "lucide-react";
+import { Check, Pencil, Trash2 } from "lucide-react";
 import type { Goal } from "@/lib/types";
 
 interface GoalSlotProps {
   goal?: Goal | null;
   onToggleDone?: (id: string) => void;
   onEdit?: (id: string, title: string) => void;
+  onDelete?: (id: string) => void;
 }
 
-export default function GoalSlot({ goal, onToggleDone, onEdit }: GoalSlotProps) {
+export default function GoalSlot({ goal, onToggleDone, onEdit, onDelete }: GoalSlotProps) {
   function handleEdit() {
     if (!goal || !onEdit) return;
     const t = window.prompt("Edit goal title", goal.title);
@@ -41,6 +42,14 @@ export default function GoalSlot({ goal, onToggleDone, onEdit }: GoalSlotProps) 
               onClick={handleEdit}
             >
               <Pencil className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              className="goal-tv__delete"
+              aria-label="Delete goal"
+              onClick={() => onDelete?.(goal.id)}
+            >
+              <Trash2 className="h-4 w-4" />
             </button>
           </>
         ) : (

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -136,7 +136,6 @@ export default function GoalsPage() {
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   function removeGoal(id: string) {
     setErr(null);
     const g = goals.find((x) => x.id === id) || null;
@@ -219,6 +218,7 @@ export default function GoalsPage() {
                           goal={filtered[i]}
                           onToggleDone={toggleDone}
                           onEdit={editGoal}
+                          onDelete={removeGoal}
                         />
                       ))}
                     </div>

--- a/src/components/goals/style.css
+++ b/src/components/goals/style.css
@@ -181,7 +181,8 @@
   color: hsl(var(--muted-foreground));
 }
 .goal-tv__check,
-.goal-tv__edit {
+.goal-tv__edit,
+.goal-tv__delete {
   position: absolute;
   bottom: 0.25rem;
   padding: 0.15rem;
@@ -198,6 +199,12 @@
   opacity: 0;
   transition: opacity 0.2s;
 }
-.goal-tv:hover .goal-tv__edit {
+.goal-tv__delete {
+  left: 1.75rem;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.goal-tv:hover .goal-tv__edit,
+.goal-tv:hover .goal-tv__delete {
   opacity: 1;
 }


### PR DESCRIPTION
## Summary
- allow goals to be deleted with a new trash button in each goal slot
- wire delete action to existing removeGoal logic and undo snackbar
- drop eslint-disable to restore linting

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ba8de273d0832c9094cfa7e09b82ae