### PR TITLE
feat: update button sizing and default

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -77,6 +77,9 @@ export default function Page() {
       <p className="mb-4 text-sm text-muted-foreground">
         Control height token <code>--control-h</code> now snaps to 44px to align with the 4px spacing grid.
       </p>
+      <p className="mb-4 text-sm text-muted-foreground">
+        Buttons now default to the 40px <code>md</code> size and follow a 36/40/44px scale.
+      </p>
       <div className="mb-8">
         <TabBar items={viewTabs} value={view} onValueChange={setView} />
       </div>

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -8,21 +8,21 @@ import { neuRaised, neuInset } from "./Neu";
 
 export const buttonSizes = {
   sm: {
-    height: "h-5",
-    padding: "px-3",
-    text: "text-[12px]",
-    gap: "gap-2",
-  },
-  md: {
-    height: "h-6",
+    height: "h-9",
     padding: "px-4",
     text: "text-[14px]",
     gap: "gap-2",
   },
-  lg: {
-    height: "h-7",
+  md: {
+    height: "h-10",
     padding: "px-5",
     text: "text-[16px]",
+    gap: "gap-2",
+  },
+  lg: {
+    height: "h-11",
+    padding: "px-6",
+    text: "text-[18px]",
     gap: "gap-2",
   },
 } as const;
@@ -35,7 +35,7 @@ export type ButtonProps = React.ComponentProps<typeof motion.button> & {
 };
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, size = "sm", variant = "secondary", children, ...rest }, ref) => {
+  ({ className, size = "md", variant = "secondary", children, ...rest }, ref) => {
     const s = buttonSizes[size];
     const base = cn(
       "relative inline-flex items-center justify-center rounded-2xl border border-[--theme-ring] font-medium transition-all duration-200 focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--theme-ring]",


### PR DESCRIPTION
## Summary
- scale button sizes to 36/40/44px with adjusted padding and fonts
- default `Button` to medium (40px) size
- document new button scale on prompts page

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck` *(fails: Type 'string' is not assignable to type 'boolean | undefined')*


------
https://chatgpt.com/codex/tasks/task_e_68bd8d47e6a4832ca928c21d29513455