### PR TITLE
Increase uid length

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -144,12 +144,15 @@ export function useLocalDB<T>(
 /**
  * Tiny uid helper.
  * Uses `crypto.randomUUID` when available; falls back to `Math.random`.
- * Example: "review_123e4567"
+ * Example: "review_123e4567e89b12d3"
  */
 export function uid(prefix = "id"): string {
   const id =
     typeof globalThis.crypto?.randomUUID === "function"
-      ? globalThis.crypto.randomUUID().slice(0, 8)
-      : Math.random().toString(36).slice(2, 10);
+      ? globalThis.crypto.randomUUID().replace(/-/g, "").slice(0, 16)
+      : (
+          Math.random().toString(36).slice(2) +
+          Math.random().toString(36).slice(2)
+        ).slice(0, 16);
   return `${prefix}_${id}`;
 }

--- a/tests/lib/db.test.ts
+++ b/tests/lib/db.test.ts
@@ -111,12 +111,16 @@ describe('useLocalDB', () => {
 // Tests for uid
 
 describe('uid', () => {
-  it('generates unique identifiers', () => {
+  it('generates unique identifiers of sufficient length', () => {
     const ids = new Set<string>();
     for (let i = 0; i < 100; i++) {
       ids.add(uid('test'));
     }
     expect(ids.size).toBe(100);
+
+    const sample = uid('test');
+    expect(sample.startsWith('test_')).toBe(true);
+    expect(sample.slice('test_'.length).length).toBeGreaterThanOrEqual(16);
   });
 });
 


### PR DESCRIPTION
## Summary
- generate 16-character ids from crypto.randomUUID or Math.random fallback
- ensure uid test checks for longer ids

## Testing
- `npm test` *(fails: Snapshot mismatches in UI tests)*
- `npm run lint` *(fails: Parsing error in GoalSlot.tsx)*
- `npm run typecheck` *(fails: Parsing error in GoalSlot.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bd78253044832cbe25cb3a3cfbd65b