### PR TITLE
Fix UI primitive import casing

### DIFF
--- a/src/components/goals/GoalSlot.tsx
+++ b/src/components/goals/GoalSlot.tsx
@@ -4,8 +4,7 @@ import * as React from "react";
 import { Check, Pencil, Trash2, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { Goal } from "@/lib/types";
-import { PillarBadge } from "@/components/ui";
-import Input from "@/components/ui/primitives/input";
+import { PillarBadge, Input } from "@/components/ui";
 
 interface GoalSlotProps {
   goal?: Goal | null;

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -7,13 +7,11 @@
  */
 
 import * as React from "react";
-import SectionCard from "@/components/ui/layout/SectionCard";
-import Textarea from "@/components/ui/primitives/textarea";
-import Button from "@/components/ui/primitives/button";
-import Input from "@/components/ui/primitives/input";
+import { SectionCard, Textarea, Button, Input } from "@/components/ui";
 import { useLocalDB, uid } from "@/lib/db";
 import { LOCALE } from "@/lib/utils";
 import { Check as CheckIcon } from "lucide-react";
+import OutlineGlowDemo from "./OutlineGlowDemo";
 
 type Prompt = {
   id: string;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -7,12 +7,12 @@
 //
 export { default as Button } from "./primitives/Button";
 export { default as IconButton } from "./primitives/IconButton";
-export { default as Input } from "./primitives/input";
-export { default as Textarea } from "./primitives/textarea";
-export { default as Badge } from "./primitives/badge";
-export { default as Pill } from "./primitives/pill";
-export { default as SearchBar } from "./primitives/searchbar";
-export { GlitchSegmentedGroup, GlitchSegmentedButton } from "./primitives/glitch-segmented";
+export { default as Input } from "./primitives/Input";
+export { default as Textarea } from "./primitives/Textarea";
+export { default as Badge } from "./primitives/Badge";
+export { default as Pill } from "./primitives/Pill";
+export { default as SearchBar } from "./primitives/SearchBar";
+export { GlitchSegmentedGroup, GlitchSegmentedButton } from "./primitives/GlitchSegmented";
 //
 // Feedback
 //


### PR DESCRIPTION
## Summary
- correct casing of UI primitive exports in ui index
- import primitives via centralized UI module on Prompts and GoalSlot
- add missing OutlineGlowDemo import

## Testing
- `npm test`
- `npm run build` *(fails: 'PILLARS' is assigned a value but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb977e34bc832c9bdb6e274c34abe8