### PR TITLE
test: cover GoalsPage interactions

### DIFF
--- a/tests/goals/goals-page.test.tsx
+++ b/tests/goals/goals-page.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen, fireEvent, cleanup, within, waitFor } from '@testing-library/react';
+import { describe, it, beforeEach, afterEach, expect } from 'vitest';
+import GoalsPage from '@/components/goals/GoalsPage';
+
+// Clean up DOM after each test
+afterEach(cleanup);
+
+describe('GoalsPage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('handles adding goals, cap enforcement, completion toggles, and undo', async () => {
+    render(<GoalsPage />);
+
+    const titleInput = screen.getByRole('textbox', { name: 'Title' });
+    const addButton = screen.getByRole('button', { name: /add goal/i });
+
+    // Add three goals up to the active cap
+    for (let i = 1; i <= 3; i++) {
+      fireEvent.change(titleInput, { target: { value: `Goal ${i}` } });
+      fireEvent.click(addButton);
+      // ensure each goal appears
+      // eslint-disable-next-line no-await-in-loop
+      await screen.findByText(`Goal ${i}`);
+    }
+
+    // Attempt to add a fourth active goal, expect cap error
+    fireEvent.change(titleInput, { target: { value: 'Goal 4' } });
+    fireEvent.click(addButton);
+    expect(screen.getByRole('status')).toHaveTextContent('Cap reached');
+
+    // Mark the first goal as done
+    const goal1Article = screen.getByText('Goal 1').closest('article') as HTMLElement;
+    const toggleBtn = within(goal1Article).getByRole('checkbox', { name: 'Mark done' });
+    fireEvent.pointerDown(toggleBtn);
+    fireEvent.click(toggleBtn);
+    await waitFor(() => {
+      const goal1 = screen.getByText('Goal 1').closest('article') as HTMLElement;
+      expect(within(goal1).getByText('Done')).toBeInTheDocument();
+    });
+
+    // Now adding another goal should succeed
+    fireEvent.change(titleInput, { target: { value: 'Goal 4' } });
+    fireEvent.click(addButton);
+    await waitFor(() => expect(screen.queryByRole('status')).toBeNull());
+    const goal4 = await screen.findByText('Goal 4');
+    expect(goal4).toBeInTheDocument();
+
+    // Remove the new goal and then undo
+    const goal4Article = goal4.closest('article') as HTMLElement;
+    const deleteButton = within(goal4Article).getByLabelText('Delete goal');
+    fireEvent.click(deleteButton);
+    await waitFor(() => expect(screen.queryByText('Goal 4')).not.toBeInTheDocument());
+    const undoButton = screen.getByRole('button', { name: 'Undo' });
+    fireEvent.click(undoButton);
+    expect(await screen.findByText('Goal 4')).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- test adding and capping goals in GoalsPage
- verify completing goals and undoing deletions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc94ceb6ac832c90b209be36f66bbf