### PR TITLE
chore: hyphenate accent color token

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -6,6 +6,7 @@ This project ships with a small design system based on Tailwind CSS and CSS vari
 - Color, radius, shadows and transitions are defined as CSS variables in `tailwind.config.ts` and `src/app/themes.css`.
 - Use semantic classes like `bg-background`, `text-foreground` and `ring` instead of hard-coded values.
 - If you need to introduce a new static color, map it to a token in [`COLOR_MAPPINGS.md`](../COLOR_MAPPINGS.md).
+- Name color tokens in kebab-case with hyphenated numeric variants (e.g. `accent-2`).
 - Input elements use `--control-radius` (16px) for consistent corner rounding.
 
 ## Layout and spacing

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -235,7 +235,7 @@ export default function PromptsPage() {
           <div>
             <h4 className="type-subtitle">Colors</h4>
             <div className="flex gap-2">
-              <div className="size-6 rounded bg-accent2" />
+                <div className="size-6 rounded bg-accent-2" />
               <div className="size-6 rounded bg-danger" />
               <div className="size-6 rounded bg-success" />
               <div className="size-6 rounded bg-glow" />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,7 +21,7 @@ const config: Config = {
           soft: "hsl(var(--primary-soft))"
         },
         accent: { DEFAULT: "hsl(var(--accent))", soft: "hsl(var(--accent-soft))" },
-        accent2: "hsl(var(--accent-2))",
+        "accent-2": "hsl(var(--accent-2))",
         glow: "hsl(var(--glow))",
         ringMuted: "hsl(var(--ring-muted))",
         danger: "hsl(var(--danger))",


### PR DESCRIPTION
## Summary
- rename `accent2` color token to `accent-2`
- replace `accent2` class usage with `accent-2`
- document kebab-case color token naming in design guidelines

## Testing
- `npm test` *(fails: Snapshot mismatch)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bd637a906c832ca3f4d3035d01bae1