### PR TITLE
feat: style badge pill variant

### DIFF
--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -16,7 +16,8 @@ export default function Badge({ variant = "neutral", className, children, ...pro
       "rounded-md px-2 py-1 bg-[hsl(var(--muted)/0.25)] border-[hsl(var(--border)/0.2)] text-[hsl(var(--muted-foreground))]",
     accent:
       "rounded-md px-2 py-1 bg-[hsl(var(--accent)/0.15)] border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))] shadow-[0_0_8px_hsl(var(--accent)/0.3)]",
-    pill: "pill",
+    pill:
+      "rounded-full px-2 py-1 bg-[hsl(var(--accent)/0.15)] border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))]",
   };
 
   return (


### PR DESCRIPTION
## Summary
- style badge pill variant with rounded-full, accent colors, and border

## Testing
- `npm test` *(fails: Snapshot mismatches in various UI tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6e29115c832caa24d1120bf31e97