### PR TITLE
feat: showcase focus container for goal tabs

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -19,6 +19,7 @@ import {
   SearchBar,
 } from "@/components/ui";
 import { Plus, Sun } from "lucide-react";
+import GoalsTabs, { FilterKey } from "@/components/goals/GoalsTabs";
 
 export default function Page() {
   const viewTabs = [
@@ -50,6 +51,7 @@ export default function Page() {
   ];
 
   const [view, setView] = React.useState("components");
+  const [goalFilter, setGoalFilter] = React.useState<FilterKey>("All");
 
   return (
     <main className="page-shell py-6 bg-background text-foreground">
@@ -89,6 +91,12 @@ export default function Page() {
           <div className="flex flex-col items-center space-y-2">
             <span className="text-sm font-medium">Tabs</span>
             <TabBar items={demoTabs} className="w-56" />
+          </div>
+          <div className="flex flex-col items-center space-y-2">
+            <span className="text-sm font-medium">Goals Tabs</span>
+            <div className="w-56">
+              <GoalsTabs value={goalFilter} onChange={setGoalFilter} />
+            </div>
           </div>
           <div className="flex flex-col items-center space-y-2">
             <span className="text-sm font-medium">Progress</span>

--- a/src/components/goals/GoalsTabs.tsx
+++ b/src/components/goals/GoalsTabs.tsx
@@ -21,24 +21,31 @@ export default function GoalsTabs({ value, onChange }: GoalsTabsProps) {
       {FILTERS.map((f) => {
         const active = value === f;
         return (
-          <button
+          <div
             key={f}
-            type="button"
-            role="tab"
-            aria-selected={active}
-            onClick={() => onChange(f)}
             className={cn(
-              "text-left font-mono text-sm transition",
-              "px-3 py-2 rounded-2xl",
-              "hover:-translate-y-px hover:ring-1 hover:ring-[hsl(var(--ring))]",
-              "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[hsl(var(--accent))]",
-              active
-                ? "font-semibold text-[hsl(var(--accent))] bg-[hsl(var(--accent)/0.1)]"
-                : undefined,
+              "rounded-2xl",
+              "focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0"
             )}
           >
-            {f}
-          </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => onChange(f)}
+              className={cn(
+                "text-left font-mono text-sm transition",
+                "px-3 py-2 rounded-2xl",
+                "hover:-translate-y-px",
+                "border-none outline-none focus:outline-none focus-visible:outline-none",
+                active
+                  ? "font-semibold text-[hsl(var(--accent))] bg-[hsl(var(--accent)/0.1)]"
+                  : undefined,
+              )}
+            >
+              {f}
+            </button>
+          </div>
         );
       })}
     </div>


### PR DESCRIPTION
## Summary
- add focus container with ring styles around goal tabs
- remove button outlines and rings from goal tab buttons
- demo goal tabs on prompts page

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bd07b504f8832c916ef86083524151