### PR TITLE
style: use ring token for ReviewPanel border

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -166,6 +166,14 @@ export default function Page() {
         </div>
       ),
     },
+    {
+      label: "Ring Subtle",
+      element: (
+        <div className="w-56 h-6 flex items-center justify-center rounded ring-1 ring-[hsl(var(--ring)/0.05)]">
+          Ring 5%
+        </div>
+      ),
+    },
     { label: "SearchBar", element: <SearchBar value={query} onValueChange={setQuery} className="w-56" /> },
     {
       label: "Segmented",

--- a/src/components/reviews/ReviewPanel.tsx
+++ b/src/components/reviews/ReviewPanel.tsx
@@ -5,7 +5,7 @@ export default function ReviewPanel({ className, ...props }: HTMLAttributes<HTML
   return (
     <div
       className={cn(
-        "max-w-[880px] w-full rounded-xl p-5 bg-[hsl(var(--card)/0.6)] ring-1 ring-white/5 shadow-[0_0_40px_-12px_hsl(var(--glow-soft))]",
+        "max-w-[880px] w-full rounded-xl p-5 bg-[hsl(var(--card)/0.6)] ring-1 ring-[hsl(var(--ring)/0.05)] shadow-[0_0_40px_-12px_hsl(var(--glow-soft))]",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- use `hsl(var(--ring)/0.05)` for ReviewPanel ring
- document subtle ring style on prompts page

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bebf4b9228832c8dd82d38f34380b3