### PR TITLE
Refactor Textarea styles

### DIFF
--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -89,7 +89,7 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
             <span className="text-xs text-[hsl(var(--muted-foreground))]">Notes (optional)</span>
             <Textarea
               tone="default"
-              className="min-h-24 text-sm"
+              textareaClassName="min-h-24 text-sm"
               value={notes}
               onChange={(e) => onNotesChange(e.target.value)}
               aria-describedby="goal-form-help goal-form-error"

--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -353,7 +353,7 @@ function ReminderCard({
               placeholder="Short, skimmable sentence. Keep it actionable."
               value={body}
               onChange={(e) => setBody(e.currentTarget.value)}
-              className="min-h-[88px]"
+              textareaClassName="min-h-[88px]"
             />
             <Input
               aria-label="Tags (comma separated)"

--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -500,7 +500,7 @@ function RemTile({
               placeholder="Short, skimmable sentence."
               value={body}
               onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setBody(e.currentTarget.value)}
-              className="textarea-base"
+              textareaClassName="textarea-base"
             />
 
             <label className="text-xs opacity-70">Tags</label>

--- a/src/components/planner/WeekNotes.tsx
+++ b/src/components/planner/WeekNotes.tsx
@@ -51,7 +51,7 @@ export default function WeekNotes({ iso }: Props) {
           value={value}
           onChange={(e) => setValue(e.target.value)}
           name={`notes-${iso}`}
-          className="planner-textarea"
+          textareaClassName="planner-textarea"
           onBlur={commit}
         />
         <div className="mt-2 text-xs text-[hsl(var(--muted-foreground))]" aria-live="polite">

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -1034,7 +1034,7 @@ export default function ReviewEditor({
             onChange={(e) => setNotes(e.target.value)}
             onBlur={commitNotes}
             placeholder="Key moments, mistakes to fix, drills to run…"
-            className="textarea-base min-h-[180px]"
+            textareaClassName="textarea-base min-h-[180px]"
           />
         </div>
       </div>

--- a/src/components/team/Builder.tsx
+++ b/src/components/team/Builder.tsx
@@ -283,7 +283,7 @@ function SideEditor(props: {
             placeholder="Short plan, spikes, target calls…"
             value={value.notes ?? ""}
             onChange={(e) => onNotes(e.currentTarget.value)}
-            className="planner-textarea"
+            textareaClassName="planner-textarea"
             rows={4}
           />
         </div>

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -404,7 +404,7 @@ export default function MyComps({ query = "" }: MyCompsProps) {
                           dir="ltr"
                           aria-label="Notes"
                           rows={4}
-                          className="planner-textarea"
+                          textareaClassName="planner-textarea"
                           value={c.notes ?? ""}
                           onChange={e => patch(c.id, { notes: e.target.value })}
                         />


### PR DESCRIPTION
## Summary
- use `textareaClassName` prop to style inner `<textarea>` elements across planner, goal, team, and review components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdad502fe4832ca491080ab83ec79c