### PR TITLE
Reset state on localStorage key removal

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -81,6 +81,12 @@ export function useLocalDB<T>(
 ): [T, React.Dispatch<React.SetStateAction<T>>] {
   const [state, setState] = React.useState<T>(initial);
 
+  // Keep the latest initial value for resets
+  const initialRef = React.useRef(initial);
+  React.useEffect(() => {
+    initialRef.current = initial;
+  }, [initial]);
+
   // Track whether we've mounted and whether we performed the initial load
   const loadedRef = React.useRef(false);
   const fullKeyRef = React.useRef(sk(key));
@@ -109,6 +115,10 @@ export function useLocalDB<T>(
     const onStorage = (e: StorageEvent) => {
       if (e.storageArea !== window.localStorage) return;
       if (e.key !== fullKeyRef.current) return;
+      if (e.newValue === null) {
+        setState(initialRef.current);
+        return;
+      }
       const next = parseJSON<T>(e.newValue);
       if (next !== null) setState(next);
     };

--- a/tests/lib/db.test.ts
+++ b/tests/lib/db.test.ts
@@ -79,6 +79,33 @@ describe('useLocalDB', () => {
     });
     expect(result.current[0]).toBe('b');
   });
+
+  it('resets state to initial when storage key is removed', async () => {
+    const { result } = renderHook(() => useLocalDB('remove', 'init'));
+    await waitFor(() =>
+      expect(window.localStorage.getItem('13lr:remove')).toBe(JSON.stringify('init'))
+    );
+
+    // Change state so it differs from the initial value
+    act(() => result.current[1]('changed'));
+    await waitFor(() =>
+      expect(window.localStorage.getItem('13lr:remove')).toBe(JSON.stringify('changed'))
+    );
+
+    // Simulate another tab removing the key
+    await act(async () => {
+      window.localStorage.removeItem('13lr:remove');
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: '13lr:remove',
+          newValue: null,
+          storageArea: window.localStorage,
+        })
+      );
+    });
+
+    expect(result.current[0]).toBe('init');
+  });
 });
 
 // Tests for uid


### PR DESCRIPTION
## Summary
- retain initial value inside `useLocalDB` for reset behavior
- reset state to initial value when storage key is removed
- test state reset on storage removal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc90333c28832c8d16357893e2602a