### PR TITLE
feat: add accessible focus rings

### DIFF
--- a/src/app/prompts/ComponentGallery.tsx
+++ b/src/app/prompts/ComponentGallery.tsx
@@ -74,6 +74,10 @@ export default function ComponentGallery() {
 
   return (
     <main className="p-6 bg-background text-foreground">
+      <p className="mb-4 text-sm text-[hsl(var(--muted-foreground))]">
+        Focus styles now use <code>focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]</code>
+        for accessible highlights.
+      </p>
       <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
         <Item label="Button">
           <Button className="w-56">Click me</Button>

--- a/src/components/goals/DurationSelector.tsx
+++ b/src/components/goals/DurationSelector.tsx
@@ -36,7 +36,7 @@ export default function DurationSelector({
               "border transition-colors",
               "border-white/10 bg-white/5 text-white/70",
               "hover:bg-white/10 hover:text-white/70",
-              "focus:outline-none focus:ring-2 focus:ring-purple-400/70",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
               active &&
                 "border-purple-400/60 bg-purple-500/20 text-white/70 font-semibold"
             )}

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -204,7 +204,7 @@ export default function TimerTab() {
                       onChange={(e) => setTimeEdit(e.currentTarget.value)}
                       onBlur={commitEdit}
                       onKeyDown={(e) => e.key === "Enter" && commitEdit()}
-                      className="bg-transparent text-center opacity-0 focus:opacity-100 focus:outline-none text-6xl sm:text-7xl font-bold tabular-nums"
+                      className="bg-transparent text-center opacity-0 focus:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] text-6xl sm:text-7xl font-bold tabular-nums"
                     />
                   </div>
                 )}

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -737,7 +737,7 @@ export default function ReviewEditor({
               type="button"
               aria-label={focusOn ? "Brain light on" : "Brain light off"}
               aria-pressed={focusOn}
-              className="rounded-full outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
+              className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
               onClick={() => {
                 const v = !focusOn;
                 setFocusOn(v);
@@ -813,7 +813,7 @@ export default function ReviewEditor({
                   onClick={() => togglePillar(p)}
                   onKeyDown={(e) => onIconKey(e, () => togglePillar(p))}
                   aria-pressed={active}
-                  className="rounded-2xl outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
+                  className="rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
                   title={active ? `${p} selected` : `Select ${p}`}
                 >
                   <NeonPillarChip active={active}>
@@ -832,7 +832,7 @@ export default function ReviewEditor({
               type="button"
               aria-label="Use timestamp"
               aria-pressed={useTimestamp}
-              className="rounded-full outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
+              className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
               onClick={() => {
                 setUseTimestamp(true);
                 setLastMarkerMode(true);
@@ -854,7 +854,7 @@ export default function ReviewEditor({
               type="button"
               aria-label="Use note only"
               aria-pressed={!useTimestamp}
-              className="rounded-full outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
+              className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
               onClick={() => {
                 setUseTimestamp(false);
                 setLastMarkerMode(false);

--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -210,7 +210,7 @@ function TitleEdit({
       dir="ltr"
       value={value}
       onChange={(e) => onChange(e.currentTarget.value)}
-      className="w-full bg-transparent border-none outline-none text-lg sm:text-xl font-semibold glitch-title title-glow"
+      className="w-full bg-transparent border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] text-lg sm:text-xl font-semibold glitch-title title-glow"
       aria-label="Archetype title"
       autoFocus
     />
@@ -232,7 +232,7 @@ function ParagraphEdit({
       value={value}
       onChange={(e) => onChange(e.currentTarget.value)}
       rows={2}
-      className="mt-1 w-full resize-y bg-transparent border-none outline-none text-sm text-[hsl(var(--muted-foreground))] planner-textarea"
+      className="mt-1 w-full resize-y bg-transparent border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] text-sm text-[hsl(var(--muted-foreground))] planner-textarea"
       aria-label="Description"
     />
   );
@@ -386,7 +386,7 @@ function ChampPillsEdit({
                 removeAt(i);
               }
             }}
-            className="bg-transparent outline-none border-none w-24"
+            className="bg-transparent border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] w-24"
           />
         </span>
       ))}

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -203,7 +203,7 @@ function ChampChips({
                 removeAt(i);
               }
             }}
-            className="bg-transparent outline-none border-none w-24"
+            className="bg-transparent border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] w-24"
           />
         </span>
       ))}

--- a/src/components/ui/AnimationToggle.tsx
+++ b/src/components/ui/AnimationToggle.tsx
@@ -41,8 +41,8 @@ export default function AnimationToggle() {
         className={[
           "inline-flex h-9 w-9 items-center justify-center rounded-full shrink-0",
           "border border-[hsl(var(--border))] bg-[hsl(var(--card))]",
-          "hover:shadow-[0_0_12px_hsl(var(--ring)/.35)] focus:outline-none",
-          "focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+          "hover:shadow-[0_0_12px_hsl(var(--ring)/.35)]",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
         ].join(" ")}
       >
         {enabled ? <Zap className="h-4 w-4" /> : <ZapOff className="h-4 w-4" />}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -55,7 +55,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(function Select(
           aria-invalid={errorText ? "true" : props["aria-invalid"]}
           aria-describedby={describedBy}
           className={cn(
-            "flex-1 h-11 px-3.5 pr-9 text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] outline-none appearance-none disabled:cursor-not-allowed",
+            "flex-1 h-11 px-3.5 pr-9 text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
             selectClassName
           )}
           {...props}

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -153,10 +153,10 @@ export default function TabBar({
                 onClick={() => !item.disabled && commitValue(item.key)}
                 className={cn(
                   "relative inline-flex items-center select-none rounded-full transition-[color,opacity,text-shadow] duration-200",
-                  "bg-transparent border-0 outline-none",
+                  "bg-transparent border-0",
                   s.h, s.px, s.text, size === "lg" ? "font-medium" : "font-normal",
                   "text-white/70 hover:text-white/70 data-[active=true]:text-white/70",
-                  "focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] focus-visible:ring-offset-0",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] focus-visible:ring-offset-0",
                   item.disabled && "opacity-40 pointer-events-none",
                   item.className
                 )}

--- a/src/components/ui/primitives/GlitchSegmented.tsx
+++ b/src/components/ui/primitives/GlitchSegmented.tsx
@@ -101,7 +101,7 @@ export const GlitchSegmentedButton = React.forwardRef<
       onClick={onSelect}
       className={cn(
         "glitch-scanlines flex-1 h-9 px-3 inline-flex items-center justify-center gap-2 text-sm font-medium select-none",
-        "rounded-full transition focus-visible:outline-none",
+        "rounded-full transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
         "bg-[var(--btn-bg)] text-[var(--btn-fg)]",
         "hover:shadow-[0_0_8px_var(--neon),0_0_16px_var(--neon-soft)]",
         "focus-visible:shadow-[0_0_8px_var(--neon),0_0_16px_var(--neon-soft)]",

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -71,7 +71,7 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
         name={finalName}
         size={typeof size === "number" ? size : undefined}
         className={cn(
-          "w-full bg-transparent px-3.5 pr-10 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] outline-none border-none",
+          "w-full bg-transparent px-3.5 pr-10 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
           typeof size === "string" ? SIZE[size] : SIZE.sm,
           indent && "pl-10",
           inputClassName

--- a/src/components/ui/primitives/Textarea.tsx
+++ b/src/components/ui/primitives/Textarea.tsx
@@ -16,7 +16,7 @@ export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & 
 const INNER =
   "block w-full max-w-[343px] min-h-[160px] px-4 py-3 text-base bg-transparent " +
   "text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] " +
-  "outline-none resize-y disabled:opacity-50 disabled:cursor-not-allowed";
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] resize-y disabled:opacity-50 disabled:cursor-not-allowed";
 
 export default React.forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
   {

--- a/src/components/ui/selects/AnimatedSelect.tsx
+++ b/src/components/ui/selects/AnimatedSelect.tsx
@@ -330,12 +330,12 @@ export default function AnimatedSelect({
                         onClick={() => selectByIndex(idx)}
                         onFocus={() => setActiveIndex(idx)}
                         className={[
-                          "group relative w-full rounded-xl px-3.5 py-2.5 text-left outline-none transition",
+                          "group relative w-full rounded-xl px-3.5 py-2.5 text-left transition",
                           disabledItem ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
                           active
                             ? "bg-[hsl(var(--primary)/.14)] text-[hsl(var(--primary-foreground))]"
                             : "hover:bg-white/5",
-                          "focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]/60",
+                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring)/0.6)]",
                           it.className ?? "",
                         ].join(" ")}
                       >

--- a/src/components/ui/theme/ThemeToggle.tsx
+++ b/src/components/ui/theme/ThemeToggle.tsx
@@ -82,8 +82,8 @@ export default function ThemeToggle({
         className={[
           "inline-flex h-9 w-9 items-center justify-center rounded-full shrink-0",
           "border border-[hsl(var(--border))] bg-[hsl(var(--card))]",
-          "hover:shadow-[0_0_12px_hsl(var(--ring)/.35)] focus:outline-none",
-          "focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+          "hover:shadow-[0_0_12px_hsl(var(--ring)/.35)]",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
           modeDisabled ? "opacity-60 cursor-not-allowed" : "",
         ].join(" ")}
       >
@@ -96,7 +96,7 @@ export default function ThemeToggle({
         aria-label={`${aria}: cycle background`}
         onClick={cycleBg}
         title="Change background"
-        className="inline-flex h-9 w-9 items-center justify-center rounded-full shrink-0 border border-[hsl(var(--border))] bg-[hsl(var(--card))] hover:shadow-[0_0_12px_hsl(var(--ring)/.35)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
+        className="inline-flex h-9 w-9 items-center justify-center rounded-full shrink-0 border border-[hsl(var(--border))] bg-[hsl(var(--card))] hover:shadow-[0_0_12px_hsl(var(--ring)/.35)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
       >
         <ImageIcon className="h-4 w-4" />
       </button>

--- a/src/components/ui/toggles/CheckCircle.tsx
+++ b/src/components/ui/toggles/CheckCircle.tsx
@@ -165,8 +165,8 @@ export default function CheckCircle({
           onBlur={() => setFocused(false)}
           onPointerDown={retriggerIgnite}
           className={cn(
-            "relative inline-grid place-items-center rounded-full outline-none transition",
-            "focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+            "relative inline-grid place-items-center rounded-full transition",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
             "disabled:opacity-50 disabled:pointer-events-none",
             "h-full w-full"
           )}
@@ -290,7 +290,7 @@ export default function CheckCircle({
               "absolute -right-2 -top-2 grid h-5 w-5 place-items-center rounded-full",
               "border border-[hsl(var(--card-hairline))] bg-[hsl(var(--card))] text-[hsl(var(--foreground))]",
               "shadow-sm hover:shadow-[0_0_10px_hsl(var(--ring)/.45)]",
-              "focus:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
             )}
           >
             <svg viewBox="0 0 18 18" className="h-3.5 w-3.5" aria-hidden>

--- a/tests/ui/__snapshots__/input.test.tsx.snap
+++ b/tests/ui/__snapshots__/input.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Input > renders default state 1`] = `
   class="relative inline-flex w-full items-center rounded-[16px] border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:ring-2 focus-within:ring-[hsl(var(--accent)/0.28)] focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--background))] focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('https://grainy-gradients.vercel.app/noise.svg')]"
 >
   <input
-    class="w-full bg-transparent px-3.5 pr-10 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] outline-none border-none h-11"
+    class="w-full bg-transparent px-3.5 pr-10 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] h-11"
     id=":r0:"
     name="test"
   />
@@ -25,7 +25,7 @@ exports[`Input > renders disabled state 1`] = `
   class="relative inline-flex w-full items-center rounded-[16px] border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:ring-2 focus-within:ring-[hsl(var(--accent)/0.28)] focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--background))] focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('https://grainy-gradients.vercel.app/noise.svg')] opacity-60 pointer-events-none"
 >
   <input
-    class="w-full bg-transparent px-3.5 pr-10 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] outline-none border-none h-11"
+    class="w-full bg-transparent px-3.5 pr-10 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] h-11"
     disabled=""
     id=":r3:"
     name="test"
@@ -47,7 +47,7 @@ exports[`Input > renders error state 1`] = `
 >
   <input
     aria-invalid="true"
-    class="w-full bg-transparent px-3.5 pr-10 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] outline-none border-none h-11"
+    class="w-full bg-transparent px-3.5 pr-10 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] h-11"
     id=":r2:"
     name="test"
   />
@@ -67,7 +67,7 @@ exports[`Input > renders focus state 1`] = `
   class="relative inline-flex w-full items-center rounded-[16px] border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:ring-2 focus-within:ring-[hsl(var(--accent)/0.28)] focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--background))] focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('https://grainy-gradients.vercel.app/noise.svg')]"
 >
   <input
-    class="w-full bg-transparent px-3.5 pr-10 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] outline-none border-none h-11"
+    class="w-full bg-transparent px-3.5 pr-10 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] h-11"
     id=":r1:"
     name="test"
   />

--- a/tests/ui/__snapshots__/select.test.tsx.snap
+++ b/tests/ui/__snapshots__/select.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Select > renders default state 1`] = `
   >
     <select
       aria-label="test"
-      class="flex-1 h-11 px-3.5 pr-9 text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] outline-none appearance-none disabled:cursor-not-allowed"
+      class="flex-1 h-11 px-3.5 pr-9 text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
       id=":r0:"
       name="test"
     >
@@ -53,7 +53,7 @@ exports[`Select > renders disabled state 1`] = `
   >
     <select
       aria-label="test"
-      class="flex-1 h-11 px-3.5 pr-9 text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] outline-none appearance-none disabled:cursor-not-allowed"
+      class="flex-1 h-11 px-3.5 pr-9 text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
       disabled=""
       id=":r3:"
       name="test"
@@ -95,7 +95,7 @@ exports[`Select > renders error state 1`] = `
       aria-describedby=":r2:-error"
       aria-invalid="true"
       aria-label="test"
-      class="flex-1 h-11 px-3.5 pr-9 text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] outline-none appearance-none disabled:cursor-not-allowed"
+      class="flex-1 h-11 px-3.5 pr-9 text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
       id=":r2:"
       name="test"
     >
@@ -140,7 +140,7 @@ exports[`Select > renders focus state 1`] = `
   >
     <select
       aria-label="test"
-      class="flex-1 h-11 px-3.5 pr-9 text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] outline-none appearance-none disabled:cursor-not-allowed"
+      class="flex-1 h-11 px-3.5 pr-9 text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
       id=":r1:"
       name="test"
     >

--- a/tests/ui/__snapshots__/textarea.test.tsx.snap
+++ b/tests/ui/__snapshots__/textarea.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Textarea > renders default state 1`] = `
   class="relative inline-flex w-full items-center rounded-[16px] border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:ring-2 focus-within:ring-[hsl(var(--accent)/0.28)] focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--background))] focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('https://grainy-gradients.vercel.app/noise.svg')]"
 >
   <textarea
-    class="block w-full max-w-[343px] min-h-[160px] px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] outline-none resize-y disabled:opacity-50 disabled:cursor-not-allowed"
+    class="block w-full max-w-[343px] min-h-[160px] px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] resize-y disabled:opacity-50 disabled:cursor-not-allowed"
     id=":r0:"
     name="test"
   />
@@ -17,7 +17,7 @@ exports[`Textarea > renders disabled state 1`] = `
   class="relative inline-flex w-full items-center rounded-[16px] border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:ring-2 focus-within:ring-[hsl(var(--accent)/0.28)] focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--background))] focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('https://grainy-gradients.vercel.app/noise.svg')] opacity-60 pointer-events-none"
 >
   <textarea
-    class="block w-full max-w-[343px] min-h-[160px] px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] outline-none resize-y disabled:opacity-50 disabled:cursor-not-allowed"
+    class="block w-full max-w-[343px] min-h-[160px] px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] resize-y disabled:opacity-50 disabled:cursor-not-allowed"
     disabled=""
     id=":r2:"
     name="test"
@@ -30,7 +30,7 @@ exports[`Textarea > renders focus state 1`] = `
   class="relative inline-flex w-full items-center rounded-[16px] border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:ring-2 focus-within:ring-[hsl(var(--accent)/0.28)] focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--background))] focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('https://grainy-gradients.vercel.app/noise.svg')]"
 >
   <textarea
-    class="block w-full max-w-[343px] min-h-[160px] px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] outline-none resize-y disabled:opacity-50 disabled:cursor-not-allowed"
+    class="block w-full max-w-[343px] min-h-[160px] px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] resize-y disabled:opacity-50 disabled:cursor-not-allowed"
     id=":r1:"
     name="test"
   />
@@ -42,7 +42,7 @@ exports[`Textarea > renders pill tone 1`] = `
   class="relative inline-flex w-full items-center rounded-[16px] border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:ring-2 focus-within:ring-[hsl(var(--accent)/0.28)] focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--background))] focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('https://grainy-gradients.vercel.app/noise.svg')] rounded-full"
 >
   <textarea
-    class="block w-full max-w-[343px] min-h-[160px] px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] outline-none resize-y disabled:opacity-50 disabled:cursor-not-allowed rounded-full min-h-[120px]"
+    class="block w-full max-w-[343px] min-h-[160px] px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] resize-y disabled:opacity-50 disabled:cursor-not-allowed rounded-full min-h-[120px]"
     id=":r3:"
     name="test"
   />


### PR DESCRIPTION
## Summary
- ensure focus rings are visible across controls by replacing `outline-none`
- document standard focus ring utility on the Component Gallery prompt page

## Testing
- `npm test -- -u`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcb16154d8832cb0b0be3ced070c87