### PR TITLE
fix: correct UI primitive imports

### DIFF
--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import * as React from "react";
+import { SectionCard } from "@/components/ui";
 import Input from "@/components/ui/primitives/Input";
 import IconButton from "@/components/ui/primitives/IconButton";
-import { GripVertical, Trash2 } from "lucide-react";
+import { Trash2 } from "lucide-react";
+import { LOCALE } from "@/lib/utils";
 
 export type WaitItem = { id: string; text: string; createdAt: number };
 
@@ -28,62 +30,50 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
     <SectionCard className="card-neo-soft">
       <SectionCard.Header title={<h2 className="text-lg font-semibold">Goal Queue</h2>} />
       <SectionCard.Body className="grid gap-6">
-        <ul className="divide-y divide-white/10">
-          {items.length === 0 ? (
-            <li className="py-3 text-sm text-white/60">No queued goals</li>
-          ) : (
-            items.map((it) => (
-              <li key={it.id} className="group flex items-center gap-2 py-3">
-                <span className="h-1.5 w-1.5 rounded-full bg-white/40" aria-hidden />
-                <p className="flex-1 truncate text-sm">{it.text}</p>
-                <time
-                  className="text-xs text-white/60 opacity-0 group-hover:opacity-100"
-                  dateTime={new Date(it.createdAt).toISOString()}
-                >
-                  {new Date(it.createdAt).toLocaleDateString(LOCALE)}
-                </time>
-                <div className="flex items-center gap-1 ml-2">
-                  <IconButton
-                    title="Promote"
-                    aria-label="Promote"
-                    onClick={() => onPromote(it)}
-                    circleSize="sm"
-                    iconSize="sm"
-                    variant="ring"
-                    className="opacity-0 group-hover:opacity-100"
+          <ul className="divide-y divide-white/10">
+            {items.length === 0 ? (
+              <li className="py-3 text-sm text-white/60">No queued goals</li>
+            ) : (
+              items.map((it) => (
+                <li key={it.id} className="group flex items-center gap-2 py-3">
+                  <span className="h-1.5 w-1.5 rounded-full bg-white/40" aria-hidden />
+                  <p className="flex-1 truncate text-sm">{it.text}</p>
+                  <time
+                    className="text-xs text-white/60 opacity-0 group-hover:opacity-100"
+                    dateTime={new Date(it.createdAt).toISOString()}
                   >
-                    <ArrowUpRight />
-                  </IconButton>
-                  <IconButton
-                    title="Delete"
-                    aria-label="Delete"
-                    onClick={() => onRemove(it.id)}
-                    circleSize="sm"
-                    iconSize="sm"
-                    variant="ring"
-                    className="opacity-0 group-hover:opacity-100"
-                  >
-                    <Trash2 />
-                  </IconButton>
-                </div>
-              </li>
-            ))
-          )}
-        </ul>
-      )}
+                    {new Date(it.createdAt).toLocaleDateString(LOCALE)}
+                  </time>
+                  <div className="flex items-center gap-1 ml-2">
+                    <IconButton
+                      title="Delete"
+                      aria-label="Delete"
+                      onClick={() => onRemove(it.id)}
+                      circleSize="sm"
+                      iconSize="sm"
+                      variant="ring"
+                      className="opacity-0 group-hover:opacity-100"
+                    >
+                      <Trash2 />
+                    </IconButton>
+                  </div>
+                </li>
+              ))
+            )}
+          </ul>
 
-        <form onSubmit={submit} className="flex items-center gap-2 pt-3">
-          <span className="h-1.5 w-1.5 rounded-full bg-white/40" aria-hidden />
-          <Input
-            tone="default"
-            className="flex-1 h-9 text-sm focus:ring-2 focus:ring-purple-400/60"
-            value={val}
-            onChange={(e) => setVal(e.currentTarget.value)}
-            placeholder="Add to queue and press Enter"
-          />
-        </form>
-      </SectionCard.Body>
-    </SectionCard>
-  );
-}
+          <form onSubmit={submit} className="flex items-center gap-2 pt-3">
+            <span className="h-1.5 w-1.5 rounded-full bg-white/40" aria-hidden />
+            <Input
+              tone="default"
+              className="flex-1 h-9 text-sm focus:ring-2 focus:ring-purple-400/60"
+              value={val}
+              onChange={(e) => setVal(e.currentTarget.value)}
+              placeholder="Add to queue and press Enter"
+            />
+          </form>
+        </SectionCard.Body>
+      </SectionCard>
+    );
+  }
 

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -7,12 +7,12 @@
 //
 export { default as Button } from "./primitives/Button";
 export { default as IconButton } from "./primitives/IconButton";
-export { default as Input } from "./primitives/input";
-export { default as Textarea } from "./primitives/textarea";
-export { default as Badge } from "./primitives/badge";
-export { default as Pill } from "./primitives/pill";
-export { default as SearchBar } from "./primitives/searchbar";
-export { GlitchSegmentedGroup, GlitchSegmentedButton } from "./primitives/glitch-segmented";
+export { default as Input } from "./primitives/Input";
+export { default as Textarea } from "./primitives/Textarea";
+export { default as Badge } from "./primitives/Badge";
+export { default as Pill } from "./primitives/Pill";
+export { default as SearchBar } from "./primitives/SearchBar";
+export { GlitchSegmentedGroup, GlitchSegmentedButton } from "./primitives/GlitchSegmented";
 //
 // Feedback
 //

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
-import { buttonSizes, type ButtonSize } from "./button";
+import type { ButtonSize } from "./Button";
 
 type Icon = "xs" | "sm" | "md" | "lg";
 
@@ -35,7 +35,7 @@ const sizeMap: Record<ButtonSize, string> = {
 
 const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
   (
-    { size = "md", circleSize, iconSize = size, className, ...rest },
+    { size = "md", circleSize, iconSize = size as Icon, className, ...rest },
     ref
   ) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -3,7 +3,6 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
-import { neuInset } from "./neu";
 
 /** Small helper to generate a stable name from aria-label if missing. */
 function slug(s?: string) {


### PR DESCRIPTION
## Summary
- fix case-sensitive UI primitive imports
- clean up GoalQueue component and icon button types

## Testing
- `npm test -- --run`
- `npm run typecheck` *(fails: Cannot find name 'SectionCard', etc.)*
- `npm run lint` *(fails: unused vars in goal components)*
- `npm run build` *(fails: ESLint errors in goal components)*

------
https://chatgpt.com/codex/tasks/task_e_68bba16ef738832c93a3fa63fe5a5714