### PR TITLE
Fix styled-jsx attribute types

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -330,7 +330,7 @@ export default function GoalsPage() {
         </div>
       </section>
 
-      <style jsx="true">{`
+      <style jsx>{`
         .tabular-nums {
           font-variant-numeric: tabular-nums;
         }

--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -347,7 +347,7 @@ export default function RemindersTab() {
         </SectionCard.Body>
 
         {/* Local styles: keep neon-note flicker; divider is handled by Hero2 */}
-        <style jsx="true">{`
+        <style jsx>{`
           .neon-primary { --neon: var(--primary); }
           .neon-life { --neon: var(--accent); }
 

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -294,7 +294,7 @@ export default function TimerTab() {
       </SectionCard.Body>
 
       {/* Local styles for neon pills, glitch loader, and complete state */}
-      <style jsx="true">{`
+      <style jsx>{`
         /* Disable card hover bloom */
         .no-hover.goal-card:hover {
           box-shadow: 0 0 0 var(--hairline-w) hsl(var(--card-hairline)) inset,

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -191,7 +191,7 @@ function NeonIcon({
           opacity: phase === "powerdown" ? 0.6 : 0,
         }}
       />
-      <style jsx="true">{`
+      <style jsx>{`
         @keyframes neonCore {
           0% { opacity:.66; transform:scale(1) }
           50%{ opacity:.88; transform:scale(1.012) }

--- a/src/components/reviews/ReviewSummary.tsx
+++ b/src/components/reviews/ReviewSummary.tsx
@@ -190,7 +190,7 @@ function NeonIcon({
       )}
 
       {/* keyframes (scoped) */}
-      <style jsx="true">{`
+      <style jsx>{`
         @keyframes neonCore {
           0% { opacity: .66; transform: scale(1) }
           50%{ opacity: .88; transform: scale(1.012) }

--- a/src/components/ui/layout/Hero2.tsx
+++ b/src/components/ui/layout/Hero2.tsx
@@ -247,7 +247,7 @@ export function Hero2SearchBar({
 /* ───────────── CSS injected globally via styled-jsx (unchanged) ─────────── */
 export function Hero2GlitchStyles() {
   return (
-    <style jsx="true" global>{`
+    <style jsx global>{`
       /* === Hero2: header background layers =============================== */
       .hero2-frame {
         --hero2-c1: hsl(var(--accent));

--- a/src/components/ui/layout/TitleBar.tsx
+++ b/src/components/ui/layout/TitleBar.tsx
@@ -15,7 +15,7 @@ export default function TitleBar({ label, idText = "ID:0x13LG" }: Props) {
       </div>
 
       {/* Scoped styles — no globals, no theme drift */}
-      <style jsx="true">{`
+      <style jsx>{`
         .term-mini {
           border: 1px solid hsl(var(--border));
           background:

--- a/src/components/ui/league/pillars/PillarBadge.tsx
+++ b/src/components/ui/league/pillars/PillarBadge.tsx
@@ -115,7 +115,7 @@ export default function PillarBadge({
       {withIcon && <Icon className="icon" aria-hidden="true" />}
       <span className="label">{pillar}</span>
 
-      <style jsx="true">{`
+      <style jsx>{`
         .lg-pillar-badge {
           position: relative;
           display: inline-flex;

--- a/src/components/ui/selects/AnimatedSelect.tsx
+++ b/src/components/ui/selects/AnimatedSelect.tsx
@@ -401,7 +401,7 @@ export default function AnimatedSelect({
    ───────────────────────────────────────────────────────── */
 function GlitchStyles() {
   return (
-    <style jsx="true">{`
+    <style jsx>{`
       /* caret jitter */
       .caret { transition: transform .18s var(--ease-out), filter .18s var(--ease-out); }
       .caret-open { transform: rotate(180deg); }

--- a/src/components/ui/toggles/CheckCircle.tsx
+++ b/src/components/ui/toggles/CheckCircle.tsx
@@ -302,7 +302,7 @@ export default function CheckCircle({
         )}
       </span>
 
-      <style jsx="true">{`
+      <style jsx>{`
         @keyframes ccShift {
           0% { background-position: 0% 50%; }
           100% { background-position: 200% 50%; }

--- a/src/components/ui/toggles/NeonIcon.tsx
+++ b/src/components/ui/toggles/NeonIcon.tsx
@@ -166,7 +166,7 @@ export function NeonIcon({
       />
 
       {/* Scoped keyframes */}
-      <style jsx="true">{`
+      <style jsx>{`
         .ni-root { width: var(--ni-size); height: var(--ni-size); }
 
         @keyframes niCore {


### PR DESCRIPTION
## Summary
- replace `jsx="true"` with boolean `jsx` in styled-jsx blocks across the app

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: React warnings about `jsx` attribute)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd944e66f4832c88b74c5bee9959e6