### PR TITLE
Apply neomorphic inset styling to progress bars and sliders

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -923,7 +923,10 @@ html.bg-intense body::after {
   border-radius: 9999px;
   background: hsl(var(--foreground) / 0.08);
   overflow: hidden;
-  box-shadow: inset 0 0 0 1px hsl(var(--foreground) / 0.06);
+  box-shadow:
+    inset 0 0 0 1px hsl(var(--foreground) / 0.06),
+    inset 2px 2px 4px hsl(var(--shadow-color) / 0.45),
+    inset -2px -2px 4px hsl(var(--foreground) / 0.06);
 }
 .glitch-fill {
   height: 100%;
@@ -933,6 +936,7 @@ html.bg-intense body::after {
   background-size: 200% 100%;
   transition: width 0.35s cubic-bezier(0.22, 0.99, 0.28, 0.99);
   animation: glitchSheen 3s linear infinite;
+  box-shadow: 0 0 8px hsl(var(--accent) / 0.5);
 }
 .glitch-scan {
   position: absolute;

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -716,13 +716,12 @@ export default function ReviewEditor({
               aria-label="Score from 0 to 10"
             />
             <div className="absolute left-4 right-4 top-1/2 -translate-y-1/2">
-              <div className="relative h-2 w-full rounded-full bg-[hsl(var(--muted))]">
+              <div className="relative h-2 w-full rounded-full bg-[hsl(var(--muted))] shadow-[inset_2px_2px_4px_hsl(var(--shadow-color)/0.45),inset_-2px_-2px_4px_hsl(var(--foreground)/0.06)]">
                 <div
-                  className="absolute left-0 top-0 h-2 rounded-full"
+                  className="absolute left-0 top-0 h-2 rounded-full shadow-[0_0_8px_hsl(var(--primary)/0.5)]"
                   style={{
                     width: `calc(${(score / 10) * 100}% + 10px)`,
                     background: "linear-gradient(90deg, hsl(var(--primary)), hsl(var(--accent)))",
-                    boxShadow: "0 0 16px hsl(var(--primary)/.35)",
                   }}
                 />
                 <div
@@ -785,14 +784,13 @@ export default function ReviewEditor({
                   aria-label="Focus from 0 to 10"
                 />
                 <div className="absolute left-4 right-4 top-1/2 -translate-y-1/2">
-                  <div className="relative h-2 w-full rounded-full bg-[hsl(var(--muted))]">
+                  <div className="relative h-2 w-full rounded-full bg-[hsl(var(--muted))] shadow-[inset_2px_2px_4px_hsl(var(--shadow-color)/0.45),inset_-2px_-2px_4px_hsl(var(--foreground)/0.06)]">
                     <div
-                      className="absolute left-0 top-0 h-2 rounded-full"
+                      className="absolute left-0 top-0 h-2 rounded-full shadow-[0_0_8px_hsl(var(--accent)/0.5)]"
                       style={{
                         width: `calc(${(focus / 10) * 100}% + 10px)`,
                         background:
                           "linear-gradient(90deg, hsl(var(--accent)), hsl(var(--primary)))",
-                        boxShadow: "0 0 16px hsl(var(--accent)/.35)",
                       }}
                     />
                     <div

--- a/src/components/reviews/ReviewSummary.tsx
+++ b/src/components/reviews/ReviewSummary.tsx
@@ -359,13 +359,12 @@ export default function ReviewSummary({ review, onEdit, className }: Props) {
           <SectionLabel>Score</SectionLabel>
           <div className="relative h-12 rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-4">
             <div className="absolute left-4 right-4 top-1/2 -translate-y-1/2">
-              <div className="relative h-2 w-full rounded-full bg-[hsl(var(--muted))]">
+              <div className="relative h-2 w-full rounded-full bg-[hsl(var(--muted))] shadow-[inset_2px_2px_4px_hsl(var(--shadow-color)/0.45),inset_-2px_-2px_4px_hsl(var(--foreground)/0.06)]">
                 <div
-                  className="absolute left-0 top-0 h-2 rounded-full"
+                  className="absolute left-0 top-0 h-2 rounded-full shadow-[0_0_8px_hsl(var(--primary)/0.5)]"
                   style={{
                     width: `calc(${(Number.isFinite(score) ? score : 5) * 10}% + 10px)`,
                     background: "linear-gradient(90deg, hsl(var(--primary)), hsl(var(--accent)))",
-                    boxShadow: "0 0 16px hsl(var(--primary)/.35)",
                   }}
                 />
                 <div
@@ -391,21 +390,20 @@ export default function ReviewSummary({ review, onEdit, className }: Props) {
 
               <div className="relative h-12 rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-4">
                 <div className="absolute left-4 right-4 top-1/2 -translate-y-1/2">
-                  <div className="relative h-2 w-full rounded-full bg-[hsl(var(--muted))]">
-                    <div
-                      className="absolute left-0 top-0 h-2 rounded-full"
-                      style={{
-                        width: `calc(${(focus / 10) * 100}% + 10px)`,
-                        background:
-                          "linear-gradient(90deg, hsl(var(--accent)), hsl(var(--primary)))",
-                        boxShadow: "0 0 16px hsl(var(--accent)/.35)",
-                      }}
-                    />
-                    <div
-                      className="absolute top-1/2 h-5 w-5 -translate-y-1/2 rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--card))] shadow-[0_10px_25px_hsl(var(--shadow-color)/.25)]"
-                      style={{ left: `calc(${(focus / 10) * 100}% - 10px)` }}
-                    />
-                  </div>
+              <div className="relative h-2 w-full rounded-full bg-[hsl(var(--muted))] shadow-[inset_2px_2px_4px_hsl(var(--shadow-color)/0.45),inset_-2px_-2px_4px_hsl(var(--foreground)/0.06)]">
+                <div
+                  className="absolute left-0 top-0 h-2 rounded-full shadow-[0_0_8px_hsl(var(--accent)/0.5)]"
+                  style={{
+                    width: `calc(${(focus / 10) * 100}% + 10px)`,
+                    background:
+                      "linear-gradient(90deg, hsl(var(--accent)), hsl(var(--primary)))",
+                  }}
+                />
+                <div
+                  className="absolute top-1/2 h-5 w-5 -translate-y-1/2 rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--card))] shadow-[0_10px_25px_hsl(var(--shadow-color)/.25)]"
+                  style={{ left: `calc(${(focus / 10) * 100}% - 10px)` }}
+                />
+              </div>
                 </div>
               </div>
               <div className="mt-1 flex items-center gap-2 text-[13px] text-muted-foreground">

--- a/src/components/ui/feedback/Progress.tsx
+++ b/src/components/ui/feedback/Progress.tsx
@@ -5,9 +5,12 @@
 export default function Progress({ value, label }: { value: number; label?: string }) {
   const v = Math.max(0, Math.min(100, Math.round(value)));
   return (
-    <div className="h-2 w-full rounded-full bg-muted" aria-label={label}>
+    <div
+      className="h-2 w-full rounded-full bg-[hsl(var(--muted))] shadow-[inset_2px_2px_4px_hsl(var(--shadow-color)/0.45),inset_-2px_-2px_4px_hsl(var(--foreground)/0.06)]"
+      aria-label={label}
+    >
       <div
-        className="h-2 rounded-full bg-[hsl(var(--primary))] transition-[width]"
+        className="h-2 rounded-full bg-[hsl(var(--primary))] shadow-[0_0_8px_hsl(var(--primary)/0.5)] transition-[width]"
         style={{ width: `${v}%` }}
         aria-valuemin={0}
         aria-valuemax={100}


### PR DESCRIPTION
## Summary
- restyle progress component with inset shadows and glowing fill
- give score and focus sliders a matching neomorphic track
- enhance planner progress bars with global neomorphic track styling

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68babbd9e968832cb9b4f81810813aa9