### PR TITLE
refactor: memoize deriveTitle in prompts page

### DIFF
--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -36,6 +36,12 @@ export default function PromptsPage() {
 
   const titleId = React.useId();
 
+  const deriveTitle = React.useCallback((p: Prompt) => {
+    if (p.title && p.title.trim()) return p.title.trim();
+    const firstLine = (p.text || "").split(/\r?\n/)[0]?.trim() || "";
+    return firstLine || "Untitled";
+  }, []);
+
   // Derived: filtered list (compute titles once per prompt)
   type PromptWithTitle = Prompt & { title: string };
   const filtered: PromptWithTitle[] = React.useMemo(() => {
@@ -48,13 +54,7 @@ export default function PromptsPage() {
       }
       return acc;
     }, []);
-  }, [prompts, query]);
-
-  function deriveTitle(p: Prompt) {
-    if (p.title && p.title.trim()) return p.title.trim();
-    const firstLine = (p.text || "").split(/\r?\n/)[0]?.trim() || "";
-    return firstLine || "Untitled";
-  }
+  }, [prompts, query, deriveTitle]);
 
   function save() {
     const text = textDraft.trim();


### PR DESCRIPTION
## Summary
- memoize deriveTitle with `React.useCallback`
- reference memoized title helper in filtered prompt list

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bdc3d08018832cbe2ad8d11e7afb45