### PR TITLE
feat(ui): add accessible success feedback to Select

### DIFF
--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -33,7 +33,12 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(function Select(
   const fromAria = slugify(props["aria-label"] as string | undefined);
   const finalId = id || auto;
   const finalName = props.name || fromAria || finalId;
-  const describedBy = errorText ? `${finalId}-error` : helperText ? `${finalId}-helper` : undefined;
+  const successId = `${finalId}-success`;
+  const errorId = errorText ? `${finalId}-error` : undefined;
+  const helperId = helperText ? `${finalId}-helper` : undefined;
+  const describedBy = [errorId, helperId, success ? successId : undefined]
+    .filter(Boolean)
+    .join(" ") || undefined;
   return (
     <div className="space-y-1">
       <FieldShell
@@ -64,9 +69,19 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(function Select(
         </select>
           <ChevronDown className="pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]" />
       </FieldShell>
+      {success && (
+        <p
+          id={successId}
+          className="sr-only"
+          role="status"
+          aria-live="polite"
+        >
+          Selection saved
+        </p>
+      )}
       {(helperText || errorText) && (
         <p
-          id={errorText ? `${finalId}-error` : helperText ? `${finalId}-helper` : undefined}
+          id={errorId || helperId}
           className={cn(
             "text-xs mt-1 line-clamp-2",
             errorText ? "text-[hsl(var(--destructive))]" : "text-[hsl(var(--muted-foreground))]"

--- a/tests/ui/__snapshots__/select.test.tsx.snap
+++ b/tests/ui/__snapshots__/select.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`Select > renders disabled state 1`] = `
       aria-label="test"
       class="flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
       disabled=""
-      id=":r3:"
+      id=":r4:"
       name="test"
     >
       <option
@@ -172,5 +172,53 @@ exports[`Select > renders focus state 1`] = `
       />
     </svg>
   </div>
+</div>
+`;
+
+exports[`Select > renders success state 1`] = `
+<div
+  class="space-y-1"
+>
+  <div
+    class="relative inline-flex w-full items-center rounded-[16px] border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:ring-2 focus-within:ring-[hsl(var(--accent)/0.28)] focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--background))] focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('https://grainy-gradients.vercel.app/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)] border-[hsl(var(--success)/0.45)] focus-within:ring-[hsl(var(--success)/0.28)]"
+  >
+    <select
+      aria-describedby=":r3:-success"
+      aria-label="test"
+      class="flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
+      id=":r3:"
+      name="test"
+    >
+      <option
+        value=""
+      >
+        Choose…
+      </option>
+    </select>
+    <svg
+      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+      />
+    </svg>
+  </div>
+  <p
+    aria-live="polite"
+    class="sr-only"
+    id=":r3:-success"
+    role="status"
+  >
+    Selection saved
+  </p>
 </div>
 `;

--- a/tests/ui/select.test.tsx
+++ b/tests/ui/select.test.tsx
@@ -36,6 +36,15 @@ describe('Select', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  it('renders success state', () => {
+    const { container } = render(
+      <Select aria-label="test" success>
+        <option value="">Choose…</option>
+      </Select>
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   it('renders disabled state', () => {
     const { container } = render(
       <Select aria-label="test" disabled>


### PR DESCRIPTION
## Summary
- append screen-reader-only success message to Select when `success` is true
- wire `aria-describedby` to include success, error, and helper messages
- add unit test and snapshot for success state

## Testing
- `npm test -- -u`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bce7e31a74832c90fa13581a5c06b6