### PR TITLE
refactor: use spacing tokens for planner scroll button

### DIFF
--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -66,7 +66,7 @@ function ScrollTopFloatingButton({ watchRef }: { watchRef: React.RefObject<HTMLE
     <IconButton
       aria-label="Scroll to top"
       onClick={scrollTop}
-      className="fixed top-1/2 -translate-y-1/2 right-2 z-50"
+      className="fixed bottom-20 right-2 z-50"
     >
       <ArrowUp />
     </IconButton>

--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -25,13 +25,11 @@
 
 /* ============ Row action buttons ============ */
 .daycard :where(.iconbtn) {
-  width: 32px;
-  height: 32px;
-  border-radius: 9999px;
-  opacity: 0;
-  transition: opacity .15s var(--ease-out);
+  @apply size-8 rounded-full opacity-0 transition-opacity duration-150 ease-out;
 }
-.daycard :where(.iconbtn > svg) { width: 14px; height: 14px; }
+.daycard :where(.iconbtn > svg) {
+  @apply size-3.5;
+}
 
 /* Reveal actions on hover or focus-within for a11y */
 .daycard .group:hover .iconbtn,

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -8,6 +8,8 @@
 
 import * as React from "react";
 import { SectionCard, Textarea, Button, Input, Card, FieldShell, SearchBar } from "@/components/ui";
+import IconButton from "@/components/ui/primitives/IconButton";
+import { ArrowUp } from "lucide-react";
 import { useLocalDB, uid } from "@/lib/db";
 import { LOCALE } from "@/lib/utils";
 import { Check as CheckIcon } from "lucide-react";
@@ -194,6 +196,14 @@ export default function PromptsPage() {
           <h3 className="type-title">Card</h3>
           <div className="space-y-3">
             <Card>Card content</Card>
+          </div>
+        </Card>
+        <Card className="mt-8 space-y-4">
+          <h3 className="type-title">IconButton</h3>
+          <div className="space-x-3">
+            <IconButton aria-label="Scroll to top">
+              <ArrowUp />
+            </IconButton>
           </div>
         </Card>
         <Card className="mt-8 space-y-4">


### PR DESCRIPTION
## Summary
- place planner scroll-to-top button with spacing token offsets
- refactor planner row action styles to use Tailwind spacing and radius utilities
- document IconButton on prompts page

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bcfa482944832c9eb113be1ff88da6