### PR TITLE
feat: add theme contrast glow outlines

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,8 +27,9 @@ html.no-animations *::after {
 
 /* Global focus & selection styling */
 *:focus-visible {
-  outline: 2px solid hsl(var(--ring));
+  outline: 2px solid hsl(var(--ring-contrast));
   outline-offset: 2px;
+  box-shadow: 0 0 6px hsl(var(--glow) / 0.6);
 }
 
 ::selection {

--- a/src/components/prompts/OutlineGlowDemo.tsx
+++ b/src/components/prompts/OutlineGlowDemo.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+
+export default function OutlineGlowDemo() {
+  return (
+    <div className="mb-4">
+      <button className="p-2 rounded-md border">
+        Focus me to see the glow
+      </button>
+    </div>
+  );
+}

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -11,6 +11,7 @@ import SectionCard from "@/components/ui/layout/SectionCard";
 import Textarea from "@/components/ui/primitives/textarea";
 import Button from "@/components/ui/primitives/button";
 import Input from "@/components/ui/primitives/input";
+import OutlineGlowDemo from "@/components/prompts/OutlineGlowDemo";
 import { useLocalDB, uid } from "@/lib/db";
 import { LOCALE } from "@/lib/utils";
 
@@ -100,6 +101,7 @@ export default function PromptsPage() {
       </SectionCard.Header>
 
       <SectionCard.Body>
+        <OutlineGlowDemo />
         {/* Compose panel */}
         <div className="space-y-2.5">
           <Input


### PR DESCRIPTION
## Summary
- add global focus outlines that use theme contrast and glow
- showcase outline glow component on prompts page

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bb6962260c832c9ddafc109af191c1