### PR TITLE
Increase goal TV button padding for balance

### DIFF
--- a/src/components/goals/style.css
+++ b/src/components/goals/style.css
@@ -184,26 +184,37 @@
 .goal-tv__edit,
 .goal-tv__delete {
   position: absolute;
-  bottom: 0.25rem;
-  padding: 0.15rem;
+  bottom: 0.5rem;
   border-radius: 4px;
   background: hsl(var(--surface));
   color: hsl(var(--foreground));
   display: flex;
+  align-items: center;
+  justify-content: center;
 }
-.goal-tv__check {
-  right: 0.25rem;
-}
+
+.goal-tv__check,
 .goal-tv__edit {
-  left: 0.25rem;
+  padding: 0.5rem;
+}
+
+.goal-tv__check {
+  right: 0.5rem;
+}
+
+.goal-tv__edit {
+  left: 0.5rem;
   opacity: 0;
   transition: opacity 0.2s;
 }
+
 .goal-tv__delete {
-  left: 1.75rem;
+  left: 3rem;
+  padding: 0.15rem;
   opacity: 0;
   transition: opacity 0.2s;
 }
+
 .goal-tv:hover .goal-tv__edit,
 .goal-tv:hover .goal-tv__delete {
   opacity: 1;


### PR DESCRIPTION
## Summary
- enlarge goal TV check and edit buttons for easier taps and centered icons
- keep hover transitions while adjusting layout spacing

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ba937364c0832c82ffd02918bbd3a3