### PR TITLE
feat(goals): add list semantics

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -111,6 +111,23 @@ export default function Page() {
             </div>
           </div>
           <div className="flex flex-col items-center space-y-2">
+            <span className="text-sm font-medium">Grid List</span>
+            <ul className="w-56 grid grid-cols-2 gap-2 list-none">
+              <li role="listitem" className="p-2 border rounded-md text-sm text-center">
+                One
+              </li>
+              <li role="listitem" className="p-2 border rounded-md text-sm text-center">
+                Two
+              </li>
+              <li role="listitem" className="p-2 border rounded-md text-sm text-center">
+                Three
+              </li>
+              <li role="listitem" className="p-2 border rounded-md text-sm text-center">
+                Four
+              </li>
+            </ul>
+          </div>
+          <div className="flex flex-col items-center space-y-2">
             <span className="text-sm font-medium">Progress</span>
             <div className="w-56">
               <Progress value={50} />

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -113,10 +113,10 @@ export default function Page() {
           <div className="flex flex-col items-center space-y-2">
             <span className="text-sm font-medium">Grid List</span>
             <ul className="w-56 grid grid-cols-2 gap-2 list-none">
-              <li className="p-2 border rounded-md text-sm text-center">One</li>
-              <li className="p-2 border rounded-md text-sm text-center">Two</li>
-              <li className="p-2 border rounded-md text-sm text-center">Three</li>
-              <li className="p-2 border rounded-md text-sm text-center">Four</li>
+              <li role="listitem" className="p-2 border rounded-md text-sm text-center">One</li>
+              <li role="listitem" className="p-2 border rounded-md text-sm text-center">Two</li>
+              <li role="listitem" className="p-2 border rounded-md text-sm text-center">Three</li>
+              <li role="listitem" className="p-2 border rounded-md text-sm text-center">Four</li>
             </ul>
           </div>
           <div className="flex flex-col items-center space-y-2">

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -113,18 +113,10 @@ export default function Page() {
           <div className="flex flex-col items-center space-y-2">
             <span className="text-sm font-medium">Grid List</span>
             <ul className="w-56 grid grid-cols-2 gap-2 list-none">
-              <li role="listitem" className="p-2 border rounded-md text-sm text-center">
-                One
-              </li>
-              <li role="listitem" className="p-2 border rounded-md text-sm text-center">
-                Two
-              </li>
-              <li role="listitem" className="p-2 border rounded-md text-sm text-center">
-                Three
-              </li>
-              <li role="listitem" className="p-2 border rounded-md text-sm text-center">
-                Four
-              </li>
+              <li className="p-2 border rounded-md text-sm text-center">One</li>
+              <li className="p-2 border rounded-md text-sm text-center">Two</li>
+              <li className="p-2 border rounded-md text-sm text-center">Three</li>
+              <li className="p-2 border rounded-md text-sm text-center">Four</li>
             </ul>
           </div>
           <div className="flex flex-col items-center space-y-2">

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -213,7 +213,7 @@ export default function GoalsPage() {
                     ) : (
                       <ul className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 [grid-auto-rows:1fr] list-none">
                         {filtered.map((g) => (
-                          <li key={g.id} className="h-full">
+                          <li role="listitem" key={g.id} className="h-full">
                             <article
                               className={[
                                 "relative h-full rounded-2xl p-6",

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -206,27 +206,31 @@ export default function GoalsPage() {
                     <GoalsTabs value={filter} onChange={setFilter} />
                   </SectionCard.Header>
                   <SectionCard.Body>
-                    <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 [grid-auto-rows:1fr]">
-                      {filtered.length === 0 ? (
-                        <p className="text-sm text-[hsl(var(--muted-foreground))]">
-                          No goals here. Add one simple, finishable thing.
-                        </p>
-                      ) : (
-                        filtered.map((g) => (
-                          <article
+                    {filtered.length === 0 ? (
+                      <p className="text-sm text-[hsl(var(--muted-foreground))]">
+                        No goals here. Add one simple, finishable thing.
+                      </p>
+                    ) : (
+                      <ul className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 [grid-auto-rows:1fr] list-none">
+                        {filtered.map((g) => (
+                          <li
                             key={g.id}
-                            className={[
-                              "relative rounded-2xl p-6",
-                              "card-neo transition",
-                              "hover:shadow-[0_0_0_1px_hsl(var(--primary)/.25),0_12px_40px_rgba(0,0,0,.35)]",
-                              "min-h-40 flex flex-col",
-                            ].join(" ")}
+                            role="listitem"
+                            className="h-full"
                           >
-                            <span
-                              aria-hidden
-                              className="absolute inset-y-4 left-0 w-0.5 rounded-full bg-gradient-to-b from-[hsl(var(--primary))] via-[hsl(var(--accent))] to-transparent opacity-60"
-                            />
-                            <header className="flex items-start justify-between gap-2">
+                            <article
+                              className={[
+                                "relative h-full rounded-2xl p-6",
+                                "card-neo transition",
+                                "hover:shadow-[0_0_0_1px_hsl(var(--primary)/.25),0_12px_40px_rgba(0,0,0,.35)]",
+                                "min-h-40 flex flex-col",
+                              ].join(" ")}
+                            >
+                              <span
+                                aria-hidden
+                                className="absolute inset-y-4 left-0 w-0.5 rounded-full bg-gradient-to-b from-[hsl(var(--primary))] via-[hsl(var(--accent))] to-transparent opacity-60"
+                              />
+                              <header className="flex items-start justify-between gap-2">
                               <h3 className="font-semibold leading-tight pr-6 line-clamp-2">
                                 {g.title}
                               </h3>
@@ -270,10 +274,11 @@ export default function GoalsPage() {
                                 {g.done ? "Done" : "Active"}
                               </span>
                             </footer>
-                          </article>
-                        ))
-                      )}
-                    </div>
+                            </article>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
                   </SectionCard.Body>
                 </SectionCard>
               )}

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -213,11 +213,7 @@ export default function GoalsPage() {
                     ) : (
                       <ul className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 [grid-auto-rows:1fr] list-none">
                         {filtered.map((g) => (
-                          <li
-                            key={g.id}
-                            role="listitem"
-                            className="h-full"
-                          >
+                          <li key={g.id} className="h-full">
                             <article
                               className={[
                                 "relative h-full rounded-2xl p-6",

--- a/tests/goals/goals-page.test.tsx
+++ b/tests/goals/goals-page.test.tsx
@@ -32,12 +32,12 @@ describe('GoalsPage', () => {
     expect(screen.getByRole('status')).toHaveTextContent('Cap reached');
 
     // Mark the first goal as done
-    const goal1Article = screen.getByText('Goal 1').closest('article') as HTMLElement;
-    const toggleBtn = within(goal1Article).getByRole('checkbox', { name: 'Mark done' });
+    const goal1Item = screen.getByText('Goal 1').closest('[role="listitem"]') as HTMLElement;
+    const toggleBtn = within(goal1Item).getByRole('checkbox', { name: 'Mark done' });
     fireEvent.pointerDown(toggleBtn);
     fireEvent.click(toggleBtn);
     await waitFor(() => {
-      const goal1 = screen.getByText('Goal 1').closest('article') as HTMLElement;
+      const goal1 = screen.getByText('Goal 1').closest('[role="listitem"]') as HTMLElement;
       expect(within(goal1).getByText('Done')).toBeInTheDocument();
     });
 
@@ -49,8 +49,8 @@ describe('GoalsPage', () => {
     expect(goal4).toBeInTheDocument();
 
     // Remove the new goal and then undo
-    const goal4Article = goal4.closest('article') as HTMLElement;
-    const deleteButton = within(goal4Article).getByLabelText('Delete goal');
+    const goal4Item = goal4.closest('[role="listitem"]') as HTMLElement;
+    const deleteButton = within(goal4Item).getByLabelText('Delete goal');
     fireEvent.click(deleteButton);
     await waitFor(() => expect(screen.queryByText('Goal 4')).not.toBeInTheDocument());
     const undoButton = screen.getByRole('button', { name: 'Undo' });

--- a/tests/goals/goals-page.test.tsx
+++ b/tests/goals/goals-page.test.tsx
@@ -32,12 +32,16 @@ describe('GoalsPage', () => {
     expect(screen.getByRole('status')).toHaveTextContent('Cap reached');
 
     // Mark the first goal as done
-    const goal1Item = screen.getByText('Goal 1').closest('li') as HTMLElement;
+    const goal1Item = screen
+      .getAllByRole('listitem')
+      .find((li) => within(li).queryByText('Goal 1')) as HTMLElement;
     const toggleBtn = within(goal1Item).getByRole('checkbox', { name: 'Mark done' });
     fireEvent.pointerDown(toggleBtn);
     fireEvent.click(toggleBtn);
     await waitFor(() => {
-      const goal1 = screen.getByText('Goal 1').closest('li') as HTMLElement;
+      const goal1 = screen
+        .getAllByRole('listitem')
+        .find((li) => within(li).queryByText('Goal 1')) as HTMLElement;
       expect(within(goal1).getByText('Done')).toBeInTheDocument();
     });
 
@@ -49,7 +53,9 @@ describe('GoalsPage', () => {
     expect(goal4).toBeInTheDocument();
 
     // Remove the new goal and then undo
-    const goal4Item = goal4.closest('li') as HTMLElement;
+    const goal4Item = screen
+      .getAllByRole('listitem')
+      .find((li) => within(li).queryByText('Goal 4')) as HTMLElement;
     const deleteButton = within(goal4Item).getByLabelText('Delete goal');
     fireEvent.click(deleteButton);
     await waitFor(() => expect(screen.queryByText('Goal 4')).not.toBeInTheDocument());

--- a/tests/goals/goals-page.test.tsx
+++ b/tests/goals/goals-page.test.tsx
@@ -32,12 +32,12 @@ describe('GoalsPage', () => {
     expect(screen.getByRole('status')).toHaveTextContent('Cap reached');
 
     // Mark the first goal as done
-    const goal1Item = screen.getByText('Goal 1').closest('[role="listitem"]') as HTMLElement;
+    const goal1Item = screen.getByText('Goal 1').closest('li') as HTMLElement;
     const toggleBtn = within(goal1Item).getByRole('checkbox', { name: 'Mark done' });
     fireEvent.pointerDown(toggleBtn);
     fireEvent.click(toggleBtn);
     await waitFor(() => {
-      const goal1 = screen.getByText('Goal 1').closest('[role="listitem"]') as HTMLElement;
+      const goal1 = screen.getByText('Goal 1').closest('li') as HTMLElement;
       expect(within(goal1).getByText('Done')).toBeInTheDocument();
     });
 
@@ -49,7 +49,7 @@ describe('GoalsPage', () => {
     expect(goal4).toBeInTheDocument();
 
     // Remove the new goal and then undo
-    const goal4Item = goal4.closest('[role="listitem"]') as HTMLElement;
+    const goal4Item = goal4.closest('li') as HTMLElement;
     const deleteButton = within(goal4Item).getByLabelText('Delete goal');
     fireEvent.click(deleteButton);
     await waitFor(() => expect(screen.queryByText('Goal 4')).not.toBeInTheDocument());


### PR DESCRIPTION
## Summary
- render goals grid as `<ul>` with `<li role="listitem">` cards
- adjust goals page tests for list queries
- showcase grid list style in prompts page

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd20e70c84832c836695786edbee08