### PR TITLE
refactor: unify theme storage

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import "./themes.css";
 
 import type { Metadata } from "next";
 import SiteChrome from "@/components/chrome/SiteChrome";
+import { themeBootstrapScript } from "@/lib/theme";
 
 export const metadata: Metadata = {
   title: "13 League Review",
@@ -14,78 +15,11 @@ export const metadata: Metadata = {
 
 /**
  * No-flash bootstrap:
- * - Reads ('lg-mode' | 'lg-variant')
- * - (Optional) migrates legacy 'lg-theme' -> new keys
- * - Applies one 'theme-*' class
- * - Only applies '.light' when variant === 'lg'
+ * - Reads stored theme via namespaced key
+ * - Falls back to system preference
+ * - Applies appropriate theme classes
  */
-const noFlash = `
-(function () {
-  try {
-    var MODE_KEY = 'lg-mode';
-    var VAR_KEY  = 'lg-variant';
-    var BG_KEY   = 'lg-bg';
-    var LEGACY   = 'lg-theme';
-    var cl = document.documentElement.classList;
-
-    // ---- migrate legacy 'lg-theme' if present ----
-    var legacy = localStorage.getItem(LEGACY);
-    if (legacy) {
-      var migratedMode =
-        legacy.indexOf('light') >= 0 ? 'light' : 'dark';
-      // Map any old custom names to your new set if needed
-      var migratedVariant =
-        legacy.indexOf('theme-citrus') >= 0 ? 'citrus' :
-        legacy.indexOf('theme-noir')   >= 0 ? 'noir'   :
-        'lg';
-
-      try {
-        localStorage.setItem(MODE_KEY, migratedMode);
-        localStorage.setItem(VAR_KEY, migratedVariant);
-        localStorage.removeItem(LEGACY);
-      } catch (_) {}
-    }
-
-    // ---- read current mode/variant, with sensible fallbacks ----
-    var mode = localStorage.getItem(MODE_KEY);
-    if (mode !== 'light' && mode !== 'dark') {
-      mode =
-        (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches)
-          ? 'dark' : 'light';
-      try { localStorage.setItem(MODE_KEY, mode); } catch (_) {}
-    }
-
-    var variant = localStorage.getItem(VAR_KEY);
-    if (!variant) {
-      variant = 'lg';
-      try { localStorage.setItem(VAR_KEY, variant); } catch (_) {}
-    }
-      var bg = parseInt(localStorage.getItem(BG_KEY) || '0', 10);
-      if (bg !== 1 && bg !== 2 && bg !== 3 && bg !== 4 && bg !== 5) {
-        bg = 0;
-        try { localStorage.setItem(BG_KEY, String(bg)); } catch (_) {}
-      }
-
-    // ---- apply one theme-* class ----
-    Array.from(cl).forEach(function (name) {
-      if (name.indexOf('theme-') === 0) cl.remove(name);
-    });
-    cl.add('theme-' + variant);
-      ['bg-alt1','bg-alt2','bg-light','bg-vhs','bg-streak'].forEach(function (c) { cl.remove(c); });
-      if (bg === 1) cl.add('bg-alt1');
-      else if (bg === 2) cl.add('bg-alt2');
-      else if (bg === 3) cl.add('bg-light');
-      else if (bg === 4) cl.add('bg-vhs');
-      else if (bg === 5) cl.add('bg-streak');
-
-    // ---- light only matters for the base LG theme ----
-    if (variant === 'lg') {
-      if (mode === 'light') cl.add('light'); else cl.remove('light');
-    } else {
-      cl.remove('light');
-    }
-  } catch (_) {}
-})();`;
+const noFlash = themeBootstrapScript();
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (

--- a/src/components/ui/AnimationToggle.tsx
+++ b/src/components/ui/AnimationToggle.tsx
@@ -2,38 +2,33 @@
 
 import * as React from "react";
 import { Zap, ZapOff } from "lucide-react";
+import { useLocalDB, readLocal, writeLocal } from "@/lib/db";
 
-const KEY = "animations-enabled";
+const KEY = "ui:animations";
 
 export default function AnimationToggle() {
-  const [enabled, setEnabled] = React.useState(true);
+  const [enabled, setEnabled] = useLocalDB<boolean>(KEY, true);
   const [showNotice, setShowNotice] = React.useState(false);
 
   React.useEffect(() => {
-    let isEnabled = true;
-    let notice = false;
-    try {
-      const stored = localStorage.getItem(KEY);
-      if (stored !== null) {
-        isEnabled = stored === "true";
-      } else if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-        isEnabled = false;
-        notice = true;
-      }
-    } catch {}
-    setEnabled(isEnabled);
-    setShowNotice(notice);
-    document.documentElement.classList.toggle("no-animations", !isEnabled);
-  }, []);
+    if (
+      readLocal<boolean>(KEY) === null &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      setEnabled(false);
+      writeLocal(KEY, false);
+      setShowNotice(true);
+    }
+  }, [setEnabled]);
+
+  React.useEffect(() => {
+    document.documentElement.classList.toggle("no-animations", !enabled);
+  }, [enabled]);
 
   function toggle() {
     const next = !enabled;
     setEnabled(next);
     setShowNotice(false);
-    try {
-      localStorage.setItem(KEY, String(next));
-    } catch {}
-    document.documentElement.classList.toggle("no-animations", !next);
   }
 
   return (

--- a/src/components/ui/theme/ThemeToggle.tsx
+++ b/src/components/ui/theme/ThemeToggle.tsx
@@ -1,97 +1,27 @@
-// src/components/ui/ThemeToggle.tsx
+// src/components/ui/theme/ThemeToggle.tsx
 "use client";
 
 import * as React from "react";
 import { Sun, Moon, Image as ImageIcon } from "lucide-react";
 import AnimatedSelect, { DropItem } from "@/components/ui/selects/AnimatedSelect";
-
-type Mode = "dark" | "light";
-type Variant = "lg" | "glitch2" | "citrus" | "noir" | "ocean" | "rose";
-type Background = 0 | 1 | 2 | 3 | 4 | 5;
+import { useLocalDB } from "@/lib/db";
+import {
+  applyTheme,
+  defaultTheme,
+  THEME_STORAGE_KEY,
+  VARIANTS,
+  BG_CLASSES,
+  ThemeState,
+  Variant,
+  Background,
+} from "@/lib/theme";
 
 type ThemeToggleProps = {
   className?: string;
   id?: string;
-  ariaLabel?: string;          // preferred
-  "aria-label"?: string;       // backward compat
+  ariaLabel?: string; // preferred
+  "aria-label"?: string; // backward compat
 };
-
-const THEME_KEY = "lg-theme";
-const MODE_KEY  = "lg-mode";
-const VAR_KEY   = "lg-variant";
-const BG_KEY    = "lg-bg";
-
-const BG_CLASSES = ["", "bg-alt1", "bg-alt2", "bg-light", "bg-vhs", "bg-streak"] as const;
-
-const VARIANTS: { id: Variant; label: string }[] = [
-  { id: "lg",       label: "Glitch" },
-  { id: "glitch2",  label: "Glitch v2" },
-  { id: "rose",     label: "Rose Quartz" },
-  { id: "ocean",    label: "Oceanic" },
-  { id: "citrus",   label: "Citrus" },
-  { id: "noir",     label: "Noir" },
-];
-
-const LEGACY = ["theme-lg-dark","theme-lg-light","theme-cyber-void","theme-sunset-synth"];
-
-function parseTheme(v: string | null): { variant: Variant; mode: Mode } {
-  if (v === "theme-lg-light") return { variant: "lg", mode: "light" };
-  if (v === "theme-lg-dark")  return { variant: "lg", mode: "dark" };
-  if (v === "theme-glitch2")  return { variant: "glitch2", mode: "dark" };
-  if (v === "theme-citrus")   return { variant: "citrus", mode: "dark" };
-  if (v === "theme-noir")     return { variant: "noir", mode: "dark" };
-  if (v === "theme-ocean")    return { variant: "ocean", mode: "dark" };
-  if (v === "theme-rose")     return { variant: "rose", mode: "dark" };
-  const prefersDark = typeof window !== "undefined" && window.matchMedia?.("(prefers-color-scheme: dark)").matches;
-  return { variant: "lg", mode: prefersDark ? "dark" : "light" };
-}
-const asThemeString = (v: Variant, m: Mode) => (v === "lg" ? (m === "light" ? "theme-lg-light" : "theme-lg-dark") : `theme-${v}`);
-
-function writeStorage(variant: Variant, mode: Mode, bg: Background) {
-  try {
-    localStorage.setItem(THEME_KEY, asThemeString(variant, mode));
-    localStorage.setItem(MODE_KEY, mode);
-    localStorage.setItem(VAR_KEY, variant);
-    localStorage.setItem(BG_KEY, String(bg));
-  } catch {}
-}
-function readStorage(): { variant: Variant; mode: Mode; bg: Background } {
-  try {
-    const t = localStorage.getItem(THEME_KEY);
-    if (t) {
-      const { variant, mode } = parseTheme(t);
-      const b = parseInt(localStorage.getItem(BG_KEY) || "0", 10);
-      const bg: Background = b >= 1 && b <= 5 ? (b as Background) : 0;
-      return { variant, mode, bg };
-    }
-    const m = localStorage.getItem(MODE_KEY) as Mode | null;
-    const v = localStorage.getItem(VAR_KEY) as Variant | null;
-      const b = parseInt(localStorage.getItem(BG_KEY) || "0", 10);
-      const bg: Background = b >= 1 && b <= 5 ? (b as Background) : 0;
-    if ((m === "dark" || m === "light") && v && VARIANTS.some(x => x.id === v)) return { variant: v, mode: m, bg };
-  } catch {}
-  const { variant, mode } = parseTheme(null);
-  return { variant, mode, bg: 0 };
-}
-function applyClasses(variant: Variant, mode: Mode, bg: Background) {
-  const cl = document.documentElement.classList;
-  // remove previous theme classes
-  cl.forEach(n => { if (n.startsWith("theme-")) cl.remove(n); });
-  LEGACY.forEach(k => cl.remove(k));
-  cl.add(`theme-${variant}`);
-
-  BG_CLASSES.forEach(c => { if (c) cl.remove(c); });
-  if (bg > 0) cl.add(BG_CLASSES[bg]);
-
-  // mode only matters for LG
-  if (variant === "lg") {
-    if (mode === "dark") cl.add("dark"); else cl.remove("dark");
-    if (mode === "light") cl.add("light"); else cl.remove("light");
-  } else {
-    cl.add("dark");
-    cl.remove("light");
-  }
-}
 
 export default function ThemeToggle({
   className = "",
@@ -102,59 +32,41 @@ export default function ThemeToggle({
   const aria = ariaLabel ?? ariaLabelAttr ?? "Theme";
 
   const [mounted, setMounted] = React.useState(false);
-  const [{ variant, mode, bg }, setState] = React.useState<{ variant: Variant; mode: Mode; bg: Background }>({
-    variant: "lg",
-    mode: "dark",
-    bg: 0,
-  });
+  const [state, setState] = useLocalDB<ThemeState>(THEME_STORAGE_KEY, defaultTheme());
+  const { variant, mode } = state;
 
   React.useEffect(() => {
     setMounted(true);
-    const s = readStorage();
-    setState(s);
-    applyClasses(s.variant, s.mode, s.bg);
-    writeStorage(s.variant, s.mode, s.bg);
-    const onStorage = () => {
-      const ns = readStorage();
-      setState(ns);
-      applyClasses(ns.variant, ns.mode, ns.bg);
-    };
-    window.addEventListener("storage", onStorage);
-    return () => window.removeEventListener("storage", onStorage);
   }, []);
+
+  React.useEffect(() => {
+    applyTheme(state);
+  }, [state]);
 
   const modeDisabled = variant !== "lg";
   const isDark = mode === "dark";
 
   function setVariantPersist(v: Variant) {
-    const nextMode: Mode = v === "lg" ? mode : "dark";
-    const next = { variant: v, mode: nextMode, bg };
-    setState(next);
-    writeStorage(next.variant, next.mode, next.bg);
-    applyClasses(next.variant, next.mode, next.bg);
+    setState((prev) => ({ variant: v, mode: v === "lg" ? prev.mode : "dark", bg: prev.bg }));
   }
   function toggleMode() {
     if (modeDisabled) return;
-    const next: Mode = isDark ? "light" : "dark";
-    const s = { variant, mode: next, bg };
-    setState(s);
-    writeStorage(s.variant, s.mode, s.bg);
-    applyClasses(s.variant, s.mode, s.bg);
+    setState((prev) => ({ ...prev, mode: prev.mode === "dark" ? "light" : "dark" }));
   }
-
   function cycleBg() {
-      const next: Background = ((bg + 1) % BG_CLASSES.length) as Background;
-    const s = { variant, mode, bg: next };
-    setState(s);
-    writeStorage(s.variant, s.mode, s.bg);
-    applyClasses(s.variant, s.mode, s.bg);
+    setState((prev) => ({ ...prev, bg: ((prev.bg + 1) % BG_CLASSES.length) as Background }));
   }
 
   if (!mounted) {
-    return <span aria-hidden className={`inline-block h-9 w-9 rounded-full bg-[hsl(var(--input))] ${className}`} />;
+    return (
+      <span
+        aria-hidden
+        className={`inline-block h-9 w-9 rounded-full bg-[hsl(var(--input))] ${className}`}
+      />
+    );
   }
 
-  const items: DropItem[] = VARIANTS.map(v => ({ value: v.id, label: v.label }));
+  const items: DropItem[] = VARIANTS.map((v) => ({ value: v.id, label: v.label }));
 
   return (
     <div className={`flex items-center gap-2 whitespace-nowrap ${className}`}>
@@ -203,3 +115,4 @@ export default function ThemeToggle({
     </div>
   );
 }
+

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,93 @@
+import { readLocal, writeLocal } from "./db";
+
+export type Mode = "dark" | "light";
+export type Variant = "lg" | "glitch2" | "citrus" | "noir" | "ocean" | "rose";
+export type Background = 0 | 1 | 2 | 3 | 4 | 5;
+export interface ThemeState {
+  variant: Variant;
+  mode: Mode;
+  bg: Background;
+}
+
+export const THEME_STORAGE_KEY = "ui:theme";
+
+export const BG_CLASSES = ["", "bg-alt1", "bg-alt2", "bg-light", "bg-vhs", "bg-streak"] as const;
+
+export const VARIANTS: { id: Variant; label: string }[] = [
+  { id: "lg", label: "Glitch" },
+  { id: "glitch2", label: "Glitch v2" },
+  { id: "rose", label: "Rose Quartz" },
+  { id: "ocean", label: "Oceanic" },
+  { id: "citrus", label: "Citrus" },
+  { id: "noir", label: "Noir" },
+];
+
+export function defaultTheme(): ThemeState {
+  const prefersDark =
+    typeof window !== "undefined" &&
+    window.matchMedia?.("(prefers-color-scheme: dark)").matches;
+  return { variant: "lg", mode: prefersDark ? "dark" : "light", bg: 0 };
+}
+
+export function readTheme(): ThemeState {
+  return readLocal<ThemeState>(THEME_STORAGE_KEY) ?? defaultTheme();
+}
+
+export function writeTheme(state: ThemeState) {
+  writeLocal(THEME_STORAGE_KEY, state);
+}
+
+export function applyTheme({ variant, mode, bg }: ThemeState) {
+  const cl = document.documentElement.classList;
+  cl.forEach((n) => {
+    if (n.startsWith("theme-")) cl.remove(n);
+  });
+  cl.add(`theme-${variant}`);
+
+  BG_CLASSES.forEach((c) => {
+    if (c) cl.remove(c);
+  });
+  if (bg > 0) cl.add(BG_CLASSES[bg]);
+
+  if (variant === "lg") {
+    if (mode === "dark") cl.add("dark");
+    else cl.remove("dark");
+    if (mode === "light") cl.add("light");
+    else cl.remove("light");
+  } else {
+    cl.add("dark");
+    cl.remove("light");
+  }
+}
+
+export function themeBootstrapScript(): string {
+  return `((function(){
+    try {
+      var STORAGE_PREFIX = "13lr:";
+      function parseJSON(raw){ if(!raw) return null; try{return JSON.parse(raw);}catch{return null;} }
+      function readLocal(key){ try{ return parseJSON(localStorage.getItem(STORAGE_PREFIX+key)); } catch { return null; } }
+      function writeLocal(key,val){ try{ localStorage.setItem(STORAGE_PREFIX+key, JSON.stringify(val)); } catch {} }
+      var key = "${THEME_STORAGE_KEY}";
+      var data = readLocal(key);
+      if(!data){
+        var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        data = { variant: 'lg', mode: prefersDark ? 'dark' : 'light', bg: 0 };
+        writeLocal(key, data);
+      }
+      var BG_CLASSES = ${JSON.stringify(BG_CLASSES)};
+      var cl = document.documentElement.classList;
+      Array.from(cl).forEach(function(n){ if(n.indexOf('theme-')===0) cl.remove(n); });
+      cl.add('theme-' + data.variant);
+      BG_CLASSES.forEach(function(c){ if(c) cl.remove(c); });
+      if(data.bg>0) cl.add(BG_CLASSES[data.bg]);
+      if(data.variant==='lg'){
+        if(data.mode==='dark') cl.add('dark'); else cl.remove('dark');
+        if(data.mode==='light') cl.add('light'); else cl.remove('light');
+      } else {
+        cl.add('dark');
+        cl.remove('light');
+      }
+    } catch { }
+  })())`;
+}
+


### PR DESCRIPTION
## Summary
- centralize theme persistence and class application in new utility
- store theme and animation settings via `useLocalDB` helpers
- bootstrap theme with namespaced local DB to avoid flash

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bae459fb94832c9d3d5791d42945eb