### PR TITLE
feat: add shared clipboard helper

### DIFF
--- a/src/components/team/Builder.tsx
+++ b/src/components/team/Builder.tsx
@@ -27,6 +27,7 @@ import {
   Copy,
 } from "lucide-react";
 import { useLocalDB } from "@/lib/db";
+import { copyText } from "@/lib/clipboard";
 
 /* ───────────────── types & constants ───────────────── */
 
@@ -135,16 +136,7 @@ export default function Builder() {
             enemies: selection === "enemies" ? state.enemies : EMPTY_TEAM,
           });
 
-    try {
-      await navigator.clipboard.writeText(text);
-    } catch {
-      const ta = document.createElement("textarea");
-      ta.value = text;
-      document.body.appendChild(ta);
-      ta.select();
-      document.execCommand("copy");
-      document.body.removeChild(ta);
-    }
+    await copyText(text);
     setCopied(selection);
     setTimeout(() => setCopied(null), 1300);
   }

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -14,6 +14,7 @@ import "../team/style.css";
 
 import * as React from "react";
 import { useLocalDB, uid } from "@/lib/db";
+import { copyText } from "@/lib/clipboard";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import IconButton from "@/components/ui/primitives/IconButton";
 import Input from "@/components/ui/primitives/Input";
@@ -77,19 +78,6 @@ function isStringArray(v: unknown): v is string[] {
 function safeNumber(v: unknown, fallback: number): number {
   const n = typeof v === "number" ? v : Number.NaN;
   return Number.isFinite(n) ? n : fallback;
-}
-
-async function copyText(text: string) {
-  try {
-    await navigator.clipboard.writeText(text);
-  } catch {
-    const ta = document.createElement("textarea");
-    ta.value = text;
-    document.body.appendChild(ta);
-    ta.select();
-    document.execCommand("copy");
-    ta.remove();
-  }
 }
 
 function stringify(c: TeamComp) {

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,16 @@
+// src/lib/clipboard.ts
+// Shared clipboard helper with textarea fallback.
+
+export async function copyText(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    document.body.appendChild(ta);
+    ta.select();
+    document.execCommand("copy");
+    ta.remove();
+  }
+}
+


### PR DESCRIPTION
## Summary
- add clipboard helper with textarea fallback
- use clipboard helper in team builder
- use clipboard helper in custom comps

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdcccac25c832c9231b72f095f8374