### PR TITLE
fix: make prompts page a client component

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -1,4 +1,5 @@
-import type { Metadata } from "next";
+"use client";
+
 import {
   Button,
   SectionCard,
@@ -21,8 +22,6 @@ import {
   AnimatedSelect,
 } from "@/components/ui";
 import { Plus, Sun } from "lucide-react";
-
-export const metadata: Metadata = { title: "Prompts · 13 League Review" };
 
 export default function Page() {
   const tabs = [


### PR DESCRIPTION
## Summary
- convert prompts page to a client component so event handlers can be passed safely
- remove server-only metadata export from prompts page

## Testing
- `npx vitest run`
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb54870ffc832c97975ba5424acef5