### PR TITLE
style: add neomorphic raised chips

### DIFF
--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -103,12 +103,8 @@ function DayChip({
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
         today && "chip--today",
         selected
-          ? cn(
-              // “armed” personality: dashed, tinted border + subtle glow
-              "border-dashed border-[hsl(var(--primary)/.75)] shadow-[0_8px_22px_hsl(var(--shadow-color)/.22)]",
-              "ring-1 ring-[hsl(var(--primary)/.45)]"
-            )
-          : "hover:border-[hsl(var(--primary)/.4)] hover:shadow-[0_6px_18px_hsl(var(--shadow-color)/.18)]"
+          ? "border-dashed border-[hsl(var(--primary)/.75)]"
+          : "hover:border-[hsl(var(--primary)/.4)]"
       )}
       data-today={today || undefined}
       data-active={selected || undefined}

--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -138,19 +138,31 @@
   isolation: isolate;
   contain: paint;
   will-change: box-shadow, background, border-color;
+  --neo-shadow:
+    -2px -2px 4px hsl(var(--background) / .6),
+    2px 2px 4px hsl(var(--shadow-color) / .3);
+  box-shadow: var(--neo-shadow);
 }
 .chip:hover {
   animation: chip-flicker 3.2s steps(1,end) infinite;
   background: color-mix(in oklab, hsl(var(--card)) 88%, hsl(var(--primary)) 12% / .08);
   border-color: hsl(var(--primary) / .55);
   box-shadow:
-    inset 0 0 0 1px hsl(var(--primary) / .65),
-    0 8px 22px hsl(var(--shadow-color) / .25);
+    var(--neo-shadow),
+    0 6px 18px hsl(var(--shadow-color) / .18);
+}
+
+.chip[data-active] {
+  box-shadow:
+    var(--neo-shadow),
+    0 0 0 1px hsl(var(--primary) / .45),
+    0 8px 22px hsl(var(--shadow-color) / .22);
 }
 
 /* “Today” hint — faint ring and glow rail inside */
 .chip--today {
   box-shadow:
+    var(--neo-shadow),
     0 0 0 1px hsl(var(--ring) / .55) inset,
     0 0 0 2px hsl(var(--ring) / .15);
 }
@@ -161,6 +173,7 @@
   border-color: hsl(var(--ring));
   box-shadow:
     inset 0 0 0 2px hsl(var(--ring) / .35),
+    var(--neo-shadow),
     0 12px 28px hsl(var(--shadow-color) / .30);
 }
 .chip--active .chip__edge {


### PR DESCRIPTION
## Summary
- restyle planner day chips with neomorphic raised shadow
- simplify WeekPicker chip classnames to rely on new CSS

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68babc579834832c8413aaf0ce5ce22b