### PR TITLE
Refresh noir theme palette

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -167,6 +167,19 @@ export default function Page() {
             </div>
           </div>
           <div className="flex flex-col items-center space-y-2">
+            <span className="text-sm font-medium">Noir Background</span>
+            <div
+              className="w-56 h-24 rounded-md flex items-center justify-center"
+              style={{
+                backgroundColor: "hsl(350 70% 4%)",
+                color: "hsl(0 0% 92%)",
+                border: "1px solid hsl(350 40% 22%)",
+              }}
+            >
+              Noir
+            </div>
+          </div>
+          <div className="flex flex-col items-center space-y-2">
             <span className="text-sm font-medium">Hero</span>
             <div className="w-56">
               <Hero heading="Hero" eyebrow="Eyebrow" subtitle="Subtitle" sticky={false} />

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -214,26 +214,26 @@ html.theme-citrus {
 
 /* ---------- Noir ---------- */
 html.theme-noir {
-  --background: 0 0% 2%;
+  --background: 350 70% 4%;
   --foreground: 0 0% 92%;
   --text: var(--foreground);
-  --card: 0 0% 8%;
+  --card: 350 65% 8%;
   --panel: var(--card);
-  --border: 0 0% 18%;
+  --border: 350 40% 22%;
   --line: var(--border);
-  --input: 0 0% 14%;
-  --ring: 0 0% 40%;
+  --input: 350 45% 12%;
+  --ring: 0 90% 60%;
   --theme-ring: hsl(var(--ring));
-  --primary: 0 0% 40%;
+  --primary: 0 90% 60%;
   --primary-foreground: 0 0% 100%;
-  --primary-soft: 0 0% 20%;
-  --accent: 0 0% 67%;
-  --accent-2: 0 0% 94%;
-  --accent-soft: 0 0% 27%;
-  --muted: 0 0% 18%;
-  --muted-foreground: 0 0% 60%;
-  --shadow-color: 0 0% 40%;
-  --lav-deep: 0 0% 67%;
+  --primary-soft: 0 90% 24%;
+  --accent: 178 90% 60%;
+  --accent-2: 40 96% 58%;
+  --accent-soft: 178 90% 20%;
+  --muted: 350 35% 18%;
+  --muted-foreground: 350 25% 65%;
+  --shadow-color: 0 90% 50%;
+  --lav-deep: 0 90% 65%;
   --success: 140 60% 50%;
   --success-glow: 140 60% 40% / 0.6;
 }
@@ -375,23 +375,23 @@ html.theme-citrus body::after {
 /* Noir backdrop */
 html.theme-noir body {
   background-image:
-    radial-gradient(1000px 520px at 15% -10%, hsl(0 0% 100% / 0.06), transparent 60%),
-    radial-gradient(900px 520px at 110% 15%, hsl(0 0% 100% / 0.05), transparent 60%),
+    radial-gradient(1000px 520px at 15% -10%, hsl(0 80% 60% / 0.15), transparent 60%),
+    radial-gradient(900px 520px at 110% 15%, hsl(0 70% 55% / 0.12), transparent 60%),
     linear-gradient(180deg, hsl(var(--card) / 0.9), hsl(var(--background)));
   background-attachment: fixed, fixed, fixed;
 }
 html.theme-noir body::before {
   content: ""; position: fixed; inset: 0; pointer-events: none; z-index: 0;
-  background: repeating-linear-gradient(0deg, hsl(0 0% 100% / 0.045) 0 1px, transparent 1px 3px);
-  mix-blend-mode: soft-light; opacity: 0.25; animation: noir-scan 14s linear infinite;
+  background: repeating-linear-gradient(0deg, hsl(0 80% 60% / 0.05) 0 1px, transparent 1px 3px);
+  mix-blend-mode: screen; opacity: 0.2; animation: noir-scan 14s linear infinite;
 }
 html.theme-noir body::after {
   content: ""; position: fixed; inset: -12%; pointer-events: none; z-index: 0;
   background:
-    radial-gradient(80% 60% at 50% 120%, hsl(0 0% 0% / 0.4), transparent 70%),
-    radial-gradient(40% 25% at 6% 4%,  hsl(0 0% 67% / 0.12), transparent 60%),
-    radial-gradient(40% 25% at 94% 10%, hsl(0 0% 94% / 0.10), transparent 60%);
-  filter: blur(1.5px) saturate(105%); opacity: 0.9; animation: noir-drift 26s ease-in-out infinite alternate;
+    radial-gradient(80% 60% at 50% 120%, hsl(0 90% 6% / 0.45), transparent 70%),
+    radial-gradient(40% 25% at 6% 4%,  hsl(0 80% 60% / 0.15), transparent 60%),
+    radial-gradient(40% 25% at 94% 10%, hsl(0 60% 50% / 0.12), transparent 60%);
+  filter: blur(1.5px) saturate(110%); opacity: 0.9; animation: noir-drift 26s ease-in-out infinite alternate;
 }
 @keyframes noir-scan { 0%{background-position-y:0} 100%{background-position-y:100%} }
 @keyframes noir-drift { 0%{transform:translate3d(-1%,0,0)} 100%{transform:translate3d(1%,0,0)} }


### PR DESCRIPTION
## Summary
- Recolor Noir theme with deeper reds and cyan accents for sharper contrast
- Add red-hued backdrop gradients and scanline effects to Noir theme
- Showcase Noir theme background on prompts page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdbbe1880c832caf8820bffd7a2359