### PR TITLE
feat: highlight active goal tab

### DIFF
--- a/src/components/goals/GoalsTabs.tsx
+++ b/src/components/goals/GoalsTabs.tsx
@@ -28,14 +28,15 @@ export default function GoalsTabs({ value, onChange }: GoalsTabsProps) {
             aria-selected={active}
             onClick={() => onChange(f)}
             className={cn(
-              "text-left font-mono text-sm transition whitespace-pre",
+              "text-left font-mono text-sm transition",
               "px-3 py-2 rounded-2xl",
               "hover:-translate-y-px hover:ring-1 hover:ring-[hsl(var(--ring))]",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))]",
-              active ? "font-semibold" : undefined,
+              "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[hsl(var(--accent))]",
+              active
+                ? "font-semibold text-[hsl(var(--accent))] bg-[hsl(var(--accent)/0.1)]"
+                : undefined,
             )}
           >
-            {active ? "-> " : "   "}
             {f}
           </button>
         );


### PR DESCRIPTION
## Summary
- highlight active tab with accent text and subtle background
- add focus outline that matches accent color

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ba9365a58c832cb8ec9ab18e909b4b