### PR TITLE
refactor: centralize slug helper

### DIFF
--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import * as React from "react";
-import { cn } from "@/lib/utils";
+import { cn, slugify } from "@/lib/utils";
 
 type InputSize = "sm" | "md" | "lg";
 
@@ -43,17 +43,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(function Input(
   },
   ref
 ) {
-  function slug(s?: string) {
-    return (s ?? "")
-      .toLowerCase()
-      .trim()
-      .replace(/\s+/g, "-")
-      .replace(/[^a-z0-9\-]/g, "")
-      .slice(0, 64);
-  }
-
   const auto = React.useId();
-  const fromAria = slug(props["aria-label"] as string | undefined);
+  const fromAria = slugify(props["aria-label"] as string | undefined);
   const finalId = id || auto;
   const finalName = props.name || fromAria || finalId;
   const describedBy = errorText ? `${finalId}-error` : helperText ? `${finalId}-helper` : undefined;

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import * as React from "react";
-import { cn } from "@/lib/utils";
+import { cn, slugify } from "@/lib/utils";
 import { ChevronDown } from "lucide-react";
 
 export interface SelectProps
@@ -16,17 +16,8 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(function Select(
   { className, helperText, errorText, success, disabled, id, children, ...props },
   ref
 ) {
-  function slug(s?: string) {
-    return (s ?? "")
-      .toLowerCase()
-      .trim()
-      .replace(/\s+/g, "-")
-      .replace(/[^a-z0-9\-]/g, "")
-      .slice(0, 64);
-  }
-
   const auto = React.useId();
-  const fromAria = slug(props["aria-label"] as string | undefined);
+  const fromAria = slugify(props["aria-label"] as string | undefined);
   const finalId = id || auto;
   const finalName = props.name || fromAria || finalId;
   const describedBy = errorText ? `${finalId}-error` : helperText ? `${finalId}-helper` : undefined;

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import * as React from "react";
-import { cn } from "@/lib/utils";
+import { cn, slugify } from "@/lib/utils";
 
 export interface TextareaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -29,17 +29,8 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(function T
   },
   ref
 ) {
-  function slug(s?: string) {
-    return (s ?? "")
-      .toLowerCase()
-      .trim()
-      .replace(/\s+/g, "-")
-      .replace(/[^a-z0-9\-]/g, "")
-      .slice(0, 64);
-  }
-
   const auto = React.useId();
-  const fromAria = slug(props["aria-label"] as string | undefined);
+  const fromAria = slugify(props["aria-label"] as string | undefined);
   const finalId = id || auto;
   const finalName = props.name || fromAria || finalId;
   const describedBy = errorText ? `${finalId}-error` : helperText ? `${finalId}-helper` : undefined;

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -2,17 +2,7 @@
 "use client";
 
 import * as React from "react";
-import { cn } from "@/lib/utils";
-
-/** Small helper to generate a stable name from aria-label if missing. */
-function slug(s?: string) {
-  return (s ?? "")
-    .toLowerCase()
-    .trim()
-    .replace(/\s+/g, "-")
-    .replace(/[^a-z0-9\-]/g, "")
-    .slice(0, 64);
-}
+import { cn, slugify } from "@/lib/utils";
 
 type InputSize = "sm" | "md" | "lg";
 
@@ -56,7 +46,7 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
   ref
 ) {
   const auto = React.useId();
-  const fromAria = slug(ariaLabel as string | undefined);
+  const fromAria = slugify(ariaLabel as string | undefined);
   const finalId = id || auto;
   const finalName = name || fromAria || finalId;
 

--- a/src/components/ui/primitives/Textarea.tsx
+++ b/src/components/ui/primitives/Textarea.tsx
@@ -1,16 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { cn } from "@/lib/utils";
-
-function slug(s?: string) {
-  return (s ?? "")
-    .toLowerCase()
-    .trim()
-    .replace(/\s+/g, "-")
-    .replace(/[^a-z0-9\-]/g, "")
-    .slice(0, 64);
-}
+import { cn, slugify } from "@/lib/utils";
 
 export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
   /** Rounded look without needing a global .planner-textarea class. */
@@ -30,7 +21,7 @@ export default React.forwardRef<HTMLTextAreaElement, TextareaProps>(function Tex
   ref
 ) {
   const auto = React.useId();
-  const fromAria = slug(ariaLabel as string | undefined);
+  const fromAria = slugify(ariaLabel as string | undefined);
   // Use React-generated id by default so multiple fields sharing an aria-label
   // do not end up with duplicate ids.
   const finalId = id || auto;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -98,3 +98,13 @@ export function normalizeDate(src?: Date | number | string): Date {
   return dt;
 }
 
+/** Create a URL-friendly slug from a string. */
+export function slugify(s?: string): string {
+  return (s ?? "")
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .slice(0, 64);
+}
+

--- a/tests/lib/utils.test.ts
+++ b/tests/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { cn, fromISODate } from '../../src/lib/utils';
+import { cn, fromISODate, slugify } from '../../src/lib/utils';
 
 describe('cn', () => {
   it('handles strings', () => {
@@ -47,5 +47,17 @@ describe('fromISODate', () => {
     ).toBe(true);
     expect(fromISODate('2024-02-30')).toBeNull();
     expect(fromISODate('not-a-date')).toBeNull();
+  });
+});
+
+describe('slugify', () => {
+  it('converts strings to kebab-case', () => {
+    expect(slugify('Hello World!')).toBe('hello-world');
+    expect(slugify('  Multiple   Spaces ')).toBe('multiple-spaces');
+  });
+
+  it('handles empty values', () => {
+    expect(slugify('')).toBe('');
+    expect(slugify(undefined)).toBe('');
   });
 });


### PR DESCRIPTION
## Summary
- add `slugify` utility for generating stable slugs
- refactor Input, Textarea, and Select components to use shared helper
- test `slugify` behavior

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bc34dcfcc8832cbbcb472d2142137e