### PR TITLE
Add tests for AnimationToggle, Badge, and Label components

### DIFF
--- a/tests/ui/animation-toggle.test.tsx
+++ b/tests/ui/animation-toggle.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AnimationToggle } from '@/components/ui';
+
+beforeEach(() => {
+  window.localStorage.clear();
+  document.documentElement.classList.remove('no-animations');
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  document.documentElement.classList.remove('no-animations');
+});
+
+describe('AnimationToggle', () => {
+  it('renders a pressed button by default', async () => {
+    const { getByRole } = render(<AnimationToggle />);
+    const button = getByRole('button', { name: 'Disable animations' });
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains('no-animations')).toBe(false);
+    });
+  });
+
+  it('toggles animations and updates aria attributes', async () => {
+    const { getByRole } = render(<AnimationToggle />);
+    const button = getByRole('button');
+    fireEvent.click(button);
+    await waitFor(() => {
+      expect(button).toHaveAttribute('aria-pressed', 'false');
+      expect(button).toHaveAttribute('aria-label', 'Enable animations');
+      expect(document.documentElement.classList.contains('no-animations')).toBe(true);
+    });
+  });
+});
+

--- a/tests/ui/badge.test.tsx
+++ b/tests/ui/badge.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { Badge } from '@/components/ui';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Badge', () => {
+  it('renders neutral variant by default', () => {
+    const { getByText } = render(<Badge>Neutral</Badge>);
+    const badge = getByText('Neutral');
+    expect(badge).toHaveClass('bg-[hsl(var(--muted)/0.25)]');
+  });
+
+  it('applies accent variant styles', () => {
+    const { getByText } = render(<Badge variant="accent">Accent</Badge>);
+    const badge = getByText('Accent');
+    expect(badge).toHaveClass('text-[hsl(var(--accent))]');
+  });
+
+  it('applies pill variant styles', () => {
+    const { getByText } = render(<Badge variant="pill">Pill</Badge>);
+    const badge = getByText('Pill');
+    expect(badge).toHaveClass('rounded-full');
+  });
+});
+

--- a/tests/ui/label.test.tsx
+++ b/tests/ui/label.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { Label } from '@/components/ui';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Label', () => {
+  it('renders provided text', () => {
+    const { getByText } = render(<Label>Username</Label>);
+    expect(getByText('Username')).toBeInTheDocument();
+  });
+
+  it('associates with input via htmlFor', () => {
+    const { getByLabelText } = render(
+      <>
+        <Label htmlFor="email">Email</Label>
+        <input id="email" />
+      </>
+    );
+    expect(getByLabelText('Email')).toBeInTheDocument();
+  });
+
+  it('merges custom class names', () => {
+    const { getByText } = render(<Label className="custom">Name</Label>);
+    expect(getByText('Name')).toHaveClass('custom');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for AnimationToggle ensuring aria attributes and DOM class toggling
- verify Badge variant styling
- test Label rendering and htmlFor association

## Testing
- `npm test`
- `npm test -- tests/ui/animation-toggle.test.tsx tests/ui/badge.test.tsx tests/ui/label.test.tsx --run`


------
https://chatgpt.com/codex/tasks/task_e_68bd7a647130832c9b803602b1ce6bee