### PR TITLE
feat: add Hardstuck theme palette

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -180,6 +180,19 @@ export default function Page() {
             </div>
           </div>
           <div className="flex flex-col items-center space-y-2">
+            <span className="text-sm font-medium">Hardstuck Background</span>
+            <div
+              className="w-56 h-24 rounded-md flex items-center justify-center"
+              style={{
+                backgroundColor: "hsl(165 60% 3%)",
+                color: "hsl(160 12% 95%)",
+                border: "1px solid hsl(165 40% 22%)",
+              }}
+            >
+              Hardstuck
+            </div>
+          </div>
+          <div className="flex flex-col items-center space-y-2">
             <span className="text-sm font-medium">Hero</span>
             <div className="w-56">
               <Hero heading="Hero" eyebrow="Eyebrow" subtitle="Subtitle" sticky={false} />

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -290,6 +290,40 @@ html.theme-rose {
   --success-glow: 150 65% 36% / 0.6;
 }
 
+/* ---------- Hardstuck ---------- */
+html.theme-hardstuck {
+  --background: 165 60% 3%;
+  --foreground: 160 12% 95%;
+  --text: var(--foreground);
+  --card: 165 55% 7%;
+  --panel: var(--card);
+  --border: 165 40% 22%;
+  --line: var(--border);
+  --input: 165 45% 10%;
+  --ring: 160 100% 60%;
+  --theme-ring: hsl(var(--ring));
+  --primary: 160 100% 60%;
+  --primary-foreground: 0 0% 100%;
+  --primary-soft: 160 100% 24%;
+  --accent: 300 90% 60%;
+  --accent-2: 160 100% 60%;
+  --accent-foreground: 0 0% 100%;
+  --accent-soft: 300 90% 20%;
+  --glow: 160 100% 60%;
+  --ring-muted: 165 30% 20%;
+  --danger: 0 84% 60%;
+  --muted: 165 35% 14%;
+  --muted-foreground: 165 15% 70%;
+  --surface: 165 32% 12%;
+  --surface-2: 165 32% 16%;
+  --surface-vhs: 210 27% 6%;
+  --surface-streak: 240 16% 12%;
+  --shadow-color: 160 100% 40%;
+  --lav-deep: 300 90% 60%;
+  --success: 150 70% 50%;
+  --success-glow: 150 70% 40% / 0.6;
+}
+
 /* =========================================================
    Per-theme glitch backdrops
    ========================================================= */
@@ -299,7 +333,7 @@ html.theme-rose {
 html.theme-lg body,
 html.theme-lg-dark body,
 html.theme-lg-light body,
-html:not(.theme-citrus):not(.theme-noir):not(.theme-ocean):not(.theme-rose):not(.theme-aurora) body {
+html:not(.theme-citrus):not(.theme-noir):not(.theme-ocean):not(.theme-rose):not(.theme-aurora):not(.theme-hardstuck) body {
   background-image:
     radial-gradient(1200px 700px at 18% -10%, hsl(262 83% 58% / 0.16), transparent 60%),
     radial-gradient(1100px 600px at 110% 18%, hsl(192 90% 50% / 0.14), transparent 60%),
@@ -309,7 +343,7 @@ html:not(.theme-citrus):not(.theme-noir):not(.theme-ocean):not(.theme-rose):not(
 html.theme-lg body::before,
 html.theme-lg-dark body::before,
 html.theme-lg-light body::before,
-html:not(.theme-citrus):not(.theme-noir):not(.theme-ocean):not(.theme-rose):not(.theme-aurora) body::before {
+html:not(.theme-citrus):not(.theme-noir):not(.theme-ocean):not(.theme-rose):not(.theme-aurora):not(.theme-hardstuck) body::before {
   content: ""; position: fixed; inset: 0; pointer-events: none; z-index: 0; opacity: 0.1;
   background:
     repeating-linear-gradient(90deg, hsl(var(--accent)) 0 1px, transparent 1px 26px),
@@ -319,7 +353,7 @@ html:not(.theme-citrus):not(.theme-noir):not(.theme-ocean):not(.theme-rose):not(
 html.theme-lg body::after,
 html.theme-lg-dark body::after,
 html.theme-lg-light body::after,
-html:not(.theme-citrus):not(.theme-noir):not(.theme-ocean):not(.theme-rose):not(.theme-aurora) body::after {
+html:not(.theme-citrus):not(.theme-noir):not(.theme-ocean):not(.theme-rose):not(.theme-aurora):not(.theme-hardstuck) body::after {
   content: ""; position: fixed; inset: -10%; pointer-events: none; z-index: 0;
   background:
     radial-gradient(60% 40% at 10% 0%,   hsl(262 83% 58% / 0.2), transparent 60%),
@@ -449,6 +483,30 @@ html.theme-rose body::after {
   filter: blur(2px) saturate(112%); animation: rose-pan 27s ease-in-out infinite alternate;
 }
 @keyframes rose-pan { 0% { transform: translate3d(-1%,-1%,0) } 100% { transform: translate3d(1%,1%,0) } }
+
+/* Hardstuck backdrop */
+html.theme-hardstuck body {
+  background-image:
+    radial-gradient(1000px 520px at 20% -10%, hsl(160 100% 60% / 0.15), transparent 60%),
+    radial-gradient(900px 520px at 110% 15%, hsl(300 90% 60% / 0.12), transparent 60%),
+    linear-gradient(180deg, hsl(var(--card) / 0.9), hsl(var(--background)));
+  background-attachment: fixed, fixed, fixed;
+}
+html.theme-hardstuck body::before {
+  content:""; position:fixed; inset:0; pointer-events:none; z-index:0;
+  background: repeating-linear-gradient(0deg, hsl(160 100% 60% / 0.05) 0 1px, transparent 1px 3px);
+  mix-blend-mode: screen; opacity:0.2; animation: hardstuck-scan 14s linear infinite;
+}
+html.theme-hardstuck body::after {
+  content:""; position:fixed; inset:-12%; pointer-events:none; z-index:0;
+  background:
+    radial-gradient(80% 60% at 50% 120%, hsl(160 90% 6% / 0.45), transparent 70%),
+    radial-gradient(40% 25% at 6% 4%,  hsl(160 100% 60% / 0.15), transparent 60%),
+    radial-gradient(40% 25% at 94% 10%, hsl(300 80% 60% / 0.12), transparent 60%);
+  filter: blur(1.5px) saturate(110%); opacity:0.9; animation: hardstuck-drift 26s ease-in-out infinite alternate;
+}
+@keyframes hardstuck-scan { 0%{background-position-y:0} 100%{background-position-y:100%} }
+@keyframes hardstuck-drift { 0%{transform:translate3d(-1%,0,0)} 100%{transform:translate3d(1%,0,0)} }
 
 /* Additional background options */
 html.bg-alt1 body {

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,7 +1,7 @@
 import { readLocal, writeLocal } from "./db";
 
 export type Mode = "dark" | "light";
-export type Variant = "lg" | "aurora" | "citrus" | "noir" | "ocean" | "rose";
+export type Variant = "lg" | "aurora" | "citrus" | "noir" | "ocean" | "rose" | "hardstuck";
 export type Background = 0 | 1 | 2 | 3 | 4 | 5;
 export interface ThemeState {
   variant: Variant;
@@ -20,6 +20,7 @@ export const VARIANTS: { id: Variant; label: string }[] = [
   { id: "ocean", label: "Oceanic" },
   { id: "citrus", label: "Citrus" },
   { id: "noir", label: "Noir" },
+  { id: "hardstuck", label: "Hardstuck" },
 ];
 
 export function defaultTheme(): ThemeState {


### PR DESCRIPTION
## Summary
- add new Hardstuck variant to theme system
- style Hardstuck palette and backdrop in themes.css
- showcase Hardstuck background on prompts page

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be00045f48832c89751dfa3678c572