### PR TITLE
Ensure IconButton ring/glow variants have visible borders

### DIFF
--- a/src/app/prompts/ComponentGallery.tsx
+++ b/src/app/prompts/ComponentGallery.tsx
@@ -87,9 +87,14 @@ export default function ComponentGallery() {
           <Button className="w-56">Click me</Button>
         </Item>
         <Item label="IconButton">
-          <IconButton className="w-12 h-12">
-            <SearchIcon />
-          </IconButton>
+          <div className="flex gap-2">
+            <IconButton variant="ring" className="w-12 h-12">
+              <SearchIcon />
+            </IconButton>
+            <IconButton variant="glow" className="w-12 h-12">
+              <SearchIcon />
+            </IconButton>
+          </div>
         </Item>
         <Item label="Input">
           <Input placeholder="Type here" className="w-56" />

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -34,9 +34,9 @@ const sizeMap: Record<ButtonSize, string> = {
 };
 
 const variantBase: Record<Variant, string> = {
-  ring: "bg-transparent hover:bg-[hsl(var(--panel)/0.45)]",
-  solid: "",
-  glow: "bg-transparent hover:bg-[hsl(var(--panel)/0.45)]",
+  ring: "border bg-transparent hover:bg-[hsl(var(--panel)/0.45)]",
+  solid: "border",
+  glow: "border bg-transparent hover:bg-[hsl(var(--panel)/0.45)]",
 };
 
 const toneClasses: Record<Variant, Record<Tone, string>> = {


### PR DESCRIPTION
## Summary
- add explicit border width to IconButton variants so ring/glow styles render consistently
- show ring and glow IconButton variants in the prompts ComponentGallery

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcf3218938832c9c0d30a5595a3040