### PR TITLE
feat: auto-select first review after hydration

### DIFF
--- a/src/components/reviews/ReviewPage.tsx
+++ b/src/components/reviews/ReviewPage.tsx
@@ -14,6 +14,13 @@ export default function ReviewPage() {
   const [reviews, setReviews] = useLocalDB<Review[]>("reviews.v1", []);
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
+  // After local DB hydration, select the first review if none is chosen
+  useEffect(() => {
+    if (!selectedId && reviews.length > 0) {
+      setSelectedId(reviews[0].id);
+    }
+  }, [reviews, selectedId]);
+
   // Auto-heal selection if the selected review gets deleted or doesn't exist yet
   useEffect(() => {
     if (selectedId && !reviews.some(r => r.id === selectedId)) {


### PR DESCRIPTION
## Summary
- auto-select first review once local DB is hydrated
- keep selection valid if review is deleted

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bc4bfbb130832c9085af7620b019a4