### PR TITLE
fix: remove fixed height from chrome bar

### DIFF
--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -15,7 +15,7 @@ export default function SiteChrome() {
   return (
     <header role="banner" className="sticky-blur top-0 z-50">
       {/* Bar content */}
-        <div className="page-shell h-4 flex items-center justify-between py-2">
+        <div className="page-shell flex items-center justify-between py-2">
         <div className="flex items-center gap-2">
           <span
             className="h-2 w-2 rounded-full animate-pulse"


### PR DESCRIPTION
## Summary
- remove h-4 from SiteChrome bar to rely on padding for consistent height

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bebd1fbbb0832cb52e29f3684cd929