### PR TITLE
refactor: use spacing tokens for titlebar

### DIFF
--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -194,7 +194,7 @@ export default function PromptsPage() {
           <h3 className="type-title">Design Tokens</h3>
             <div>
               <h4 className="type-subtitle">Spacing</h4>
-              <p className="type-body">4, 8, 12, 14, 16, 20, 24, 32, 36, 40, 48, 64</p>
+              <p className="type-body">4, 6, 8, 12, 14, 16, 20, 24, 32, 36, 40, 48, 64</p>
             </div>
           <div>
             <h4 className="type-subtitle">Glow</h4>

--- a/src/components/ui/layout/TitleBar.tsx
+++ b/src/components/ui/layout/TitleBar.tsx
@@ -9,7 +9,7 @@ type Props = {
 export default function TitleBar({ label, idText = "ID:0x13LG" }: Props) {
   return (
     <>
-      <div className="term-mini">
+      <div className="term-mini flex items-center gap-2 px-2 py-1.5">
         <span className="term-mini__text">{label}</span>
         <span className="pill pill--pulse ml-auto">{idText}</span>
       </div>
@@ -17,10 +17,6 @@ export default function TitleBar({ label, idText = "ID:0x13LG" }: Props) {
       {/* Scoped styles — no globals, no theme drift */}
       <style jsx>{`
         .term-mini {
-          display: flex;
-          align-items: center;
-          gap: 0.5rem;
-          padding: 0.35rem 0.6rem;
           border: 1px solid hsl(var(--border));
           border-radius: 9999px;
           background:


### PR DESCRIPTION
## Summary
- refactor TitleBar to use Tailwind spacing utilities instead of hard-coded values
- document spacing token `6` on prompts page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bce089f9e0832cb16cc61da443aa1a