### PR TITLE
Use responsive page shell on prompts page

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -52,7 +52,7 @@ export default function Page() {
   const [view, setView] = React.useState("components");
 
   return (
-    <main className="p-6 bg-background text-foreground">
+    <main className="page-shell py-6 bg-background text-foreground">
       <div className="mb-8">
         <TabBar items={viewTabs} value={view} onValueChange={setView} />
       </div>


### PR DESCRIPTION
## Summary
- replace fixed padding on prompts gallery with responsive `page-shell` container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcc734b4c8832c8ef174ba0f499561