### PR TITLE
Extract reusable review panel component

### DIFF
--- a/src/app/prompts/ComponentGallery.tsx
+++ b/src/app/prompts/ComponentGallery.tsx
@@ -28,6 +28,7 @@ import {
 import type { Pillar } from '@/lib/types';
 import type { GameSide } from '@/components/ui/league/SideSelector';
 import { Search as SearchIcon, Star } from 'lucide-react';
+import ReviewPanel from '@/components/reviews/ReviewPanel';
 
 function Item({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -157,6 +158,9 @@ export default function ComponentGallery() {
             className="w-56"
             hideLabel
           />
+        </Item>
+        <Item label="ReviewPanel">
+          <ReviewPanel>Content</ReviewPanel>
         </Item>
       </div>
     </main>

--- a/src/components/reviews/ReviewPanel.tsx
+++ b/src/components/reviews/ReviewPanel.tsx
@@ -1,0 +1,14 @@
+import { cn } from "@/lib/utils";
+import type { HTMLAttributes } from "react";
+
+export default function ReviewPanel({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "max-w-[880px] w-full rounded-[var(--radius)] p-5 bg-[hsl(var(--card)/0.6)] ring-1 ring-white/5 shadow-[0_0_40px_-12px_hsl(var(--glow-soft))]",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import ReviewList from "./ReviewList";
 import ReviewEditor from "./ReviewEditor";
 import ReviewSummary from "./ReviewSummary";
+import ReviewPanel from "./ReviewPanel";
 import { Ghost, Plus } from "lucide-react";
 
 import Button from "@/components/ui/primitives/Button";
@@ -162,40 +163,40 @@ export default function ReviewsPage({
                 className="max-h-[66dvh] overflow-auto p-2"
               />
             </div>
-          </div>
-        </aside>
+            </div>
+          </aside>
 
-        <div className="lg:col-span-9 flex justify-center">
-          {!active ? (
-            <div className="max-w-[880px] w-full rounded-[var(--radius)] p-5 bg-[hsl(var(--card)/0.6)] ring-1 ring-white/5 shadow-[0_0_40px_-12px_hsl(var(--glow-soft))] flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
-              <Ghost className="h-6 w-6 opacity-60" />
-              <p>Select a review from the list or create a new one.</p>
-            </div>
-          ) : panelMode === "summary" ? (
-            <div className="max-w-[880px] w-full rounded-[var(--radius)] p-5 bg-[hsl(var(--card)/0.6)] ring-1 ring-white/5 shadow-[0_0_40px_-12px_hsl(var(--glow-soft))]">
-              <ReviewSummary
-                key={`summary-${active.id}`}
-                review={active}
-                onEdit={() => setPanelMode("edit")}
-              />
-            </div>
-          ) : (
-            <div className="max-w-[880px] w-full rounded-[var(--radius)] p-5 bg-[hsl(var(--card)/0.6)] ring-1 ring-white/5 shadow-[0_0_40px_-12px_hsl(var(--glow-soft))]">
-              <ReviewEditor
-                key={`editor-${active.id}`}
-                review={active}
-                onChangeNotes={(value: string) => onChangeNotes?.(active.id, value)}
-                onChangeTags={(values: string[]) => onChangeTags?.(active.id, values)}
-                onRename={(title: string) => onRename(active.id, title)}
-                onChangeMeta={(partial: Partial<Review>) =>
-                  onChangeMeta?.(active.id, partial)
-                }
-                onDone={() => setPanelMode("summary")}
-                onDelete={onDelete ? () => onDelete(active.id) : undefined}
-              />
-            </div>
-          )}
-        </div>
+          <div className="lg:col-span-9 flex justify-center">
+            {!active ? (
+              <ReviewPanel className="flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
+                <Ghost className="h-6 w-6 opacity-60" />
+                <p>Select a review from the list or create a new one.</p>
+              </ReviewPanel>
+            ) : panelMode === "summary" ? (
+              <ReviewPanel>
+                <ReviewSummary
+                  key={`summary-${active.id}`}
+                  review={active}
+                  onEdit={() => setPanelMode("edit")}
+                />
+              </ReviewPanel>
+            ) : (
+              <ReviewPanel>
+                <ReviewEditor
+                  key={`editor-${active.id}`}
+                  review={active}
+                  onChangeNotes={(value: string) => onChangeNotes?.(active.id, value)}
+                  onChangeTags={(values: string[]) => onChangeTags?.(active.id, values)}
+                  onRename={(title: string) => onRename(active.id, title)}
+                  onChangeMeta={(partial: Partial<Review>) =>
+                    onChangeMeta?.(active.id, partial)
+                  }
+                  onDone={() => setPanelMode("summary")}
+                  onDelete={onDelete ? () => onDelete(active.id) : undefined}
+                />
+              </ReviewPanel>
+            )}
+          </div>
       </div>
     </main>
   );

--- a/src/components/reviews/index.ts
+++ b/src/components/reviews/index.ts
@@ -4,3 +4,4 @@ export { default as ReviewEditor } from "./ReviewEditor";
 export { default as ReviewList } from "./ReviewList";
 export { default as ReviewSummary } from "./ReviewSummary";
 export { default as StatsStrip } from "./StatsStrip";
+export { default as ReviewPanel } from "./ReviewPanel";


### PR DESCRIPTION
## Summary
- factor out shared review container styles into new `ReviewPanel` component
- refactor ReviewsPage to use `ReviewPanel` instead of repeated div blocks
- showcase `ReviewPanel` in ComponentGallery prompts page

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bc9b0f4dc8832c980c12d566d78fae