### PR TITLE
feat: increase input control heights

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -188,8 +188,8 @@ export default function Page() {
             <div className="flex flex-col items-center space-y-2">
               <span className="text-sm font-medium">Input</span>
               <div className="w-56 space-y-2">
-                <Input placeholder="Small" />
-                <Input size="md" placeholder="Medium" />
+                <Input size="sm" placeholder="Small" />
+                <Input placeholder="Medium" />
                 <Input size="lg" placeholder="Large" />
                 <Input tone="pill" placeholder="Pill" />
                 <Input placeholder="With icon" hasEndSlot>

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -159,10 +159,15 @@ export default function PromptsPage() {
             Customize focus rings with the <code>--theme-ring</code> variable.
           </p>
           <div className="space-y-3">
-            <Input placeholder="Default" />
+            <Input size="sm" placeholder="Small" />
+            <Input placeholder="Medium" />
+            <Input size="lg" placeholder="Large" />
             <Input placeholder="Pill" tone="pill" />
             <Input placeholder="Error" aria-invalid="true" />
-            <Input placeholder="Custom ring" style={{ '--theme-ring': 'hsl(var(--danger))' } as React.CSSProperties} />
+            <Input
+              placeholder="Custom ring"
+              style={{ '--theme-ring': 'hsl(var(--danger))' } as React.CSSProperties}
+            />
             <Input placeholder="With action">
               <button
                 type="button"

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -13,7 +13,7 @@ export type InputProps = Omit<
 > & {
   /** Rounded look: "pill" = capsule, "default" = 16px corners (default) */
   tone?: "default" | "pill";
-  /** Visual size of the control (defaults to small) */
+  /** Visual size of the control (defaults to medium) */
   size?: InputSize | number;
   /** When true, increases left padding for icons */
   indent?: boolean;
@@ -24,9 +24,9 @@ export type InputProps = Omit<
 };
 
 const SIZE: Record<InputSize, string> = {
-  sm: "h-5",
-  md: "h-6",
-  lg: "h-7",
+  sm: "2.25rem", // h-9
+  md: "2.5rem", // h-10
+  lg: "2.75rem", // h-11
 };
 
 /**
@@ -44,7 +44,7 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
     name,
     "aria-label": ariaLabel,
     tone = "default",
-    size = "sm",
+    size = "md",
     indent = false,
     children,
     hasEndSlot = false,
@@ -63,13 +63,15 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
 
   const showEndSlot = hasEndSlot || React.Children.count(children) > 0;
 
+  const controlHeight = typeof size === "string" ? SIZE[size] : SIZE.md;
+
   return (
     <FieldShell
       tone={tone}
       error={error}
       disabled={disabled}
       className={className}
-      style={style}
+      style={{ "--control-h": controlHeight, ...style } as React.CSSProperties}
     >
       <input
         ref={ref}
@@ -77,8 +79,7 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
         name={finalName}
         size={typeof size === "number" ? size : undefined}
         className={cn(
-          "w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none",
-          typeof size === "string" ? SIZE[size] : SIZE.sm,
+          "w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]",
           indent && "pl-7",
           showEndSlot && "pr-7",
           inputClassName

--- a/tests/ui/__snapshots__/input.test.tsx.snap
+++ b/tests/ui/__snapshots__/input.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`Input > renders default state 1`] = `
 <div
   class="relative inline-flex w-full items-center rounded-xl border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
-  style="--theme-ring: hsl(var(--ring));"
+  style="--theme-ring: hsl(var(--ring)); --control-h: 2.5rem;"
 >
   <input
-    class="w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-5"
+    class="w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
     id=":r0:"
     name="test"
   />
@@ -16,10 +16,10 @@ exports[`Input > renders default state 1`] = `
 exports[`Input > renders disabled state 1`] = `
 <div
   class="relative inline-flex w-full items-center rounded-xl border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-60 pointer-events-none"
-  style="--theme-ring: hsl(var(--ring));"
+  style="--theme-ring: hsl(var(--ring)); --control-h: 2.5rem;"
 >
   <input
-    class="w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-5"
+    class="w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
     disabled=""
     id=":r4:"
     name="test"
@@ -30,11 +30,11 @@ exports[`Input > renders disabled state 1`] = `
 exports[`Input > renders error state 1`] = `
 <div
   class="relative inline-flex w-full items-center rounded-xl border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-[hsl(var(--destructive)/0.6)] focus-within:ring-[hsl(var(--destructive)/0.35)]"
-  style="--theme-ring: hsl(var(--ring));"
+  style="--theme-ring: hsl(var(--ring)); --control-h: 2.5rem;"
 >
   <input
     aria-invalid="true"
-    class="w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-5"
+    class="w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
     id=":r2:"
     name="test"
   />
@@ -44,10 +44,10 @@ exports[`Input > renders error state 1`] = `
 exports[`Input > renders focus state 1`] = `
 <div
   class="relative inline-flex w-full items-center rounded-xl border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,rgba(195,255,255,0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
-  style="--theme-ring: hsl(var(--ring));"
+  style="--theme-ring: hsl(var(--ring)); --control-h: 2.5rem;"
 >
   <input
-    class="w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-5"
+    class="w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
     id=":r1:"
     name="test"
   />


### PR DESCRIPTION
## Summary
- expand input control sizes to 36/40/44px and default to medium
- showcase new input sizes on prompts pages
- update tests for new input height

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Type 'string' is not assignable to type 'boolean | undefined')*


------
https://chatgpt.com/codex/tasks/task_e_68bd8af0abd8832c9e96a1aacb472a59