### PR TITLE
Ensure AnimationToggle cleans up animation class

### DIFF
--- a/src/components/ui/AnimationToggle.tsx
+++ b/src/components/ui/AnimationToggle.tsx
@@ -24,6 +24,9 @@ export default function AnimationToggle() {
 
   React.useEffect(() => {
     document.documentElement.classList.toggle("no-animations", !enabled);
+    return () => {
+      document.documentElement.classList.remove("no-animations");
+    };
   }, [enabled]);
 
   function toggle() {


### PR DESCRIPTION
## Summary
- ensure AnimationToggle removes `no-animations` class on unmount

## Testing
- `npm test` *(fails: 18 failed, 49 passed)*
- `npm run lint` *(fails: Parsing error: Expression expected in GoalSlot.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7a829d2c832c99583c4a66356649