### PR TITLE
chore: remove unused IconButton props

### DIFF
--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -13,8 +13,6 @@ export type IconButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   size?: ButtonSize;
   iconSize?: Icon;
   tone?: Tone;
-  active?: boolean;
-  fx?: boolean;
   variant?: Variant;
   /** @deprecated use size */
   circleSize?: ButtonSize;


### PR DESCRIPTION
## Summary
- drop unused `active` and `fx` props from `IconButton`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcffd23fb0832c85708efddb02bb74