### PR TITLE
test: add date utility edge case tests

### DIFF
--- a/tests/lib/utils.test.ts
+++ b/tests/lib/utils.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest';
-import { cn, fromISODate, slugify } from '../../src/lib/utils';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  cn,
+  fromISODate,
+  slugify,
+  toISODate,
+  normalizeDate,
+} from '../../src/lib/utils';
 
 describe('cn', () => {
   it('handles strings', () => {
@@ -47,6 +53,61 @@ describe('fromISODate', () => {
     ).toBe(true);
     expect(fromISODate('2024-02-30')).toBeNull();
     expect(fromISODate('not-a-date')).toBeNull();
+  });
+});
+
+describe('toISODate', () => {
+  it('formats dates and timestamps', () => {
+    const d = new Date('2024-02-29T12:00:00Z');
+    expect(toISODate(d)).toBe('2024-02-29');
+    const ts = Date.UTC(2024, 1, 29);
+    expect(toISODate(ts)).toBe('2024-02-29');
+  });
+
+  it('falls back to today for invalid values', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-02T00:00:00Z'));
+    expect(toISODate('not-a-date')).toBe('2024-01-02');
+    expect(toISODate(NaN)).toBe('2024-01-02');
+    vi.useRealTimers();
+  });
+
+  it('handles timezone offsets', () => {
+    const d = new Date('2024-02-29T23:00:00-02:00');
+    const expected = `${d.getFullYear()}-${`${d.getMonth() + 1}`.padStart(2, '0')}-${`${d.getDate()}`.padStart(2, '0')}`;
+    expect(toISODate(d)).toBe(expected);
+  });
+});
+
+describe('normalizeDate', () => {
+  it('parses various inputs', () => {
+    const d = new Date('2024-02-29T12:34:56Z');
+    expect(normalizeDate(d).getTime()).toBe(d.getTime());
+    const ts = Date.UTC(2024, 1, 29);
+    expect(normalizeDate(ts).getTime()).toBe(ts);
+  });
+
+  it('returns local midnight for ISO strings', () => {
+    const dt = normalizeDate('2024-02-29');
+    expect(dt.getHours()).toBe(0);
+    expect(dt.getMinutes()).toBe(0);
+    expect(dt.getSeconds()).toBe(0);
+  });
+
+  it('falls back to now on invalid values', () => {
+    vi.useFakeTimers();
+    const now = new Date('2024-06-15T00:00:00Z');
+    vi.setSystemTime(now);
+    expect(normalizeDate('not-a-date').getTime()).toBe(now.getTime());
+    expect(normalizeDate(NaN).getTime()).toBe(now.getTime());
+    vi.useRealTimers();
+  });
+
+  it('rolls over out-of-range ISO dates', () => {
+    const dt = normalizeDate('2024-02-30');
+    expect(dt.getFullYear()).toBe(2024);
+    expect(dt.getMonth()).toBe(2); // March
+    expect(dt.getDate()).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- add comprehensive tests for toISODate covering timestamps, invalid inputs, and timezone offsets
- add normalizeDate tests for ISO parsing, invalid input fallback, and rollover behavior

## Testing
- `npx vitest run tests/lib/utils.test.ts`
- `npm test` *(fails: snapshot mismatches in various UI tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bd780590f0832cbe2ee6e128ffc9f5