### PR TITLE
Improve review page responsive layout

### DIFF
--- a/src/app/prompts/ComponentGallery.tsx
+++ b/src/app/prompts/ComponentGallery.tsx
@@ -184,6 +184,12 @@ export default function ComponentGallery() {
         <Item label="ReviewPanel">
           <ReviewPanel>Content</ReviewPanel>
         </Item>
+        <Item label="Review Layout">
+          <div className="grid w-full gap-4 md:grid-cols-12">
+            <div className="md:col-span-4 md:w-[240px] bg-secondary h-10 rounded" />
+            <div className="md:col-span-8 bg-muted h-10 rounded" />
+          </div>
+        </Item>
       </div>
     </main>
   );

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -143,8 +143,8 @@ export default function ReviewsPage({
         }
       />
 
-      <div className={cn("grid items-start gap-6 lg:grid-cols-12")}> 
-        <aside className="lg:col-span-3 lg:w-[280px]">
+      <div className={cn("grid items-start gap-6 md:grid-cols-12")}>
+        <aside className="md:col-span-4 md:w-[240px] lg:col-span-3 lg:w-[280px]">
           <div
             className="card-neo-soft overflow-hidden bg-card/50"
             style={{ boxShadow: neuRaised(14) }}
@@ -166,7 +166,7 @@ export default function ReviewsPage({
             </div>
           </aside>
 
-          <div className="lg:col-span-9 flex justify-center">
+          <div className="md:col-span-8 lg:col-span-9 flex justify-center">
             {!active ? (
               <ReviewPanel className="flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
                 <Ghost className="h-6 w-6 opacity-60" />


### PR DESCRIPTION
## Summary
- refine ReviewsPage grid with md breakpoints for smoother tablet/laptop layout
- showcase new responsive layout in ComponentGallery

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcaf8a80f4832c8a0ff497d7f4df3f