### PR TITLE
feat: default IconButton to sm

### DIFF
--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -73,7 +73,7 @@ const toneClasses: Record<Variant, Record<Tone, string>> = {
 const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
   (
     {
-      size = "md",
+      size = "sm",
       circleSize,
       iconSize = size as Icon,
       className,


### PR DESCRIPTION
## Summary
- set IconButton's default `size` to `sm`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bd02141eb4832cafbafedae885a162