### PR TITLE
refactor: use tailwind radius token

### DIFF
--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -191,6 +191,12 @@ export default function PromptsPage() {
           </FieldShell>
         </Card>
         <Card className="mt-8 space-y-4">
+          <h3 className="type-title">Card</h3>
+          <div className="space-y-3">
+            <Card>Card content</Card>
+          </div>
+        </Card>
+        <Card className="mt-8 space-y-4">
           <h3 className="type-title">Design Tokens</h3>
             <div>
               <h4 className="type-subtitle">Spacing</h4>

--- a/src/components/ui/primitives/Card.tsx
+++ b/src/components/ui/primitives/Card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
       <div
         ref={ref}
         className={cn(
-          "rounded-[16px] p-4 border border-[hsl(var(--border)/0.25)] bg-[hsl(var(--card)/0.6)] shadow-[0_0_0_1px_hsl(var(--border)/0.12)]",
+          "rounded-xl p-4 border border-[hsl(var(--border)/0.25)] bg-[hsl(var(--card)/0.6)] shadow-[0_0_0_1px_hsl(var(--border)/0.12)]",
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary
- use Tailwind `rounded-xl` token in Card primitive
- showcase Card component on prompts page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bce52cbadc832c9d5eefb17bf542a0