### PR TITLE
feat: make textarea resize customizable

### DIFF
--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -131,6 +131,7 @@ export default function PromptsPage() {
             placeholder="Write your prompt or snippet…"
             value={textDraft}
             onChange={(e) => setTextDraft(e.target.value)}
+            resize="resize-y"
           />
         </div>
 
@@ -199,8 +200,8 @@ export default function PromptsPage() {
         <Card className="mt-8 space-y-4">
           <h3 className="type-title">Textarea</h3>
           <div className="space-y-3">
-            <Textarea placeholder="Default" />
-            <Textarea placeholder="Pill" tone="pill" />
+            <Textarea placeholder="Default" resize="resize-y" />
+            <Textarea placeholder="Pill" tone="pill" resize="resize-y" />
           </div>
         </Card>
         <Card className="mt-8 space-y-4">

--- a/src/components/ui/primitives/Textarea.tsx
+++ b/src/components/ui/primitives/Textarea.tsx
@@ -4,6 +4,11 @@ import * as React from "react";
 import { cn, slugify } from "@/lib/utils";
 import FieldShell from "./FieldShell";
 
+/**
+ * Textarea primitive with optional pill tone.
+ * No default `resize-*` utility is applied; use the `resize` prop or
+ * `textareaClassName` to control resizing behavior.
+ */
 export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
   /** Rounded look without needing a global .planner-textarea class. */
   tone?: "default" | "pill";
@@ -11,17 +16,20 @@ export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & 
   className?: string;
   /** Optional className for the inner <textarea> element */
   textareaClassName?: string;
+  /** Tailwind `resize-*` utility to control resizing behavior */
+  resize?: string;
 };
 
-  const INNER =
-    "block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent " +
+const INNER =
+  "block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent " +
   "text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] " +
-  "focus:[outline:none] focus-visible:[outline:none] resize-y disabled:opacity-50 disabled:cursor-not-allowed";
+  "focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed";
 
 export default React.forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
   {
     className,
     textareaClassName,
+    resize,
     id,
     name,
     "aria-label": ariaLabel,
@@ -51,7 +59,12 @@ export default React.forwardRef<HTMLTextAreaElement, TextareaProps>(function Tex
         ref={ref}
         id={finalId}
         name={finalName}
-          className={cn(INNER, tone === "pill" && "rounded-full min-h-6", textareaClassName)}
+        className={cn(
+          INNER,
+          tone === "pill" && "rounded-full min-h-6",
+          resize,
+          textareaClassName,
+        )}
         {...props}
       />
     </FieldShell>

--- a/tests/ui/__snapshots__/textarea.test.tsx.snap
+++ b/tests/ui/__snapshots__/textarea.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Textarea > renders default state 1`] = `
   style="--theme-ring: hsl(var(--ring));"
 >
   <textarea
-    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus:[outline:none] focus-visible:[outline:none] resize-y disabled:opacity-50 disabled:cursor-not-allowed"
+    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
     id=":r0:"
     name="test"
   />
@@ -19,7 +19,7 @@ exports[`Textarea > renders disabled state 1`] = `
   style="--theme-ring: hsl(var(--ring));"
 >
   <textarea
-    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus:[outline:none] focus-visible:[outline:none] resize-y disabled:opacity-50 disabled:cursor-not-allowed"
+    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
     disabled=""
     id=":r2:"
     name="test"
@@ -34,7 +34,7 @@ exports[`Textarea > renders error state 1`] = `
 >
   <textarea
     aria-invalid="true"
-    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus:[outline:none] focus-visible:[outline:none] resize-y disabled:opacity-50 disabled:cursor-not-allowed"
+    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
     id=":r5:"
     name="test"
   />
@@ -47,7 +47,7 @@ exports[`Textarea > renders focus state 1`] = `
   style="--theme-ring: hsl(var(--ring));"
 >
   <textarea
-    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus:[outline:none] focus-visible:[outline:none] resize-y disabled:opacity-50 disabled:cursor-not-allowed"
+    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
     id=":r1:"
     name="test"
   />
@@ -60,7 +60,7 @@ exports[`Textarea > renders pill tone 1`] = `
   style="--theme-ring: hsl(var(--ring));"
 >
   <textarea
-    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus:[outline:none] focus-visible:[outline:none] resize-y disabled:opacity-50 disabled:cursor-not-allowed rounded-full min-h-6"
+    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed rounded-full min-h-6"
     id=":r3:"
     name="test"
   />

--- a/tests/ui/textarea.test.tsx
+++ b/tests/ui/textarea.test.tsx
@@ -63,6 +63,14 @@ describe('Textarea', () => {
     expect(style.outlineWidth === '0px' || style.outlineWidth === '').toBe(true);
   });
 
+  it('applies resize prop', () => {
+    const { getByRole } = render(
+      <Textarea aria-label="resize" resize="resize-y" />
+    );
+    const ta = getByRole('textbox');
+    expect(ta).toHaveClass('resize-y');
+  });
+
   it('slugifies generated id for default name', () => {
     const { getByRole } = render(<Textarea />);
     const ta = getByRole('textbox') as HTMLTextAreaElement;


### PR DESCRIPTION
## Summary
- allow Textarea resize behavior to be customized via new `resize` prop
- remove default `resize-y` utility and document behavior
- update PromptsPage and tests for new API

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bdb528c0b8832c82f6ac9ecb60c748