### PR TITLE
refactor: replace hardcoded colors with theme tokens

### DIFF
--- a/COLOR_MAPPINGS.md
+++ b/COLOR_MAPPINGS.md
@@ -8,3 +8,9 @@
 | `#000` | `hsl(var(--foreground))` |
 | `rgba(0, 0, 0, 0.05)` (text-shadow) | `hsl(var(--shadow-color) / 0.05)` |
 | `rgb(0 0 0 / .18)` | `hsl(var(--shadow-color) / 0.18)` |
+| `#ff2d75` | `hsl(var(--glitch-r))` |
+| `#ffc4f0` | `hsl(var(--glitch-r-light))` |
+| `#3aa8ff` | `hsl(var(--glitch-b))` |
+| `#cde9ff` | `hsl(var(--glitch-b-light))` |
+| `#0b0b12` | `hsl(var(--background))` |
+| `#9a8cff` | `hsl(var(--icon-fg))` |

--- a/src/app/Icon.tsx
+++ b/src/app/Icon.tsx
@@ -16,8 +16,8 @@ export default function Icon() {
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          background: "#0b0b12",
-          color: "#9a8cff",
+          background: "hsl(var(--background))",
+          color: "hsl(var(--icon-fg))",
         }}
       >
         13

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -52,6 +52,11 @@ export default function Page() {
     "success",
     "glow-strong",
     "glow-soft",
+    "glitch-r",
+    "glitch-r-light",
+    "glitch-b",
+    "glitch-b-light",
+    "icon-fg",
   ];
 
   const [view, setView] = React.useState("components");

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -28,6 +28,11 @@
   --lav-deep: 320 85% 60%;
   --success: 316 92% 70%;
   --success-glow: 316 92% 52% / 0.6;
+  --glitch-r: 339 100% 59%;
+  --glitch-r-light: 315 100% 88%;
+  --glitch-b: 206 100% 61%;
+  --glitch-b-light: 206 100% 90%;
+  --icon-fg: 247 100% 77%;
   --accent-overlay: hsl(var(--accent));
   --ring-contrast: hsl(var(--ring));
   --glow-active: hsl(var(--glow));

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -331,9 +331,9 @@ export default function TimerTab() {
             inset 0 0 16px hsl(var(--accent) / .6);
           border-right: 0 solid transparent;
           -webkit-mask-image:
-            repeating-linear-gradient(180deg, #000 0 3px, transparent 3px 5px);
+            repeating-linear-gradient(180deg, hsl(var(--foreground)) 0 3px, transparent 3px 5px);
           mask-image:
-            repeating-linear-gradient(180deg, #000 0 3px, transparent 3px 5px);
+            repeating-linear-gradient(180deg, hsl(var(--foreground)) 0 3px, transparent 3px 5px);
           animation:
             widthEase 220ms ease,
             jitter 900ms steps(12) infinite;
@@ -345,14 +345,14 @@ export default function TimerTab() {
           filter: blur(1px);
         }
         .lg-progress.rgb.r {
-          background: linear-gradient(90deg, #ff2d75 0%, #ffc4f0 100%);
+          background: linear-gradient(90deg, hsl(var(--glitch-r)) 0%, hsl(var(--glitch-r-light)) 100%);
           transform: translateX(-1px);
           animation:
             widthEase 220ms ease,
             jitterX 900ms steps(12) infinite reverse;
         }
         .lg-progress.rgb.b {
-          background: linear-gradient(90deg, #3aa8ff 0%, #cde9ff 100%);
+          background: linear-gradient(90deg, hsl(var(--glitch-b)) 0%, hsl(var(--glitch-b-light)) 100%);
           transform: translateX(1px);
           animation:
             widthEase 220ms ease,


### PR DESCRIPTION
## Summary
- replace inline hex values in TimerTab with theme color variables
- centralize favicon colors through theme tokens
- document new color mappings and expose tokens on prompts page

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bd0b88f86c832c8a98e394a12b2f4d