### PR TITLE
refactor: use surface variables for glitch backgrounds

### DIFF
--- a/COLOR_MAPPINGS.md
+++ b/COLOR_MAPPINGS.md
@@ -14,3 +14,5 @@
 | `#cde9ff` | `hsl(var(--glitch-b-light))` |
 | `#0b0b12` | `hsl(var(--background))` |
 | `#9a8cff` | `hsl(var(--icon-fg))` |
+| `#0b0f13` | `hsl(var(--surface-vhs))` |
+| `#1a1a24` | `hsl(var(--surface-streak))` |

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -48,6 +48,8 @@ export default function Page() {
     "muted-foreground",
     "surface",
     "surface-2",
+    "surface-vhs",
+    "surface-streak",
     "danger",
     "success",
     "glow-strong",

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -24,6 +24,8 @@
   --muted-foreground: 250 15% 70%;
   --surface: 248 24% 12%;
   --surface-2: 248 24% 16%;
+  --surface-vhs: 210 27% 6%;
+  --surface-streak: 240 16% 12%;
   --shadow-color: 262 83% 58%;
   --lav-deep: 320 85% 60%;
   --success: 316 92% 70%;
@@ -123,6 +125,8 @@ html.light {
   --muted-foreground: 240 4% 35%;
   --surface: 240 7% 98%;
   --surface-2: 240 6% 96%;
+  --surface-vhs: 210 27% 6%;
+  --surface-streak: 240 16% 12%;
   --shadow-color: 262 83% 58%;
   --lav-deep: 320 85% 60%;
   --success: 316 86% 62%;
@@ -453,7 +457,7 @@ html.bg-light body::after {
 }
 
 html.bg-vhs body {
-  background-color: #0b0f13;
+  background-color: hsl(var(--surface-vhs));
   background-image:
     radial-gradient(circle at 20% 30%, rgba(70, 230, 255, 0.15), transparent 60%),
     repeating-linear-gradient(
@@ -471,7 +475,7 @@ html.bg-vhs body::after {
 }
 
 html.bg-streak body {
-  background-color: #1a1a24;
+  background-color: hsl(var(--surface-streak));
   background-image:
     radial-gradient(circle at 70% 40%, rgba(180, 100, 255, 0.25), transparent 40%),
     repeating-linear-gradient(

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -30,7 +30,9 @@ const config: Config = {
           glow: "hsl(var(--success-glow))"
         },
         muted: { DEFAULT: "hsl(var(--muted))", foreground: "hsl(var(--muted-foreground))" },
-        lavDeep: "hsl(var(--lav-deep))"
+        lavDeep: "hsl(var(--lav-deep))",
+        surfaceVhs: "hsl(var(--surface-vhs))",
+        surfaceStreak: "hsl(var(--surface-streak))"
       },
       borderRadius: { md: "8px", lg: "12px", xl: "16px", "2xl": "24px" },
       boxShadow: {


### PR DESCRIPTION
## Summary
- replace hard-coded VHS/streak background colors with `--surface-vhs` and `--surface-streak` tokens
- map new surface tokens in color documentation and Tailwind config
- expose new surface colors on the prompts page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd1b19f614832c84230a77ee20bf77