### PR TITLE
refactor: centralize color tokens

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -42,6 +42,7 @@ import type { Pillar, Review } from "@/lib/types";
 import type { GameSide } from "@/components/ui/league/SideSelector";
 import { Search as SearchIcon, Star, Plus, Sun } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { COLOR_TOKENS } from "@/lib/theme";
 
 /**
  * Prompt component gallery.
@@ -71,35 +72,6 @@ export default function Page() {
     { key: "colors", label: "Colors" },
   ];
 
-  const colorList = [
-    "background",
-    "foreground",
-    "text",
-    "card",
-    "panel",
-    "border",
-    "line",
-    "input",
-    "ring",
-    "accent",
-    "accent-2",
-    "accent-foreground",
-    "muted",
-    "muted-foreground",
-    "surface",
-    "surface-2",
-    "surface-vhs",
-    "surface-streak",
-    "danger",
-    "success",
-    "glow-strong",
-    "glow-soft",
-    "aurora-g",
-    "aurora-g-light",
-    "aurora-p",
-    "aurora-p-light",
-    "icon-fg",
-  ];
 
   const [view, setView] = React.useState("components");
   const [goalFilter, setGoalFilter] = React.useState<FilterKey>("All");
@@ -620,7 +592,7 @@ export default function Page() {
               Use <code>auroraG</code>, <code>auroraGLight</code>, <code>auroraP</code>, and<code>auroraPLight</code> Tailwind classes for aurora effects.
             </p>
           </div>
-          {colorList.map((c) => (
+          {COLOR_TOKENS.map((c) => (
             <div key={c} className="flex flex-col items-center gap-2">
               <span className="text-xs uppercase tracking-wide text-purple-300">{c}</span>
               <div

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -13,6 +13,36 @@ export const THEME_STORAGE_KEY = "ui:theme";
 
 export const BG_CLASSES = ["", "bg-alt1", "bg-alt2", "bg-light", "bg-vhs", "bg-streak"] as const;
 
+export const COLOR_TOKENS = [
+  "background",
+  "foreground",
+  "text",
+  "card",
+  "panel",
+  "border",
+  "line",
+  "input",
+  "ring",
+  "accent",
+  "accent-2",
+  "accent-foreground",
+  "muted",
+  "muted-foreground",
+  "surface",
+  "surface-2",
+  "surface-vhs",
+  "surface-streak",
+  "danger",
+  "success",
+  "glow-strong",
+  "glow-soft",
+  "aurora-g",
+  "aurora-g-light",
+  "aurora-p",
+  "aurora-p-light",
+  "icon-fg",
+] as const;
+
 export const VARIANTS: { id: Variant; label: string }[] = [
   { id: "lg", label: "Glitch" },
   { id: "aurora", label: "Aurora" },


### PR DESCRIPTION
## Summary
- export color token list from theme module
- use shared color tokens in prompts gallery so new tokens appear automatically

## Testing
- `npm test` *(fails: Error: Failed to resolve import "clsx" from "src/lib/utils.ts")*
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module 'clsx' or 'tailwind-merge')*


------
https://chatgpt.com/codex/tasks/task_e_68be110afa7c832c94c751f8579e97fe