### PR TITLE
Optimize prompts filtering

### DIFF
--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -32,15 +32,18 @@ export default function PromptsPage() {
   // Search (now lives in the header)
   const [query, setQuery] = React.useState("");
 
-  // Derived: filtered list
-  const filtered = React.useMemo(() => {
+  // Derived: filtered list (compute titles once per prompt)
+  type PromptWithTitle = Prompt & { title: string };
+  const filtered: PromptWithTitle[] = React.useMemo(() => {
     const q = query.trim().toLowerCase();
-    if (!q) return prompts.slice();
-    return prompts.filter((p) => {
-      const title = deriveTitle(p).toLowerCase();
-      const text = (p.text || "").toLowerCase();
-      return title.includes(q) || text.includes(q);
-    });
+    return prompts.reduce<PromptWithTitle[]>((acc, p) => {
+      const title = deriveTitle(p);
+      const text = p.text || "";
+      if (!q || title.toLowerCase().includes(q) || text.toLowerCase().includes(q)) {
+        acc.push({ ...p, title });
+      }
+      return acc;
+    }, []);
   }, [prompts, query]);
 
   function deriveTitle(p: Prompt) {
@@ -116,7 +119,7 @@ export default function PromptsPage() {
           {filtered.map((p) => (
             <article key={p.id} className="card-neo p-3">
               <header className="flex items-center justify-between">
-                <h3 className="font-semibold">{deriveTitle(p)}</h3>
+                <h3 className="font-semibold">{p.title}</h3>
                 <time className="text-xs text-muted-foreground">
                   {new Date(p.createdAt).toLocaleString(LOCALE)}
                 </time>


### PR DESCRIPTION
## Summary
- compute prompt titles once and reuse during filtering

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bb4a060aac832c8bc8667c68aee1aa