### PR TITLE
Add spinner UI component

### DIFF
--- a/src/app/prompts/ComponentGallery.tsx
+++ b/src/app/prompts/ComponentGallery.tsx
@@ -11,6 +11,7 @@ import {
   GlitchSegmentedGroup,
   GlitchSegmentedButton,
   Progress,
+  Spinner,
   ThemeToggle,
   AnimationToggle,
   CheckCircle,
@@ -94,6 +95,11 @@ export default function ComponentGallery() {
         <Item label="Progress">
           <div className="w-56">
             <Progress value={50} />
+          </div>
+        </Item>
+        <Item label="Spinner">
+          <div className="w-56 flex justify-center">
+            <Spinner />
           </div>
         </Item>
         <Item label="ThemeToggle">

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -11,6 +11,7 @@ import {
   GlitchSegmentedButton,
   TabBar,
   Progress,
+  Spinner,
   ThemeToggle,
   SectionCard,
   TitleBar,
@@ -93,6 +94,12 @@ export default function Page() {
             <span className="text-sm font-medium">Progress</span>
             <div className="w-56">
               <Progress value={50} />
+            </div>
+          </div>
+          <div className="flex flex-col items-center space-y-2">
+            <span className="text-sm font-medium">Spinner</span>
+            <div className="w-56 flex justify-center">
+              <Spinner />
             </div>
           </div>
           <div className="flex flex-col items-center space-y-2">

--- a/src/components/ui/feedback/Spinner.tsx
+++ b/src/components/ui/feedback/Spinner.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export default function Spinner({
+  className,
+  size = 24,
+}: {
+  className?: string;
+  size?: number;
+}) {
+  return (
+    <div
+      role="status"
+      aria-label="Loading"
+      className={cn(
+        "inline-block animate-spin rounded-full border-2 border-[hsl(var(--accent))] border-t-transparent",
+        className
+      )}
+      style={{ width: size, height: size }}
+    >
+      <span className="sr-only">Loading...</span>
+    </div>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -17,6 +17,7 @@ export { GlitchSegmentedGroup, GlitchSegmentedButton } from "./primitives/Glitch
 // Feedback
 //
 export { default as Progress } from "./feedback/Progress";
+export { default as Spinner } from "./feedback/Spinner";
 
 //
 // Theme

--- a/tests/ui/spinner.test.tsx
+++ b/tests/ui/spinner.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Spinner from '@/components/ui/feedback/Spinner';
+import { describe, expect, it } from 'vitest';
+
+describe('Spinner', () => {
+  it('renders with status role', () => {
+    const { getByRole } = render(<Spinner />);
+    expect(getByRole('status')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable Spinner component for loading states
- showcase spinner on prompts page gallery
- cover spinner with a basic rendering test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc389bdd24832c8f3c8c82a45fe7f7