### PR TITLE
feat: add theme ring variable

### DIFF
--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -10,6 +10,7 @@
   --border: 252 20% 22%;
   --input: 250 22% 12%;
   --ring: 262 83% 58%;
+  --theme-ring: hsl(var(--ring));
   --primary: 262 83% 58%;
   --primary-foreground: 0 0% 100%;
   --primary-soft: 262 83% 18%;
@@ -111,6 +112,7 @@ html.light {
   --border: 240 9% 90%;
   --input: 240 9% 97%;
   --ring: 262 83% 58%;
+  --theme-ring: hsl(var(--ring));
   --primary: 262 83% 58%;
   --primary-foreground: 0 0% 100%;
   --primary-soft: 262 83% 92%;
@@ -141,6 +143,7 @@ html.theme-glitch2 {
   --border: 256 20% 24%;
   --input: 254 22% 14%;
   --ring: 268 70% 66%;
+  --theme-ring: hsl(var(--ring));
   --primary: 268 70% 66%;
   --primary-foreground: 0 0% 100%;
   --primary-soft: 268 70% 24%;
@@ -179,6 +182,7 @@ html.theme-citrus {
   --border: 30 25% 24%;
   --input: 30 22% 16%;
   --ring: 33 92% 58%;
+  --theme-ring: hsl(var(--ring));
   --primary: 33 92% 58%;
   --primary-foreground: 0 0% 100%;
   --primary-soft: 33 90% 22%;
@@ -201,6 +205,7 @@ html.theme-noir {
   --border: 0 0% 20%;
   --input: 0 0% 14%;
   --ring: 0 0% 80%;
+  --theme-ring: hsl(var(--ring));
   --primary: 0 0% 80%;
   --primary-foreground: 0 0% 0%;
   --primary-soft: 0 0% 30%;
@@ -223,6 +228,7 @@ html.theme-ocean {
   --border: 220 20% 24%;
   --input: 220 24% 14%;
   --ring: 195 85% 55%;
+  --theme-ring: hsl(var(--ring));
   --primary: 195 85% 55%;
   --primary-foreground: 0 0% 100%;
   --primary-soft: 195 85% 16%;
@@ -245,6 +251,7 @@ html.theme-rose {
   --border: 330 14% 26%;
   --input: 330 18% 16%;
   --ring: 325 80% 62%;
+  --theme-ring: hsl(var(--ring));
   --primary: 325 80% 62%;
   --primary-foreground: 0 0% 100%;
   --primary-soft: 325 80% 20%;

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -237,6 +237,10 @@ export default function PromptsPage() {
             <p className="type-body">--glow-strong, --glow-soft</p>
           </div>
           <div>
+            <h4 className="type-subtitle">Focus Ring</h4>
+            <p className="type-body">--theme-ring for theme-aware ring color</p>
+          </div>
+          <div>
             <h4 className="type-subtitle">Radius</h4>
             <p className="type-body">--radius-md, --radius-lg, --radius-xl</p>
           </div>

--- a/src/components/ui/primitives/FieldShell.tsx
+++ b/src/components/ui/primitives/FieldShell.tsx
@@ -13,7 +13,7 @@ const FIELD_SHELL_BASE =
   "relative inline-flex w-full items-center rounded-xl border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-140 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]";
 
 const FieldShell = React.forwardRef<HTMLDivElement, FieldShellProps>(
-  ({ tone = "default", error, disabled, className, ...props }, ref) => (
+  ({ tone = "default", error, disabled, className, style, ...props }, ref) => (
     <div
       ref={ref}
       className={cn(
@@ -24,6 +24,7 @@ const FieldShell = React.forwardRef<HTMLDivElement, FieldShellProps>(
         disabled && "opacity-60 pointer-events-none",
         className
       )}
+      style={{ "--theme-ring": "hsl(var(--ring))", ...style } as React.CSSProperties}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- add --theme-ring var to all themes
- default --theme-ring fallback in FieldShell
- document --theme-ring in prompts design tokens

## Testing
- `npm test` (fails: Snapshot mismatched)
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bd20acf3dc832cb436ea9942443fa8