### PR TITLE
chore: standardize primitive file names

### DIFF
--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
-import { buttonSizes, type ButtonSize } from "./button";
+import { buttonSizes, type ButtonSize } from "./Button";
 
 type Icon = "xs" | "sm" | "md" | "lg";
 


### PR DESCRIPTION
## Summary
- rename primitive component files to PascalCase
- update all imports to match new names
- fix IconButton import to use renamed Button component

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68baeea47bf8832c8ddc09d0320c957d