### PR TITLE
Align IconButton with input field height

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -21,7 +21,7 @@ import {
   Toggle,
   AnimatedSelect,
 } from "@/components/ui";
-import { Plus, Sun } from "lucide-react";
+import { Plus, Sun, Search } from "lucide-react";
 
 export default function Page() {
   const tabs = [
@@ -131,6 +131,15 @@ export default function Page() {
             <Input size="md" placeholder="Medium" />
             <Input size="lg" placeholder="Large" />
             <Input tone="pill" placeholder="Pill" />
+          </div>
+        </div>
+        <div className="flex flex-col items-center space-y-2">
+          <span className="text-sm font-medium">Input w/ Icon</span>
+          <div className="w-56 flex items-center gap-2">
+            <Input size="md" placeholder="Search" className="flex-1" />
+            <IconButton size="md">
+              <Search />
+            </IconButton>
           </div>
         </div>
         <div className="flex flex-col items-center space-y-2">

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
-import { buttonSizes, type ButtonSize } from "./button";
+import type { ButtonSize } from "./button";
 
 type Icon = "xs" | "sm" | "md" | "lg";
 
@@ -27,6 +27,12 @@ const iconMap: Record<Icon, string> = {
   lg: "[&>svg]:h-6 [&>svg]:w-6",
 };
 
+const sizeMap: Record<ButtonSize, string> = {
+  sm: "h-9 w-9",
+  md: "h-[52px] w-[52px]",
+  lg: "h-14 w-14",
+};
+
 const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
   (
     { size = "md", circleSize, iconSize = size, className, ...rest },
@@ -35,8 +41,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { tone: _tone, active: _active, fx: _fx, variant: _variant, ...props } = rest;
     const finalSize = circleSize ?? size;
-    const h = buttonSizes[finalSize].height;
-    const sizeClass = `${h} ${h.replace("h-", "w-")}`;
+    const sizeClass = sizeMap[finalSize];
     return (
       <button
         ref={ref}


### PR DESCRIPTION
## Summary
- Ensure `IconButton` uses explicit height/width pairs matching input field sizes
- Document new icon-adjacent input example on the prompts page

## Testing
- `npm test` (fails: require() of ES Module Vite)
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bb6eb23830832c8a1b3b853ff38b9b