### PR TITLE
fix accessibility main landmark

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,9 +30,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body className="min-h-screen bg-[hsl(var(--background))] text-[hsl(var(--foreground))] glitch-root">
         <SiteChrome />
-        <main className="relative z-10">
+        <div className="relative z-10">
           {children}
-        </main>
+        </div>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- remove extra layout `<main>` to avoid nested landmarks and hidden duplicates

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb50449964832ca213eb360504afa3