### PR TITLE
feat: accent snackbar action button

### DIFF
--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -7,9 +7,8 @@
  */
 
 import * as React from "react";
-import { SectionCard, Textarea, Button, Input, Select, Card, FieldShell, SearchBar } from "@/components/ui";
+import { SectionCard, Textarea, Button, Input, Select, Card, FieldShell, SearchBar, Snackbar } from "@/components/ui";
 import IconButton from "@/components/ui/primitives/IconButton";
-import { GlitchSegmentedGroup, GlitchSegmentedButton } from "@/components/ui/primitives/GlitchSegmented";
 import { ArrowUp } from "lucide-react";
 import { useLocalDB, uid } from "@/lib/db";
 import { LOCALE } from "@/lib/utils";
@@ -235,6 +234,19 @@ export default function PromptsPage() {
             <IconButton aria-label="Scroll to top">
               <ArrowUp />
             </IconButton>
+          </div>
+        </Card>
+        <Card className="mt-8 space-y-4">
+          <h3 className="type-title">Snackbar</h3>
+          <p className="text-sm text-muted-foreground">
+            Temporary message with an action. Tab to focus the action button.
+          </p>
+          <div className="space-y-3">
+            <Snackbar
+              message="Copy saved"
+              actionLabel="Undo"
+              onAction={() => console.log("Undo")}
+            />
           </div>
         </Card>
         <Card className="mt-8 space-y-4">

--- a/src/components/ui/feedback/Snackbar.tsx
+++ b/src/components/ui/feedback/Snackbar.tsx
@@ -32,7 +32,7 @@ export default function Snackbar({
           {" "}
           <button
             type="button"
-            className="underline underline-offset-2"
+            className="underline underline-offset-2 text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring]"
             onClick={onAction}
           >
             {actionLabel}


### PR DESCRIPTION
## Summary
- add accent color and focus ring to Snackbar action button
- showcase Snackbar on prompts page

## Testing
- `npm test` *(fails: snapshot mismatches)*
- `npm run lint` *(fails: Parsing error in GoalSlot.tsx)*
- `npx eslint src/components/ui/feedback/Snackbar.tsx src/components/prompts/PromptsPage.tsx`
- `npm run typecheck` *(fails: parse errors in GoalSlot.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bd71c724d4832cb73c03c290c133e4