### PR TITLE
Use slugified id as Textarea name fallback

### DIFF
--- a/src/components/ui/primitives/Textarea.tsx
+++ b/src/components/ui/primitives/Textarea.tsx
@@ -35,7 +35,7 @@ export default React.forwardRef<HTMLTextAreaElement, TextareaProps>(function Tex
   // Use React-generated id by default so multiple fields sharing an aria-label
   // do not end up with duplicate ids.
   const finalId = id || auto;
-  const finalName = name || fromAria || finalId;
+  const finalName = name || fromAria || slugify(finalId);
 
   const error =
     props["aria-invalid"] === true || props["aria-invalid"] === "true";

--- a/tests/ui/textarea.test.tsx
+++ b/tests/ui/textarea.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, cleanup, fireEvent } from '@testing-library/react';
 import { describe, it, expect, afterEach } from 'vitest';
 import Textarea from '../../src/components/ui/primitives/Textarea';
+import { slugify } from '../../src/lib/utils';
 
 afterEach(cleanup);
 
@@ -60,5 +61,11 @@ describe('Textarea', () => {
     const style = getComputedStyle(ta);
     expect(style.outlineStyle === 'none' || style.outlineStyle === '').toBe(true);
     expect(style.outlineWidth === '0px' || style.outlineWidth === '').toBe(true);
+  });
+
+  it('slugifies generated id for default name', () => {
+    const { getByRole } = render(<Textarea />);
+    const ta = getByRole('textbox') as HTMLTextAreaElement;
+    expect(ta.name).toBe(slugify(ta.id));
   });
 });


### PR DESCRIPTION
## Summary
- sanitize Textarea `name` fallback by slugifying generated id
- test that Textarea uses slugified id when no name provided

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bdb1e5c450832cb44d6c77e84783e5