### PR TITLE
fix: clarify styled-jsx boolean attribute

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -330,6 +330,7 @@ export default function GoalsPage() {
         </div>
       </section>
 
+      {/* Use boolean styled-jsx attribute to satisfy typings */}
       <style jsx>{`
         .tabular-nums {
           font-variant-numeric: tabular-nums;


### PR DESCRIPTION
## Summary
- note in `GoalsPage` that `styled-jsx` uses a boolean attribute to satisfy typings

## Testing
- `npm test -- --run`
- `npm run build`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bda063cb08832c9026b586a1d70efa