### PR TITLE
refactor: tokenized badge sizing

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -20,6 +20,7 @@ import {
   SearchBar,
   Snackbar,
 } from "@/components/ui";
+import BadgePrimitive from "@/components/ui/primitives/Badge";
 import { Plus, Sun } from "lucide-react";
 import GoalsTabs, { FilterKey } from "@/components/goals/GoalsTabs";
 
@@ -242,6 +243,13 @@ export default function Page() {
               <Badge>Neutral</Badge>
               <Badge variant="accent">Accent</Badge>
               <Badge variant="pill">Pill</Badge>
+            </div>
+          </div>
+          <div className="flex flex-col items-center space-y-2">
+            <span className="text-sm font-medium">Badge Primitive</span>
+            <div className="w-56 flex justify-center gap-2">
+              <BadgePrimitive size="xs">XS</BadgePrimitive>
+              <BadgePrimitive size="sm">SM</BadgePrimitive>
             </div>
           </div>
           <div className="flex flex-col items-center space-y-2">

--- a/src/components/ui/primitives/Badge.tsx
+++ b/src/components/ui/primitives/Badge.tsx
@@ -27,8 +27,8 @@ export type BadgeProps<T extends React.ElementType = "span"> = BadgeOwnProps<T> 
   Omit<React.ComponentPropsWithoutRef<T>, keyof BadgeOwnProps<T>>;
 
 const sizeMap: Record<Size, string> = {
-  xs: "px-2 py-[3px] text-[11px] leading-none",
-  sm: "px-2.5 py-[5px] text-[12px] leading-none",
+  xs: "px-2 py-1 text-xs leading-none",
+  sm: "px-2.5 py-2 text-xs leading-none",
 };
 
 const toneBorder: Record<Tone, string> = {


### PR DESCRIPTION
## Summary
- replace hard-coded badge padding with spacing tokens
- align badge xs font with design system and display primitive on prompts page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd8f58d1a8832c8c1073e5dd0cf633