### PR TITLE
feat(goals): use flexible grid auto rows

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -253,6 +253,15 @@ export default function Page() {
             </GlitchSegmentedGroup>
           </div>
           <div className="flex flex-col items-center space-y-2">
+            <span className="text-sm font-medium">Grid Auto Rows</span>
+            <div className="w-56 grid grid-cols-2 gap-2 [grid-auto-rows:minmax(0,1fr)]">
+              <div className="card-neo p-2">A</div>
+              <div className="card-neo p-4">B with more content</div>
+              <div className="card-neo p-4">C</div>
+              <div className="card-neo p-2">D</div>
+            </div>
+          </div>
+          <div className="flex flex-col items-center space-y-2">
             <span className="text-sm font-medium">Widths</span>
             <div className="flex gap-2">
               <div className="h-10 w-72 border rounded-md flex items-center justify-center text-xs text-muted-foreground">

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -206,7 +206,7 @@ export default function GoalsPage() {
                     <GoalsTabs value={filter} onChange={setFilter} />
                   </SectionCard.Header>
                   <SectionCard.Body>
-                    <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 [grid-auto-rows:1fr]">
+                    <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 [grid-auto-rows:minmax(0,1fr)]">
                       {filtered.length === 0 ? (
                         <p className="text-sm text-[hsl(var(--muted-foreground))]">
                           No goals here. Add one simple, finishable thing.


### PR DESCRIPTION
## Summary
- use `grid-auto-rows:minmax(0,1fr)` for goal cards to allow flexible heights
- document new grid auto rows pattern on prompts page

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bd20e2bc3c832c92621f1ea220f142