### PR TITLE
Add color function fallbacks

### DIFF
--- a/src/app/prompts/ComponentGallery.tsx
+++ b/src/app/prompts/ComponentGallery.tsx
@@ -99,6 +99,11 @@ export default function ComponentGallery() {
         <Item label="Badge Pill">
           <Badge variant="pill">Pill</Badge>
         </Item>
+        <Item label="Accent Overlay Box">
+          <div className="w-56 h-20 flex items-center justify-center rounded bg-[var(--accent-overlay)] text-[var(--text-on-accent)]">
+            Overlay
+          </div>
+        </Item>
         <Item label="SearchBar">
           <SearchBar value={query} onValueChange={setQuery} className="w-56" />
         </Item>

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -25,14 +25,14 @@
   --lav-deep: 320 85% 60%;
   --success: 316 92% 70%;
   --success-glow: 316 92% 52% / 0.6;
-  --accent-overlay: color-mix(in oklab, hsl(var(--accent)) 60%, transparent);
-  --ring-contrast: color-mix(in oklab, hsl(var(--ring)) 70%, hsl(var(--background)) 30%);
-  --glow-active: color-mix(in oklab, hsl(var(--glow)) 50%, transparent);
-  --text-on-accent: color-contrast(var(--accent-overlay) vs hsl(var(--foreground)), hsl(var(--background)));
+  --accent-overlay: hsl(var(--accent));
+  --ring-contrast: hsl(var(--ring));
+  --glow-active: hsl(var(--glow));
+  --text-on-accent: hsl(var(--foreground));
 
   /* Default button tones */
   --neon: var(--glow);
-  --neon-soft: color-mix(in oklab, hsl(var(--neon)) 50%, transparent);
+  --neon-soft: hsl(var(--neon));
   --btn-bg: transparent;
   --btn-fg: hsl(var(--foreground));
 
@@ -66,14 +66,25 @@
   --shadow: 0 10px 30px hsl(250 30% 2% / 0.35);
 }
 
-/* Upgrade hairline when color-mix(oklab) is supported */
+/* Upgrade tokens when color-mix(oklab) is supported */
 @supports (color: color-mix(in oklab, white, black)) {
   :root {
+    --accent-overlay: color-mix(in oklab, hsl(var(--accent)) 60%, transparent);
+    --ring-contrast: color-mix(in oklab, hsl(var(--ring)) 70%, hsl(var(--background)) 30%);
+    --glow-active: color-mix(in oklab, hsl(var(--glow)) 50%, transparent);
+    --neon-soft: color-mix(in oklab, hsl(var(--neon)) 50%, transparent);
     --card-hairline: color-mix(
       in oklab,
       hsl(var(--border)) 82%,
       hsl(var(--accent)) 18%
     );
+  }
+}
+
+/* Upgrade contrast token when color-contrast is supported */
+@supports (color: color-contrast(white vs black)) {
+  :root {
+    --text-on-accent: color-contrast(var(--accent-overlay) vs hsl(var(--foreground)), hsl(var(--background)));
   }
 }
 


### PR DESCRIPTION
## Summary
- add fallback values for tokens using `color-mix` and `color-contrast`
- wrap advanced color functions in `@supports` blocks
- showcase accent overlay token in component gallery

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bcbe3854d4832c840293bb85d05160