### PR TITLE
refactor: improve type safety for UI primitives

### DIFF
--- a/src/components/ui/primitives/badge.tsx
+++ b/src/components/ui/primitives/badge.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 "use client";
 
 import * as React from "react";
@@ -15,14 +14,17 @@ type Tone =
   | "adc"
   | "support";
 
-export type BadgeProps = React.HTMLAttributes<HTMLSpanElement> & {
+type BadgeOwnProps<T extends React.ElementType = "span"> = {
   size?: Size;
   tone?: Tone;
   interactive?: boolean;
   selected?: boolean;
   glitch?: boolean;
-  as?: "span" | "button";
+  as?: T;
 };
+
+export type BadgeProps<T extends React.ElementType = "span"> = BadgeOwnProps<T> &
+  Omit<React.ComponentPropsWithoutRef<T>, keyof BadgeOwnProps<T>>;
 
 const sizeMap: Record<Size, string> = {
   xs: "px-2 py-[3px] text-[11px] leading-none",
@@ -40,18 +42,18 @@ const toneBorder: Record<Tone, string> = {
   support: "border-[hsl(var(--tone-sup))]",
 };
 
-export default function Badge({
+export default function Badge<T extends React.ElementType = "span">({
   size = "sm",
   tone = "neutral",
   interactive = false,
   selected = false,
   glitch = false,
-  as = "span",
+  as,
   className,
   children,
   ...rest
-}: BadgeProps) {
-  const Comp = as as any;
+}: BadgeProps<T>) {
+  const Comp = as ?? "span";
 
   return (
     <Comp

--- a/src/components/ui/primitives/button.tsx
+++ b/src/components/ui/primitives/button.tsx
@@ -1,7 +1,7 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 "use client";
 
 import * as React from "react";
+import type { CSSProperties } from "react";
 import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { neuRaised, neuInset } from "./neu";
@@ -53,7 +53,10 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           className={cn(base, "bg-[hsl(var(--panel)/0.85)]")}
           style={{ boxShadow: neuRaised(12) }}
           whileHover={{ scale: 1.03, boxShadow: neuRaised(16) }}
-          whileTap={{ scale: 0.96, boxShadow: neuInset(10) as any }}
+          whileTap={{
+            scale: 0.96,
+            boxShadow: neuInset(10) as CSSProperties["boxShadow"],
+          }}
           {...rest}
         >
           <span
@@ -77,7 +80,10 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           className={cn(base, "bg-[hsl(var(--panel)/0.6)]")}
           style={{ boxShadow: neuRaised(10) }}
           whileHover={{ scale: 1.02, boxShadow: neuRaised(14) }}
-          whileTap={{ scale: 0.97, boxShadow: neuInset(8) as any }}
+          whileTap={{
+            scale: 0.97,
+            boxShadow: neuInset(8) as CSSProperties["boxShadow"],
+          }}
           {...rest}
         >
           {children}
@@ -91,7 +97,10 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         className={cn(base, "bg-[hsl(var(--panel)/0.8)]")}
         style={{ boxShadow: neuRaised(12) }}
         whileHover={{ scale: 1.02, boxShadow: neuRaised(15) }}
-        whileTap={{ scale: 0.97, boxShadow: neuInset(9) as any }}
+        whileTap={{
+          scale: 0.97,
+          boxShadow: neuInset(9) as CSSProperties["boxShadow"],
+        }}
         {...rest}
       >
         {children}


### PR DESCRIPTION
## Summary
- type `boxShadow` animations in button component
- make badge component generic over element type and remove explicit any usage
- drop `eslint-disable @typescript-eslint/no-explicit-any` comments

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bad99581a4832c974a53ab2f2de3d6