### PR TITLE
refactor: use spacing token for label

### DIFF
--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -7,9 +7,8 @@
  */
 
 import * as React from "react";
-import { SectionCard, Textarea, Button, Input, Select, Card, FieldShell, SearchBar } from "@/components/ui";
+import { SectionCard, Textarea, Button, Input, Select, Card, FieldShell, SearchBar, Label } from "@/components/ui";
 import IconButton from "@/components/ui/primitives/IconButton";
-import { GlitchSegmentedGroup, GlitchSegmentedButton } from "@/components/ui/primitives/GlitchSegmented";
 import { ArrowUp } from "lucide-react";
 import { useLocalDB, uid } from "@/lib/db";
 import { LOCALE } from "@/lib/utils";
@@ -197,6 +196,15 @@ export default function PromptsPage() {
           <div className="space-y-3">
             <Textarea placeholder="Default" />
             <Textarea placeholder="Pill" tone="pill" />
+          </div>
+        </Card>
+        <Card className="mt-8 space-y-4">
+          <h3 className="type-title">Label</h3>
+          <div className="space-y-3">
+            <div>
+              <Label htmlFor="label-demo">Label</Label>
+              <Input id="label-demo" placeholder="With spacing" />
+            </div>
           </div>
         </Card>
         <Card className="mt-8 space-y-4">

--- a/src/components/ui/Label.tsx
+++ b/src/components/ui/Label.tsx
@@ -14,7 +14,7 @@ const Label = React.forwardRef<HTMLLabelElement, LabelProps>(function Label(
     <label
       ref={ref}
       className={cn(
-        "text-xs font-medium text-[hsl(var(--muted-foreground))] mb-1.5",
+        "text-xs font-medium text-[hsl(var(--muted-foreground))] mb-2",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- use `mb-2` spacing token in Label component
- document Label usage on prompts page

## Testing
- `npm test` *(fails: Snapshot mismatched)*
- `npm run lint` *(fails: Parsing error in GoalSlot.tsx)*
- `npm run typecheck` *(fails: TS errors in GoalSlot.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bd71b41a68832c806536eb42fb80e8