### PR TITLE
feat(goal): mark completed goals visually

### DIFF
--- a/src/components/goals/GoalSlot.tsx
+++ b/src/components/goals/GoalSlot.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { Check, Pencil, Trash2 } from "lucide-react";
+import { cn } from "@/lib/utils";
 import type { Goal } from "@/lib/types";
 import { PillarBadge } from "@/components/ui";
 
@@ -23,7 +24,7 @@ export default function GoalSlot({ goal, onToggleDone, onEdit, onDelete }: GoalS
   }
 
   return (
-    <div className="goal-tv group shadow-neoSoft">
+    <div className={cn("goal-tv group shadow-neoSoft", goal?.done && "goal-tv--done")}>
       <div className="goal-tv__screen">
         {goal ? (
           <>
@@ -36,7 +37,8 @@ export default function GoalSlot({ goal, onToggleDone, onEdit, onDelete }: GoalS
             <button
               type="button"
               className="goal-tv__check"
-              aria-label="Mark goal done"
+              aria-label={goal.done ? "Mark goal undone" : "Mark goal done"}
+              aria-pressed={goal.done}
               onClick={() => onToggleDone?.(goal.id)}
             >
               <Check className="h-4 w-4" />

--- a/src/components/goals/style.css
+++ b/src/components/goals/style.css
@@ -208,3 +208,15 @@
 .goal-tv:hover .goal-tv__delete {
   opacity: 1;
 }
+
+/* Done state */
+.goal-tv--done .goal-tv__screen {
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+}
+.goal-tv--done .goal-tv__screen > div > span:first-child {
+  text-decoration: line-through;
+}
+.goal-tv--done .goal-tv__check {
+  color: hsl(var(--success));
+}


### PR DESCRIPTION
## Summary
- dim finished goals with new `goal-tv--done` styling and strike-through title
- highlight completion check icon and toggle accessibility attributes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba9364c5c4832c90df589215622c84