### PR TITLE
fix: clear selected project on deletion

### DIFF
--- a/src/components/planner/DayCard.tsx
+++ b/src/components/planner/DayCard.tsx
@@ -38,8 +38,7 @@ export default function DayCard({ iso, isToday }: Props) {
     if (selectedProjectId && !projects.some(p => p.id === selectedProjectId)) {
       setSelectedProjectId("");
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [projects.length]);
+  }, [projects, selectedProjectId, setSelectedProjectId]);
 
   // Header text + progress
   const date = React.useMemo(() => new Date(`${iso}T00:00:00`), [iso]);

--- a/tests/planner/DayCard.test.tsx
+++ b/tests/planner/DayCard.test.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { render, act, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import DayCard from '@/components/planner/DayCard';
+import { PlannerProvider, useDay, useSelectedProject } from '@/components/planner/usePlanner';
+
+const iso = '2024-01-01';
+
+const TestHarness = React.forwardRef((_, ref: React.Ref<any>) => {
+  const day = useDay(iso);
+  const [selectedProjectId, setSelectedProjectId] = useSelectedProject(iso);
+  React.useImperativeHandle(ref, () => ({ day, selectedProjectId, setSelectedProjectId }));
+  return <DayCard iso={iso} />;
+});
+
+TestHarness.displayName = 'TestHarness';
+
+describe('DayCard', () => {
+  it('clears selection when selected project is deleted', async () => {
+    const harnessRef = React.createRef<any>();
+    render(
+      <PlannerProvider>
+        <TestHarness ref={harnessRef} />
+      </PlannerProvider>
+    );
+
+    let pid = '';
+    act(() => {
+      pid = harnessRef.current.day.addProject('Proj');
+      harnessRef.current.setSelectedProjectId(pid);
+    });
+    expect(harnessRef.current.selectedProjectId).toBe(pid);
+
+    act(() => {
+      harnessRef.current.day.deleteProject(pid);
+    });
+
+    await waitFor(() => {
+      expect(harnessRef.current.selectedProjectId).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- reactively clear selected project when it's removed
- add regression test for project deletion clearing selection

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bdb2900cc0832c9e021ea365099e23