### PR TITLE
Use global neo-soft card styles

### DIFF
--- a/src/components/ui/layout/SectionCard.tsx
+++ b/src/components/ui/layout/SectionCard.tsx
@@ -18,17 +18,10 @@ type BodyProps = React.HTMLAttributes<HTMLDivElement>;
 function Root({ className, children, ...props }: RootProps) {
   return (
     <section
-      className={cn("relative rounded-2xl bg-[hsl(var(--panel)/0.9)]", className)}
+      className={cn("card-neo-soft", className)}
       style={{ boxShadow: neuRaised(14) }}
       {...props}
     >
-      <div
-        className="pointer-events-none absolute inset-0 rounded-2xl"
-        style={{
-          background:
-            "linear-gradient(180deg, rgba(255,255,255,.04), rgba(255,255,255,0))",
-        }}
-      />
       {children}
     </section>
   );


### PR DESCRIPTION
## Summary
- use global `card-neo-soft` class in SectionCard root and drop redundant overlay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bac5179cec832cbd83007f437b9447