### PR TITLE
refactor: align DayCard spacing to design tokens

### DIFF
--- a/src/components/planner/DayCard.tsx
+++ b/src/components/planner/DayCard.tsx
@@ -153,9 +153,9 @@ export default function DayCard({ iso, isToday }: Props) {
                         if (active) setSelectedTaskId("");
                       }}
                       className={cn(
-                        "proj-card group relative [overflow:visible] w-full text-left rounded-2xl border pl-5 pr-3 py-2.5",
+                        "proj-card group relative [overflow:visible] w-full text-left rounded-2xl border pl-4 pr-2 py-2",
                         "bg-[hsl(var(--card)/0.55)] hover:bg-[hsl(var(--card)/0.7)] transition",
-                        "grid min-h-[44px] grid-cols-[auto,1fr,auto] items-center gap-4",
+                        "grid min-h-12 grid-cols-[auto,1fr,auto] items-center gap-4",
                         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
                         active && "proj-card--active ring-1 ring-[hsl(var(--ring))]"
                       )}
@@ -273,7 +273,7 @@ function TaskRow({
     <li className="group">
       <div
         className={cn(
-          "relative [overflow:visible] grid min-h-[44px] min-w-0 grid-cols-[auto,1fr,auto] items-center gap-4 rounded-2xl border pl-5 pr-3 py-2.5",
+          "relative [overflow:visible] grid min-h-12 min-w-0 grid-cols-[auto,1fr,auto] items-center gap-4 rounded-2xl border pl-4 pr-2 py-2",
           "bg-[hsl(var(--card)/0.55)] hover:bg-[hsl(var(--card)/0.7)]",
           "focus-within:ring-2 focus-within:ring-[hsl(var(--ring))]"
         )}

--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -42,9 +42,11 @@
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  min-height: 44px;
-  padding-left: .9rem;
-  padding-right: .6rem;
+  min-height: 48px;
+  padding-left: 1rem;
+  padding-right: .5rem;
+  padding-top: .5rem;
+  padding-bottom: .5rem;
   border: 1px solid hsl(var(--card-hairline));
   background: hsl(var(--card) / .55);
   transition:

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -200,7 +200,7 @@ export default function PromptsPage() {
           <h3 className="type-title">Design Tokens</h3>
             <div>
               <h4 className="type-subtitle">Spacing</h4>
-              <p className="type-body">4, 6, 8, 12, 14, 16, 20, 24, 32, 36, 40, 48, 64</p>
+              <p className="type-body">8, 16, 24, 32, 40, 48, 64</p>
             </div>
           <div>
             <h4 className="type-subtitle">Glow</h4>


### PR DESCRIPTION
## Summary
- replace DayCard paddings with 8px tokenized spacing
- update project card CSS and prompts page spacing tokens

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bcf9ffac34832cbfe34aaa35c35bb1