### PR TITLE
feat: extract shared date helpers

### DIFF
--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -14,31 +14,10 @@ import Button from "@/components/ui/primitives/button";
 import { useFocusDate, useDay, type ISODate } from "./usePlanner";
 import { cn } from "@/lib/utils";
 import { CalendarDays, ChevronLeft, ChevronRight, ArrowUpToLine } from "lucide-react";
+import { isoToDate, toISO, addDays, mondayStartOfWeek } from "@/lib/date";
 
 /* ───────── date helpers ───────── */
 
-function isoToDate(iso: string) {
-  const [y, m, d] = iso.split("-").map(Number);
-  return new Date(y, m - 1, d);
-}
-function toISO(d: Date) {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
-function addDays(d: Date, n: number) {
-  const x = new Date(d);
-  x.setDate(d.getDate() + n);
-  return x;
-}
-function mondayStart(d: Date) {
-  const shift = (d.getDay() + 6) % 7; // Mon=0..Sun=6
-  const s = new Date(d);
-  s.setDate(d.getDate() - shift);
-  s.setHours(0, 0, 0, 0);
-  return s;
-}
 const dmy = new Intl.DateTimeFormat(undefined, { day: "2-digit", month: "short" });
 
 /* ───────── safe week stats (7 fixed calls) ───────── */
@@ -137,7 +116,7 @@ export default function WeekPicker() {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { start, end, heading, rangeLabel, isoStart, isoEnd, days } = React.useMemo(() => {
     const base = isoToDate(iso);
-    const s = mondayStart(base);
+    const s = mondayStartOfWeek(base);
     const e = addDays(s, 6);
     const list: ISODate[] = Array.from({ length: 7 }, (_, i) => toISO(addDays(s, i)) as ISODate);
     return {

--- a/src/components/planner/usePlanner.ts
+++ b/src/components/planner/usePlanner.ts
@@ -9,6 +9,7 @@
 import "./style.css";
 import * as React from "react";
 import { useLocalDB, uid } from "@/lib/db";
+import { toISO, addDays, weekRangeFromISO } from "@/lib/date";
 
 /* ───────────────── Types ───────────────── */
 export type ISODate = string;
@@ -41,17 +42,7 @@ type Selection = {
 };
 
 /* ───────────────── Date helpers ───────────────── */
-export function toISO(d: Date): ISODate {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
 function todayISO(): ISODate { return toISO(new Date()); }
-export function addDays(date: Date, n: number): Date { const d = new Date(date); d.setDate(d.getDate() + n); return d; }
-function mondayStartOfWeek(d: Date): Date { const copy = new Date(d); const day = copy.getDay(); const diff = (day + 6) % 7; copy.setHours(0,0,0,0); return addDays(copy, -diff); }
-function sundayEndOfWeek(d: Date): Date { const start = mondayStartOfWeek(d); const end = addDays(start, 6); end.setHours(23,59,59,999); return end; }
-export function weekRangeFromISO(iso: ISODate): { start: Date; end: Date } { const d = new Date(`${iso}T00:00:00`); return { start: mondayStartOfWeek(d), end: sundayEndOfWeek(d) }; }
 
 /* ───────────────── Context ───────────────── */
 type PlannerState = {

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,40 @@
+// src/lib/date.ts
+// Shared date helpers for planner components
+
+export function toISO(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export function isoToDate(iso: string): Date {
+  const [y, m, d] = iso.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+export function addDays(date: Date, n: number): Date {
+  const d = new Date(date);
+  d.setDate(d.getDate() + n);
+  return d;
+}
+
+export function mondayStartOfWeek(d: Date): Date {
+  const copy = new Date(d);
+  const day = copy.getDay();
+  const diff = (day + 6) % 7; // shift so Monday=0
+  copy.setHours(0, 0, 0, 0);
+  return addDays(copy, -diff);
+}
+
+export function sundayEndOfWeek(d: Date): Date {
+  const start = mondayStartOfWeek(d);
+  const end = addDays(start, 6);
+  end.setHours(23, 59, 59, 999);
+  return end;
+}
+
+export function weekRangeFromISO(iso: string): { start: Date; end: Date } {
+  const d = isoToDate(iso);
+  return { start: mondayStartOfWeek(d), end: sundayEndOfWeek(d) };
+}


### PR DESCRIPTION
## Summary
- centralize date utilities like `toISO` and `addDays` in `src/lib/date.ts`
- use shared date helpers in `WeekPicker` and `usePlanner`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bae3820900832cb4d5238b7bd51add