### PR TITLE
refactor: modularize global styles

### DIFF
--- a/src/app/animations.css
+++ b/src/app/animations.css
@@ -1,0 +1,210 @@
+/* Centralized animation keyframes */
+
+@keyframes glitchSheen {
+  0% {
+    background-position: 0% 50%;
+    filter: saturate(1);
+  }
+  50% {
+    background-position: 100% 50%;
+    filter: saturate(1.2);
+  }
+  100% {
+    background-position: 0% 50%;
+    filter: saturate(1);
+  }
+}
+
+@keyframes glitchScan {
+  0%,
+  100% {
+    opacity: 0.15;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+@keyframes glitchJitter {
+  0% {
+    transform: translateY(0);
+  }
+  25% {
+    transform: translateY(-0.5px);
+  }
+  50% {
+    transform: translateY(0.5px);
+  }
+  75% {
+    transform: translateY(-0.25px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+@keyframes pill-pulse {
+  0% {
+    opacity: 0.7;
+    transform: scale(0.98);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.15);
+  }
+}
+
+@keyframes sheen-rotate {
+  to {
+    --a: 1turn;
+  }
+}
+
+@keyframes sheenSweep {
+  from {
+    transform: translateX(-40%) skewX(-20deg);
+  }
+  to {
+    transform: translateX(140%) skewX(-20deg);
+  }
+}
+
+@keyframes edgePulse {
+  0%,
+  100% {
+    opacity: 0.45;
+  }
+  50% {
+    opacity: 0.7;
+  }
+}
+
+@keyframes chromaJitter {
+  0%,
+  100% {
+    transform: translateZ(0);
+  }
+  25% {
+    transform: translateX(-0.25px);
+  }
+  50% {
+    transform: translateX(0.25px);
+  }
+  75% {
+    transform: translateX(-0.15px);
+  }
+}
+
+@keyframes fadeSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.995);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes popIn {
+  from {
+    opacity: 0;
+    transform: scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes ghost {
+  0% {
+    transform: translate(0, 0);
+  }
+  20% {
+    transform: translate(0.4px, -0.2px);
+  }
+  40% {
+    transform: translate(-0.3px, 0.2px);
+  }
+  60% {
+    transform: translate(0.2px, 0.3px);
+  }
+  80% {
+    transform: translate(-0.2px, -0.1px);
+  }
+  100% {
+    transform: translate(0, 0);
+  }
+}
+
+@keyframes glx-flicker {
+  0%,
+  19%,
+  21%,
+  23%,
+  25%,
+  54%,
+  56%,
+  100% {
+    opacity: 1;
+  }
+  20%,
+  24%,
+  55% {
+    opacity: 0.4;
+  }
+}
+
+@keyframes glx-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
+}
+
+@keyframes scan {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes lg-grid-drift {
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+  100% {
+    transform: translate3d(26px, 26px, 0);
+  }
+}
+
+@keyframes lg-aurora-pan {
+  0% {
+    transform: translate3d(-2%, -1%, 0) scale(1.02);
+    opacity: 0.95;
+  }
+  50% {
+    transform: translate3d(1%, 0.5%, 0) scale(1.01);
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(2%, 1%, 0) scale(1.02);
+    opacity: 0.95;
+  }
+}
+

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+@import './animations.css';
+@import './overlays.css';
+@import './utilities.css';
+
 /* ---------- Base reset ---------- */
 html,
 body,
@@ -727,117 +731,6 @@ html.bg-intense body::after {
   }
 }
 
-/* ---------- Utilities ---------- */
-:root {
-  --shell-max: 1120px;
-}
-.page-shell {
-  width: 100%;
-  max-width: var(--shell-max, 1120px);
-  margin-inline: auto;
-  padding-inline: clamp(12px, 2.5vw, 24px);
-}
-
-@layer utilities {
-  .text-muted-foreground {
-    color: hsl(var(--muted-foreground));
-  }
-
-  .sticky-blur {
-    position: sticky;
-    top: 0;
-    z-index: 30;
-    backdrop-filter: saturate(120%) blur(12px);
-    background: color-mix(in oklab, hsl(var(--background)) 65%, transparent);
-    border-bottom: 1px solid hsl(var(--card-hairline));
-  }
-
-  .r-card-sm {
-    --radius-card: var(--radius-md);
-  }
-  .r-card-md {
-    --radius-card: var(--radius-lg);
-  }
-  .r-card-lg {
-    --radius-card: var(--radius-xl);
-  }
-  .rounded-card {
-    border-radius: var(--radius-card) !important;
-  }
-
-  .anim-in {
-    animation: fadeSlideIn var(--dur-chill) var(--ease-out) both;
-  }
-  .anim-pop {
-    animation: popIn var(--dur-quick) var(--ease-out) both;
-  }
-
-  .animate-glx-flicker {
-    animation: glx-flicker 6s infinite;
-  }
-  .animate-glx-pulse {
-    animation: glx-pulse 10s ease-in-out infinite;
-  }
-  .animate-glx-scan {
-    animation: scan 2.2s linear infinite;
-  }
-
-  .skeleton {
-    position: relative;
-    overflow: hidden;
-    background: hsl(var(--muted) / 0.6);
-  }
-  .skeleton::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(
-      90deg,
-      transparent,
-      hsl(var(--foreground) / 0.08),
-      transparent
-    );
-    animation: shimmer var(--dur-slow) linear infinite;
-  }
-
-  .card-pad {
-    padding: 1.5rem;
-  }
-  .card-pad-lg {
-    padding: 1.5rem;
-  }
-  @media (min-width: 640px) {
-    .card-pad {
-      padding: 1rem;
-    }
-    .card-pad-lg {
-      padding: 2rem;
-    }
-  }
-
-  .toolbar {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    gap: 0.75rem;
-    align-items: center;
-  }
-  .toolbar-right {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-  @media (max-width: 640px) {
-    .toolbar {
-      grid-template-columns: 1fr;
-    }
-    .toolbar-right {
-      justify-content: flex-start;
-    }
-  }
-  .hairline {
-    border-top: 1px solid hsl(var(--card-hairline));
-  }
-}
 
 /* ---------- Planner visuals ---------- */
 .bg-hero-soft-lite {
@@ -877,46 +770,6 @@ html.bg-intense body::after {
 }
 
 /* ---------- Progress bars ---------- */
-@keyframes glitchSheen {
-  0% {
-    background-position: 0% 50%;
-    filter: saturate(1);
-  }
-  50% {
-    background-position: 100% 50%;
-    filter: saturate(1.2);
-  }
-  100% {
-    background-position: 0% 50%;
-    filter: saturate(1);
-  }
-}
-@keyframes glitchScan {
-  0%,
-  100% {
-    opacity: 0.15;
-  }
-  50% {
-    opacity: 0.4;
-  }
-}
-@keyframes glitchJitter {
-  0% {
-    transform: translateY(0);
-  }
-  25% {
-    transform: translateY(-0.5px);
-  }
-  50% {
-    transform: translateY(0.5px);
-  }
-  75% {
-    transform: translateY(-0.25px);
-  }
-  100% {
-    transform: translateY(0);
-  }
-}
 
 .glitch-track {
   position: relative;
@@ -1024,159 +877,8 @@ html.bg-intense body::after {
   @apply h-12 flex items-center;
 }
 
-@keyframes pill-pulse {
-  0% {
-    opacity: 0.7;
-    transform: scale(0.98);
-  }
-  100% {
-    opacity: 0;
-    transform: scale(1.15);
-  }
-}
 
 /* ---------- Animations ---------- */
-@keyframes sheen-rotate {
-  to {
-    --a: 1turn;
-  }
-}
-@keyframes sheenSweep {
-  from {
-    transform: translateX(-40%) skewX(-20deg);
-  }
-  to {
-    transform: translateX(140%) skewX(-20deg);
-  }
-}
-@keyframes edgePulse {
-  0%,
-  100% {
-    opacity: 0.45;
-  }
-  50% {
-    opacity: 0.7;
-  }
-}
-@keyframes chromaJitter {
-  0%,
-  100% {
-    transform: translateZ(0);
-  }
-  25% {
-    transform: translateX(-0.25px);
-  }
-  50% {
-    transform: translateX(0.25px);
-  }
-  75% {
-    transform: translateX(-0.15px);
-  }
-}
-@keyframes fadeSlideIn {
-  from {
-    opacity: 0;
-    transform: translateY(8px) scale(0.995);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-@keyframes popIn {
-  from {
-    opacity: 0;
-    transform: scale(0.985);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-@keyframes shimmer {
-  0% {
-    transform: translateX(-100%);
-  }
-  100% {
-    transform: translateX(100%);
-  }
-}
-@keyframes ghost {
-  0% {
-    transform: translate(0, 0);
-  }
-  20% {
-    transform: translate(0.4px, -0.2px);
-  }
-  40% {
-    transform: translate(-0.3px, 0.2px);
-  }
-  60% {
-    transform: translate(0.2px, 0.3px);
-  }
-  80% {
-    transform: translate(-0.2px, -0.1px);
-  }
-  100% {
-    transform: translate(0, 0);
-  }
-}
-@keyframes glx-flicker {
-  0%,
-  19%,
-  21%,
-  23%,
-  25%,
-  54%,
-  56%,
-  100% {
-    opacity: 1;
-  }
-  20%,
-  24%,
-  55% {
-    opacity: 0.4;
-  }
-}
-@keyframes glx-pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.6;
-  }
-}
-@keyframes scan {
-  0% {
-    transform: translateX(-100%);
-  }
-  100% {
-    transform: translateX(100%);
-  }
-}
-@keyframes lg-grid-drift {
-  0% {
-    transform: translate3d(0, 0, 0);
-  }
-  100% {
-    transform: translate3d(26px, 26px, 0);
-  }
-}
-@keyframes lg-aurora-pan {
-  0% {
-    transform: translate3d(-2%, -1%, 0) scale(1.02);
-    opacity: 0.95;
-  }
-  50% {
-    transform: translate3d(1%, 0.5%, 0) scale(1.01);
-    opacity: 1;
-  }
-  100% {
-    transform: translate3d(2%, 1%, 0) scale(1.02);
-    opacity: 0.95;
-  }
-}
 
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
@@ -1188,55 +890,6 @@ html.bg-intense body::after {
     transition-duration: 0.001ms !important;
     scroll-behavior: auto !important;
   }
-}
-
-/* ---------- Optional global overlays ---------- */
-html.fx-scanlines::after,
-body.fx-scanlines::after {
-  content: "";
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: 5;
-  background: repeating-linear-gradient(
-    to bottom,
-    hsl(var(--foreground) / 0.02) 0px,
-    hsl(var(--foreground) / 0.02) 1px,
-    transparent 2px,
-    transparent 3px
-  );
-  mix-blend-mode: soft-light;
-}
-html.fx-noise::before,
-body.fx-noise::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: 4;
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='140' height='140'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.06'/></svg>");
-  background-size: 140px 140px;
-}
-html.fx-gifbars::before,
-body.fx-gifbars::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: 3;
-  background-image: url("https://www.gifcen.com/wp-content/uploads/2022/05/glitch-gif.gif");
-  background-size: cover;
-  background-position: center;
-  mix-blend-mode: overlay;
-  opacity: 0.08;
-}
-html.fx-overdrive .card-neo:hover::before,
-html.fx-overdrive .card-neo-soft:hover::before {
-  animation: edgePulse 1.6s ease-in-out infinite;
-}
-html.fx-overdrive .card-neo.glitchy:hover .card-title,
-html.fx-overdrive .card-neo-soft.glitchy:hover .card-title {
-  animation: chromaJitter 0.8s steps(3, end) infinite;
 }
 
 /* ---------- Scrollbar ---------- */

--- a/src/app/overlays.css
+++ b/src/app/overlays.css
@@ -1,0 +1,54 @@
+/* Optional global overlays */
+
+html.fx-scanlines::after,
+body.fx-scanlines::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 5;
+  background: repeating-linear-gradient(
+    to bottom,
+    hsl(var(--foreground) / 0.02) 0px,
+    hsl(var(--foreground) / 0.02) 1px,
+    transparent 2px,
+    transparent 3px
+  );
+  mix-blend-mode: soft-light;
+}
+
+html.fx-noise::before,
+body.fx-noise::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 4;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='140' height='140'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.06'/></svg>");
+  background-size: 140px 140px;
+}
+
+html.fx-gifbars::before,
+body.fx-gifbars::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 3;
+  background-image: url("https://www.gifcen.com/wp-content/uploads/2022/05/glitch-gif.gif");
+  background-size: cover;
+  background-position: center;
+  mix-blend-mode: overlay;
+  opacity: 0.08;
+}
+
+html.fx-overdrive .card-neo:hover::before,
+html.fx-overdrive .card-neo-soft:hover::before {
+  animation: edgePulse 1.6s ease-in-out infinite;
+}
+
+html.fx-overdrive .card-neo.glitchy:hover .card-title,
+html.fx-overdrive .card-neo-soft.glitchy:hover .card-title {
+  animation: chromaJitter 0.8s steps(3, end) infinite;
+}
+

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -70,6 +70,10 @@ export default function Page() {
 
   return (
     <main className="page-shell py-6 bg-background text-foreground">
+      <p className="mb-4 text-sm text-muted-foreground">
+        Global styles are now modularized into <code>animations.css</code>,
+        <code>overlays.css</code>, and <code>utilities.css</code>.
+      </p>
       <div className="mb-8">
         <TabBar items={viewTabs} value={view} onValueChange={setView} />
       </div>

--- a/src/app/utilities.css
+++ b/src/app/utilities.css
@@ -1,0 +1,114 @@
+/* Global utility classes */
+
+:root {
+  --shell-max: 1120px;
+}
+
+.page-shell {
+  width: 100%;
+  max-width: var(--shell-max, 1120px);
+  margin-inline: auto;
+  padding-inline: clamp(12px, 2.5vw, 24px);
+}
+
+@layer utilities {
+  .text-muted-foreground {
+    color: hsl(var(--muted-foreground));
+  }
+
+  .sticky-blur {
+    position: sticky;
+    top: 0;
+    z-index: 30;
+    backdrop-filter: saturate(120%) blur(12px);
+    background: color-mix(in oklab, hsl(var(--background)) 65%, transparent);
+    border-bottom: 1px solid hsl(var(--card-hairline));
+  }
+
+  .r-card-sm {
+    --radius-card: var(--radius-md);
+  }
+  .r-card-md {
+    --radius-card: var(--radius-lg);
+  }
+  .r-card-lg {
+    --radius-card: var(--radius-xl);
+  }
+  .rounded-card {
+    border-radius: var(--radius-card) !important;
+  }
+
+  .anim-in {
+    animation: fadeSlideIn var(--dur-chill) var(--ease-out) both;
+  }
+  .anim-pop {
+    animation: popIn var(--dur-quick) var(--ease-out) both;
+  }
+
+  .animate-glx-flicker {
+    animation: glx-flicker 6s infinite;
+  }
+  .animate-glx-pulse {
+    animation: glx-pulse 10s ease-in-out infinite;
+  }
+  .animate-glx-scan {
+    animation: scan 2.2s linear infinite;
+  }
+
+  .skeleton {
+    position: relative;
+    overflow: hidden;
+    background: hsl(var(--muted) / 0.6);
+  }
+  .skeleton::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      hsl(var(--foreground) / 0.08),
+      transparent
+    );
+    animation: shimmer var(--dur-slow) linear infinite;
+  }
+
+  .card-pad {
+    padding: 1.5rem;
+  }
+  .card-pad-lg {
+    padding: 1.5rem;
+  }
+  @media (min-width: 640px) {
+    .card-pad {
+      padding: 1rem;
+    }
+    .card-pad-lg {
+      padding: 2rem;
+    }
+  }
+
+  .toolbar {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.75rem;
+    align-items: center;
+  }
+  .toolbar-right {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  @media (max-width: 640px) {
+    .toolbar {
+      grid-template-columns: 1fr;
+    }
+    .toolbar-right {
+      justify-content: flex-start;
+    }
+  }
+  .hairline {
+    border-top: 1px solid hsl(var(--card-hairline));
+  }
+}
+


### PR DESCRIPTION
## Summary
- split monolithic `globals.css` into separate `animations.css`, `overlays.css`, and `utilities.css`
- import new style modules from `globals.css`
- note new stylesheet structure on the prompts page

## Testing
- `npm run lint` *(fails: Parsing error: Expression expected.)*
- `npm run typecheck` *(fails: TypeScript errors in GoalSlot.tsx)*
- `npm test` *(fails: snapshot mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7813f880832c8a551ba493df5902