### PR TITLE
feat(reviews): enable creation from empty list

### DIFF
--- a/src/components/reviews/ReviewList.tsx
+++ b/src/components/reviews/ReviewList.tsx
@@ -12,6 +12,7 @@ export type ReviewListProps = {
   reviews: Review[];
   selectedId: string | null;
   onSelect?: (id: string) => void;
+  onCreate?: () => void;
   className?: string;
 };
 
@@ -19,6 +20,7 @@ export default function ReviewList({
   reviews,
   selectedId,
   onSelect,
+  onCreate,
   className,
 }: ReviewListProps) {
   const count = reviews.length;
@@ -32,7 +34,9 @@ export default function ReviewList({
         <div className="flex flex-col items-center justify-center gap-3 p-6 text-sm text-muted-foreground">
           <Tv className="h-6 w-6 opacity-60" />
           <p>No reviews yet</p>
-          <Button variant="primary">New Review</Button>
+          <Button variant="primary" onClick={onCreate}>
+            New Review
+          </Button>
         </div>
       </Card>
     );

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -160,6 +160,7 @@ export default function ReviewsPage({
                   setPanelMode("summary");
                   onSelect(id);
                 }}
+                onCreate={onCreate}
                 className="max-h-screen overflow-auto p-2"
               />
             </div>


### PR DESCRIPTION
## Summary
- add optional onCreate handler to ReviewList
- call onCreate from empty-state "New Review" button
- forward ReviewsPage onCreate handler to ReviewList

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bd191ebde8832c98396ebc663eec0f