### PR TITLE
refactor: unify spacing tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1567,20 +1567,6 @@ textarea:-webkit-autofill {
 
 /* ===== Design Tokens ===== */
 :root {
-  /* Spacing scale */
-  --space-1: 4px;
-  --space-2: 8px;
-  --space-3: 12px;
-  --space-4: 16px;
-  --space-5: 24px;
-  --space-6: 32px;
-  --space-7: 48px;
-  --space-8: 64px;
-  --space-14: 14px;
-  --space-20: 20px;
-  --space-36: 36px;
-  --space-40: 40px;
-
   /* Glow tokens */
   --glow-strong: 260 85% 60% / .55;
   --glow-soft: 260 85% 60% / .25;
@@ -1617,19 +1603,19 @@ textarea:-webkit-autofill {
   }
 }
 .ds-grid-gap {
-  gap: var(--space-4);
+  @apply gap-4;
 }
 @media (min-width: 640px) {
   .ds-grid-gap {
-    gap: var(--space-5);
+    @apply gap-5;
   }
 }
-.ds-card-gap > * + * {
-  margin-top: var(--space-4);
+.ds-card-gap {
+  @apply space-y-4;
 }
 @media (min-width: 640px) {
-  .ds-card-gap > * + * {
-    margin-top: var(--space-5);
+  .ds-card-gap {
+    @apply space-y-5;
   }
 }
 
@@ -1637,45 +1623,42 @@ textarea:-webkit-autofill {
   display: grid;
   align-items: center;
   grid-template-columns: 1fr;
-  gap: var(--space-3);
+  @apply gap-3;
 }
 @media (min-width: 1024px) {
   .ds-toolbar {
     grid-template-columns: 1fr auto;
-    gap: var(--space-4);
+    @apply gap-4;
   }
 }
 .ds-toolbar-controls {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: var(--space-2);
+  @apply gap-2;
 }
 @media (min-width: 640px) {
   .ds-toolbar-controls {
-    gap: var(--space-3);
+    @apply gap-3;
   }
 }
 .ds-card-pad {
-  padding: var(--space-4);
+  @apply p-4;
 }
 @media (min-width: 640px) {
   .ds-card-pad {
-    padding: var(--space-5);
+    @apply p-5;
   }
 }
 .ds-list {
-  @apply list-disc pl-5;
-}
-.ds-list > li + li {
-  margin-top: 0.375rem;
+  @apply list-disc pl-5 space-y-1.5;
 }
 
 /* === Champ badges ===================================== */
 .champ-badges {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  @apply gap-2;
 }
 .champ-badge {
   display: inline-flex;

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -246,6 +246,23 @@ export default function PromptsPage() {
           </div>
         </Card>
         <Card className="mt-8 space-y-4">
+          <h3 className="type-title">Spacing Demo</h3>
+          <div className="flex flex-wrap items-end gap-4">
+            <div className="h-4 w-1 bg-accent" />
+            <div className="h-4 w-2 bg-accent" />
+            <div className="h-4 w-3 bg-accent" />
+            <div className="h-4 w-4 bg-accent" />
+            <div className="h-4 w-5 bg-accent" />
+            <div className="h-4 w-6 bg-accent" />
+            <div className="h-4 w-7 bg-accent" />
+            <div className="h-4 w-8 bg-accent" />
+            <div className="h-4 w-14 bg-accent" />
+            <div className="h-4 w-20 bg-accent" />
+            <div className="h-4 w-36 bg-accent" />
+            <div className="h-4 w-40 bg-accent" />
+          </div>
+        </Card>
+        <Card className="mt-8 space-y-4">
           <h3 className="type-title">Motion</h3>
           <div className="flex gap-2">
             <button className="px-3 py-1 rounded bg-[hsl(var(--accent)/0.2)] transition-opacity duration-420 hover:opacity-60">

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -60,14 +60,14 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(function Select(
           aria-invalid={errorText ? "true" : props["aria-invalid"]}
           aria-describedby={describedBy}
             className={cn(
-              "flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none",
+              "flex-1 h-11 px-14 pr-36 text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none",
               selectClassName
             )}
           {...props}
         >
           {children}
         </select>
-          <ChevronDown className="pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]" />
+          <ChevronDown className="pointer-events-none absolute right-14 h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]" />
       </FieldShell>
       {success && (
         <p

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -77,10 +77,10 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
         name={finalName}
         size={typeof size === "number" ? size : undefined}
         className={cn(
-          "w-full bg-transparent px-[var(--space-14)] text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none",
+          "w-full bg-transparent px-14 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none",
           typeof size === "string" ? SIZE[size] : SIZE.sm,
-          indent && "pl-[var(--space-40)]",
-          showEndSlot && "pr-[var(--space-40)]",
+          indent && "pl-40",
+          showEndSlot && "pr-40",
           inputClassName
         )}
         {...props}

--- a/src/components/ui/primitives/SearchBar.tsx
+++ b/src/components/ui/primitives/SearchBar.tsx
@@ -92,7 +92,7 @@ export default function SearchBar({
           indent
           className={cn(
             "w-full",
-              showClear && "pr-[var(--space-40)]",
+              showClear && "pr-40",
             "border-[hsl(var(--border))] bg-[hsl(var(--input))]"
           )}
           aria-label={rest["aria-label"] ?? "Search"}
@@ -109,7 +109,7 @@ export default function SearchBar({
               type="button"
               aria-label="Clear"
               title="Clear"
-              className="absolute right-[var(--space-20)] top-1/2 -translate-y-1/2 text-muted-foreground"
+              className="absolute right-20 top-1/2 -translate-y-1/2 text-muted-foreground"
               onClick={() => {
               setQuery("");
               onValueChange?.("");

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -52,7 +52,11 @@ const config: Config = {
         5: "24px",
         6: "32px",
         7: "48px",
-        8: "64px"
+        8: "64px",
+        14: "14px",
+        20: "20px",
+        36: "36px",
+        40: "40px"
       },
       keyframes: {
         shimmer: {

--- a/tests/ui/__snapshots__/input.test.tsx.snap
+++ b/tests/ui/__snapshots__/input.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Input > renders default state 1`] = `
   class="relative inline-flex w-full items-center rounded-xl border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-140 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
 >
   <input
-    class="w-full bg-transparent px-[var(--space-14)] text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-11"
+    class="w-full bg-transparent px-14 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-11"
     id=":r0:"
     name="test"
   />
@@ -17,7 +17,7 @@ exports[`Input > renders disabled state 1`] = `
   class="relative inline-flex w-full items-center rounded-xl border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-140 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-60 pointer-events-none"
 >
   <input
-    class="w-full bg-transparent px-[var(--space-14)] text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-11"
+    class="w-full bg-transparent px-14 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-11"
     disabled=""
     id=":r4:"
     name="test"
@@ -31,7 +31,7 @@ exports[`Input > renders error state 1`] = `
 >
   <input
     aria-invalid="true"
-    class="w-full bg-transparent px-[var(--space-14)] text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-11"
+    class="w-full bg-transparent px-14 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-11"
     id=":r2:"
     name="test"
   />
@@ -43,7 +43,7 @@ exports[`Input > renders focus state 1`] = `
   class="relative inline-flex w-full items-center rounded-xl border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-140 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
 >
   <input
-    class="w-full bg-transparent px-[var(--space-14)] text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-11"
+    class="w-full bg-transparent px-14 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-11"
     id=":r1:"
     name="test"
   />

--- a/tests/ui/__snapshots__/select.test.tsx.snap
+++ b/tests/ui/__snapshots__/select.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Select > renders default state 1`] = `
   >
     <select
       aria-label="test"
-      class="flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
+      class="flex-1 h-11 px-14 pr-36 text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
       id=":r0:"
       name="test"
     >
@@ -25,7 +25,7 @@ exports[`Select > renders default state 1`] = `
       </option>
     </select>
     <svg
-      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]"
+      class="lucide lucide-chevron-down pointer-events-none absolute right-14 h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]"
       fill="none"
       height="24"
       stroke="currentColor"
@@ -53,7 +53,7 @@ exports[`Select > renders disabled state 1`] = `
   >
     <select
       aria-label="test"
-      class="flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
+      class="flex-1 h-11 px-14 pr-36 text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
       disabled=""
       id=":r4:"
       name="test"
@@ -65,7 +65,7 @@ exports[`Select > renders disabled state 1`] = `
       </option>
     </select>
     <svg
-      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]"
+      class="lucide lucide-chevron-down pointer-events-none absolute right-14 h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]"
       fill="none"
       height="24"
       stroke="currentColor"
@@ -95,7 +95,7 @@ exports[`Select > renders error state 1`] = `
       aria-describedby=":r2:-error"
       aria-invalid="true"
       aria-label="test"
-      class="flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
+      class="flex-1 h-11 px-14 pr-36 text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
       id=":r2:"
       name="test"
     >
@@ -106,7 +106,7 @@ exports[`Select > renders error state 1`] = `
       </option>
     </select>
     <svg
-      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]"
+      class="lucide lucide-chevron-down pointer-events-none absolute right-14 h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]"
       fill="none"
       height="24"
       stroke="currentColor"
@@ -140,7 +140,7 @@ exports[`Select > renders focus state 1`] = `
   >
     <select
       aria-label="test"
-      class="flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
+      class="flex-1 h-11 px-14 pr-36 text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
       id=":r1:"
       name="test"
     >
@@ -156,7 +156,7 @@ exports[`Select > renders focus state 1`] = `
       </option>
     </select>
     <svg
-      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]"
+      class="lucide lucide-chevron-down pointer-events-none absolute right-14 h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]"
       fill="none"
       height="24"
       stroke="currentColor"
@@ -185,7 +185,7 @@ exports[`Select > renders success state 1`] = `
     <select
       aria-describedby=":r3:-success"
       aria-label="test"
-      class="flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
+      class="flex-1 h-11 px-14 pr-36 text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
       id=":r3:"
       name="test"
     >
@@ -196,7 +196,7 @@ exports[`Select > renders success state 1`] = `
       </option>
     </select>
     <svg
-      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]"
+      class="lucide lucide-chevron-down pointer-events-none absolute right-14 h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]"
       fill="none"
       height="24"
       stroke="currentColor"

--- a/tests/ui/input.test.tsx
+++ b/tests/ui/input.test.tsx
@@ -42,18 +42,18 @@ describe('Input', () => {
         <span />
       </Input>
     );
-    expect(getByRole('textbox')).toHaveClass('pr-[var(--space-40)]');
+    expect(getByRole('textbox')).toHaveClass('pr-40');
   });
 
   it('adds padding when hasEndSlot is true', () => {
     const { getByRole } = render(
       <Input aria-label="test" hasEndSlot />
     );
-    expect(getByRole('textbox')).toHaveClass('pr-[var(--space-40)]');
+    expect(getByRole('textbox')).toHaveClass('pr-40');
   });
 
   it('has smaller padding by default', () => {
     const { getByRole } = render(<Input aria-label="test" />);
-    expect(getByRole('textbox')).not.toHaveClass('pr-[var(--space-40)]');
+    expect(getByRole('textbox')).not.toHaveClass('pr-40');
   });
 });


### PR DESCRIPTION
## Summary
- simplify spacing source of truth by defining all tokens in Tailwind
- migrate components to Tailwind spacing utilities
- document spacing tokens with a demo on Prompts page

## Testing
- `npm test -- -u`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bd20be9b78832c898befcfc8e66971