### PR TITLE
feat: make tasks editable via button

### DIFF
--- a/src/components/planner/TodayHero.tsx
+++ b/src/components/planner/TodayHero.tsx
@@ -227,9 +227,21 @@ export default function TodayHero({ iso }: Props) {
                           aria-label={`Rename task ${t.text}`}
                         />
                       ) : (
-                        <span className={cn("task-tile__text", t.done && "line-through-soft")} onClick={() => setEditingTaskId(t.id)} role="button" tabIndex={0} onKeyDown={e => { if (e.key === "Enter") setEditingTaskId(t.id); }} aria-label={`Edit task ${t.text}`} title="Edit task">
+                        <button
+                          type="button"
+                          className={cn("task-tile__text", t.done && "line-through-soft")}
+                          onClick={() => setEditingTaskId(t.id)}
+                          onKeyDown={e => {
+                            if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault();
+                              setEditingTaskId(t.id);
+                            }
+                          }}
+                          aria-label={`Edit task ${t.text}`}
+                          title="Edit task"
+                        >
                           {t.text}
-                        </span>
+                        </button>
                       )}
                     </div>
 

--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -90,12 +90,22 @@
 
 /* ============ Task rows (right column) ============ */
 .task-tile__text {
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
   color: hsl(var(--foreground));
   transition: color .15s var(--ease-out), text-shadow .15s var(--ease-out);
 }
 .task-tile__text:hover {
   color: hsl(var(--primary-foreground));
   text-shadow: 0 0 10px hsl(var(--accent) / .18);
+}
+.task-tile__text:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 2px;
+  border-radius: var(--radius-md, 6px);
 }
 
 /* Soft, readable strike-through for completed tasks */

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -207,6 +207,17 @@ export default function PromptsPage() {
           </div>
         </Card>
         <Card className="mt-8 space-y-4">
+          <h3 className="type-title">Task Tile Text</h3>
+          <div className="space-y-2">
+            <button type="button" className="task-tile__text">
+              Editable task
+            </button>
+            <button type="button" className="task-tile__text line-through-soft">
+              Completed task
+            </button>
+          </div>
+        </Card>
+        <Card className="mt-8 space-y-4">
           <h3 className="type-title">Design Tokens</h3>
           <div>
             <h4 className="type-subtitle">Colors</h4>


### PR DESCRIPTION
## Summary
- make task titles buttons so Enter and Space start editing
- reset `task-tile__text` style and add focus ring
- document task tile button on prompts page

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bd16099634832cbaefa9306bbac8cb