### PR TITLE
fix: handle false aria-invalid state

### DIFF
--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -54,7 +54,8 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
   const finalId = id || auto;
   const finalName = name || fromAria || finalId;
 
-  const error = props["aria-invalid"] ? true : false;
+  const error =
+    props["aria-invalid"] === true || props["aria-invalid"] === "true";
   const disabled = props.disabled;
 
   return (

--- a/src/components/ui/primitives/Textarea.tsx
+++ b/src/components/ui/primitives/Textarea.tsx
@@ -37,7 +37,8 @@ export default React.forwardRef<HTMLTextAreaElement, TextareaProps>(function Tex
   const finalId = id || auto;
   const finalName = name || fromAria || finalId;
 
-  const error = props["aria-invalid"] ? true : false;
+  const error =
+    props["aria-invalid"] === true || props["aria-invalid"] === "true";
 
   return (
     <FieldShell

--- a/tests/ui/__snapshots__/input.test.tsx.snap
+++ b/tests/ui/__snapshots__/input.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Input > renders disabled state 1`] = `
   <input
     class="w-full bg-transparent px-[var(--space-14)] pr-[var(--space-40)] text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] h-11"
     disabled=""
-    id=":r3:"
+    id=":r4:"
     name="test"
   />
 </div>

--- a/tests/ui/__snapshots__/textarea.test.tsx.snap
+++ b/tests/ui/__snapshots__/textarea.test.tsx.snap
@@ -25,6 +25,19 @@ exports[`Textarea > renders disabled state 1`] = `
 </div>
 `;
 
+exports[`Textarea > renders error state 1`] = `
+<div
+  class="relative inline-flex w-full items-center rounded-[16px] border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:ring-2 focus-within:ring-[hsl(var(--accent)/0.28)] focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--background))] focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('https://grainy-gradients.vercel.app/noise.svg')] border-[hsl(var(--destructive)/0.6)] focus-within:ring-[hsl(var(--destructive)/0.35)]"
+>
+  <textarea
+    aria-invalid="true"
+    class="block w-full max-w-full min-h-40 px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] resize-y disabled:opacity-50 disabled:cursor-not-allowed"
+    id=":r4:"
+    name="test"
+  />
+</div>
+`;
+
 exports[`Textarea > renders focus state 1`] = `
 <div
   class="relative inline-flex w-full items-center rounded-[16px] border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:ring-2 focus-within:ring-[hsl(var(--accent)/0.28)] focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--background))] focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('https://grainy-gradients.vercel.app/noise.svg')]"

--- a/tests/ui/input.test.tsx
+++ b/tests/ui/input.test.tsx
@@ -22,6 +22,15 @@ describe('Input', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  it('handles aria-invalid="false" as non-error', () => {
+    const { container } = render(
+      <Input aria-label="test" aria-invalid="false" />
+    );
+    expect(container.firstChild).not.toHaveClass(
+      'border-[hsl(var(--destructive)/0.6)]'
+    );
+  });
+
   it('renders disabled state', () => {
     const { container } = render(<Input aria-label="test" disabled />);
     expect(container.firstChild).toMatchSnapshot();

--- a/tests/ui/textarea.test.tsx
+++ b/tests/ui/textarea.test.tsx
@@ -26,4 +26,20 @@ describe('Textarea', () => {
     const { container } = render(<Textarea aria-label="test" tone="pill" />);
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  it('renders error state', () => {
+    const { container } = render(
+      <Textarea aria-label="test" aria-invalid="true" />
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('handles aria-invalid="false" as non-error', () => {
+    const { container } = render(
+      <Textarea aria-label="test" aria-invalid="false" />
+    );
+    expect(container.firstChild).not.toHaveClass(
+      'border-[hsl(var(--destructive)/0.6)]'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- fix Input and Textarea to only flag errors when `aria-invalid` is `true`
- test `aria-invalid="false"` for Input and Textarea to avoid false positives

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68bcef25831c832ca734900f232103f1