### PR TITLE
Add accent-foreground and surface theme tokens

### DIFF
--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -16,6 +16,9 @@
   --accent: 292 80% 60%;
   --accent-2: 192 90% 50%;
   --accent-soft: 292 80% 20%;
+  --accent-foreground: 248 30% 10%;
+  --surface: 248 26% 12%;
+  --surface-2: 248 26% 18%;
   --glow: 292 80% 60%;
   --ring-muted: 248 20% 22%;
   --danger: 0 84% 60%;
@@ -107,6 +110,9 @@ html.light {
   --accent: 292 80% 45%;
   --accent-2: 200 100% 50%;
   --accent-soft: 292 80% 94%;
+  --accent-foreground: 0 0% 100%;
+  --surface: 240 6% 96%;
+  --surface-2: 240 6% 92%;
   --glow: 292 80% 45%;
   --ring-muted: 240 9% 90%;
   --danger: 0 84% 55%;

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -221,6 +221,10 @@ export default function PromptsPage() {
             <p className="type-body">--radius</p>
           </div>
           <div>
+            <h4 className="type-subtitle">Surfaces</h4>
+            <p className="type-body">--accent-foreground, --surface, --surface-2</p>
+          </div>
+          <div>
             <h4 className="type-subtitle">Type Ramp</h4>
             <p className="type-body">eyebrow, title, subtitle, body, caption</p>
           </div>


### PR DESCRIPTION
## Summary
- define `--accent-foreground`, `--surface`, and `--surface-2` tokens for dark and light themes
- document new color tokens on the prompts page

## Testing
- `npx vitest run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bd0a2f4648832cbd705b00088ac5cf