### PR TITLE
feat: add inline goal edit form with focus handling

### DIFF
--- a/src/components/goals/GoalSlot.tsx
+++ b/src/components/goals/GoalSlot.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import * as React from "react";
-import { Check, Pencil, Trash2 } from "lucide-react";
+import { Check, Pencil, Trash2, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { Goal } from "@/lib/types";
 import { PillarBadge } from "@/components/ui";
+import Input from "@/components/ui/primitives/input";
 
 interface GoalSlotProps {
   goal?: Goal | null;
@@ -14,52 +15,118 @@ interface GoalSlotProps {
 }
 
 export default function GoalSlot({ goal, onToggleDone, onEdit, onDelete }: GoalSlotProps) {
-  function handleEdit() {
-    if (!goal || !onEdit) return;
-    const t = window.prompt("Edit goal title", goal.title);
-    if (t !== null) {
-      const clean = t.trim();
-      if (clean) onEdit(goal.id, clean);
+  const [editing, setEditing] = React.useState(false);
+  const [title, setTitle] = React.useState("");
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const editBtnRef = React.useRef<HTMLButtonElement>(null);
+
+  React.useEffect(() => {
+    if (editing) {
+      setTitle(goal?.title ?? "");
+      inputRef.current?.focus();
     }
+  }, [editing, goal?.title]);
+
+  function startEdit() {
+    if (!goal) return;
+    setEditing(true);
+  }
+
+  function cancelEdit() {
+    setEditing(false);
+    setTitle(goal?.title ?? "");
+    editBtnRef.current?.focus();
+  }
+
+  function submitEdit() {
+    if (!goal || !onEdit) return;
+    const clean = title.trim();
+    if (clean) onEdit(goal.id, clean);
+    setEditing(false);
+    editBtnRef.current?.focus();
   }
 
   return (
     <div className={cn("goal-tv group shadow-neoSoft", goal?.done && "goal-tv--done")}>
       <div className="goal-tv__screen">
         {goal ? (
-          <>
-            <div className="flex flex-col items-center">
-              <span className="block">{goal.title}</span>
-              {goal.pillar && (
-                <PillarBadge pillar={goal.pillar} size="sm" className="mt-1" as="span" />
-              )}
-            </div>
-            <button
-              type="button"
-              className="goal-tv__check"
-              aria-label={goal.done ? "Mark goal undone" : "Mark goal done"}
-              aria-pressed={goal.done}
-              onClick={() => onToggleDone?.(goal.id)}
+          editing ? (
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                submitEdit();
+              }}
+              className="relative flex h-full w-full items-center justify-center"
             >
-              <Check className="h-4 w-4" />
-            </button>
-            <button
-              type="button"
-              className="goal-tv__edit"
-              aria-label="Edit goal"
-              onClick={handleEdit}
-            >
-              <Pencil className="h-4 w-4" />
-            </button>
-            <button
-              type="button"
-              className="goal-tv__delete"
-              aria-label="Delete goal"
-              onClick={() => onDelete?.(goal.id)}
-            >
-              <Trash2 className="h-4 w-4" />
-            </button>
-          </>
+              <label htmlFor={`goal-${goal.id}-edit`} className="sr-only">
+                Edit goal title
+              </label>
+              <Input
+                ref={inputRef}
+                id={`goal-${goal.id}-edit`}
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                aria-label="Goal title"
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    e.preventDefault();
+                    cancelEdit();
+                  }
+                }}
+                className="h-8 w-full rounded-sm bg-[hsl(var(--surface))] px-1 text-center"
+              />
+              <button
+                type="submit"
+                className="goal-tv__check"
+                aria-label="Save title"
+              >
+                <Check className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                className="goal-tv__delete"
+                aria-label="Cancel edit"
+                onClick={cancelEdit}
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </form>
+          ) : (
+            <>
+              <div className="flex flex-col items-center">
+                <span className="block">{goal.title}</span>
+                {goal.pillar && (
+                  <PillarBadge pillar={goal.pillar} size="sm" className="mt-1" as="span" />
+                )}
+              </div>
+              <button
+                type="button"
+                className="goal-tv__check"
+                aria-label={goal.done ? "Mark goal undone" : "Mark goal done"}
+                aria-pressed={goal.done}
+                onClick={() => onToggleDone?.(goal.id)}
+              >
+                <Check className="h-4 w-4" />
+              </button>
+              <button
+                ref={editBtnRef}
+                type="button"
+                className="goal-tv__edit"
+                aria-label="Edit goal"
+                onClick={startEdit}
+              >
+                <Pencil className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                className="goal-tv__delete"
+                aria-label="Delete goal"
+                onClick={() => onDelete?.(goal.id)}
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </>
+          )
         ) : (
           <span className="goal-tv__empty">NO SIGNAL</span>
         )}


### PR DESCRIPTION
## Summary
- replace prompt dialog with inline form for editing goal titles
- add focus management and accessible controls for goal edits

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bae39b4b6c832cbfb78437f3dc0615