### PR TITLE
Remove hardcoded goal focus rings and document theme override

### DIFF
--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -53,7 +53,7 @@ export default function GoalForm({
             <span className="text-xs text-[hsl(var(--muted-foreground))]">Title</span>
             <Input
               tone="default"
-              className="h-10 text-sm focus:ring-2 focus:ring-purple-400/60"
+              className="h-10 text-sm"
               value={title}
               onChange={(e) => onTitleChange(e.target.value)}
               aria-required="true"
@@ -65,7 +65,7 @@ export default function GoalForm({
             <span className="text-xs text-[hsl(var(--muted-foreground))]">Metric (optional)</span>
             <Input
               tone="default"
-              className="h-10 text-sm focus:ring-2 focus:ring-purple-400/60 tabular-nums"
+              className="h-10 text-sm tabular-nums"
               value={metric}
               onChange={(e) => onMetricChange(e.target.value)}
               aria-describedby="goal-form-help goal-form-error"
@@ -76,7 +76,7 @@ export default function GoalForm({
             <span className="text-xs text-[hsl(var(--muted-foreground))]">Notes (optional)</span>
             <Textarea
               tone="default"
-              className="min-h-24 text-sm focus:ring-2 focus:ring-purple-400/60"
+              className="min-h-24 text-sm"
               value={notes}
               onChange={(e) => onNotesChange(e.target.value)}
               aria-describedby="goal-form-help goal-form-error"

--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -66,7 +66,7 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
             <span className="h-1.5 w-1.5 rounded-full bg-white/40" aria-hidden />
             <Input
               tone="default"
-              className="flex-1 h-9 text-sm focus:ring-2 focus:ring-purple-400/60"
+              className="flex-1 h-9 text-sm"
               value={val}
               onChange={(e) => setVal(e.currentTarget.value)}
               placeholder="Add to queue and press Enter"

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -155,9 +155,13 @@ export default function PromptsPage() {
         </div>
         <Card className="mt-8 space-y-4">
           <h3 className="type-title">Input</h3>
+          <p className="text-sm text-muted-foreground">
+            Customize focus rings with the <code>--theme-ring</code> variable.
+          </p>
           <div className="space-y-3">
             <Input placeholder="Default" />
             <Input placeholder="Error" aria-invalid="true" />
+            <Input placeholder="Custom ring" style={{ '--theme-ring': 'hsl(var(--danger))' } as React.CSSProperties} />
             <Input placeholder="With action">
               <button
                 type="button"


### PR DESCRIPTION
## Summary
- remove hard-coded `focus:ring` styles from goal inputs
- showcase custom ring color via `--theme-ring` on the prompts page

## Testing
- `npx vitest run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bd20b0cd38832cb1581bafec94dae9