### PR TITLE
Restore focus to goal title field after adding

### DIFF
--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -19,18 +19,30 @@ interface GoalFormProps {
   err?: string | null;
 }
 
-export default function GoalForm({
-  title,
-  metric,
-  notes,
-  onTitleChange,
-  onMetricChange,
-  onNotesChange,
-  onSubmit,
-  activeCount,
-  activeCap,
-  err,
-}: GoalFormProps) {
+export interface GoalFormHandle {
+  focus: (options?: FocusOptions) => void;
+}
+export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm(
+  {
+    title,
+    metric,
+    notes,
+    onTitleChange,
+    onMetricChange,
+    onNotesChange,
+    onSubmit,
+    activeCount,
+    activeCap,
+    err,
+  }: GoalFormProps,
+  ref
+) {
+  const titleRef = React.useRef<HTMLInputElement>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    focus: (options?: FocusOptions) => titleRef.current?.focus(options),
+  }));
+
   return (
     <form
       onSubmit={(e) => {
@@ -52,6 +64,7 @@ export default function GoalForm({
           <label className="grid gap-2">
             <span className="text-xs text-[hsl(var(--muted-foreground))]">Title</span>
             <Input
+              ref={titleRef}
               tone="default"
               className="h-10 text-sm focus:ring-2 focus:ring-purple-400/60"
               value={title}
@@ -105,5 +118,5 @@ export default function GoalForm({
       </SectionCard>
     </form>
   );
-}
+});
 

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -24,7 +24,7 @@ import {
   Snackbar,
 } from "@/components/ui";
 import GoalsTabs, { FilterKey } from "./GoalsTabs";
-import GoalForm from "./GoalForm";
+import GoalForm, { GoalFormHandle } from "./GoalForm";
 import GoalsProgress from "./GoalsProgress";
 
 import { useLocalDB, uid } from "@/lib/db";
@@ -66,6 +66,7 @@ export default function GoalsPage() {
   const [lastDeleted, setLastDeleted] = React.useState<Goal | null>(null);
   const undoTimer = React.useRef<number | null>(null);
   const formRef = React.useRef<HTMLDivElement | null>(null);
+  const titleInputRef = React.useRef<GoalFormHandle>(null);
 
   // stats
   const totalCount = goals.length;
@@ -111,6 +112,7 @@ export default function GoalsPage() {
     };
     setGoals((prev) => [g, ...prev]);
     resetForm();
+    titleInputRef.current?.focus({ preventScroll: true });
   }
 
   function toggleDone(id: string) {
@@ -280,6 +282,7 @@ export default function GoalsPage() {
 
               <div ref={formRef}>
                 <GoalForm
+                  ref={titleInputRef}
                   title={title}
                   metric={metric}
                   notes={notes}


### PR DESCRIPTION
## Summary
- expose a focus handle on GoalForm
- refocus title field after adding a goal without scrolling

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bd20d4c794832cba27498d3bad4de6