### PR TITLE
refactor: use radius CSS vars

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1228,6 +1228,7 @@ textarea:-webkit-autofill {
   --radius-md: 8px;
   --radius-lg: 12px;
   --radius-xl: 16px;
+  --radius-2xl: 24px;
 }
 
 @layer components {

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -55,7 +55,10 @@
   --card-hairline: hsl(var(--border));
 
   --hairline-w: 1px;
-  --radius-md: 8px; --radius-lg: 12px; --radius-xl: 16px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-2xl: 24px;
   --radius-card: var(--radius-xl);
   --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
   --ease-snap: cubic-bezier(0.2, 0.8, 0.2, 1);

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -293,7 +293,7 @@ export default function PromptsPage() {
           </div>
           <div>
             <h4 className="type-subtitle">Radius</h4>
-            <p className="type-body">--radius-md, --radius-lg, --radius-xl</p>
+            <p className="type-body">--radius-md, --radius-lg, --radius-xl, --radius-2xl</p>
           </div>
           <div>
             <h4 className="type-subtitle">Type Ramp</h4>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -38,7 +38,12 @@ const config: Config = {
         surfaceVhs: "hsl(var(--surface-vhs))",
         surfaceStreak: "hsl(var(--surface-streak))"
       },
-      borderRadius: { md: "8px", lg: "12px", xl: "16px", "2xl": "24px" },
+      borderRadius: {
+        md: "var(--radius-md)",
+        lg: "var(--radius-lg)",
+        xl: "var(--radius-xl)",
+        "2xl": "var(--radius-2xl)"
+      },
       boxShadow: {
         "neo-sm":
           "4px 4px 8px hsl(var(--panel)/0.72), -4px -4px 8px hsl(var(--foreground)/0.06)",


### PR DESCRIPTION
## Summary
- replace Tailwind border radius values with CSS variables
- define matching `--radius-*` variables in global theme files
- document new radius token on Prompts page

## Testing
- `npm test` *(fails: Snapshot mismatched)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bd821069f0832c86b2a1a0c98e4f5c