### PR TITLE
refactor: share review section label

### DIFF
--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -12,6 +12,7 @@ import { useLocalDB, uid } from "@/lib/db";
 import { LOCALE } from "@/lib/utils";
 import { Check as CheckIcon } from "lucide-react";
 import OutlineGlowDemo from "./OutlineGlowDemo";
+import SectionLabel from "@/components/reviews/SectionLabel";
 
 type Prompt = {
   id: string;
@@ -102,6 +103,8 @@ export default function PromptsPage() {
 
       <SectionCard.Body>
         <OutlineGlowDemo />
+          <SectionLabel>Section Label</SectionLabel>
+          <p className="text-sm text-muted-foreground">Divider used in reviews</p>
         {/* Compose panel */}
         <div className="space-y-2.5">
           <Input

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -3,6 +3,7 @@
 // Full Review Editor with icon-only header actions and RoleSelector rail control.
 import "../reviews/style.css";
 import RoleSelector from "@/components/reviews/RoleSelector";
+import SectionLabel from "@/components/reviews/SectionLabel";
 
 import * as React from "react";
 import type { Review, Pillar, Role } from "@/lib/types";
@@ -34,15 +35,6 @@ import {
   scoreIcon,
 } from "@/components/reviews/reviewData";
 
-/** Faint section label + rule used throughout the form. */
-function SectionLabel({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="mb-2 flex items-center gap-2">
-      <div className="text-xs tracking-wide text-white/20">{children}</div>
-      <div className="h-px flex-1 bg-gradient-to-r from-white/20 via-white/5 to-transparent" />
-    </div>
-  );
-}
 
 /** Parse "m:ss" or "mm:ss" into seconds. Returns null for invalid input. */
 function parseTime(mmss: string): number | null {

--- a/src/components/reviews/ReviewSummary.tsx
+++ b/src/components/reviews/ReviewSummary.tsx
@@ -7,6 +7,7 @@ import type { Review, Pillar, Role, ReviewMarker } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import IconButton from "@/components/ui/primitives/IconButton";
 import PillarBadge from "@/components/ui/league/pillars/PillarBadge"; // keep your existing path
+import SectionLabel from "@/components/reviews/SectionLabel";
 import { Pencil, FileText, Brain, Clock } from "lucide-react";
 import {
   ROLE_OPTIONS,
@@ -16,15 +17,6 @@ import {
   scoreIcon,
 } from "@/components/reviews/reviewData";
 
-/** Subtle label divider for section groupings */
-function SectionLabel({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="mb-2 flex items-center gap-2">
-      <div className="text-xs tracking-wide text-white/20">{children}</div>
-      <div className="h-px flex-1 bg-gradient-to-r from-white/20 via-white/5 to-transparent" />
-    </div>
-  );
-}
 
 /** Static neon wrapper so badges look “selected” like in the editor */
 function StaticNeonWrap({ children }: { children: React.ReactNode }) {

--- a/src/components/reviews/SectionLabel.tsx
+++ b/src/components/reviews/SectionLabel.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+
+/** Reusable section label divider for grouping review sections. */
+export default function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mb-2 flex items-center gap-2">
+      <div className="text-xs tracking-wide text-white/20">{children}</div>
+      <div className="h-px flex-1 bg-gradient-to-r from-white/20 via-white/5 to-transparent" />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- extract `SectionLabel` into shared reviews component
- reuse `SectionLabel` in review editor and summary
- document `SectionLabel` example on prompts page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc40bf348c832c8e076b8dcb5d25a9