### PR TITLE
feat: map additional color tokens to tailwind

### DIFF
--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -208,10 +208,19 @@ export default function PromptsPage() {
         </Card>
         <Card className="mt-8 space-y-4">
           <h3 className="type-title">Design Tokens</h3>
-            <div>
-              <h4 className="type-subtitle">Spacing</h4>
-              <p className="type-body">8, 16, 24, 32, 40, 48, 64</p>
+          <div>
+            <h4 className="type-subtitle">Colors</h4>
+            <div className="flex gap-2">
+              <div className="size-6 rounded bg-accent2" />
+              <div className="size-6 rounded bg-danger" />
+              <div className="size-6 rounded bg-success" />
+              <div className="size-6 rounded bg-glow" />
             </div>
+          </div>
+          <div>
+            <h4 className="type-subtitle">Spacing</h4>
+            <p className="type-body">8, 16, 24, 32, 40, 48, 64</p>
+          </div>
           <div>
             <h4 className="type-subtitle">Glow</h4>
             <p className="type-body">--glow-strong, --glow-soft</p>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,7 +21,16 @@ const config: Config = {
           soft: "hsl(var(--primary-soft))"
         },
         accent: { DEFAULT: "hsl(var(--accent))", soft: "hsl(var(--accent-soft))" },
-        muted: { DEFAULT: "hsl(var(--muted))", foreground: "hsl(var(--muted-foreground))" }
+        accent2: "hsl(var(--accent-2))",
+        glow: "hsl(var(--glow))",
+        ringMuted: "hsl(var(--ring-muted))",
+        danger: "hsl(var(--danger))",
+        success: {
+          DEFAULT: "hsl(var(--success))",
+          glow: "hsl(var(--success-glow))"
+        },
+        muted: { DEFAULT: "hsl(var(--muted))", foreground: "hsl(var(--muted-foreground))" },
+        lavDeep: "hsl(var(--lav-deep))"
       },
       borderRadius: { lg: "12px", xl: "16px", "2xl": "24px" },
       boxShadow: {


### PR DESCRIPTION
## Summary
- map accent2, glow, danger, success and other theme tokens to Tailwind colors
- document new color tokens in Prompts demo page

## Testing
- `npx tailwindcss -c tailwind.config.ts -i src/app/globals.css -o /tmp/tailwind.css`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd081c83f8832cbc4f474af225ebb0