### PR TITLE
feat: turn off browser text helpers in SearchBar

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -65,6 +65,7 @@ Following these guidelines keeps the interface consistent and lets theme updates
 ## SearchBar
 - Wraps its input in a `<form role="search">` for accessibility.
 - Submitting the form calls `onValueChange` immediately and optionally `onSubmit` with the current query.
+- Disables `autoComplete`, `autoCorrect`, `spellCheck`, and `autoCapitalize` by default for consistent text entry.
 
 ```tsx
 import { SearchBar } from "@/components/ui";

--- a/src/components/ui/primitives/SearchBar.tsx
+++ b/src/components/ui/primitives/SearchBar.tsx
@@ -28,6 +28,10 @@ export default function SearchBar({
   className,
   clearable = true,
   debounceMs = 0,
+  autoComplete = "off",
+  autoCorrect = "off",
+  spellCheck = false,
+  autoCapitalize = "none",
   ...rest
 }: SearchBarProps) {
   // Hydration-safe: initial render = prop value
@@ -93,6 +97,10 @@ export default function SearchBar({
           )}
           aria-label={rest["aria-label"] ?? "Search"}
           type="search"
+          autoComplete={autoComplete}
+          autoCorrect={autoCorrect}
+          spellCheck={spellCheck}
+          autoCapitalize={autoCapitalize}
           {...rest}
         />
 

--- a/tests/primitives/search-bar.test.tsx
+++ b/tests/primitives/search-bar.test.tsx
@@ -26,4 +26,33 @@ describe('SearchBar', () => {
     expect(handleSubmit).toHaveBeenCalledWith('hello');
     vi.useRealTimers();
   });
+
+  it('disables browser text help by default', () => {
+    const { getByRole } = render(
+      <SearchBar value="" onValueChange={() => {}} />
+    );
+    const input = getByRole('searchbox');
+    expect(input).toHaveAttribute('autocomplete', 'off');
+    expect(input).toHaveAttribute('autocorrect', 'off');
+    expect(input).toHaveAttribute('autocapitalize', 'none');
+    expect(input).toHaveAttribute('spellcheck', 'false');
+  });
+
+  it('allows overriding text helpers', () => {
+    const { getByRole } = render(
+      <SearchBar
+        value=""
+        onValueChange={() => {}}
+        autoComplete="on"
+        autoCorrect="on"
+        spellCheck={true}
+        autoCapitalize="words"
+      />
+    );
+    const input = getByRole('searchbox');
+    expect(input).toHaveAttribute('autocomplete', 'on');
+    expect(input).toHaveAttribute('autocorrect', 'on');
+    expect(input).toHaveAttribute('autocapitalize', 'words');
+    expect(input).toHaveAttribute('spellcheck', 'true');
+  });
 });


### PR DESCRIPTION
## Summary
- default SearchBar input to disable autocomplete, autocorrect, spellcheck, and autocapitalize unless overridden
- document the new defaults in the design system guide
- test default and override behavior for SearchBar text helpers

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bcff38d108832c969f3af73fd4ae82