### PR TITLE
test: ensure textareaClassName is applied

### DIFF
--- a/tests/ui/textarea.test.tsx
+++ b/tests/ui/textarea.test.tsx
@@ -71,6 +71,14 @@ describe('Textarea', () => {
     expect(ta).toHaveClass('resize-y');
   });
 
+  it('applies textareaClassName to textarea', () => {
+    const { getByRole } = render(
+      <Textarea aria-label="custom" textareaClassName="custom" />
+    );
+    const ta = getByRole('textbox');
+    expect(ta).toHaveClass('custom');
+  });
+
   it('slugifies generated id for default name', () => {
     const { getByRole } = render(<Textarea />);
     const ta = getByRole('textbox') as HTMLTextAreaElement;


### PR DESCRIPTION
## Summary
- test that Textarea forwards `textareaClassName` to the underlying element

## Testing
- `npm test tests/ui/textarea.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bde4727d24832ca4cbddf0c9fd60f2