### PR TITLE
feat: add save status to week notes

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -204,6 +204,14 @@ export default function Page() {
             </div>
           </div>
           <div className="flex flex-col items-center space-y-2">
+            <span className="text-sm font-medium">Save Status</span>
+            <div className="w-56">
+              <div className="text-xs text-[hsl(var(--muted-foreground))]" aria-live="polite">
+                All changes saved
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-col items-center space-y-2">
             <span className="text-sm font-medium">Badge</span>
             <div className="w-56 flex justify-center gap-2">
               <Badge>Neutral</Badge>

--- a/src/components/planner/WeekNotes.tsx
+++ b/src/components/planner/WeekNotes.tsx
@@ -17,6 +17,22 @@ type Props = { iso: ISODate };
 export default function WeekNotes({ iso }: Props) {
   const { focus, setFocus, day, setNotes } = usePlanner();
   const [value, setValue] = React.useState(day.notes ?? "");
+  const trimmed = value.trim();
+  const original = (day.notes ?? "").trim();
+  const isDirty = trimmed !== original;
+  const [saving, setSaving] = React.useState(false);
+  const lastSavedRef = React.useRef(original);
+
+  const commit = React.useCallback(async () => {
+    if (!isDirty) return;
+    setSaving(true);
+    try {
+      await Promise.resolve(setNotes(trimmed));
+      lastSavedRef.current = trimmed;
+    } finally {
+      setSaving(false);
+    }
+  }, [isDirty, setNotes, trimmed]);
 
   React.useEffect(() => {
     if (focus !== iso) setFocus(iso);
@@ -36,9 +52,17 @@ export default function WeekNotes({ iso }: Props) {
           onChange={(e) => setValue(e.target.value)}
           name={`notes-${iso}`}
           className="planner-textarea"
-          onBlur={() => setNotes(value)}
+          onBlur={commit}
         />
-        <p className="mt-2 text-xs text-[hsl(var(--muted-foreground))]">Autosaves on blur.</p>
+        <div className="mt-2 text-xs text-[hsl(var(--muted-foreground))]" aria-live="polite">
+          {saving
+            ? "Saving changes…"
+            : isDirty
+            ? "Unsaved changes"
+            : lastSavedRef.current
+            ? "All changes saved"
+            : "No notes yet"}
+        </div>
       </SectionCard.Body>
     </SectionCard>
   );


### PR DESCRIPTION
## Summary
- add aria-live save status indicator to WeekNotes component
- document save status on prompts component gallery

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bd160b0010832cb20a3fa540a9d08b