### PR TITLE
chore: move input autofill styles to global css

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1338,6 +1338,7 @@ html.fx-overdrive .card-neo-soft.glitchy:hover .card-title {
 /* Autofill fix */
 input:-webkit-autofill,
 textarea:-webkit-autofill {
+  box-shadow: 0 0 0 1000px hsl(var(--card)) inset;
   -webkit-text-fill-color: hsl(var(--foreground));
   transition: background-color 9999s ease-out 0s;
   caret-color: hsl(var(--foreground));

--- a/src/app/prompts/ComponentGallery.tsx
+++ b/src/app/prompts/ComponentGallery.tsx
@@ -79,6 +79,9 @@ export default function ComponentGallery() {
         Focus styles now use <code>focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]</code>
         for accessible highlights.
       </p>
+      <p className="mb-4 text-sm text-[hsl(var(--muted-foreground))]">
+        Input autofill colors are controlled globally via <code>input:-webkit-autofill</code>.
+      </p>
       <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
         <Item label="Button">
           <Button className="w-56">Click me</Button>

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -79,14 +79,6 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
         {...props}
       />
       {children}
-
-      {/* Autofill override */}
-      <style>{`
-        input:-webkit-autofill {
-          box-shadow: 0 0 0 1000px hsl(var(--card)) inset;
-          -webkit-text-fill-color: hsl(var(--foreground));
-        }
-      `}</style>
     </FieldShell>
   );
 });

--- a/tests/ui/__snapshots__/input.test.tsx.snap
+++ b/tests/ui/__snapshots__/input.test.tsx.snap
@@ -9,14 +9,6 @@ exports[`Input > renders default state 1`] = `
     id=":r0:"
     name="test"
   />
-  <style>
-    
-        input:-webkit-autofill {
-          box-shadow: 0 0 0 1000px hsl(var(--card)) inset;
-          -webkit-text-fill-color: hsl(var(--foreground));
-        }
-      
-  </style>
 </div>
 `;
 
@@ -30,14 +22,6 @@ exports[`Input > renders disabled state 1`] = `
     id=":r3:"
     name="test"
   />
-  <style>
-    
-        input:-webkit-autofill {
-          box-shadow: 0 0 0 1000px hsl(var(--card)) inset;
-          -webkit-text-fill-color: hsl(var(--foreground));
-        }
-      
-  </style>
 </div>
 `;
 
@@ -51,14 +35,6 @@ exports[`Input > renders error state 1`] = `
     id=":r2:"
     name="test"
   />
-  <style>
-    
-        input:-webkit-autofill {
-          box-shadow: 0 0 0 1000px hsl(var(--card)) inset;
-          -webkit-text-fill-color: hsl(var(--foreground));
-        }
-      
-  </style>
 </div>
 `;
 
@@ -71,13 +47,5 @@ exports[`Input > renders focus state 1`] = `
     id=":r1:"
     name="test"
   />
-  <style>
-    
-        input:-webkit-autofill {
-          box-shadow: 0 0 0 1000px hsl(var(--card)) inset;
-          -webkit-text-fill-color: hsl(var(--foreground));
-        }
-      
-  </style>
 </div>
 `;


### PR DESCRIPTION
## Summary
- apply unified `input:-webkit-autofill` styles in `globals.css`
- drop inline autofill `<style>` block from `Input` primitive
- document new global autofill styling in prompts ComponentGallery

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bce37fa7dc832c9cdd320bc8d6b835