### PR TITLE
chore: regenerate ui index before dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
+This project automatically regenerates its UI component export index. The `npm run dev` and `npm run build` commands run `npm run regen-ui` to keep exports in sync, and the `postinstall` script does the same after dependency installs. You can run `npm run regen-ui` manually whenever components are added or removed.
+
 First, run the development server:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -7,14 +7,15 @@
   "private": true,
   "version": "1.0.0",
   "scripts": {
-    "dev": "next dev -p 3000",
+    "dev": "npm run regen-ui && next dev -p 3000",
     "regen-ui": "ts-node scripts/generate-ui-index.ts",
     "build": "npm run regen-ui && next build",
     "start": "next start -p 3000",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "vitest",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "postinstall": "npm run regen-ui"
   },
   "dependencies": {
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- run `regen-ui` before starting the dev server
- run `regen-ui` automatically after installs
- document UI index regeneration workflow

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bebc8b217c832c8adb30255dad4eb0