### PR TITLE
Add optional end slot padding to Input

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -149,15 +149,18 @@ export default function Page() {
               </IconButton>
             </div>
           </div>
-          <div className="flex flex-col items-center space-y-2">
-            <span className="text-sm font-medium">Input</span>
-            <div className="w-56 space-y-2">
-              <Input placeholder="Small" />
-              <Input size="md" placeholder="Medium" />
-              <Input size="lg" placeholder="Large" />
-              <Input tone="pill" placeholder="Pill" />
+            <div className="flex flex-col items-center space-y-2">
+              <span className="text-sm font-medium">Input</span>
+              <div className="w-56 space-y-2">
+                <Input placeholder="Small" />
+                <Input size="md" placeholder="Medium" />
+                <Input size="lg" placeholder="Large" />
+                <Input tone="pill" placeholder="Pill" />
+                <Input placeholder="With icon" hasEndSlot>
+                  <Plus className="absolute right-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+                </Input>
+              </div>
             </div>
-          </div>
           <div className="flex flex-col items-center space-y-2">
             <span className="text-sm font-medium">Textarea</span>
             <div className="w-56 space-y-2">

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -19,6 +19,8 @@ export type InputProps = Omit<
   indent?: boolean;
   /** Optional className for the inner <input> element */
   inputClassName?: string;
+  /** Reserve space for a trailing slot even if no children are provided */
+  hasEndSlot?: boolean;
 };
 
 const SIZE: Record<InputSize, string> = {
@@ -45,6 +47,7 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
     size = "sm",
     indent = false,
     children,
+    hasEndSlot = false,
     ...props
   },
   ref
@@ -57,6 +60,8 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
   const error =
     props["aria-invalid"] === true || props["aria-invalid"] === "true";
   const disabled = props.disabled;
+
+  const showEndSlot = hasEndSlot || React.Children.count(children) > 0;
 
   return (
     <FieldShell
@@ -71,12 +76,13 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
         id={finalId}
         name={finalName}
         size={typeof size === "number" ? size : undefined}
-          className={cn(
-            "w-full bg-transparent px-[var(--space-14)] pr-[var(--space-40)] text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
-            typeof size === "string" ? SIZE[size] : SIZE.sm,
-            indent && "pl-[var(--space-40)]",
-            inputClassName
-          )}
+        className={cn(
+          "w-full bg-transparent px-[var(--space-14)] text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+          typeof size === "string" ? SIZE[size] : SIZE.sm,
+          indent && "pl-[var(--space-40)]",
+          showEndSlot && "pr-[var(--space-40)]",
+          inputClassName
+        )}
         {...props}
       />
       {children}

--- a/tests/ui/__snapshots__/input.test.tsx.snap
+++ b/tests/ui/__snapshots__/input.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Input > renders default state 1`] = `
   class="relative inline-flex w-full items-center rounded-[16px] border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:ring-2 focus-within:ring-[hsl(var(--accent)/0.28)] focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--background))] focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('https://grainy-gradients.vercel.app/noise.svg')]"
 >
   <input
-    class="w-full bg-transparent px-[var(--space-14)] pr-[var(--space-40)] text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] h-11"
+    class="w-full bg-transparent px-[var(--space-14)] text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] h-11"
     id=":r0:"
     name="test"
   />
@@ -17,7 +17,7 @@ exports[`Input > renders disabled state 1`] = `
   class="relative inline-flex w-full items-center rounded-[16px] border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:ring-2 focus-within:ring-[hsl(var(--accent)/0.28)] focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--background))] focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('https://grainy-gradients.vercel.app/noise.svg')] opacity-60 pointer-events-none"
 >
   <input
-    class="w-full bg-transparent px-[var(--space-14)] pr-[var(--space-40)] text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] h-11"
+    class="w-full bg-transparent px-[var(--space-14)] text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] h-11"
     disabled=""
     id=":r4:"
     name="test"
@@ -31,7 +31,7 @@ exports[`Input > renders error state 1`] = `
 >
   <input
     aria-invalid="true"
-    class="w-full bg-transparent px-[var(--space-14)] pr-[var(--space-40)] text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] h-11"
+    class="w-full bg-transparent px-[var(--space-14)] text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] h-11"
     id=":r2:"
     name="test"
   />
@@ -43,7 +43,7 @@ exports[`Input > renders focus state 1`] = `
   class="relative inline-flex w-full items-center rounded-[16px] border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:ring-2 focus-within:ring-[hsl(var(--accent)/0.28)] focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--background))] focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('https://grainy-gradients.vercel.app/noise.svg')]"
 >
   <input
-    class="w-full bg-transparent px-[var(--space-14)] pr-[var(--space-40)] text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] h-11"
+    class="w-full bg-transparent px-[var(--space-14)] text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] h-11"
     id=":r1:"
     name="test"
   />

--- a/tests/ui/input.test.tsx
+++ b/tests/ui/input.test.tsx
@@ -35,4 +35,25 @@ describe('Input', () => {
     const { container } = render(<Input aria-label="test" disabled />);
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  it('adds padding when children are present', () => {
+    const { getByRole } = render(
+      <Input aria-label="test">
+        <span />
+      </Input>
+    );
+    expect(getByRole('textbox')).toHaveClass('pr-[var(--space-40)]');
+  });
+
+  it('adds padding when hasEndSlot is true', () => {
+    const { getByRole } = render(
+      <Input aria-label="test" hasEndSlot />
+    );
+    expect(getByRole('textbox')).toHaveClass('pr-[var(--space-40)]');
+  });
+
+  it('has smaller padding by default', () => {
+    const { getByRole } = render(<Input aria-label="test" />);
+    expect(getByRole('textbox')).not.toHaveClass('pr-[var(--space-40)]');
+  });
 });


### PR DESCRIPTION
## Summary
- add `hasEndSlot` prop to Input and apply extra right padding only when needed
- showcase Input end-slot usage on prompts page
- expand Input tests to cover end slot padding

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bcf1555e34832ca19d31e0cbf67455