### PR TITLE
feat: unify design tokens and card primitive

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -10,7 +10,7 @@ This project ships with a small design system based on Tailwind CSS and CSS vari
 
 ## Layout and spacing
 - Use a 12‑column grid with 24px gutters.
-- Spacing scale is limited to 8/12/16/20/24/32px.
+- Spacing scale: 4, 8, 12, 16, 24, 32, 48, 64.
 
 ## Typography
 - Font sizes: 12px for labels, 14px for UI text, 16px for body copy, and 20/24px for titles.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1564,14 +1564,47 @@ textarea:-webkit-autofill {
   }
 }
 
-/* ===== Design System Spacing ===== */
+/* ===== Design Tokens ===== */
 :root {
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 0.75rem;
-  --space-4: 1rem;
-  --space-5: 1.25rem;
-  --space-6: 1.5rem;
+  /* Spacing scale */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+
+  /* Glow tokens */
+  --glow-strong: 0 0 20px hsl(var(--ring) / 0.6);
+  --glow-soft: 0 0 10px hsl(var(--ring) / 0.3);
+}
+
+@layer components {
+  .type-eyebrow {
+    @apply text-xs font-medium tracking-wide uppercase;
+  }
+  .type-title {
+    @apply text-2xl font-semibold;
+  }
+  .type-subtitle {
+    @apply text-lg font-medium;
+  }
+  .type-body {
+    @apply text-base;
+  }
+  .type-caption {
+    @apply text-xs text-muted-foreground;
+  }
+  .title-ghost {
+    @apply text-2xl font-semibold opacity-60;
+    filter: blur(1px);
+  }
+  .title-glow {
+    @apply text-2xl font-semibold;
+    text-shadow: var(--glow-strong);
+  }
 }
 .ds-grid-gap {
   gap: var(--space-4);

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -7,7 +7,7 @@
  */
 
 import * as React from "react";
-import { SectionCard, Textarea, Button, Input } from "@/components/ui";
+import { SectionCard, Textarea, Button, Input, Card } from "@/components/ui";
 import { useLocalDB, uid } from "@/lib/db";
 import { LOCALE } from "@/lib/utils";
 import { Check as CheckIcon } from "lucide-react";
@@ -132,7 +132,7 @@ export default function PromptsPage() {
         {/* List */}
         <div className="mt-4 space-y-3">
           {filtered.map((p) => (
-            <article key={p.id} className="card-neo p-3">
+            <Card key={p.id} variant="neo" className="p-3">
               <header className="flex items-center justify-between">
                 <h3 className="font-semibold">{p.title}</h3>
                 <time className="text-xs text-muted-foreground">
@@ -142,12 +142,27 @@ export default function PromptsPage() {
               {p.text ? (
                 <p className="mt-1 whitespace-pre-wrap text-sm">{p.text}</p>
               ) : null}
-            </article>
+            </Card>
           ))}
           {filtered.length === 0 && (
             <div className="text-muted-foreground">Nothing matches your search. Typical.</div>
           )}
         </div>
+        <Card variant="neo" className="mt-8 space-y-4">
+          <h3 className="type-title">Design Tokens</h3>
+          <div>
+            <h4 className="type-subtitle">Spacing</h4>
+            <p className="type-body">4, 8, 12, 16, 24, 32, 48, 64</p>
+          </div>
+          <div>
+            <h4 className="type-subtitle">Glow</h4>
+            <p className="type-body">--glow-strong, --glow-soft</p>
+          </div>
+          <div>
+            <h4 className="type-subtitle">Type Ramp</h4>
+            <p className="type-body">eyebrow, title, subtitle, body, caption</p>
+          </div>
+        </Card>
       </SectionCard.Body>
     </SectionCard>
   );

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -12,6 +12,7 @@ export { default as Textarea } from "./primitives/Textarea";
 export { default as Badge } from "./primitives/Badge";
 export { default as Pill } from "./primitives/Pill";
 export { default as SearchBar } from "./primitives/SearchBar";
+export { default as Card } from "./primitives/Card";
 export { GlitchSegmentedGroup, GlitchSegmentedButton } from "./primitives/GlitchSegmented";
 //
 // Feedback

--- a/src/components/ui/primitives/Card.tsx
+++ b/src/components/ui/primitives/Card.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type CardProps = React.HTMLAttributes<HTMLDivElement> & {
+  variant?: "flat" | "neo" | "glow";
+};
+
+const variantStyles: Record<NonNullable<CardProps["variant"]>, string> = {
+  flat: "bg-background",
+  neo: "card-neo",
+  glow: "card-neo shadow-[var(--glow-strong)]",
+};
+
+const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ variant = "flat", className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn("rounded-2xl p-4", variantStyles[variant], className)}
+        {...props}
+      />
+    );
+  }
+);
+Card.displayName = "Card";
+
+export default Card;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -33,6 +33,16 @@ const config: Config = {
         snap: "cubic-bezier(0.22, 1, 0.36, 1)"
       },
       transitionDuration: { 150: "150ms", 200: "200ms", 220: "220ms" },
+      spacing: {
+        1: "4px",
+        2: "8px",
+        3: "12px",
+        4: "16px",
+        5: "24px",
+        6: "32px",
+        7: "48px",
+        8: "64px"
+      },
       keyframes: {
         shimmer: {
           "0%": { transform: "translateX(-100%)" },


### PR DESCRIPTION
## Summary
- add spacing and glow design tokens with typography utilities
- introduce Card primitive with flat, neo, glow variants
- document design tokens on prompts demo page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbb07a0bb8832c9f5f1e5f0a454f84