### PR TITLE
fix: ensure unique input names

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -34,6 +34,9 @@ This project ships with a small design system based on Tailwind CSS and CSS vari
 - Reusable building blocks live under `src/components/ui/primitives` (e.g. `Button`, `Badge`, `Input`).
 - Prefer composing these primitives rather than creating bespoke styles.
 - Variant props are provided for sizing and icon placement where appropriate.
+- `Input` fields reuse their generated `id` as the default `name` to avoid
+  collisions when several fields share the same label. Supply a custom `name`
+  (or `id`) if you need specific form field identifiers.
 
 ```tsx
 import { Button } from "@/components/ui/primitives/Button";

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -33,7 +33,9 @@ const SIZE: Record<InputSize, string> = {
  * Input — Matte field with optional trailing slot.
  * - Defaults to `tone="default"` (16px corners)
  * - Accepts className overrides and passes all standard <input> props
- * - Auto-generates stable `id` and `name` if not provided
+ * - Auto-generates a stable `id`; if no `name` is supplied, the generated id is
+ *   reused to ensure uniqueness. The `aria-label` is only slugified when a
+ *   custom `id` guarantees uniqueness.
  */
 export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
   {
@@ -55,7 +57,7 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
   const auto = React.useId();
   const fromAria = slugify(ariaLabel as string | undefined);
   const finalId = id || auto;
-  const finalName = name || fromAria || finalId;
+  const finalName = name || (id ? fromAria : undefined) || finalId;
 
   const error =
     props["aria-invalid"] === true || props["aria-invalid"] === "true";

--- a/tests/ui/__snapshots__/input.test.tsx.snap
+++ b/tests/ui/__snapshots__/input.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Input > renders default state 1`] = `
   <input
     class="w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
     id=":r0:"
-    name="test"
+    name=":r0:"
   />
 </div>
 `;
@@ -22,7 +22,7 @@ exports[`Input > renders disabled state 1`] = `
     class="w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
     disabled=""
     id=":r4:"
-    name="test"
+    name=":r4:"
   />
 </div>
 `;
@@ -36,7 +36,7 @@ exports[`Input > renders error state 1`] = `
     aria-invalid="true"
     class="w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
     id=":r2:"
-    name="test"
+    name=":r2:"
   />
 </div>
 `;
@@ -49,7 +49,7 @@ exports[`Input > renders focus state 1`] = `
   <input
     class="w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
     id=":r1:"
-    name="test"
+    name=":r1:"
   />
 </div>
 `;

--- a/tests/ui/input.test.tsx
+++ b/tests/ui/input.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, cleanup, fireEvent } from '@testing-library/react';
 import { describe, it, expect, afterEach } from 'vitest';
 import { Input } from '@/components/ui';
+import { slugify } from '@/lib/utils';
 
 afterEach(cleanup);
 
@@ -64,6 +65,21 @@ describe('Input', () => {
     const style = getComputedStyle(input);
     expect(style.outlineStyle === 'none' || style.outlineStyle === '').toBe(true);
     expect(style.outlineWidth === '0px' || style.outlineWidth === '').toBe(true);
+  });
+
+  it('defaults name to generated id', () => {
+    const { getByRole } = render(<Input aria-label="name" />);
+    const input = getByRole('textbox') as HTMLInputElement;
+    expect(input.name).toBe(input.id);
+  });
+
+  it('uses slugified label when custom id provided', () => {
+    const { getByRole } = render(
+      <Input id="email" aria-label="Email Address" />
+    );
+    const input = getByRole('textbox') as HTMLInputElement;
+    expect(input.id).toBe('email');
+    expect(input.name).toBe(slugify('Email Address'));
   });
 
   it('applies rounded-full on pill tone', () => {


### PR DESCRIPTION
## Summary
- default `Input` name to generated id when not provided
- document Input naming behavior
- add tests for new default naming

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bdb2dcd584832cb5bb01534201a6d3