### PR TITLE
feat: apply review tile styles

### DIFF
--- a/src/components/reviews/ReviewListItem.tsx
+++ b/src/components/reviews/ReviewListItem.tsx
@@ -7,9 +7,8 @@ import type { Review } from "@/lib/types";
 import { Badge } from "@/components/ui";
 
 const itemBase =
-  "relative w-full text-left h-auto min-h-[76px] p-4 rounded-xl border shadow-[0_0_0_1px_hsl(var(--border)/0.12)] bg-[hsl(var(--card)/0.60)] scanlines noise jitter transition-all duration-200 hover:ring-1 hover:ring-[hsl(var(--accent))/0.18] hover:shadow-[0_0_24px_0_hsl(var(--accent)/0.10)] hover:-translate-y-[1px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--background))] focus-visible:ring-[hsl(var(--accent))] disabled:opacity-60 disabled:pointer-events-none";
-const itemSelected =
-  "ring-2 ring-[hsl(var(--accent))] shadow-[0_0_32px_0_hsl(var(--accent)/0.18)]";
+  "review-tile relative w-full text-left h-auto min-h-[76px] p-4 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none";
+const itemSelected = "review-tile--active";
 const statusDotBase = "self-center justify-self-center h-2 w-2 rounded-full";
 const statusDotWin = "bg-[hsl(var(--success))]";
 const statusDotDefault = "bg-[hsl(var(--muted-foreground))]";
