### PR TITLE
Normalize spacing scale and update tokens

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -11,7 +11,7 @@ This project ships with a small design system based on Tailwind CSS and CSS vari
 
 ## Layout and spacing
 - Use a 12‑column grid with 24px gutters.
-- Spacing scale: 4, 8, 12, 16, 24, 32, 48, 64.
+- Spacing tokens: `1`=4px, `2`=8px, `3`=12px, `4`=16px, `5`=24px, `6`=32px, `7`=48px, `8`=64px.
 
 ## Typography
 - Font sizes: 12px for labels, 14px for UI text, 16px for body copy, and 20/24px for titles.

--- a/src/app/prompts/ComponentGallery.tsx
+++ b/src/app/prompts/ComponentGallery.tsx
@@ -109,17 +109,17 @@ export default function ComponentGallery() {
           <Badge variant="pill">Pill</Badge>
         </Item>
         <Item label="Accent Overlay Box">
-          <div className="w-56 h-20 flex items-center justify-center rounded bg-[var(--accent-overlay)] text-[hsl(var(--accent-foreground))]">
+          <div className="w-56 h-6 flex items-center justify-center rounded bg-[var(--accent-overlay)] text-[hsl(var(--accent-foreground))]">
             Overlay
           </div>
         </Item>
         <Item label="Surface">
-          <div className="w-56 h-20 flex items-center justify-center rounded bg-[hsl(var(--surface))]">
+          <div className="w-56 h-6 flex items-center justify-center rounded bg-[hsl(var(--surface))]">
             Surface
           </div>
         </Item>
         <Item label="Surface 2">
-          <div className="w-56 h-20 flex items-center justify-center rounded bg-[hsl(var(--surface-2))]">
+          <div className="w-56 h-6 flex items-center justify-center rounded bg-[hsl(var(--surface-2))]">
             Surface 2
           </div>
         </Item>
@@ -167,7 +167,7 @@ export default function ComponentGallery() {
           <Toggle value={toggleSide} onChange={setToggleSide} className="w-56" />
         </Item>
         <Item label="Card">
-          <Card className="w-56 h-40 flex items-center justify-center">
+          <Card className="w-56 h-8 flex items-center justify-center">
             Card content
           </Card>
         </Item>

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -90,7 +90,7 @@ export default function Page() {
           </div>
           <div className="flex flex-col items-center space-y-2">
             <span className="text-sm font-medium">Card</span>
-            <SectionCard className="w-56 h-40 flex items-center justify-center">
+            <SectionCard className="w-56 h-8 flex items-center justify-center">
               Card content
             </SectionCard>
           </div>
@@ -160,7 +160,7 @@ export default function Page() {
           </div>
           <div className="flex flex-col items-center space-y-2">
             <span className="text-sm font-medium">Card Neo</span>
-            <div className="card-neo w-56 h-40 flex items-center justify-center">
+            <div className="card-neo w-56 h-8 flex items-center justify-center">
               Card Neo
             </div>
           </div>

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -15,7 +15,7 @@ export default function SiteChrome() {
   return (
     <header role="banner" className="sticky-blur top-0 z-50">
       {/* Bar content */}
-      <div className="page-shell h-14 flex items-center justify-between py-2">
+        <div className="page-shell h-4 flex items-center justify-between py-2">
         <div className="flex items-center gap-2">
           <span
             className="h-2 w-2 rounded-full animate-pulse"

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -221,7 +221,7 @@ export default function GoalsPage() {
                               "relative rounded-2xl p-6",
                               "card-neo transition",
                               "hover:shadow-[0_0_0_1px_hsl(var(--primary)/.25),0_12px_40px_rgba(0,0,0,.35)]",
-                              "min-h-40 flex flex-col",
+                                "min-h-8 flex flex-col",
                             ].join(" ")}
                           >
                             <span

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -153,7 +153,7 @@ export default function TimerTab() {
         onKeyDown={(e) => e.key === "Enter" && commitEdit()}
         placeholder="mm:ss"
         disabled={running}
-        className="btn-like-segmented btn-glitch w-20 text-center"
+          className="btn-like-segmented btn-glitch w-8 text-center"
         type="text"
       />
     </div>

--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -66,7 +66,7 @@ function ScrollTopFloatingButton({ watchRef }: { watchRef: React.RefObject<HTMLE
     <IconButton
       aria-label="Scroll to top"
       onClick={scrollTop}
-      className="fixed bottom-20 right-2 z-50"
+        className="fixed bottom-8 right-2 z-50"
     >
       <ArrowUp />
     </IconButton>
@@ -106,7 +106,7 @@ function Inner() {
         </div>
 
         {/* Sticky only on large so it doesn’t eat the viewport on mobile */}
-        <aside className="lg:col-span-4 space-y-6 lg:sticky lg:top-20">
+          <aside className="lg:col-span-4 space-y-6 lg:sticky lg:top-8">
           <WeekNotes iso={iso} />
         </aside>
       </section>

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -243,7 +243,7 @@ export default function PromptsPage() {
           </div>
           <div>
             <h4 className="type-subtitle">Spacing</h4>
-            <p className="type-body">8, 16, 24, 32, 40, 48, 64</p>
+            <p className="type-body">4, 8, 12, 16, 24, 32, 48, 64</p>
           </div>
           <div>
             <h4 className="type-subtitle">Glow</h4>
@@ -273,10 +273,6 @@ export default function PromptsPage() {
             <div className="h-4 w-6 bg-accent" />
             <div className="h-4 w-7 bg-accent" />
             <div className="h-4 w-8 bg-accent" />
-            <div className="h-4 w-14 bg-accent" />
-            <div className="h-4 w-20 bg-accent" />
-            <div className="h-4 w-36 bg-accent" />
-            <div className="h-4 w-40 bg-accent" />
           </div>
         </Card>
         <Card className="mt-8 space-y-4">

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -59,15 +59,15 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(function Select(
           disabled={disabled}
           aria-invalid={errorText ? "true" : props["aria-invalid"]}
           aria-describedby={describedBy}
-            className={cn(
-              "flex-1 h-11 px-14 pr-36 text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none",
-              selectClassName
-            )}
+              className={cn(
+                "flex-1 h-5 px-4 pr-7 text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none",
+                selectClassName
+              )}
           {...props}
         >
           {children}
         </select>
-          <ChevronDown className="pointer-events-none absolute right-14 h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]" />
+            <ChevronDown className="pointer-events-none absolute right-4 h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]" />
       </FieldShell>
       {success && (
         <p

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -8,20 +8,20 @@ import { neuRaised, neuInset } from "./Neu";
 
 export const buttonSizes = {
   sm: {
-    height: "h-9",
+    height: "h-5",
     padding: "px-3",
     text: "text-[12px]",
     gap: "gap-2",
   },
   md: {
-    height: "h-12",
+    height: "h-6",
     padding: "px-4",
     text: "text-[14px]",
     gap: "gap-2",
   },
   lg: {
-    height: "h-14",
-    padding: "px-6",
+    height: "h-7",
+    padding: "px-5",
     text: "text-[16px]",
     gap: "gap-2",
   },

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -26,9 +26,9 @@ const iconMap: Record<Icon, string> = {
 };
 
 const sizeMap: Record<ButtonSize, string> = {
-  sm: "h-9 w-9",
-  md: "h-[52px] w-[52px]",
-  lg: "h-14 w-14",
+  sm: "h-5 w-5",
+  md: "h-6 w-6",
+  lg: "h-7 w-7",
 };
 
 const variantBase: Record<Variant, string> = {

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -24,9 +24,9 @@ export type InputProps = Omit<
 };
 
 const SIZE: Record<InputSize, string> = {
-  sm: "h-11",
-  md: "h-12",
-  lg: "h-14",
+  sm: "h-5",
+  md: "h-6",
+  lg: "h-7",
 };
 
 /**
@@ -77,10 +77,10 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
         name={finalName}
         size={typeof size === "number" ? size : undefined}
         className={cn(
-          "w-full bg-transparent px-14 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none",
+          "w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none",
           typeof size === "string" ? SIZE[size] : SIZE.sm,
-          indent && "pl-40",
-          showEndSlot && "pr-40",
+          indent && "pl-7",
+          showEndSlot && "pr-7",
           inputClassName
         )}
         {...props}

--- a/src/components/ui/primitives/SearchBar.tsx
+++ b/src/components/ui/primitives/SearchBar.tsx
@@ -90,11 +90,11 @@ export default function SearchBar({
           }}
           placeholder={placeholder}
           indent
-          className={cn(
-            "w-full",
-              showClear && "pr-40",
-            "border-[hsl(var(--border))] bg-[hsl(var(--input))]"
-          )}
+            className={cn(
+              "w-full",
+              showClear && "pr-7",
+              "border-[hsl(var(--border))] bg-[hsl(var(--input))]"
+            )}
           aria-label={rest["aria-label"] ?? "Search"}
           type="search"
           autoComplete={autoComplete}
@@ -109,7 +109,7 @@ export default function SearchBar({
               type="button"
               aria-label="Clear"
               title="Clear"
-              className="absolute right-20 top-1/2 -translate-y-1/2 text-muted-foreground"
+                className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-foreground"
               onClick={() => {
               setQuery("");
               onValueChange?.("");

--- a/src/components/ui/primitives/Textarea.tsx
+++ b/src/components/ui/primitives/Textarea.tsx
@@ -13,8 +13,8 @@ export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & 
   textareaClassName?: string;
 };
 
-const INNER =
-  "block w-full max-w-full min-h-40 px-4 py-3 text-base bg-transparent " +
+  const INNER =
+    "block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent " +
   "text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] " +
   "focus:outline-none focus-visible:outline-none resize-y disabled:opacity-50 disabled:cursor-not-allowed";
 
@@ -51,7 +51,7 @@ export default React.forwardRef<HTMLTextAreaElement, TextareaProps>(function Tex
         ref={ref}
         id={finalId}
         name={finalName}
-        className={cn(INNER, tone === "pill" && "rounded-full min-h-32", textareaClassName)}
+          className={cn(INNER, tone === "pill" && "rounded-full min-h-6", textareaClassName)}
         {...props}
       />
     </FieldShell>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -60,11 +60,7 @@ const config: Config = {
         5: "24px",
         6: "32px",
         7: "48px",
-        8: "64px",
-        14: "14px",
-        20: "20px",
-        36: "36px",
-        40: "40px"
+        8: "64px"
       },
       keyframes: {
         shimmer: {


### PR DESCRIPTION
## Summary
- Document canonical spacing tokens and trim Tailwind spacing scale
- Show only approved spacing tokens on prompts page
- Replace legacy spacing utilities across components

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: snapshot mismatch for Input and Textarea)*

------
https://chatgpt.com/codex/tasks/task_e_68bd660e7bfc832c9046bf3d40a9be9b