### PR TITLE
feat: add fallback for uid helper

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -142,9 +142,14 @@ export function useLocalDB<T>(
 }
 
 /**
- * Tiny uid helper using `crypto.randomUUID`.
+ * Tiny uid helper.
+ * Uses `crypto.randomUUID` when available; falls back to `Math.random`.
  * Example: "review_123e4567"
  */
 export function uid(prefix = "id"): string {
-  return `${prefix}_${crypto.randomUUID().slice(0, 8)}`;
+  const id =
+    typeof globalThis.crypto?.randomUUID === "function"
+      ? globalThis.crypto.randomUUID().slice(0, 8)
+      : Math.random().toString(36).slice(2, 10);
+  return `${prefix}_${id}`;
 }


### PR DESCRIPTION
## Summary
- check for `crypto.randomUUID` and fallback to `Math.random`
- document fallback in uid helper

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bcef4c3358832c82f1750c59ef66f8