### PR TITLE
feat(ui): add overlay fade to primary button

### DIFF
--- a/src/components/ui/primitives/button.tsx
+++ b/src/components/ui/primitives/button.tsx
@@ -57,10 +57,10 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           {...rest}
         >
           <span
-            className="absolute inset-0 rounded-2xl"
+            className="absolute inset-0 z-0 rounded-2xl ring-1 ring-[hsl(var(--line))]"
             style={{
               background:
-                "linear-gradient(90deg, hsl(275 95% 72% /.18), hsl(195 95% 68% /.18))",
+                "linear-gradient(180deg, rgba(255,255,255,0.15), transparent)",
             }}
           />
           <span className="relative z-10 font-semibold inline-flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add white fade overlay to primary button
- ring button border using line color

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bac4fec028832ca433e1bd266d8bbd