### PR TITLE
Add Select component to prompts gallery

### DIFF
--- a/src/app/prompts/ComponentGallery.tsx
+++ b/src/app/prompts/ComponentGallery.tsx
@@ -24,6 +24,7 @@ import {
   PillarBadge,
   PillarSelector,
   AnimatedSelect,
+  Select,
 } from '@/components/ui';
 import type { Pillar, Review } from '@/lib/types';
 import type { GameSide } from '@/components/ui/league/SideSelector';
@@ -198,6 +199,13 @@ export default function ComponentGallery() {
             <div className="md:col-span-4 md:w-[240px] bg-secondary h-10 rounded" />
             <div className="md:col-span-8 bg-muted h-10 rounded" />
           </div>
+        </Item>
+        <Item label="Select">
+          <Select aria-label="Fruit" className="w-56">
+            <option value="apple">Apple</option>
+            <option value="orange">Orange</option>
+            <option value="pear">Pear</option>
+          </Select>
         </Item>
       </div>
     </main>

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -11,6 +11,8 @@ export { default as Input } from "./primitives/Input";
 export { default as Textarea } from "./primitives/Textarea";
 export { default as FieldShell } from "./primitives/FieldShell";
 export { default as Badge } from "./Badge";
+export { default as Label } from "./Label";
+export { default as Select } from "./Select";
 export { default as SearchBar } from "./primitives/SearchBar";
 export { default as Card } from "./primitives/Card";
 export { GlitchSegmentedGroup, GlitchSegmentedButton } from "./primitives/GlitchSegmented";


### PR DESCRIPTION
## Summary
- export `Label` and `Select` from the UI index
- showcase `Select` with a basic example in the ComponentGallery

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bcc4e2a838832cbb8320cb322d9d80