### PR TITLE
feat: add search form submission

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -61,3 +61,22 @@ export function Header() {
 ```
 
 Following these guidelines keeps the interface consistent and lets theme updates propagate automatically.
+
+## SearchBar
+- Wraps its input in a `<form role="search">` for accessibility.
+- Submitting the form calls `onValueChange` immediately and optionally `onSubmit` with the current query.
+
+```tsx
+import { SearchBar } from "@/components/ui";
+
+export function Demo() {
+  return (
+    <SearchBar
+      value=""
+      onValueChange={() => {}}
+      onSubmit={(q) => console.log(q)}
+    />
+  );
+}
+```
+

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -176,7 +176,7 @@ export default function Page() {
           <div className="flex flex-col items-center space-y-2">
             <span className="text-sm font-medium">Search Bar</span>
             <div className="w-56">
-              <SearchBar value="" onValueChange={() => {}} />
+              <SearchBar value="" onValueChange={() => {}} onSubmit={() => {}} />
             </div>
           </div>
           <div className="flex flex-col items-center space-y-2">

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -7,7 +7,7 @@
  */
 
 import * as React from "react";
-import { SectionCard, Textarea, Button, Input, Card, FieldShell } from "@/components/ui";
+import { SectionCard, Textarea, Button, Input, Card, FieldShell, SearchBar } from "@/components/ui";
 import { useLocalDB, uid } from "@/lib/db";
 import { LOCALE } from "@/lib/utils";
 import { Check as CheckIcon } from "lucide-react";
@@ -84,10 +84,10 @@ export default function PromptsPage() {
           {/* Right: search + save */}
           <div className="flex items-center gap-2 min-w-0">
             <div className="w-48 sm:w-64 md:w-80">
-              <Input
-                placeholder="Search prompts…"
+              <SearchBar
                 value={query}
-                onChange={(e) => setQuery(e.target.value)}
+                onValueChange={setQuery}
+                placeholder="Search prompts…"
               />
             </div>
             <Button

--- a/src/components/ui/primitives/SearchBar.tsx
+++ b/src/components/ui/primitives/SearchBar.tsx
@@ -12,6 +12,7 @@ export type SearchBarProps = Omit<
   value: string;
   onValueChange?: (next: string) => void;
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  onSubmit?: (value: string) => void;
   right?: React.ReactNode;
   clearable?: boolean;
   debounceMs?: number;
@@ -21,6 +22,7 @@ export default function SearchBar({
   value,
   onValueChange,
   onChange,
+  onSubmit,
   right,
   placeholder = "Search…",
   className,
@@ -52,7 +54,8 @@ export default function SearchBar({
   const showClear = clearable && query.length > 0;
 
   return (
-    <div
+    <form
+      role="search"
       className={cn(
         // Two-column grid: search input + optional right slot
         // Tailwind's arbitrary value syntax uses an underscore instead of a comma.
@@ -60,6 +63,11 @@ export default function SearchBar({
         "grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 w-full",
         className
       )}
+      onSubmit={(e) => {
+        e.preventDefault();
+        onValueChange?.(query);
+        onSubmit?.(query);
+      }}
     >
       {/* Input column */}
       <div className="relative min-w-0">
@@ -84,6 +92,7 @@ export default function SearchBar({
             "border-[hsl(var(--border))] bg-[hsl(var(--input))]"
           )}
           aria-label={rest["aria-label"] ?? "Search"}
+          type="search"
           {...rest}
         />
 
@@ -106,6 +115,6 @@ export default function SearchBar({
 
       {/* Right slot (filters, etc.) */}
       {right ? <div className="shrink-0">{right}</div> : null}
-    </div>
+    </form>
   );
 }

--- a/tests/primitives/search-bar.test.tsx
+++ b/tests/primitives/search-bar.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { SearchBar } from '@/components/ui';
+
+afterEach(cleanup);
+
+describe('SearchBar', () => {
+  it('invokes callbacks on submit', () => {
+    vi.useFakeTimers();
+    const handleChange = vi.fn();
+    const handleSubmit = vi.fn();
+    const { getByRole } = render(
+      <SearchBar
+        value=""
+        onValueChange={handleChange}
+        onSubmit={handleSubmit}
+        debounceMs={1000}
+      />
+    );
+    const input = getByRole('searchbox');
+    fireEvent.change(input, { target: { value: 'hello' } });
+    expect(handleChange).not.toHaveBeenCalled();
+    fireEvent.submit(getByRole('search'));
+    expect(handleChange).toHaveBeenCalledWith('hello');
+    expect(handleSubmit).toHaveBeenCalledWith('hello');
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- wrap SearchBar input in a `<form role="search">`
- submit event now triggers `onValueChange` and an optional `onSubmit`
- document SearchBar and use it on the Prompts page

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bc66603e84832c85ed494e5898f661