### PR TITLE
feat: allow numeric Input heights

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -37,6 +37,9 @@ This project ships with a small design system based on Tailwind CSS and CSS vari
 - `Input` fields reuse their generated `id` as the default `name` to avoid
   collisions when several fields share the same label. Supply a custom `name`
   (or `id`) if you need specific form field identifiers.
+- Control height is set via a `height` prop that accepts `"sm" | "md" | "lg"`
+  or a numeric Tailwind token (e.g. `12` for `h-12`). The native `size`
+  attribute remains available for setting character width.
 
 ```tsx
 import { Button } from "@/components/ui/primitives/Button";

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -192,9 +192,10 @@ export default function Page() {
             <div className="flex flex-col items-center space-y-2">
               <span className="text-sm font-medium">Input</span>
               <div className="w-56 space-y-2">
-                <Input size="sm" placeholder="Small" />
+                <Input height="sm" placeholder="Small" />
                 <Input placeholder="Medium" />
-                <Input size="lg" placeholder="Large" />
+                <Input height="lg" placeholder="Large" />
+                <Input height={12} placeholder="h-12" />
                 <Input tone="pill" placeholder="Pill" />
                 <Input placeholder="With icon" hasEndSlot>
                   <Plus className="absolute right-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -160,9 +160,10 @@ export default function PromptsPage() {
             Customize focus rings with the <code>--theme-ring</code> variable.
           </p>
           <div className="space-y-3">
-            <Input size="sm" placeholder="Small" />
+            <Input height="sm" placeholder="Small" />
             <Input placeholder="Medium" />
-            <Input size="lg" placeholder="Large" />
+            <Input height="lg" placeholder="Large" />
+            <Input height={12} placeholder="h-12" />
             <Input placeholder="Pill" tone="pill" />
             <Input placeholder="Error" aria-invalid="true" />
             <Input

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -5,16 +5,16 @@ import * as React from "react";
 import { cn, slugify } from "@/lib/utils";
 import FieldShell from "./FieldShell";
 
-type InputSize = "sm" | "md" | "lg";
+export type InputSize = "sm" | "md" | "lg";
 
 export type InputProps = Omit<
   React.InputHTMLAttributes<HTMLInputElement>,
-  "size"
+  "height"
 > & {
   /** Rounded look: "pill" = capsule, "default" = 16px corners (default) */
   tone?: "default" | "pill";
-  /** Visual size of the control (defaults to medium) */
-  size?: InputSize | number;
+  /** Visual height of the control (defaults to medium) */
+  height?: InputSize | number;
   /** When true, increases left padding for icons */
   indent?: boolean;
   /** Optional className for the inner <input> element */
@@ -23,7 +23,7 @@ export type InputProps = Omit<
   hasEndSlot?: boolean;
 };
 
-const SIZE: Record<InputSize, string> = {
+const HEIGHT: Record<InputSize, string> = {
   sm: "2.25rem", // h-9
   md: "2.5rem", // h-10
   lg: "2.75rem", // h-11
@@ -46,7 +46,7 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
     name,
     "aria-label": ariaLabel,
     tone = "default",
-    size = "md",
+    height = "md",
     indent = false,
     children,
     hasEndSlot = false,
@@ -65,7 +65,12 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
 
   const showEndSlot = hasEndSlot || React.Children.count(children) > 0;
 
-  const controlHeight = typeof size === "string" ? SIZE[size] : SIZE.md;
+  const controlHeight =
+    typeof height === "string"
+      ? HEIGHT[height]
+      : typeof height === "number"
+        ? `${height / 4}rem`
+        : HEIGHT.md;
 
   return (
     <FieldShell
@@ -79,7 +84,6 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
         ref={ref}
         id={finalId}
         name={finalName}
-        size={typeof size === "number" ? size : undefined}
         className={cn(
           "w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]",
           indent && "pl-7",

--- a/src/components/ui/primitives/SearchBar.tsx
+++ b/src/components/ui/primitives/SearchBar.tsx
@@ -3,11 +3,11 @@
 import * as React from "react";
 import { Search, X } from "lucide-react";
 import { cn } from "@/lib/utils";
-import Input from "./Input";
+import Input, { type InputSize } from "./Input";
 
 export type SearchBarProps = Omit<
   React.InputHTMLAttributes<HTMLInputElement>,
-  "onChange"
+  "onChange" | "height"
 > & {
   value: string;
   onValueChange?: (next: string) => void;
@@ -16,6 +16,8 @@ export type SearchBarProps = Omit<
   right?: React.ReactNode;
   clearable?: boolean;
   debounceMs?: number;
+  /** Visual height of the control */
+  height?: InputSize | number;
 };
 
 export default function SearchBar({
@@ -32,6 +34,7 @@ export default function SearchBar({
   autoCorrect = "off",
   spellCheck = false,
   autoCapitalize = "none",
+  height,
   ...rest
 }: SearchBarProps) {
   // Hydration-safe: initial render = prop value
@@ -90,11 +93,12 @@ export default function SearchBar({
           }}
           placeholder={placeholder}
           indent
-            className={cn(
-              "w-full",
-              showClear && "pr-7",
-              "border-[hsl(var(--border))] bg-[hsl(var(--input))]"
-            )}
+          height={height}
+          className={cn(
+            "w-full",
+            showClear && "pr-7",
+            "border-[hsl(var(--border))] bg-[hsl(var(--input))]"
+          )}
           aria-label={rest["aria-label"] ?? "Search"}
           type="search"
           autoComplete={autoComplete}
@@ -105,12 +109,12 @@ export default function SearchBar({
         />
 
         {showClear && (
-            <button
-              type="button"
-              aria-label="Clear"
-              title="Clear"
-                className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-foreground"
-              onClick={() => {
+          <button
+            type="button"
+            aria-label="Clear"
+            title="Clear"
+            className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-foreground"
+            onClick={() => {
               setQuery("");
               onValueChange?.("");
               inputRef.current?.focus();
@@ -126,3 +130,4 @@ export default function SearchBar({
     </form>
   );
 }
+


### PR DESCRIPTION
## Summary
- add `height` prop to Input with support for numeric Tailwind tokens
- update SearchBar and prompts demo to showcase custom heights
- document height prop vs HTML `size`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb7471ff8832cbe01c522682324ca