### PR TITLE
feat(ui): add glitch-themed primary button

### DIFF
--- a/src/components/ui/primitives/button.tsx
+++ b/src/components/ui/primitives/button.tsx
@@ -38,10 +38,11 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, size = "md", variant = "secondary", children, ...rest }, ref) => {
     const s = buttonSizes[size];
     const base = cn(
-      "relative inline-flex items-center justify-center gap-2 rounded-2xl",
+      "relative inline-flex items-center justify-center rounded-2xl transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent)/.6)]",
       s.height,
       s.padding,
       s.text,
+      s.gap,
       "text-[hsl(var(--text))]",
       className
     );
@@ -50,7 +51,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       return (
         <motion.button
           ref={ref}
-          className={cn(base, "bg-[hsl(var(--panel)/0.85)]")}
+          className={cn(base, "bg-[hsl(var(--panel)/0.85)] overflow-hidden")}
           style={{ boxShadow: neuRaised(12) }}
           whileHover={{ scale: 1.03, boxShadow: neuRaised(16) }}
           whileTap={{
@@ -60,10 +61,10 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           {...rest}
         >
           <span
-            className="absolute inset-0 z-0 rounded-2xl ring-1 ring-[hsl(var(--line))]"
+            className="absolute inset-0 pointer-events-none rounded-2xl"
             style={{
               background:
-                "linear-gradient(180deg, rgba(255,255,255,0.15), transparent)",
+                "linear-gradient(90deg, hsl(var(--accent)/.18), hsl(var(--accent-2)/.18))",
             }}
           />
           <span className="relative z-10 font-semibold inline-flex items-center gap-2">


### PR DESCRIPTION
## Summary
- enhance button base with transitions and focus ring
- add accent gradient overlay for glitch-themed primary variant

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68baef7a799c832c88ab53a073225b67