### PR TITLE
Define panel/line tokens and update component styles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -699,9 +699,9 @@ html.bg-intense body::after {
     height: 1.75rem;
     padding: 0 0.75rem;
     gap: 0.5rem;
-    background: hsl(var(--panel));
-    color: hsl(var(--text));
-    border-color: hsl(var(--line) / 0.35);
+    background: hsl(var(--card));
+    color: hsl(var(--foreground));
+    border-color: hsl(var(--border) / 0.35);
   }
   .pill--low {
     background: hsl(var(--accent) / 0.15);

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -38,8 +38,11 @@ export default function Page() {
   const colorList = [
     "background",
     "foreground",
+    "text",
     "card",
+    "panel",
     "border",
+    "line",
     "input",
     "ring",
     "accent",

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -6,8 +6,11 @@
 :root {
   --background: 246 35% 7%;
   --foreground: 260 20% 96%;
+  --text: var(--foreground);
   --card: 248 30% 10%;
+  --panel: var(--card);
   --border: 252 20% 22%;
+  --line: var(--border);
   --input: 250 22% 12%;
   --ring: 262 83% 58%;
   --theme-ring: hsl(var(--ring));
@@ -108,8 +111,11 @@
 html.light {
   --background: 0 0% 100%;
   --foreground: 240 10% 10%;
+  --text: var(--foreground);
   --card: 0 0% 100%;
+  --panel: var(--card);
   --border: 240 9% 90%;
+  --line: var(--border);
   --input: 240 9% 97%;
   --ring: 262 83% 58%;
   --theme-ring: hsl(var(--ring));
@@ -139,8 +145,11 @@ html.light {
 html.theme-glitch2 {
   --background: 252 35% 9%;
   --foreground: 260 20% 98%;
+  --text: var(--foreground);
   --card: 254 30% 12%;
+  --panel: var(--card);
   --border: 256 20% 24%;
+  --line: var(--border);
   --input: 254 22% 14%;
   --ring: 268 70% 66%;
   --theme-ring: hsl(var(--ring));
@@ -178,8 +187,11 @@ html.theme-citrus {
   /* Dark Citrus palette */
   --background: 28 30% 9%;
   --foreground: 30 35% 96%;
+  --text: var(--foreground);
   --card: 28 30% 14%;
+  --panel: var(--card);
   --border: 30 25% 24%;
+  --line: var(--border);
   --input: 30 22% 16%;
   --ring: 33 92% 58%;
   --theme-ring: hsl(var(--ring));
@@ -201,8 +213,11 @@ html.theme-citrus {
 html.theme-noir {
   --background: 0 0% 6%;
   --foreground: 0 0% 92%;
+  --text: var(--foreground);
   --card: 0 0% 10%;
+  --panel: var(--card);
   --border: 0 0% 20%;
+  --line: var(--border);
   --input: 0 0% 14%;
   --ring: 0 0% 80%;
   --theme-ring: hsl(var(--ring));
@@ -224,8 +239,11 @@ html.theme-noir {
 html.theme-ocean {
   --background: 220 50% 8%;
   --foreground: 210 20% 96%;
+  --text: var(--foreground);
   --card: 220 35% 12%;
+  --panel: var(--card);
   --border: 220 20% 24%;
+  --line: var(--border);
   --input: 220 24% 14%;
   --ring: 195 85% 55%;
   --theme-ring: hsl(var(--ring));
@@ -247,8 +265,11 @@ html.theme-ocean {
 html.theme-rose {
   --background: 330 22% 10%;
   --foreground: 330 20% 96%;
+  --text: var(--foreground);
   --card: 330 24% 14%;
+  --panel: var(--card);
   --border: 330 14% 26%;
+  --line: var(--border);
   --input: 330 18% 16%;
   --ring: 325 80% 62%;
   --theme-ring: hsl(var(--ring));

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -43,7 +43,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       s.padding,
       s.text,
       s.gap,
-      "text-[hsl(var(--text))]",
+      "text-[hsl(var(--foreground))]",
       className
     );
 

--- a/src/components/ui/primitives/Neu.ts
+++ b/src/components/ui/primitives/Neu.ts
@@ -1,5 +1,5 @@
 export const neuRaised = (d = 12) =>
-  `${d}px ${d}px ${d * 2}px hsl(var(--bg)/0.72), -${d}px -${d}px ${d * 2}px hsl(var(--text)/0.06)`;
+  `${d}px ${d}px ${d * 2}px hsl(var(--panel)/0.72), -${d}px -${d}px ${d * 2}px hsl(var(--foreground)/0.06)`;
 
 export const neuInset = (d = 10) =>
-  `inset ${Math.round(d * 0.7)}px ${Math.round(d * 0.7)}px ${Math.round(d * 1.6)}px hsl(var(--bg)/0.85), inset -${Math.round(d * 0.7)}px -${Math.round(d * 0.7)}px ${Math.round(d * 1.6)}px hsl(var(--text)/0.08)`;
+  `inset ${Math.round(d * 0.7)}px ${Math.round(d * 0.7)}px ${Math.round(d * 1.6)}px hsl(var(--panel)/0.85), inset -${Math.round(d * 0.7)}px -${Math.round(d * 0.7)}px ${Math.round(d * 1.6)}px hsl(var(--foreground)/0.08)`;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -37,13 +37,13 @@ const config: Config = {
       borderRadius: { md: "8px", lg: "12px", xl: "16px", "2xl": "24px" },
       boxShadow: {
         "neo-sm":
-          "4px 4px 8px hsl(var(--bg)/0.72), -4px -4px 8px hsl(var(--text)/0.06)",
+          "4px 4px 8px hsl(var(--panel)/0.72), -4px -4px 8px hsl(var(--foreground)/0.06)",
         neo:
-          "12px 12px 24px hsl(var(--bg)/0.72), -12px -12px 24px hsl(var(--text)/0.06)",
+          "12px 12px 24px hsl(var(--panel)/0.72), -12px -12px 24px hsl(var(--foreground)/0.06)",
         "neo-strong":
-          "14px 14px 28px hsl(var(--bg)/0.72), -14px -14px 28px hsl(var(--text)/0.06)",
+          "14px 14px 28px hsl(var(--panel)/0.72), -14px -14px 28px hsl(var(--foreground)/0.06)",
         "neo-inset":
-          "inset 4px 4px 10px hsl(var(--bg)/0.85), inset -4px -4px 10px hsl(var(--text)/0.08)",
+          "inset 4px 4px 10px hsl(var(--panel)/0.85), inset -4px -4px 10px hsl(var(--foreground)/0.08)",
         ring: "0 0 12px hsl(var(--ring))",
         neoSoft: "0 3px 12px -4px hsl(var(--shadow-color))"
       },


### PR DESCRIPTION
## Summary
- map new `--panel`, `--line`, and `--text` tokens to existing theme colors
- align `.pill`, Button, Neu, and shadow utilities with foreground/border/card tokens
- surface new tokens on the prompts color gallery

## Testing
- `npm test` *(fails: 14 failed)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bd65c3442c832c9e60d8571159172f