### PR TITLE
Expand Reviews list column width

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -194,6 +194,17 @@ export default function Page() {
               <GlitchSegmentedButton value="c">C</GlitchSegmentedButton>
             </GlitchSegmentedGroup>
           </div>
+          <div className="flex flex-col items-center space-y-2">
+            <span className="text-sm font-medium">Widths</span>
+            <div className="flex gap-2">
+              <div className="h-10 w-72 border rounded-md flex items-center justify-center text-xs text-muted-foreground">
+                w-72
+              </div>
+              <div className="h-10 w-80 border rounded-md flex items-center justify-center text-xs text-muted-foreground">
+                w-80
+              </div>
+            </div>
+          </div>
         </div>
       ) : (
         <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-3">

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -144,7 +144,7 @@ export default function ReviewsPage({
       />
 
       <div className={cn("grid items-start gap-6 md:grid-cols-12")}>
-        <aside className="md:col-span-4 md:w-60 lg:col-span-3 lg:w-72">
+        <aside className="md:col-span-5 md:w-72 lg:col-span-4 lg:w-80">
           <div
             className="card-neo-soft overflow-hidden bg-card/50"
             style={{ boxShadow: neuRaised(14) }}
@@ -166,7 +166,7 @@ export default function ReviewsPage({
             </div>
           </aside>
 
-          <div className="md:col-span-8 lg:col-span-9 flex justify-center">
+          <div className="md:col-span-7 lg:col-span-8 flex justify-center">
             {!active ? (
               <ReviewPanel className="flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
                 <Ghost className="h-6 w-6 opacity-60" />


### PR DESCRIPTION
## Summary
- widen review list to md:col-span-5 lg:col-span-4 with larger widths
- shrink detail panel to md:col-span-7 lg:col-span-8
- document new width utilities on prompts page

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bd05321c6c832c92ae0ef088bf6cbc