### PR TITLE
feat: add reusable snackbar for undo announcements

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -18,6 +18,7 @@ import {
   TitleBar,
   Hero,
   SearchBar,
+  Snackbar,
 } from "@/components/ui";
 import { Plus, Sun } from "lucide-react";
 import GoalsTabs, { FilterKey } from "@/components/goals/GoalsTabs";
@@ -117,6 +118,12 @@ export default function Page() {
             <span className="text-sm font-medium">Spinner</span>
             <div className="w-56 flex justify-center">
               <Spinner />
+            </div>
+          </div>
+          <div className="flex flex-col items-center space-y-2">
+            <span className="text-sm font-medium">Snackbar</span>
+            <div className="w-56 flex justify-center">
+              <Snackbar message="Saved" actionLabel="Undo" onAction={() => {}} />
             </div>
           </div>
           <div className="flex flex-col items-center space-y-2">

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -21,6 +21,7 @@ import CheckCircle from "@/components/ui/toggles/CheckCircle";
 import {
   GlitchSegmentedGroup,
   GlitchSegmentedButton,
+  Snackbar,
 } from "@/components/ui";
 import GoalsTabs, { FilterKey } from "./GoalsTabs";
 import GoalForm from "./GoalForm";
@@ -293,20 +294,15 @@ export default function GoalsPage() {
               </div>
 
               {lastDeleted && (
-                <div className="mx-auto w-fit rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] px-4 py-2 text-sm shadow-sm">
-                  Deleted “{lastDeleted.title}”.{" "}
-                  <button
-                    type="button"
-                    className="underline underline-offset-2"
-                    onClick={() => {
-                      if (!lastDeleted) return;
-                      setGoals((prev) => [lastDeleted, ...prev]);
-                      setLastDeleted(null);
-                    }}
-                  >
-                    Undo
-                  </button>
-                </div>
+                <Snackbar
+                  message={<>Deleted “{lastDeleted.title}”.</>}
+                  actionLabel="Undo"
+                  onAction={() => {
+                    if (!lastDeleted) return;
+                    setGoals((prev) => [lastDeleted, ...prev]);
+                    setLastDeleted(null);
+                  }}
+                />
               )}
             </>
           )}

--- a/src/components/ui/feedback/Snackbar.tsx
+++ b/src/components/ui/feedback/Snackbar.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface SnackbarProps extends React.HTMLAttributes<HTMLDivElement> {
+  message: React.ReactNode;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+export default function Snackbar({
+  message,
+  actionLabel,
+  onAction,
+  className,
+  ...props
+}: SnackbarProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "mx-auto w-fit rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] px-4 py-2 text-sm shadow-sm",
+        className,
+      )}
+      {...props}
+    >
+      {message}
+      {actionLabel && onAction ? (
+        <>
+          {" "}
+          <button
+            type="button"
+            className="underline underline-offset-2"
+            onClick={onAction}
+          >
+            {actionLabel}
+          </button>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -21,6 +21,7 @@ export { GlitchSegmentedGroup, GlitchSegmentedButton } from "./primitives/Glitch
 //
 export { default as Progress } from "./feedback/Progress";
 export { default as Spinner } from "./feedback/Spinner";
+export { default as Snackbar } from "./feedback/Snackbar";
 
 //
 // Theme


### PR DESCRIPTION
## Summary
- add accessible `Snackbar` component for status announcements
- use `Snackbar` in goals page undo flow
- showcase `Snackbar` in prompts component gallery

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bd1af8169c832c965cbb045b79c7cc