### PR TITLE
Add FieldShell and Label examples

### DIFF
--- a/src/app/prompts/ComponentGallery.tsx
+++ b/src/app/prompts/ComponentGallery.tsx
@@ -25,6 +25,8 @@ import {
   PillarSelector,
   AnimatedSelect,
   Select,
+  FieldShell,
+  Label,
 } from '@/components/ui';
 import type { Pillar, Review } from '@/lib/types';
 import type { GameSide } from '@/components/ui/league/SideSelector';
@@ -101,6 +103,19 @@ export default function ComponentGallery() {
         </Item>
         <Item label="Textarea">
           <Textarea placeholder="Write here" className="w-56" />
+        </Item>
+        <Item label="FieldShell">
+          <FieldShell className="w-56">
+            <div className="px-4 py-2 text-sm text-muted-foreground">
+              Custom content
+            </div>
+          </FieldShell>
+        </Item>
+        <Item label="Label">
+          <div className="w-56">
+            <Label htmlFor="label-demo">Label</Label>
+            <Input id="label-demo" placeholder="With spacing" />
+          </div>
         </Item>
         <Item label="Badge">
           <Badge>Badge</Badge>


### PR DESCRIPTION
## Summary
- showcase FieldShell and Label components in the prompts ComponentGallery

## Testing
- `npm test` *(fails: snapshot mismatches)*
- `npm run lint` *(fails: Parsing error in GoalSlot.tsx)*
- `npm run typecheck` *(fails: TS errors in GoalSlot.tsx)*
- `npx eslint src/app/prompts/ComponentGallery.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bd7a8baea4832ca5ea17f3c1216d76