### PR TITLE
feat: improve AnimatedSelect accessibility

### DIFF
--- a/src/components/ui/selects/AnimatedSelect.tsx
+++ b/src/components/ui/selects/AnimatedSelect.tsx
@@ -61,6 +61,7 @@ export default function AnimatedSelect({
   const triggerRef = React.useRef<HTMLButtonElement | null>(null);
   const listRef = React.useRef<HTMLUListElement | null>(null);
   const idBase = React.useId();
+  const labelId = `${idBase}-label`;
 
   // Positioning
   const [rect, setRect] = React.useState<DOMRect | null>(null);
@@ -234,7 +235,12 @@ export default function AnimatedSelect({
   return (
     <div id={id} className={["glitch-wrap", className].join(" ")}>
       {label ? (
-        <div className={hideLabel ? "sr-only" : "mb-1 text-xs text-[hsl(var(--muted-foreground))]"}>{label}</div>
+        <div
+          id={labelId}
+          className={hideLabel ? "sr-only" : "mb-1 text-xs text-[hsl(var(--muted-foreground))]"}
+        >
+          {label}
+        </div>
       ) : null}
 
       <button
@@ -249,7 +255,8 @@ export default function AnimatedSelect({
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-controls={`${idBase}-listbox`}
-        aria-label={triggerAria}
+        aria-labelledby={label ? labelId : undefined}
+        aria-label={label ? undefined : triggerAria}
         className={triggerCls}
         data-lit={lit ? "true" : "false"}
         data-open={open ? "true" : "false"}
@@ -290,7 +297,8 @@ export default function AnimatedSelect({
                 role="listbox"
                 id={`${idBase}-listbox`}
                 tabIndex={-1}
-                aria-label={triggerAria}
+                aria-labelledby={label ? labelId : undefined}
+                aria-label={label ? undefined : triggerAria}
                 initial={{ opacity: 0, y: -4, scale: 0.98 }}
                 animate={{ opacity: 1, y: 0, scale: 1 }}
                 exit={{ opacity: 0, y: -4, scale: 0.98 }}

--- a/tests/ui/animated-select.test.tsx
+++ b/tests/ui/animated-select.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import AnimatedSelect from '../../src/components/ui/selects/AnimatedSelect';
+
+afterEach(cleanup);
+
+describe('AnimatedSelect', () => {
+  it('associates label and trigger via aria-labelledby', () => {
+    const items = [
+      { value: 'apple', label: 'Apple' },
+      { value: 'orange', label: 'Orange' },
+    ];
+    const { getByText, getByRole } = render(
+      <AnimatedSelect label="Fruit" items={items} />
+    );
+
+    const labelEl = getByText('Fruit');
+    const button = getByRole('button', { name: 'Fruit' });
+
+    expect(labelEl.id).toBeTruthy();
+    expect(button).toHaveAttribute('aria-labelledby', labelEl.id);
+
+    fireEvent.click(button);
+    const listbox = getByRole('listbox');
+    expect(listbox).toHaveAttribute('aria-labelledby', labelEl.id);
+  });
+});


### PR DESCRIPTION
## Summary
- add labeled element id in `AnimatedSelect` and wire trigger and listbox with `aria-labelledby`
- verify the label association with a new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcff479838832ca2c691978ea00f87