### PR TITLE
chore: use tailwind tokens for team styles

### DIFF
--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -26,9 +26,9 @@ import CheatSheetTabs from "./CheatSheetTabs";
 type Tab = "cheat" | "builder" | "clears";
 
 const TABS = [
-  { key: "cheat", label: "Cheat Sheet", hint: "Archetypes, counters, examples", icon: <BookOpenText className="mr-1 h-4 w-4" /> },
-  { key: "builder", label: "Builder", hint: "Fill allies vs enemies", icon: <Hammer className="mr-1 h-4 w-4" /> },
-  { key: "clears", label: "Jungle Clears", hint: "Relative buckets by speed", icon: <Timer className="mr-1 h-4 w-4" /> },
+  { key: "cheat", label: "Cheat Sheet", hint: "Archetypes, counters, examples", icon: <BookOpenText className="mr-2 h-4 w-4" /> },
+  { key: "builder", label: "Builder", hint: "Fill allies vs enemies", icon: <Hammer className="mr-2 h-4 w-4" /> },
+  { key: "clears", label: "Jungle Clears", hint: "Relative buckets by speed", icon: <Timer className="mr-2 h-4 w-4" /> },
 ] as const;
 
 export default function TeamCompPage() {

--- a/src/components/team/style.css
+++ b/src/components/team/style.css
@@ -1,17 +1,15 @@
 /* src/components/team/style.css */
 
 /* Champ badges */
-.champ-badges { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+.champ-badges { @apply flex flex-wrap gap-2; }
 .champ-badge{
-  display: inline-flex; align-items: center;
-  height: 1.75rem; padding: 0 0.6rem; border-radius: 9999px;
-  border: 1px solid hsl(var(--border));
+  @apply inline-flex items-center h-7 px-2.5 rounded-full border text-xs leading-none whitespace-nowrap;
+  border-color: hsl(var(--border));
   background: hsl(var(--card)); color: hsl(var(--foreground));
-  font-size: 0.75rem; line-height: 1; white-space: nowrap;
   transition: background .15s var(--ease-out), border-color .15s var(--ease-out), color .15s var(--ease-out);
 }
 .champ-badge:hover{ background: hsl(var(--primary-soft)); border-color: hsl(var(--ring)); }
-.champ-badge--dense{ height: 1.5rem; padding: 0 0.5rem; }
+.champ-badge--dense{ @apply h-6 px-2; }
 
 /* Title flicker ONLY within the Team scope */
 [data-scope="team"] .glitch-title{ position: relative; display: inline-block; }


### PR DESCRIPTION
## Summary
- replace fixed pixels in team styles with Tailwind spacing and radius utilities
- widen tab icon spacing by switching `mr-1` to `mr-2`

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bcf4c251cc832c8d9c7561dfed2c4d