### PR TITLE
style: matte input field

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -21,7 +21,7 @@ import {
   Toggle,
   AnimatedSelect,
 } from "@/components/ui";
-import { Plus, Sun } from "lucide-react";
+import { Plus, Sun, Check } from "lucide-react";
 
 export default function Page() {
   const tabs = [
@@ -131,6 +131,21 @@ export default function Page() {
             <Input size="md" placeholder="Medium" />
             <Input size="lg" placeholder="Large" />
             <Input tone="pill" placeholder="Pill" />
+          </div>
+        </div>
+        <div className="flex flex-col items-center space-y-2">
+          <span className="text-sm font-medium">Input w/ Icon</span>
+          <div className="w-56">
+            <Input placeholder="Confirm">
+              <button
+                type="button"
+                aria-label="Confirm"
+                className="absolute right-2 top-1/2 -translate-y-1/2 size-7 rounded-full grid place-items-center border border-[hsl(var(--accent)/0.45)] bg-[hsl(var(--accent)/0.12)] text-[hsl(var(--accent))] shadow-[0_0_0_1px_hsl(var(--accent)/0.25)] hover:shadow-[0_0_16px_hsl(var(--accent)/0.22)]"
+              >
+                <Check className="size-4" />
+              </button>
+            </Input>
+            <p className="mt-1 text-xs text-muted-foreground">Helper text</p>
           </div>
         </div>
         <div className="flex flex-col items-center space-y-2">

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -13,6 +13,7 @@ import Button from "@/components/ui/primitives/button";
 import Input from "@/components/ui/primitives/input";
 import { useLocalDB, uid } from "@/lib/db";
 import { LOCALE } from "@/lib/utils";
+import { Check as CheckIcon } from "lucide-react";
 
 type Prompt = {
   id: string;
@@ -31,6 +32,8 @@ export default function PromptsPage() {
 
   // Search (now lives in the header)
   const [query, setQuery] = React.useState("");
+
+  const titleId = React.useId();
 
   // Derived: filtered list (compute titles once per prompt)
   type PromptWithTitle = Prompt & { title: string };
@@ -103,10 +106,23 @@ export default function PromptsPage() {
         {/* Compose panel */}
         <div className="space-y-2.5">
           <Input
+            id={titleId}
             placeholder="Title"
             value={titleDraft}
             onChange={(e) => setTitleDraft(e.target.value)}
-          />
+            aria-describedby={`${titleId}-help`}
+          >
+            <button
+              type="button"
+              aria-label="Confirm"
+              className="absolute right-2 top-1/2 -translate-y-1/2 size-7 rounded-full grid place-items-center border border-[hsl(var(--accent)/0.45)] bg-[hsl(var(--accent)/0.12)] text-[hsl(var(--accent))] shadow-[0_0_0_1px_hsl(var(--accent)/0.25)] hover:shadow-[0_0_16px_hsl(var(--accent)/0.22)]"
+            >
+              <CheckIcon className="size-4" />
+            </button>
+          </Input>
+          <p id={`${titleId}-help`} className="mt-1 text-xs text-muted-foreground">
+            Add a short title
+          </p>
           <Textarea
             placeholder="Write your prompt or snippet…"
             value={textDraft}

--- a/src/components/ui/primitives/input.tsx
+++ b/src/components/ui/primitives/input.tsx
@@ -3,7 +3,6 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
-import { neuInset } from "./neu";
 
 /** Small helper to generate a stable name from aria-label if missing. */
 function slug(s?: string) {
@@ -29,21 +28,14 @@ export type InputProps = Omit<
   indent?: boolean;
 };
 
-const BASE =
-  "block w-full max-w-[343px] rounded-2xl bg-[hsl(var(--panel)/0.9)] " +
-  "text-[hsl(var(--text))] placeholder:text-[hsl(var(--muted-foreground))] " +
-  "ring-1 ring-[hsl(var(--line)/0.8)] " +
-  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] " +
-  "disabled:opacity-50 disabled:cursor-not-allowed transition-colors";
-
 const SIZE: Record<InputSize, string> = {
-  sm: "h-9 px-3 py-2 text-sm",
-  md: "h-[52px] px-4 py-3 text-base",
-  lg: "h-14 px-6 py-4 text-lg",
+  sm: "h-11",
+  md: "h-12",
+  lg: "h-14",
 };
 
 /**
- * Input — Lavender-Glitch styled input
+ * Input — Matte field with optional trailing slot.
  * - Defaults to `tone="default"` (16px corners)
  * - Accepts className overrides and passes all standard <input> props
  * - Auto-generates stable `id` and `name` if not provided
@@ -58,33 +50,52 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
     tone = "default",
     size = "sm",
     indent = false,
+    children,
     ...props
   },
   ref
 ) {
   const auto = React.useId();
   const fromAria = slug(ariaLabel as string | undefined);
-  // Always derive a unique id from React to avoid duplicates when the same
-  // aria-label is used for multiple fields.
   const finalId = id || auto;
   const finalName = name || fromAria || finalId;
 
+  const error = props["aria-invalid"] ? true : false;
+  const disabled = props.disabled;
+
   return (
-    <input
-      ref={ref}
-      id={finalId}
-      name={finalName}
-      size={typeof size === "number" ? size : undefined}
+    <div
       className={cn(
-        BASE,
-        typeof size === "string" ? SIZE[size] : SIZE.sm,
-        tone === "pill" ? "rounded-full" : undefined,
-        indent && "pl-10",
-        "relative before:absolute before:inset-0 before:rounded-2xl before:bg-gradient-to-b before:from-white/10 before:to-transparent",
+        "relative inline-flex w-full items-center rounded-[16px] border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.60)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:ring-2 focus-within:ring-[hsl(var(--accent)/0.28)] focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--background))] focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(255,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('https://grainy-gradients.vercel.app/noise.svg')]",
+        tone === "pill" && "rounded-full",
+        error && "border-[hsl(var(--destructive)/0.6)] focus-within:ring-[hsl(var(--destructive)/0.35)]",
+        disabled && "opacity-60 pointer-events-none",
         className
       )}
-      style={{ boxShadow: neuInset(10), ...style }}
-      {...props}
-    />
+      style={style}
+    >
+      <input
+        ref={ref}
+        id={finalId}
+        name={finalName}
+        size={typeof size === "number" ? size : undefined}
+        className={cn(
+          "w-full bg-transparent px-3.5 pr-10 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] outline-none border-none",
+          typeof size === "string" ? SIZE[size] : SIZE.sm,
+          indent && "pl-10"
+        )}
+        {...props}
+      />
+      {children}
+
+      {/* Autofill override */}
+      <style>{`
+        input:-webkit-autofill {
+          box-shadow: 0 0 0 1000px hsl(var(--card)) inset;
+          -webkit-text-fill-color: hsl(var(--foreground));
+        }
+      `}</style>
+    </div>
   );
 });
+

--- a/tests/primitives/input.test.tsx
+++ b/tests/primitives/input.test.tsx
@@ -8,7 +8,7 @@ afterEach(cleanup);
 describe('Input', () => {
   it('uses small size classes by default', () => {
     const { getByRole } = render(<Input aria-label="test" />);
-    expect(getByRole('textbox')).toHaveClass('h-9');
+    expect(getByRole('textbox')).toHaveClass('h-11');
   });
 
   it('adds indent padding when enabled', () => {


### PR DESCRIPTION
## Summary
- restyle input primitive with matte container, focus ring, texture layers, and autofill override
- wire title input to use in-field check icon and helper text
- add input-with-icon example to prompts showcase and update tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb6f892920832ca4724d3b83c585dd