### PR TITLE
chore: add prettier formatting setup

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "tabWidth": 2
+}

--- a/README.md
+++ b/README.md
@@ -42,3 +42,8 @@ This app respects your operating system's "reduced motion" setting. If reduced m
 ## Design System
 
 Learn more about the components and guidelines in the [Design System](docs/design-system.md).
+
+## Contributing
+
+- Run `npm run format` before committing to ensure code style consistency.
+- When introducing new styles or components, add them to the prompts page (`src/app/prompts/page.tsx`) so they can be previewed.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,7 +12,7 @@ const compat = new FlatCompat({
 
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...compat.extends("next/core-web-vitals", "next/typescript", "prettier"),
 ];
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,10 @@
         "autoprefixer": "^10.4.21",
         "eslint": "8.57.1",
         "eslint-config-next": "14.2.32",
+        "eslint-config-prettier": "^10.1.8",
         "jsdom": "^26.1.0",
         "postcss": "^8.4.49",
+        "prettier": "^3.6.2",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.9.2",
         "vitest": "^3.2.4"
@@ -3657,6 +3659,22 @@
         "glob": "10.3.10"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -6194,6 +6212,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "start": "next start -p 3000",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "vitest"
+    "test": "vitest",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "framer-motion": "12.23.12",
@@ -33,8 +34,10 @@
     "autoprefixer": "^10.4.21",
     "eslint": "8.57.1",
     "eslint-config-next": "14.2.32",
+    "eslint-config-prettier": "^10.1.8",
     "jsdom": "^26.1.0",
     "postcss": "^8.4.49",
+    "prettier": "^3.6.2",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"


### PR DESCRIPTION
## Summary
- add Prettier and eslint-config-prettier
- configure Prettier and script
- document formatting and prompts page guidelines

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be03d683e8832caf362ecc213006a9