### PR TITLE
refactor prompts page into subcomponents

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -24,6 +24,9 @@ import BadgePrimitive from "@/components/ui/primitives/Badge";
 import { Plus, Sun } from "lucide-react";
 import GoalsTabs, { FilterKey } from "@/components/goals/GoalsTabs";
 import { cn } from "@/lib/utils";
+import PromptsHeader from "@/components/prompts/PromptsHeader";
+import PromptsComposePanel from "@/components/prompts/PromptsComposePanel";
+import PromptsDemos from "@/components/prompts/PromptsDemos";
 
 export default function Page() {
   const viewTabs = [
@@ -330,6 +333,27 @@ export default function Page() {
               <div className="h-10 w-80 border rounded-md flex items-center justify-center text-xs text-muted-foreground">
                 w-80
               </div>
+            </div>
+          </div>
+          <div className="flex flex-col items-center space-y-2 sm:col-span-2 md:col-span-3">
+            <span className="text-sm font-medium">Prompts Header</span>
+            <SectionCard className="w-full">
+              <SectionCard.Header>
+                <PromptsHeader count={0} query="" onQueryChange={() => {}} onSave={() => {}} disabled />
+              </SectionCard.Header>
+              <SectionCard.Body />
+            </SectionCard>
+          </div>
+          <div className="flex flex-col items-center space-y-2 sm:col-span-2 md:col-span-3">
+            <span className="text-sm font-medium">Prompts Compose</span>
+            <div className="w-full max-w-md">
+              <PromptsComposePanel title="" onTitleChange={() => {}} text="" onTextChange={() => {}} />
+            </div>
+          </div>
+          <div className="flex flex-col items-center space-y-2 sm:col-span-2 md:col-span-3">
+            <span className="text-sm font-medium">Prompts Demos</span>
+            <div className="w-full">
+              <PromptsDemos />
             </div>
           </div>
         </div>

--- a/src/components/prompts/PromptsComposePanel.tsx
+++ b/src/components/prompts/PromptsComposePanel.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import * as React from "react";
+import { Input, Textarea } from "@/components/ui";
+import { Check as CheckIcon } from "lucide-react";
+
+interface PromptsComposePanelProps {
+  title: string;
+  onTitleChange: (value: string) => void;
+  text: string;
+  onTextChange: (value: string) => void;
+}
+
+export default function PromptsComposePanel({
+  title,
+  onTitleChange,
+  text,
+  onTextChange,
+}: PromptsComposePanelProps) {
+  const titleId = React.useId();
+  return (
+    <div className="space-y-2.5">
+      <Input
+        id={titleId}
+        placeholder="Title"
+        value={title}
+        onChange={(e) => onTitleChange(e.target.value)}
+        aria-describedby={`${titleId}-help`}
+      >
+        <button
+          type="button"
+          aria-label="Confirm"
+          className="absolute right-2 top-1/2 -translate-y-1/2 size-7 rounded-full grid place-items-center border border-[hsl(var(--accent)/0.45)] bg-[hsl(var(--accent)/0.12)] text-[hsl(var(--accent))] shadow-[0_0_0_1px_hsl(var(--accent)/0.25)] hover:shadow-[0_0_16px_hsl(var(--accent)/0.22)]"
+        >
+          <CheckIcon className="size-4" />
+        </button>
+      </Input>
+      <p id={`${titleId}-help`} className="mt-1 text-xs text-muted-foreground">
+        Add a short title
+      </p>
+      <Textarea
+        placeholder="Write your prompt or snippet…"
+        value={text}
+        onChange={(e) => onTextChange(e.target.value)}
+        resize="resize-y"
+      />
+    </div>
+  );
+}
+

--- a/src/components/prompts/PromptsDemos.tsx
+++ b/src/components/prompts/PromptsDemos.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import * as React from "react";
+import OutlineGlowDemo from "./OutlineGlowDemo";
+import SectionLabel from "@/components/reviews/SectionLabel";
+import {
+  Card,
+  Input,
+  Select,
+  Textarea,
+  FieldShell,
+  Button,
+  Label,
+} from "@/components/ui";
+import IconButton from "@/components/ui/primitives/IconButton";
+import { ArrowUp, Check as CheckIcon } from "lucide-react";
+import {
+  colorTokens,
+  spacingTokens,
+  glowTokens,
+  focusRingToken,
+  radiusTokens,
+  radiusClasses,
+  typeRamp,
+} from "./demoData";
+
+export default function PromptsDemos() {
+  return (
+    <>
+      <OutlineGlowDemo />
+      <SectionLabel>Section Label</SectionLabel>
+      <p className="text-sm text-muted-foreground">Divider used in reviews</p>
+
+      <Card className="mt-8 space-y-4">
+        <h3 className="type-title">Input</h3>
+        <p className="text-sm text-muted-foreground">
+          Customize focus rings with the <code>--theme-ring</code> variable.
+        </p>
+        <div className="space-y-3">
+          <Input height="sm" placeholder="Small" />
+          <Input placeholder="Medium" />
+          <Input height="lg" placeholder="Large" />
+          <Input height={12} placeholder="h-12" />
+          <Input placeholder="Pill" tone="pill" />
+          <Input placeholder="Error" aria-invalid="true" />
+          <Input
+            placeholder="Custom ring"
+            style={{ '--theme-ring': 'hsl(var(--danger))' } as React.CSSProperties}
+          />
+          <Input placeholder="With action">
+            <button
+              type="button"
+              aria-label="Confirm"
+              className="absolute right-2 top-1/2 -translate-y-1/2 size-7 rounded-full grid place-items-center border border-[hsl(var(--accent)/0.45)] bg-[hsl(var(--accent)/0.12)] text-[hsl(var(--accent))] shadow-[0_0_0_1px_hsl(var(--accent)/0.25)] hover:shadow-[0_0_16px_hsl(var(--accent)/0.22)]"
+            >
+              <CheckIcon className="size-4" />
+            </button>
+          </Input>
+        </div>
+      </Card>
+      <Card className="mt-8 space-y-4">
+        <h3 className="type-title">Select</h3>
+        <div className="space-y-3">
+          <Select aria-label="Default">
+            <option value="">Choose…</option>
+            <option value="a">A</option>
+          </Select>
+          <Select aria-label="Pill" tone="pill">
+            <option value="">Choose…</option>
+            <option value="a">A</option>
+          </Select>
+          <Select aria-label="Error" errorText="Error">
+            <option value="">Choose…</option>
+            <option value="a">A</option>
+          </Select>
+        </div>
+      </Card>
+      <Card className="mt-8 space-y-4">
+        <h3 className="type-title">Textarea</h3>
+        <div className="space-y-3">
+          <Textarea placeholder="Default" resize="resize-y" />
+          <Textarea placeholder="Pill" tone="pill" resize="resize-y" />
+        </div>
+      </Card>
+      <Card className="mt-8 space-y-4">
+        <h3 className="type-title">Label</h3>
+        <div className="space-y-3">
+          <div>
+            <Label htmlFor="label-demo">Label</Label>
+            <Input id="label-demo" placeholder="With spacing" />
+          </div>
+        </div>
+      </Card>
+      <Card className="mt-8 space-y-4">
+        <h3 className="type-title">FieldShell</h3>
+        <p className="type-body">
+          Shared wrapper that provides consistent borders, background, and focus
+          states for inputs. <code>Input</code>, <code>Select</code>, and
+          <code>Textarea</code> all use this wrapper internally. Extend styles
+          with the <code>className</code> prop on each component; use
+          <code>inputClassName</code>, <code>selectClassName</code>, or
+          <code>textareaClassName</code> to target the inner element.
+        </p>
+        <FieldShell>
+          <div className="px-4 py-2 text-sm text-muted-foreground">
+            Custom content
+          </div>
+        </FieldShell>
+      </Card>
+      <Card className="mt-8 space-y-4">
+        <h3 className="type-title">Button</h3>
+        <div className="space-x-3">
+          <Button>Default</Button>
+          <Button variant="primary">Primary</Button>
+          <Button variant="ghost">Ghost</Button>
+        </div>
+      </Card>
+      <Card className="mt-8 space-y-4">
+        <h3 className="type-title">Card</h3>
+        <div className="space-y-3">
+          <Card>Card content</Card>
+        </div>
+      </Card>
+      <Card className="mt-8 space-y-4">
+        <h3 className="type-title">IconButton</h3>
+        <div className="space-x-3">
+          <IconButton aria-label="Scroll to top">
+            <ArrowUp />
+          </IconButton>
+        </div>
+      </Card>
+      <Card className="mt-8 space-y-4">
+        <h3 className="type-title">Shadows</h3>
+        <div className="flex flex-wrap gap-4">
+          <div className="size-16 rounded-2xl bg-[hsl(var(--panel)/0.8)] shadow-neo" />
+          <div className="size-16 rounded-2xl bg-[hsl(var(--panel)/0.8)] shadow-neo-strong" />
+          <div className="size-16 rounded-2xl bg-[hsl(var(--panel)/0.8)] shadow-neo-inset" />
+          <div className="size-16 rounded-2xl bg-[hsl(var(--panel)/0.8)] shadow-ring" />
+        </div>
+      </Card>
+      <Card className="mt-8 space-y-4">
+        <h3 className="type-title">Task Tile Text</h3>
+        <div className="space-y-2">
+          <button type="button" className="task-tile__text">
+            Editable task
+          </button>
+          <button
+            type="button"
+            className="task-tile__text line-through-soft"
+          >
+            Completed task
+          </button>
+        </div>
+      </Card>
+      <Card className="mt-8 space-y-4">
+        <h3 className="type-title">Design Tokens</h3>
+        <div>
+          <h4 className="type-subtitle">Colors</h4>
+          <div className="flex gap-2">
+            {colorTokens.map((c) => (
+              <div key={c} className={`size-6 rounded ${c}`} />
+            ))}
+          </div>
+        </div>
+        <div>
+          <h4 className="type-subtitle">Spacing</h4>
+          <p className="type-body">{spacingTokens.join(', ')}</p>
+        </div>
+        <div>
+          <h4 className="type-subtitle">Glow</h4>
+          <p className="type-body">{glowTokens.join(', ')}</p>
+        </div>
+        <div>
+          <h4 className="type-subtitle">Focus Ring</h4>
+          <p className="type-body">{focusRingToken} for theme-aware ring color</p>
+        </div>
+        <div>
+          <h4 className="type-subtitle">Radius</h4>
+          <p className="type-body">{radiusTokens.join(', ')}</p>
+          <div className="mt-2 flex gap-2">
+            {radiusClasses.map((cls) => (
+              <div
+                key={cls}
+                className={`size-6 bg-[hsl(var(--panel)/0.8)] ${cls}`}
+              />
+            ))}
+          </div>
+        </div>
+        <div>
+          <h4 className="type-subtitle">Type Ramp</h4>
+          <p className="type-body">{typeRamp.join(', ')}</p>
+        </div>
+      </Card>
+      <Card className="mt-8 space-y-4">
+        <h3 className="type-title">Motion</h3>
+        <div className="flex gap-2">
+          <button className="px-3 py-1 rounded bg-[hsl(var(--accent)/0.2)] transition-opacity duration-420 hover:opacity-60">
+            Slow fade
+          </button>
+        </div>
+      </Card>
+    </>
+  );
+}
+

--- a/src/components/prompts/PromptsHeader.tsx
+++ b/src/components/prompts/PromptsHeader.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import * as React from "react";
+import { Button, SearchBar } from "@/components/ui";
+
+interface PromptsHeaderProps {
+  count: number;
+  query: string;
+  onQueryChange: (value: string) => void;
+  onSave: () => void;
+  disabled: boolean;
+}
+
+export default function PromptsHeader({
+  count,
+  query,
+  onQueryChange,
+  onSave,
+  disabled,
+}: PromptsHeaderProps) {
+  return (
+    <div className="flex items-center justify-between w-full">
+      <div className="flex items-center gap-3">
+        <h2 className="card-title">Prompts</h2>
+        <span className="pill">{count} saved</span>
+      </div>
+      <div className="flex items-center gap-2 min-w-0">
+        <div className="w-48 sm:w-64 md:w-80">
+          <SearchBar
+            value={query}
+            onValueChange={onQueryChange}
+            placeholder="Search prompts…"
+          />
+        </div>
+        <Button variant="primary" onClick={onSave} disabled={disabled}>
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -7,18 +7,16 @@
  */
 
 import * as React from "react";
-import { SectionCard, Textarea, Button, Input, Select, Card, FieldShell, SearchBar, Label } from "@/components/ui";
-import IconButton from "@/components/ui/primitives/IconButton";
-import { ArrowUp } from "lucide-react";
+import { SectionCard, Card } from "@/components/ui";
 import { useLocalDB, uid } from "@/lib/db";
 import { LOCALE } from "@/lib/utils";
-import { Check as CheckIcon } from "lucide-react";
-import OutlineGlowDemo from "./OutlineGlowDemo";
-import SectionLabel from "@/components/reviews/SectionLabel";
+import PromptsHeader from "./PromptsHeader";
+import PromptsComposePanel from "./PromptsComposePanel";
+import PromptsDemos from "./PromptsDemos";
 
 type Prompt = {
   id: string;
-  title?: string;             // optional for back-compat
+  title?: string; // optional for back-compat
   text: string;
   createdAt: number;
 };
@@ -33,8 +31,6 @@ export default function PromptsPage() {
 
   // Search (now lives in the header)
   const [query, setQuery] = React.useState("");
-
-  const titleId = React.useId();
 
   const deriveTitle = React.useCallback((p: Prompt) => {
     if (p.title && p.title.trim()) return p.title.trim();
@@ -58,14 +54,14 @@ export default function PromptsPage() {
 
   function save() {
     const text = textDraft.trim();
-    const title = (titleDraft.trim() || text.split(/\r?\n/)[0]?.trim() || "Untitled");
+    const title = titleDraft.trim() || text.split(/\r?\n/)[0]?.trim() || "Untitled";
     if (!text && !titleDraft.trim()) return; // nothing to save
 
     const next: Prompt = {
       id: uid("p"),
       title,
       text,
-      createdAt: Date.now()
+      createdAt: Date.now(),
     };
     setPrompts((prev) => [next, ...prev]);
     setTitleDraft("");
@@ -74,66 +70,22 @@ export default function PromptsPage() {
 
   return (
     <SectionCard>
-      {/* Sticky hero header with search on the right */}
       <SectionCard.Header sticky className="gap-3">
-        <div className="flex items-center justify-between w-full">
-          {/* Left: title + count */}
-          <div className="flex items-center gap-3">
-            <h2 className="card-title">Prompts</h2>
-            <span className="pill">{prompts.length} saved</span>
-          </div>
-
-          {/* Right: search + save */}
-          <div className="flex items-center gap-2 min-w-0">
-            <div className="w-48 sm:w-64 md:w-80">
-              <SearchBar
-                value={query}
-                onValueChange={setQuery}
-                placeholder="Search prompts…"
-              />
-            </div>
-            <Button
-              variant="primary"
-              onClick={save}
-              disabled={!titleDraft.trim() && !textDraft.trim()}
-            >
-              Save
-            </Button>
-          </div>
-        </div>
+        <PromptsHeader
+          count={prompts.length}
+          query={query}
+          onQueryChange={setQuery}
+          onSave={save}
+          disabled={!titleDraft.trim() && !textDraft.trim()}
+        />
       </SectionCard.Header>
-
       <SectionCard.Body>
-        <OutlineGlowDemo />
-          <SectionLabel>Section Label</SectionLabel>
-          <p className="text-sm text-muted-foreground">Divider used in reviews</p>
-        {/* Compose panel */}
-        <div className="space-y-2.5">
-          <Input
-            id={titleId}
-            placeholder="Title"
-            value={titleDraft}
-            onChange={(e) => setTitleDraft(e.target.value)}
-            aria-describedby={`${titleId}-help`}
-          >
-            <button
-              type="button"
-              aria-label="Confirm"
-              className="absolute right-2 top-1/2 -translate-y-1/2 size-7 rounded-full grid place-items-center border border-[hsl(var(--accent)/0.45)] bg-[hsl(var(--accent)/0.12)] text-[hsl(var(--accent))] shadow-[0_0_0_1px_hsl(var(--accent)/0.25)] hover:shadow-[0_0_16px_hsl(var(--accent)/0.22)]"
-            >
-              <CheckIcon className="size-4" />
-            </button>
-          </Input>
-          <p id={`${titleId}-help`} className="mt-1 text-xs text-muted-foreground">
-            Add a short title
-          </p>
-          <Textarea
-            placeholder="Write your prompt or snippet…"
-            value={textDraft}
-            onChange={(e) => setTextDraft(e.target.value)}
-            resize="resize-y"
-          />
-        </div>
+        <PromptsComposePanel
+          title={titleDraft}
+          onTitleChange={setTitleDraft}
+          text={textDraft}
+          onTextChange={setTextDraft}
+        />
 
         {/* List */}
         <div className="mt-4 space-y-3">
@@ -151,177 +103,15 @@ export default function PromptsPage() {
             </Card>
           ))}
           {filtered.length === 0 && (
-            <div className="text-muted-foreground">Nothing matches your search. Typical.</div>
+            <div className="text-muted-foreground">
+              Nothing matches your search. Typical.
+            </div>
           )}
         </div>
-        <Card className="mt-8 space-y-4">
-          <h3 className="type-title">Input</h3>
-          <p className="text-sm text-muted-foreground">
-            Customize focus rings with the <code>--theme-ring</code> variable.
-          </p>
-          <div className="space-y-3">
-            <Input height="sm" placeholder="Small" />
-            <Input placeholder="Medium" />
-            <Input height="lg" placeholder="Large" />
-            <Input height={12} placeholder="h-12" />
-            <Input placeholder="Pill" tone="pill" />
-            <Input placeholder="Error" aria-invalid="true" />
-            <Input
-              placeholder="Custom ring"
-              style={{ '--theme-ring': 'hsl(var(--danger))' } as React.CSSProperties}
-            />
-            <Input placeholder="With action">
-              <button
-                type="button"
-                aria-label="Confirm"
-                className="absolute right-2 top-1/2 -translate-y-1/2 size-7 rounded-full grid place-items-center border border-[hsl(var(--accent)/0.45)] bg-[hsl(var(--accent)/0.12)] text-[hsl(var(--accent))] shadow-[0_0_0_1px_hsl(var(--accent)/0.25)] hover:shadow-[0_0_16px_hsl(var(--accent)/0.22)]"
-              >
-                <CheckIcon className="size-4" />
-              </button>
-            </Input>
-          </div>
-        </Card>
-        <Card className="mt-8 space-y-4">
-          <h3 className="type-title">Select</h3>
-          <div className="space-y-3">
-            <Select aria-label="Default">
-              <option value="">Choose…</option>
-              <option value="a">A</option>
-            </Select>
-            <Select aria-label="Pill" tone="pill">
-              <option value="">Choose…</option>
-              <option value="a">A</option>
-            </Select>
-            <Select aria-label="Error" errorText="Error">
-              <option value="">Choose…</option>
-              <option value="a">A</option>
-            </Select>
-          </div>
-        </Card>
-        <Card className="mt-8 space-y-4">
-          <h3 className="type-title">Textarea</h3>
-          <div className="space-y-3">
-            <Textarea placeholder="Default" resize="resize-y" />
-            <Textarea placeholder="Pill" tone="pill" resize="resize-y" />
-          </div>
-        </Card>
-        <Card className="mt-8 space-y-4">
-          <h3 className="type-title">Label</h3>
-          <div className="space-y-3">
-            <div>
-              <Label htmlFor="label-demo">Label</Label>
-              <Input id="label-demo" placeholder="With spacing" />
-            </div>
-          </div>
-        </Card>
-        <Card className="mt-8 space-y-4">
-          <h3 className="type-title">FieldShell</h3>
-          <p className="type-body">
-            Shared wrapper that provides consistent borders, background, and focus
-            states for inputs. <code>Input</code>, <code>Select</code>, and
-            <code>Textarea</code> all use this wrapper internally. Extend styles
-            with the <code>className</code> prop on each component; use
-            <code>inputClassName</code>, <code>selectClassName</code>, or
-            <code>textareaClassName</code> to target the inner element.
-          </p>
-          <FieldShell>
-            <div className="px-4 py-2 text-sm text-muted-foreground">
-              Custom content
-            </div>
-          </FieldShell>
-        </Card>
-        <Card className="mt-8 space-y-4">
-          <h3 className="type-title">Button</h3>
-          <div className="space-x-3">
-            <Button>Default</Button>
-            <Button variant="primary">Primary</Button>
-            <Button variant="ghost">Ghost</Button>
-          </div>
-        </Card>
-        <Card className="mt-8 space-y-4">
-          <h3 className="type-title">Card</h3>
-          <div className="space-y-3">
-            <Card>Card content</Card>
-          </div>
-        </Card>
-        <Card className="mt-8 space-y-4">
-          <h3 className="type-title">IconButton</h3>
-          <div className="space-x-3">
-            <IconButton aria-label="Scroll to top">
-              <ArrowUp />
-            </IconButton>
-          </div>
-        </Card>
-        <Card className="mt-8 space-y-4">
-          <h3 className="type-title">Shadows</h3>
-          <div className="flex flex-wrap gap-4">
-            <div className="size-16 rounded-2xl bg-[hsl(var(--panel)/0.8)] shadow-neo" />
-            <div className="size-16 rounded-2xl bg-[hsl(var(--panel)/0.8)] shadow-neo-strong" />
-            <div className="size-16 rounded-2xl bg-[hsl(var(--panel)/0.8)] shadow-neo-inset" />
-            <div className="size-16 rounded-2xl bg-[hsl(var(--panel)/0.8)] shadow-ring" />
-          </div>
-        </Card>
-        <Card className="mt-8 space-y-4">
-          <h3 className="type-title">Task Tile Text</h3>
-          <div className="space-y-2">
-            <button type="button" className="task-tile__text">
-              Editable task
-            </button>
-            <button type="button" className="task-tile__text line-through-soft">
-              Completed task
-            </button>
-          </div>
-        </Card>
-        <Card className="mt-8 space-y-4">
-          <h3 className="type-title">Design Tokens</h3>
-          <div>
-            <h4 className="type-subtitle">Colors</h4>
-            <div className="flex gap-2">
-              <div className="size-6 rounded bg-ring" />
-              <div className="size-6 rounded bg-accent" />
-              <div className="size-6 rounded bg-accent-2" />
-              <div className="size-6 rounded bg-lavDeep" />
-              <div className="size-6 rounded bg-danger" />
-              <div className="size-6 rounded bg-success" />
-              <div className="size-6 rounded bg-glow" />
-            </div>
-          </div>
-          <div>
-            <h4 className="type-subtitle">Spacing</h4>
-            <p className="type-body">4, 8, 12, 16, 24, 32, 48, 64</p>
-          </div>
-          <div>
-            <h4 className="type-subtitle">Glow</h4>
-            <p className="type-body">--glow-strong, --glow-soft</p>
-          </div>
-          <div>
-            <h4 className="type-subtitle">Focus Ring</h4>
-            <p className="type-body">--theme-ring for theme-aware ring color</p>
-          </div>
-          <div>
-            <h4 className="type-subtitle">Radius</h4>
-            <p className="type-body">--radius-md, --radius-lg, --radius-xl, --radius-2xl</p>
-            <div className="mt-2 flex gap-2">
-              <div className="size-6 rounded-md bg-[hsl(var(--panel)/0.8)]" />
-              <div className="size-6 rounded-lg bg-[hsl(var(--panel)/0.8)]" />
-              <div className="size-6 rounded-xl bg-[hsl(var(--panel)/0.8)]" />
-              <div className="size-6 rounded-2xl bg-[hsl(var(--panel)/0.8)]" />
-            </div>
-          </div>
-          <div>
-            <h4 className="type-subtitle">Type Ramp</h4>
-            <p className="type-body">eyebrow, title, subtitle, body, caption</p>
-          </div>
-        </Card>
-        <Card className="mt-8 space-y-4">
-          <h3 className="type-title">Motion</h3>
-          <div className="flex gap-2">
-            <button className="px-3 py-1 rounded bg-[hsl(var(--accent)/0.2)] transition-opacity duration-420 hover:opacity-60">
-              Slow fade
-            </button>
-          </div>
-        </Card>
+
+        <PromptsDemos />
       </SectionCard.Body>
     </SectionCard>
   );
 }
+

--- a/src/components/prompts/demoData.ts
+++ b/src/components/prompts/demoData.ts
@@ -1,0 +1,20 @@
+export const colorTokens = [
+  "bg-ring",
+  "bg-accent",
+  "bg-accent-2",
+  "bg-lavDeep",
+  "bg-danger",
+  "bg-success",
+  "bg-glow",
+];
+
+export const spacingTokens = [4, 8, 12, 16, 24, 32, 48, 64];
+
+export const glowTokens = ["--glow-strong", "--glow-soft"];
+
+export const focusRingToken = "--theme-ring";
+
+export const radiusTokens = ["--radius-md", "--radius-lg", "--radius-xl", "--radius-2xl"];
+export const radiusClasses = ["rounded-md", "rounded-lg", "rounded-xl", "rounded-2xl"];
+
+export const typeRamp = ["eyebrow", "title", "subtitle", "body", "caption"];


### PR DESCRIPTION
## Summary
- break PromptsPage into PromptsHeader, PromptsComposePanel, and PromptsDemos
- move design token demo data into dedicated module
- expose new components on prompts style guide page

## Testing
- `npm test` *(fails: Failed to resolve import "clsx" from "src/lib/utils.ts")*
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module 'clsx' or 'tailwind-merge')*

------
https://chatgpt.com/codex/tasks/task_e_68be09a835b8832c838918ca9e13c4c6