### PR TITLE
Align Select className prop indentation

### DIFF
--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -63,10 +63,10 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(function Select(
           disabled={disabled}
           aria-invalid={errorText ? "true" : props["aria-invalid"]}
           aria-describedby={describedBy}
-            className={cn(
-              "flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none",
-              selectClassName
-            )}
+          className={cn(
+            "flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none",
+            selectClassName
+          )}
           {...props}
         >
           {children}


### PR DESCRIPTION
## Summary
- align Select component's className prop with other `<select>` attributes for consistent formatting

## Testing
- `npx eslint src/components/ui/Select.tsx --fix`
- `npm run lint` *(fails: Parsing error in src/components/goals/GoalSlot.tsx)*
- `npm test` *(fails: multiple snapshot mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68bd77bdcc7c832c9a5bf0f1ac0b2c8b