### PR TITLE
Use muted foreground text token across goal components

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -212,6 +212,12 @@ export default function Page() {
             </div>
           </div>
           <div className="flex flex-col items-center space-y-2">
+            <span className="text-sm font-medium">Muted Text</span>
+            <p className="w-56 text-sm text-[hsl(var(--muted-foreground))] text-center">
+              Example of muted foreground text
+            </p>
+          </div>
+          <div className="flex flex-col items-center space-y-2">
             <span className="text-sm font-medium">Badge</span>
             <div className="w-56 flex justify-center gap-2">
               <Badge>Neutral</Badge>

--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -50,7 +50,7 @@ export default function GoalForm({
         />
         <SectionCard.Body className="grid gap-6">
           <label className="grid gap-2">
-            <span className="text-xs text-white/60">Title</span>
+            <span className="text-xs text-[hsl(var(--muted-foreground))]">Title</span>
             <Input
               tone="default"
               className="h-10 text-sm focus:ring-2 focus:ring-purple-400/60"
@@ -62,7 +62,7 @@ export default function GoalForm({
           </label>
 
           <label className="grid gap-2">
-            <span className="text-xs text-white/60">Metric (optional)</span>
+            <span className="text-xs text-[hsl(var(--muted-foreground))]">Metric (optional)</span>
             <Input
               tone="default"
               className="h-10 text-sm focus:ring-2 focus:ring-purple-400/60 tabular-nums"
@@ -73,7 +73,7 @@ export default function GoalForm({
           </label>
 
           <label className="grid gap-2">
-            <span className="text-xs text-white/60">Notes (optional)</span>
+            <span className="text-xs text-[hsl(var(--muted-foreground))]">Notes (optional)</span>
             <Textarea
               tone="default"
               className="min-h-24 text-sm focus:ring-2 focus:ring-purple-400/60"
@@ -83,7 +83,7 @@ export default function GoalForm({
             />
           </label>
 
-          <div className="text-xs text-white/60">
+          <div className="text-xs text-[hsl(var(--muted-foreground))]">
             {activeCount >= activeCap ? (
               <span className="text-[hsl(var(--accent))]">
                 Cap reached. Finish one to add more.

--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -32,14 +32,14 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
       <SectionCard.Body className="grid gap-6">
           <ul className="divide-y divide-white/10">
             {items.length === 0 ? (
-              <li className="py-3 text-sm text-white/60">No queued goals</li>
+              <li className="py-3 text-sm text-[hsl(var(--muted-foreground))]">No queued goals</li>
             ) : (
               items.map((it) => (
                 <li key={it.id} className="group flex items-center gap-2 py-3">
                   <span className="h-1.5 w-1.5 rounded-full bg-white/40" aria-hidden />
                   <p className="flex-1 truncate text-sm">{it.text}</p>
                   <time
-                    className="text-xs text-white/60 opacity-0 group-hover:opacity-100"
+                    className="text-xs text-[hsl(var(--muted-foreground))] opacity-0 group-hover:opacity-100"
                     dateTime={new Date(it.createdAt).toISOString()}
                   >
                     {new Date(it.createdAt).toLocaleDateString(LOCALE)}

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -207,7 +207,7 @@ export default function GoalsPage() {
                   <SectionCard.Body>
                     <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 [grid-auto-rows:1fr]">
                       {filtered.length === 0 ? (
-                        <p className="text-sm text-white/60">
+                        <p className="text-sm text-[hsl(var(--muted-foreground))]">
                           No goals here. Add one simple, finishable thing.
                         </p>
                       ) : (
@@ -246,7 +246,7 @@ export default function GoalsPage() {
                                 </IconButton>
                               </div>
                             </header>
-                            <div className="mt-4 text-sm text-white/60 space-y-2">
+                            <div className="mt-4 text-sm text-[hsl(var(--muted-foreground))] space-y-2">
                               {g.metric ? (
                                 <div className="tabular-nums">
                                   <span className="opacity-70">Metric:</span> {g.metric}
@@ -254,7 +254,7 @@ export default function GoalsPage() {
                               ) : null}
                               {g.notes ? <p className="leading-relaxed">{g.notes}</p> : null}
                             </div>
-                            <footer className="mt-auto pt-3 flex items-center justify-between text-xs text-white/60">
+                            <footer className="mt-auto pt-3 flex items-center justify-between text-xs text-[hsl(var(--muted-foreground))]">
                               <span className="inline-flex items-center gap-2">
                                 <span
                                   aria-hidden


### PR DESCRIPTION
## Summary
- swap `text-white/60` for `text-[hsl(var(--muted-foreground))]` in goal UI
- showcase muted text style on prompts page

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bd1a54049c832ca93836766357cb3b