### PR TITLE
feat: add neo shadow utilities

### DIFF
--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -207,6 +207,15 @@ export default function PromptsPage() {
           </div>
         </Card>
         <Card className="mt-8 space-y-4">
+          <h3 className="type-title">Shadows</h3>
+          <div className="flex flex-wrap gap-4">
+            <div className="size-16 rounded-2xl bg-[hsl(var(--panel)/0.8)] shadow-neo" />
+            <div className="size-16 rounded-2xl bg-[hsl(var(--panel)/0.8)] shadow-neo-strong" />
+            <div className="size-16 rounded-2xl bg-[hsl(var(--panel)/0.8)] shadow-neo-inset" />
+            <div className="size-16 rounded-2xl bg-[hsl(var(--panel)/0.8)] shadow-ring" />
+          </div>
+        </Card>
+        <Card className="mt-8 space-y-4">
           <h3 className="type-title">Task Tile Text</h3>
           <div className="space-y-2">
             <button type="button" className="task-tile__text">

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -14,7 +14,6 @@ import Button from "@/components/ui/primitives/Button";
 // ⬇️ use the new AnimatedSelect location
 import AnimatedSelect from "@/components/ui/selects/AnimatedSelect";
 import Hero2, { Hero2SearchBar } from "@/components/ui/layout/Hero2";
-import { neuRaised } from "@/components/ui/primitives/Neu";
 
 type SortKey = "newest" | "oldest" | "title";
 
@@ -146,8 +145,7 @@ export default function ReviewsPage({
       <div className={cn("grid items-start gap-6 md:grid-cols-12")}>
         <aside className="md:col-span-5 md:w-72 lg:col-span-4 lg:w-80">
           <div
-            className="card-neo-soft overflow-hidden bg-card/50"
-            style={{ boxShadow: neuRaised(14) }}
+            className="card-neo-soft overflow-hidden bg-card/50 shadow-neo-strong"
           >
             <div className="section-b">
               <div className="mb-2 text-sm text-muted-foreground">

--- a/src/components/ui/feedback/Progress.tsx
+++ b/src/components/ui/feedback/Progress.tsx
@@ -1,8 +1,6 @@
 // src/components/ui/Progress.tsx
 "use client";
 
-import { neuInset, neuRaised } from "../primitives/Neu";
-
 /** Simple progress bar (0..100), with SR label */
 export default function Progress({ value, label }: { value: number; label?: string }) {
   const v = Math.max(0, Math.min(100, Math.round(value)));
@@ -12,12 +10,11 @@ export default function Progress({ value, label }: { value: number; label?: stri
       aria-label={label}
     >
       <div
-        className="h-full w-full overflow-hidden rounded-full bg-[hsl(var(--panel)/0.9)]"
-        style={{ boxShadow: neuInset(6) }}
+        className="h-full w-full overflow-hidden rounded-full bg-[hsl(var(--panel)/0.9)] shadow-neo-inset"
       >
         <span
-          className="block h-full rounded-full bg-[linear-gradient(90deg,hsl(var(--accent)),hsl(var(--accent-2)))] transition-[width]"
-          style={{ width: `${v}%`, boxShadow: neuRaised(4) }}
+          className="block h-full rounded-full bg-[linear-gradient(90deg,hsl(var(--accent)),hsl(var(--accent-2)))] transition-[width] shadow-neo-sm"
+          style={{ width: `${v}%` }}
           aria-valuemin={0}
           aria-valuemax={100}
           aria-valuenow={v}

--- a/src/components/ui/layout/SectionCard.tsx
+++ b/src/components/ui/layout/SectionCard.tsx
@@ -3,7 +3,6 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
-import { neuRaised } from "../primitives/Neu";
 
 type RootProps = React.HTMLAttributes<HTMLDivElement>;
 export type HeaderProps = {
@@ -18,8 +17,7 @@ type BodyProps = React.HTMLAttributes<HTMLDivElement>;
 function Root({ className, children, ...props }: RootProps) {
   return (
     <section
-      className={cn("card-neo-soft", className)}
-      style={{ boxShadow: neuRaised(14) }}
+      className={cn("card-neo-soft shadow-neo-strong", className)}
       {...props}
     >
       {children}

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -181,9 +181,9 @@ export default function TabBar({
             className={cn(
               "pointer-events-none absolute -bottom-1 h-[2px] rounded-full opacity-0",
               "[background:var(--seg-active-grad,linear-gradient(90deg,hsl(var(--primary))_0%,hsl(var(--accent))_100%))]",
-              "transition-[transform,width,opacity] duration-200 ease-out"
+              "transition-[transform,width,opacity] duration-200 ease-out",
+              "shadow-ring"
             )}
-            style={{ boxShadow: "0 0 12px hsl(var(--ring))" }}
           />
         </div>
 

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -53,9 +53,9 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           ref={ref}
           className={cn(
             base,
-            "bg-[hsl(var(--panel)/0.85)] overflow-hidden"
+            "bg-[hsl(var(--panel)/0.85)] overflow-hidden",
+            "shadow-neo"
           )}
-          style={{ boxShadow: neuRaised(12) }}
           whileHover={{
             scale: 1.03,
             boxShadow: `${neuRaised(16)},0 0 8px hsl(var(--accent)/.3)` as CSSProperties["boxShadow"],
@@ -99,8 +99,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <motion.button
         ref={ref}
-        className={cn(base, "bg-[hsl(var(--panel)/0.8)]")}
-        style={{ boxShadow: neuRaised(12) }}
+        className={cn(base, "bg-[hsl(var(--panel)/0.8)]", "shadow-neo")}
         whileHover={{ scale: 1.02, boxShadow: neuRaised(15) }}
         whileTap={{
           scale: 0.97,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -36,7 +36,15 @@ const config: Config = {
       },
       borderRadius: { md: "8px", lg: "12px", xl: "16px", "2xl": "24px" },
       boxShadow: {
-        neo: "0 6px 20px -6px hsl(var(--shadow-color))",
+        "neo-sm":
+          "4px 4px 8px hsl(var(--bg)/0.72), -4px -4px 8px hsl(var(--text)/0.06)",
+        neo:
+          "12px 12px 24px hsl(var(--bg)/0.72), -12px -12px 24px hsl(var(--text)/0.06)",
+        "neo-strong":
+          "14px 14px 28px hsl(var(--bg)/0.72), -14px -14px 28px hsl(var(--text)/0.06)",
+        "neo-inset":
+          "inset 4px 4px 10px hsl(var(--bg)/0.85), inset -4px -4px 10px hsl(var(--text)/0.08)",
+        ring: "0 0 12px hsl(var(--ring))",
         neoSoft: "0 3px 12px -4px hsl(var(--shadow-color))"
       },
       transitionTimingFunction: {


### PR DESCRIPTION
## Summary
- define reusable neo shadow utilities in Tailwind config
- refactor components to use `shadow-neo` classes instead of inline box shadows
- showcase shadow utilities on PromptsPage

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bd20c5187c832cad7491badb341ef6