### PR TITLE
Use Next.js Script for theme bootstrap

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import "./themes.css";
 import type { Metadata } from "next";
 import SiteChrome from "@/components/chrome/SiteChrome";
 import { themeBootstrapScript } from "@/lib/theme";
+import Script from "next/script";
 
 export const metadata: Metadata = {
   title: "13 League Review",
@@ -25,7 +26,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     // Default SSR state: LG (dark). The no-flash script will tweak immediately.
     <html lang="en" className="theme-lg" suppressHydrationWarning>
       <head>
-        <script dangerouslySetInnerHTML={{ __html: noFlash }} />
+        <Script
+          id="theme-bootstrap"
+          strategy="beforeInteractive"
+          dangerouslySetInnerHTML={{ __html: noFlash }}
+        />
       </head>
       <body className="min-h-screen bg-[hsl(var(--background))] text-[hsl(var(--foreground))] glitch-root">
         <SiteChrome />


### PR DESCRIPTION
## Summary
- replace inline no-flash script with Next.js `<Script>` using `beforeInteractive`

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bc81ea5760832c947af3d74dabb1f8