### PR TITLE
fix: add styled-jsx type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/node": "^24.3.1",
         "@types/react": "^18.3.24",
         "@types/react-dom": "^18.3.7",
+        "@types/styled-jsx": "^2.2.9",
         "autoprefixer": "^10.4.21",
         "eslint": "8.57.1",
         "eslint-config-next": "14.2.32",
@@ -1640,6 +1641,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/styled-jsx": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@types/styled-jsx/-/styled-jsx-2.2.9.tgz",
+      "integrity": "sha512-W/iTlIkGEyTBGTEvZCey8EgQlQ5l0DwMqi3iOXlLs2kyBwYTXHKEiU6IZ5EwoRwngL8/dGYuzezSup89ttVHLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/node": "^24.3.1",
     "@types/react": "^18.3.24",
     "@types/react-dom": "^18.3.7",
+    "@types/styled-jsx": "^2.2.9",
     "autoprefixer": "^10.4.21",
     "eslint": "8.57.1",
     "eslint-config-next": "14.2.32",


### PR DESCRIPTION
## Summary
- install @types/styled-jsx to satisfy TypeScript type references

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bb85053248832cbb76f772a560e2ed