### PR TITLE
refactor: replace color literals with tokens

### DIFF
--- a/COLOR_MAPPINGS.md
+++ b/COLOR_MAPPINGS.md
@@ -16,3 +16,14 @@
 | `#9a8cff` | `hsl(var(--icon-fg))` |
 | `#0b0f13` | `hsl(var(--surface-vhs))` |
 | `#1a1a24` | `hsl(var(--surface-streak))` |
+| `hsla(260, 90%, 72%, 0.18)` | `hsl(var(--ring) / 0.18)` |
+| `hsla(200, 90%, 60%, 0.14)` | `hsl(var(--accent-2) / 0.14)` |
+| `rgba(255, 255, 255, 0.22)` | `hsl(var(--foreground) / 0.22)` |
+| `rgba(255, 255, 255, 0.06)` | `hsl(var(--foreground) / 0.06)` |
+| `rgba(255, 255, 255, 0.15)` | `hsl(var(--foreground) / 0.15)` |
+| `rgba(0, 255, 255, 0.04)` | `hsl(var(--accent-2) / 0.04)` |
+| `rgba(255, 0, 200, 0.04)` | `hsl(var(--lav-deep) / 0.04)` |
+| `rgba(70, 230, 255, 0.15)` | `hsl(var(--accent-2) / 0.15)` |
+| `rgba(150, 210, 225, 0.15)` | `hsl(var(--accent-2) / 0.15)` |
+| `rgba(180, 100, 255, 0.25)` | `hsl(var(--accent) / 0.25)` |
+| `rgba(160, 60, 255, 0.2)` | `hsl(var(--accent) / 0.2)` |

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -487,11 +487,11 @@ html.bg-light body::after {
 html.bg-vhs body {
   background-color: hsl(var(--surface-vhs));
   background-image:
-    radial-gradient(circle at 20% 30%, rgba(70, 230, 255, 0.15), transparent 60%),
+    radial-gradient(circle at 20% 30%, hsl(var(--accent-2) / 0.15), transparent 60%),
     repeating-linear-gradient(
       to bottom,
-      rgba(150, 210, 225, 0.15),
-      rgba(150, 210, 225, 0.15) 1px,
+      hsl(var(--accent-2) / 0.15),
+      hsl(var(--accent-2) / 0.15) 1px,
       transparent 1px,
       transparent 3px
     );
@@ -505,11 +505,11 @@ html.bg-vhs body::after {
 html.bg-streak body {
   background-color: hsl(var(--surface-streak));
   background-image:
-    radial-gradient(circle at 70% 40%, rgba(180, 100, 255, 0.25), transparent 40%),
+    radial-gradient(circle at 70% 40%, hsl(var(--accent) / 0.25), transparent 40%),
     repeating-linear-gradient(
       to right,
-      rgba(160, 60, 255, 0.2),
-      rgba(160, 60, 255, 0.2) 6px,
+      hsl(var(--accent) / 0.2),
+      hsl(var(--accent) / 0.2) 6px,
       transparent 6px,
       transparent 20px
     );

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -270,7 +270,10 @@ export default function PromptsPage() {
           <div>
             <h4 className="type-subtitle">Colors</h4>
             <div className="flex gap-2">
-                <div className="size-6 rounded bg-accent-2" />
+              <div className="size-6 rounded bg-ring" />
+              <div className="size-6 rounded bg-accent" />
+              <div className="size-6 rounded bg-accent-2" />
+              <div className="size-6 rounded bg-lavDeep" />
               <div className="size-6 rounded bg-danger" />
               <div className="size-6 rounded bg-success" />
               <div className="size-6 rounded bg-glow" />

--- a/src/components/reviews/style.css
+++ b/src/components/reviews/style.css
@@ -60,8 +60,8 @@
   border-radius: var(--radius-lg);
   background: linear-gradient(
     90deg,
-    hsla(260, 90%, 72%, 0.18),
-    hsla(200, 90%, 60%, 0.14)
+    hsl(var(--ring) / 0.18),
+    hsl(var(--accent-2) / 0.14)
   );
   box-shadow: 0 10px 30px hsl(var(--shadow-color) / 0.25);
   transform: translateX(calc(var(--idx) * var(--rail-w)));
@@ -75,7 +75,7 @@
   inset: 0;
   border-radius: var(--radius-xl);
   mix-blend-mode: screen;
-  background: radial-gradient(80% 80% at 50% 50%, rgba(255,255,255,.22), transparent 60%);
+  background: radial-gradient(80% 80% at 50% 50%, hsl(var(--foreground) / 0.22), transparent 60%);
   animation: role-ignite .24s ease-out 1;
   pointer-events: none;
 }
@@ -94,7 +94,7 @@
   pointer-events: none;
   background: repeating-linear-gradient(
     0deg,
-    rgba(255,255,255,.06) 0 1px,
+    hsl(var(--foreground) / 0.06) 0 1px,
     transparent 1px 3px
   );
   opacity: .12;
@@ -115,7 +115,7 @@
   background: hsl(var(--surface-2) / .05);
   backdrop-filter: blur(4px);
   border: 1px solid hsl(var(--accent) / .4);
-  box-shadow: inset 0 1px rgba(255,255,255,.06), 0 0 8px hsl(var(--accent) / .15);
+  box-shadow: inset 0 1px hsl(var(--foreground) / 0.06), 0 0 8px hsl(var(--accent) / 0.15);
   overflow: hidden;                /* <-- keep the pill inside the border */
 }
 
@@ -157,7 +157,7 @@
   background: hsl(var(--surface-2) / .15);
   backdrop-filter: blur(4px);
   border: 1px solid hsl(var(--accent) / .5);
-  box-shadow: inset 0 1px rgba(255,255,255,.15), 0 0 8px hsl(var(--accent) / .4);
+  box-shadow: inset 0 1px hsl(var(--foreground) / 0.15), 0 0 8px hsl(var(--accent) / 0.4);
 }
 
 /* Optional subtle inner glow like the reference GIF */
@@ -168,7 +168,7 @@
   border-radius: inherit;
   pointer-events: none;
   background:
-    radial-gradient(120px 40px at 25% 50%, rgba(0,255,255,.04), transparent 60%),
-    radial-gradient(120px 40px at 75% 50%, rgba(255,0,200,.04), transparent 60%);
+    radial-gradient(120px 40px at 25% 50%, hsl(var(--accent-2) / 0.04), transparent 60%),
+    radial-gradient(120px 40px at 75% 50%, hsl(var(--lav-deep) / 0.04), transparent 60%);
   mix-blend-mode: screen;
 }


### PR DESCRIPTION
## Summary
- refactor review gradients and overlays to use HSL tokens
- replace VHS and streak background rgba values with token-based expressions
- document new color mappings and expose tokens on prompts page

## Testing
- `npm test` *(fails: Snapshot mismatched)*
- `npm run lint` *(fails: Parsing error in GoalSlot.tsx)*
- `npm run typecheck` *(fails: TS1109 Expression expected in GoalSlot.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7b9334a4832c9e29bc468509a214