### PR TITLE
feat: add glitch palette

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -282,6 +282,19 @@ export default function Page() {
         </div>
       ) : (
         <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
+          <div className="flex flex-col items-center gap-2 sm:col-span-2 md:col-span-3">
+            <span className="text-sm font-medium">Glitch Palette</span>
+            <div className="flex gap-2">
+              <div className="w-10 h-10 rounded bg-glitchR" />
+              <div className="w-10 h-10 rounded bg-glitchRLight" />
+              <div className="w-10 h-10 rounded bg-glitchB" />
+              <div className="w-10 h-10 rounded bg-glitchBLight" />
+            </div>
+            <p className="text-xs text-muted-foreground mt-2 text-center">
+              Use <code>glitchR</code>, <code>glitchRLight</code>, <code>glitchB</code>, and
+              <code>glitchBLight</code> Tailwind classes for glitch effects.
+            </p>
+          </div>
           {colorList.map((c) => (
             <div key={c} className="flex flex-col items-center gap-2">
               <span className="text-xs uppercase tracking-wide text-purple-300">

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -230,8 +230,16 @@ export default function TimerTab() {
               {/* progress core */}
               <div className="lg-progress" style={pctStyle} aria-hidden />
               {/* rgb ghost trails */}
-              <div className="lg-progress rgb r" style={pctStyle} aria-hidden />
-              <div className="lg-progress rgb b" style={pctStyle} aria-hidden />
+              <div
+                className="lg-progress rgb r bg-gradient-to-r from-glitchR to-glitchRLight"
+                style={pctStyle}
+                aria-hidden
+              />
+              <div
+                className="lg-progress rgb b bg-gradient-to-r from-glitchB to-glitchBLight"
+                style={pctStyle}
+                aria-hidden
+              />
               {/* scanline sweep */}
               <div className="lg-scan" aria-hidden />
             </div>
@@ -345,14 +353,12 @@ export default function TimerTab() {
           filter: blur(1px);
         }
         .lg-progress.rgb.r {
-          background: linear-gradient(90deg, hsl(var(--glitch-r)) 0%, hsl(var(--glitch-r-light)) 100%);
           transform: translateX(-1px);
           animation:
             widthEase 220ms ease,
             jitterX 900ms steps(12) infinite reverse;
         }
         .lg-progress.rgb.b {
-          background: linear-gradient(90deg, hsl(var(--glitch-b)) 0%, hsl(var(--glitch-b-light)) 100%);
           transform: translateX(1px);
           animation:
             widthEase 220ms ease,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -29,6 +29,10 @@ const config: Config = {
           DEFAULT: "hsl(var(--success))",
           glow: "hsl(var(--success-glow))"
         },
+        glitchR: "hsl(var(--glitch-r))",
+        glitchRLight: "hsl(var(--glitch-r-light))",
+        glitchB: "hsl(var(--glitch-b))",
+        glitchBLight: "hsl(var(--glitch-b-light))",
         muted: { DEFAULT: "hsl(var(--muted))", foreground: "hsl(var(--muted-foreground))" },
         lavDeep: "hsl(var(--lav-deep))",
         surfaceVhs: "hsl(var(--surface-vhs))",


### PR DESCRIPTION
## Summary
- add glitchR/glitchB colors to Tailwind theme
- switch TimerTab glitch trails to Tailwind gradient utilities
- document glitch palette usage on prompts page

## Testing
- `npm test` *(fails: snapshots)*
- `npm run lint` *(fails: Parsing error in GoalSlot.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7c92c8c0832cab049b63d713ddfd