@@ -43,7 +42,7 @@ export default function ReviewListItem({
 }: ReviewListItemProps) {
   if (loading) {
     return (
-      <div className={itemLoading}>
+      <div data-scope="reviews" className={itemLoading}>
         <div className={cn(loadingLine, "w-3/5 mb-3")} />
         <div className={cn(loadingLine, "w-2/5")} />
       </div>
@@ -58,56 +57,58 @@ export default function ReviewListItem({
   const dateStr = review?.createdAt ? formatDate(review.createdAt) : "";
 
   return (
-    <button
-      type="button"
-      disabled={disabled}
-      onClick={onClick}
-      aria-label={`Open review: ${title}`}
-      data-selected={selected ? "true" : undefined}
-      className={cn(itemBase, selected && itemSelected)}
-    >
-      <div className="grid grid-cols-[20px_1fr_auto] gap-3">
-        <span
-          aria-hidden
-          className={cn(
-            statusDotBase,
-            review?.result === "Win" ? statusDotWin : statusDotDefault,
-            review?.status === "new" && statusDotPulse
-          )}
-        />
-        <div className="min-w-0 flex flex-col gap-1">
-          <div
+    <div data-scope="reviews">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onClick}
+        aria-label={`Open review: ${title}`}
+        data-selected={selected ? "true" : undefined}
+        className={cn(itemBase, selected && itemSelected)}
+      >
+        <div className="grid grid-cols-[20px_1fr_auto] gap-3">
+          <span
+            aria-hidden
             className={cn(
-              "truncate font-medium text-base",
-              untitled && "text-muted-foreground/70"
+              statusDotBase,
+              review?.result === "Win" ? statusDotWin : statusDotDefault,
+              review?.status === "new" && statusDotPulse
             )}
-            aria-label={untitled ? "Untitled Review" : undefined}
-          >
-            {title}
+          />
+          <div className="min-w-0 flex flex-col gap-1">
+            <div
+              className={cn(
+                "truncate font-medium text-base",
+                untitled && "text-muted-foreground/70"
+              )}
+              aria-label={untitled ? "Untitled Review" : undefined}
+            >
+              {title}
+            </div>
+            <div className="flex items-center gap-1 text-sm text-muted-foreground">
+              {typeof score === "number" ? (
+                <Badge variant="accent" aria-label={`Rating ${score} out of 10`}>
+                  {score}/10
+                </Badge>
+              ) : null}
+              {resultTag ? (
+                <Badge
+                  variant="neutral"
+                  className="px-1.5 py-0.5 text-[10px] tracking-wide rounded-md"
+                >
+                  {resultTag}
+                </Badge>
+              ) : null}
+              {subline ? (
+                <span className="line-clamp-1 truncate">{subline}</span>
+              ) : null}
+            </div>
           </div>
-          <div className="flex items-center gap-1 text-sm text-muted-foreground">
-            {typeof score === "number" ? (
-              <Badge variant="accent" aria-label={`Rating ${score} out of 10`}>
-                {score}/10
-              </Badge>
-            ) : null}
-            {resultTag ? (
-              <Badge
-                variant="neutral"
-                className="px-1.5 py-0.5 text-[10px] tracking-wide rounded-md"
-              >
-                {resultTag}
-              </Badge>
-            ) : null}
-            {subline ? (
-              <span className="line-clamp-1 truncate">{subline}</span>
-            ) : null}
-          </div>
+          <span className="self-start text-xs text-muted-foreground whitespace-nowrap">
+            {dateStr}
+          </span>
         </div>
-        <span className="self-start text-xs text-muted-foreground whitespace-nowrap">
-          {dateStr}
-        </span>
-      </div>
-    </button>
+      </button>
+    </div>
   );
 }

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -2,62 +2,67 @@
 
 exports[`ReviewListItem > renders default state 1`] = `
 <div>
-  <button
-    aria-label="Open review: Sample Review"
-    class="relative w-full text-left h-auto min-h-[76px] p-4 rounded-xl border shadow-[0_0_0_1px_hsl(var(--border)/0.12)] bg-[hsl(var(--card)/0.60)] scanlines noise jitter transition-all duration-200 hover:ring-1 hover:ring-[hsl(var(--accent))/0.18] hover:shadow-[0_0_24px_0_hsl(var(--accent)/0.10)] hover:-translate-y-[1px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--background))] focus-visible:ring-[hsl(var(--accent))] disabled:opacity-60 disabled:pointer-events-none"
-    type="button"
+  <div
+    data-scope="reviews"
   >
-    <div
-      class="grid grid-cols-[20px_1fr_auto] gap-3"
+    <button
+      aria-label="Open review: Sample Review"
+      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
+      type="button"
     >
-      <span
-        aria-hidden="true"
-        class="self-center justify-self-center h-2 w-2 rounded-full bg-[hsl(var(--success))]"
-      />
       <div
-        class="min-w-0 flex flex-col gap-1"
+        class="grid grid-cols-[20px_1fr_auto] gap-3"
       >
+        <span
+          aria-hidden="true"
+          class="self-center justify-self-center h-2 w-2 rounded-full bg-[hsl(var(--success))]"
+        />
         <div
-          class="truncate font-medium text-base"
+          class="min-w-0 flex flex-col gap-1"
         >
-          Sample Review
+          <div
+            class="truncate font-medium text-base"
+          >
+            Sample Review
+          </div>
+          <div
+            class="flex items-center gap-1 text-sm text-muted-foreground"
+          >
+            <span
+              aria-label="Rating 9 out of 10"
+              class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--accent)/0.15)] border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))] shadow-[0_0_8px_hsl(var(--accent)/0.3)]"
+            >
+              9
+              /10
+            </span>
+            <span
+              class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--muted)/0.25)] border-[hsl(var(--border)/0.2)] text-[hsl(var(--muted-foreground))] px-1.5 py-0.5 text-[10px] tracking-wide rounded-md"
+            >
+              W
+            </span>
+            <span
+              class="line-clamp-1 truncate"
+            >
+              Quick note
+            </span>
+          </div>
         </div>
-        <div
-          class="flex items-center gap-1 text-sm text-muted-foreground"
+        <span
+          class="self-start text-xs text-muted-foreground whitespace-nowrap"
         >
-          <span
-            aria-label="Rating 9 out of 10"
-            class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--accent)/0.15)] border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))] shadow-[0_0_8px_hsl(var(--accent)/0.3)]"
-          >
-            9
-            /10
-          </span>
-          <span
-            class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--muted)/0.25)] border-[hsl(var(--border)/0.2)] text-[hsl(var(--muted-foreground))] px-1.5 py-0.5 text-[10px] tracking-wide rounded-md"
-          >
-            W
-          </span>
-          <span
-            class="line-clamp-1 truncate"
-          >
-            Quick note
-          </span>
-        </div>
+          11/14/2023
+        </span>
       </div>
-      <span
-        class="self-start text-xs text-muted-foreground whitespace-nowrap"
-      >
-        11/14/2023
-      </span>
-    </div>
-  </button>
+    </button>
+  </div>
 </div>
 `;
 
 exports[`ReviewListItem > renders loading state 1`] = `
 <div>
   <div
-    class="relative w-full text-left h-auto min-h-[76px] p-4 rounded-xl border shadow-[0_0_0_1px_hsl(var(--border)/0.12)] bg-[hsl(var(--card)/0.60)] scanlines noise jitter transition-all duration-200 hover:ring-1 hover:ring-[hsl(var(--accent))/0.18] hover:shadow-[0_0_24px_0_hsl(var(--accent)/0.10)] hover:-translate-y-[1px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--background))] focus-visible:ring-[hsl(var(--accent))] disabled:opacity-60 disabled:pointer-events-none animate-pulse"
+    class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none animate-pulse"
+    data-scope="reviews"
   >
     <div
       class="h-3 rounded bg-[hsl(var(--muted))] w-3/5 mb-3"
@@ -71,110 +76,118 @@ exports[`ReviewListItem > renders loading state 1`] = `
 
 exports[`ReviewListItem > renders selected state 1`] = `
 <div>
-  <button
-    aria-label="Open review: Sample Review"
-    class="relative w-full text-left h-auto min-h-[76px] p-4 rounded-xl border shadow-[0_0_0_1px_hsl(var(--border)/0.12)] bg-[hsl(var(--card)/0.60)] scanlines noise jitter transition-all duration-200 hover:ring-1 hover:ring-[hsl(var(--accent))/0.18] hover:shadow-[0_0_24px_0_hsl(var(--accent)/0.10)] hover:-translate-y-[1px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--background))] focus-visible:ring-[hsl(var(--accent))] disabled:opacity-60 disabled:pointer-events-none ring-2 ring-[hsl(var(--accent))] shadow-[0_0_32px_0_hsl(var(--accent)/0.18)]"
-    data-selected="true"
-    type="button"
+  <div
+    data-scope="reviews"
   >
-    <div
-      class="grid grid-cols-[20px_1fr_auto] gap-3"
+    <button
+      aria-label="Open review: Sample Review"
+      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none review-tile--active"
+      data-selected="true"
+      type="button"
     >
-      <span
-        aria-hidden="true"
-        class="self-center justify-self-center h-2 w-2 rounded-full bg-[hsl(var(--success))]"
-      />
       <div
-        class="min-w-0 flex flex-col gap-1"
+        class="grid grid-cols-[20px_1fr_auto] gap-3"
       >
+        <span
+          aria-hidden="true"
+          class="self-center justify-self-center h-2 w-2 rounded-full bg-[hsl(var(--success))]"
+        />
         <div
-          class="truncate font-medium text-base"
+          class="min-w-0 flex flex-col gap-1"
         >
-          Sample Review
+          <div
+            class="truncate font-medium text-base"
+          >
+            Sample Review
+          </div>
+          <div
+            class="flex items-center gap-1 text-sm text-muted-foreground"
+          >
+            <span
+              aria-label="Rating 9 out of 10"
+              class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--accent)/0.15)] border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))] shadow-[0_0_8px_hsl(var(--accent)/0.3)]"
+            >
+              9
+              /10
+            </span>
+            <span
+              class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--muted)/0.25)] border-[hsl(var(--border)/0.2)] text-[hsl(var(--muted-foreground))] px-1.5 py-0.5 text-[10px] tracking-wide rounded-md"
+            >
+              W
+            </span>
+            <span
+              class="line-clamp-1 truncate"
+            >
+              Quick note
+            </span>
+          </div>
         </div>
-        <div
-          class="flex items-center gap-1 text-sm text-muted-foreground"
+        <span
+          class="self-start text-xs text-muted-foreground whitespace-nowrap"
         >
-          <span
-            aria-label="Rating 9 out of 10"
-            class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--accent)/0.15)] border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))] shadow-[0_0_8px_hsl(var(--accent)/0.3)]"
-          >
-            9
-            /10
-          </span>
-          <span
-            class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--muted)/0.25)] border-[hsl(var(--border)/0.2)] text-[hsl(var(--muted-foreground))] px-1.5 py-0.5 text-[10px] tracking-wide rounded-md"
-          >
-            W
-          </span>
-          <span
-            class="line-clamp-1 truncate"
-          >
-            Quick note
-          </span>
-        </div>
+          11/14/2023
+        </span>
       </div>
-      <span
-        class="self-start text-xs text-muted-foreground whitespace-nowrap"
-      >
-        11/14/2023
-      </span>
-    </div>
-  </button>
+    </button>
+  </div>
 </div>
 `;
 
 exports[`ReviewListItem > renders untitled state 1`] = `
 <div>
-  <button
-    aria-label="Open review: Untitled Review"
-    class="relative w-full text-left h-auto min-h-[76px] p-4 rounded-xl border shadow-[0_0_0_1px_hsl(var(--border)/0.12)] bg-[hsl(var(--card)/0.60)] scanlines noise jitter transition-all duration-200 hover:ring-1 hover:ring-[hsl(var(--accent))/0.18] hover:shadow-[0_0_24px_0_hsl(var(--accent)/0.10)] hover:-translate-y-[1px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--background))] focus-visible:ring-[hsl(var(--accent))] disabled:opacity-60 disabled:pointer-events-none"
-    type="button"
+  <div
+    data-scope="reviews"
   >
-    <div
-      class="grid grid-cols-[20px_1fr_auto] gap-3"
+    <button
+      aria-label="Open review: Untitled Review"
+      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
+      type="button"
     >
-      <span
-        aria-hidden="true"
-        class="self-center justify-self-center h-2 w-2 rounded-full bg-[hsl(var(--success))]"
-      />
       <div
-        class="min-w-0 flex flex-col gap-1"
+        class="grid grid-cols-[20px_1fr_auto] gap-3"
       >
+        <span
+          aria-hidden="true"
+          class="self-center justify-self-center h-2 w-2 rounded-full bg-[hsl(var(--success))]"
+        />
         <div
-          aria-label="Untitled Review"
-          class="truncate font-medium text-base text-muted-foreground/70"
+          class="min-w-0 flex flex-col gap-1"
         >
-          Untitled Review
+          <div
+            aria-label="Untitled Review"
+            class="truncate font-medium text-base text-muted-foreground/70"
+          >
+            Untitled Review
+          </div>
+          <div
+            class="flex items-center gap-1 text-sm text-muted-foreground"
+          >
+            <span
+              aria-label="Rating 9 out of 10"
+              class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--accent)/0.15)] border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))] shadow-[0_0_8px_hsl(var(--accent)/0.3)]"
+            >
+              9
+              /10
+            </span>
+            <span
+              class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--muted)/0.25)] border-[hsl(var(--border)/0.2)] text-[hsl(var(--muted-foreground))] px-1.5 py-0.5 text-[10px] tracking-wide rounded-md"
+            >
+              W
+            </span>
+            <span
+              class="line-clamp-1 truncate"
+            >
+              Quick note
+            </span>
+          </div>
         </div>
-        <div
-          class="flex items-center gap-1 text-sm text-muted-foreground"
+        <span
+          class="self-start text-xs text-muted-foreground whitespace-nowrap"
         >
-          <span
-            aria-label="Rating 9 out of 10"
-            class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--accent)/0.15)] border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))] shadow-[0_0_8px_hsl(var(--accent)/0.3)]"
-          >
-            9
-            /10
-          </span>
-          <span
-            class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--muted)/0.25)] border-[hsl(var(--border)/0.2)] text-[hsl(var(--muted-foreground))] px-1.5 py-0.5 text-[10px] tracking-wide rounded-md"
-          >
-            W
-          </span>
-          <span
-            class="line-clamp-1 truncate"
-          >
-            Quick note
-          </span>
-        </div>
+          11/14/2023
+        </span>
       </div>
-      <span
-        class="self-start text-xs text-muted-foreground whitespace-nowrap"
-      >
-        11/14/2023
-      </span>
-    </div>
-  </button>
+    </button>
+  </div>
 </div>
 `;


### PR DESCRIPTION
## Summary
- use dedicated `review-tile` and `review-tile--active` classes in `ReviewListItem`
- wrap list items in `data-scope="reviews"` container
- update snapshots for revised markup

## Testing
- `npm test -- -u`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bd19165860832ca34c467a41bb6253