### PR TITLE
Use shared shortDate formatter for dates

### DIFF
--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -5,7 +5,7 @@ import { SectionCard } from "@/components/ui";
 import Input from "@/components/ui/primitives/Input";
 import IconButton from "@/components/ui/primitives/IconButton";
 import { Trash2 } from "lucide-react";
-import { LOCALE } from "@/lib/utils";
+import { shortDate } from "@/lib/date";
 
 export type WaitItem = { id: string; text: string; createdAt: number };
 
@@ -42,7 +42,7 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
                     className="text-xs text-[hsl(var(--muted-foreground))] opacity-0 group-hover:opacity-100"
                     dateTime={new Date(it.createdAt).toISOString()}
                   >
-                    {new Date(it.createdAt).toLocaleDateString(LOCALE)}
+                    {shortDate.format(new Date(it.createdAt))}
                   </time>
                   <div className="flex items-center gap-1 ml-2">
                     <IconButton

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -29,7 +29,7 @@ import GoalsProgress from "./GoalsProgress";
 
 import { useLocalDB, uid } from "@/lib/db";
 import type { Goal, Pillar } from "@/lib/types";
-import { LOCALE } from "@/lib/utils";
+import { shortDate } from "@/lib/date";
 
 /* Tabs */
 import RemindersTab from "./RemindersTab";
@@ -265,7 +265,7 @@ export default function GoalsPage() {
                                   style={g.done ? { background: "var(--accent-overlay)" } : undefined}
                                 />
                                 <time className="tabular-nums" dateTime={new Date(g.createdAt).toISOString()}>
-                                  {new Date(g.createdAt).toLocaleDateString(LOCALE)}
+                                  {shortDate.format(new Date(g.createdAt))}
                                 </time>
                               </span>
                               <span className={g.done ? "text-[hsl(var(--accent))]" : ""}>

--- a/src/components/reviews/ReviewCard.tsx
+++ b/src/components/reviews/ReviewCard.tsx
@@ -2,7 +2,8 @@
 import "../reviews/style.css";
 
 import type { Review } from "@/lib/types";
-import { cn, LOCALE } from "@/lib/utils";
+import { cn } from "@/lib/utils";
+import { shortDate } from "@/lib/date";
 import { Badge, IconButton } from "@/components/ui";
 import { Pencil } from "lucide-react";
 
@@ -43,7 +44,7 @@ export default function ReviewCard({
             <span>Side: {review.side || "—"}</span>
             <span>Patch: {review.patch || "—"}</span>
             <span>Duration: {review.duration || "—"}</span>
-            <span>{created ? created.toLocaleDateString(LOCALE) : "—"}</span>
+            <span>{created ? shortDate.format(created) : "—"}</span>
           </div>
 
           {Array.isArray(review.tags) && review.tags.length > 0 && (

--- a/src/components/reviews/ReviewListItem.tsx
+++ b/src/components/reviews/ReviewListItem.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { cn } from "@/lib/utils";
 import type { Review } from "@/lib/types";
 import { Badge } from "@/components/ui";
+import { shortDate } from "@/lib/date";
 
 const itemBase =
   "review-tile relative w-full text-left h-auto min-h-[76px] p-4 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none";
@@ -15,15 +16,6 @@ const statusDotDefault = "bg-[hsl(var(--muted-foreground))]";
 const statusDotPulse = "animate-[pulse_2s_ease-in-out_infinite]";
 const itemLoading = cn(itemBase, "animate-pulse");
 const loadingLine = "h-3 rounded bg-[hsl(var(--muted))]";
-
-function formatDate(value: number | Date): string {
-  const d = typeof value === "number" ? new Date(value) : value;
-  return d.toLocaleDateString("en-US", {
-    month: "numeric",
-    day: "numeric",
-    year: "numeric",
-  });
-}
 
 export type ReviewListItemProps = {
   review?: Review;
@@ -54,7 +46,9 @@ export default function ReviewListItem({
   const subline = review?.notes?.trim() || "";
   const score = review?.score;
   const resultTag = review?.result ? review.result[0] : undefined;
-  const dateStr = review?.createdAt ? formatDate(review.createdAt) : "";
+  const dateStr = review?.createdAt
+    ? shortDate.format(new Date(review.createdAt))
+    : "";
 
   return (
     <div data-scope="reviews">

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,6 +1,14 @@
 // src/lib/date.ts
 // Shared date helpers for planner components
 
+import { LOCALE } from "./utils";
+
+export const shortDate = new Intl.DateTimeFormat(LOCALE, {
+  month: "numeric",
+  day: "numeric",
+  year: "numeric",
+});
+
 export function toISO(d: Date): string {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");


### PR DESCRIPTION
## Summary
- add `shortDate` Intl.DateTimeFormat helper
- use `shortDate.format` instead of `toLocaleDateString`

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bdc6714794832c8d19d0604e9f14d2