### PR TITLE
refactor: replace Tailwind colors with tokens

### DIFF
--- a/COLOR_MAPPINGS.md
+++ b/COLOR_MAPPINGS.md
@@ -31,7 +31,9 @@
 | `rgba(255, 255, 255, 0.10)` | `hsl(var(--foreground) / 0.10)` |
 | `rgba(255, 255, 255, 0.14)` | `hsl(var(--foreground) / 0.14)` |
 | `rgba(255, 255, 255, 0.16)` | `hsl(var(--foreground) / 0.16)` |
+| `rgba(255, 255, 255, 0.2)` | `hsl(var(--foreground) / 0.2)` |
 | `rgba(255, 255, 255, 0.25)` | `hsl(var(--foreground) / 0.25)` |
+| `rgba(255, 255, 255, 0.4)` | `hsl(var(--foreground) / 0.4)` |
 | `rgba(0, 0, 0, 0.18)` | `hsl(var(--shadow-color) / 0.18)` |
 | `rgba(0, 0, 0, 0.35)` | `hsl(var(--shadow-color) / 0.35)` |
 | `rgba(0, 0, 0, 0.42)` | `hsl(var(--shadow-color) / 0.42)` |
@@ -43,3 +45,14 @@
 | `rgba(255, 0, 200, 0.08)` | `hsl(var(--lav-deep) / 0.08)` |
 | `rgba(255, 77, 210, 0.65)` | `hsl(var(--lav-deep) / 0.65)` |
 | `rgba(255, 77, 210, 0.85)` | `hsl(var(--lav-deep) / 0.85)` |
+| `#ef4444` | `hsl(var(--danger))` |
+| `#3b82f6` | `hsl(var(--accent-2))` |
+| `#d8b4fe` | `hsl(var(--accent))` |
+| `rgba(192, 132, 252, 0.6)` | `hsl(var(--accent) / 0.6)` |
+| `rgba(168, 85, 247, 0.2)` | `hsl(var(--accent) / 0.2)` |
+| `rgba(255, 255, 255, 0.7)` | `hsl(var(--foreground) / 0.7)` |
+| `rgba(255, 255, 255, 0.05)` | `hsl(var(--foreground) / 0.05)` |
+| `#fb7185` | `hsl(var(--danger))` |
+| `#fbbf24` | `hsl(var(--warning))` |
+| `#34d399` | `hsl(var(--aurora-g))` |
+| `#6ee7b7` | `hsl(var(--aurora-g-light))` |

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -480,11 +480,11 @@ export default function Page() {
       element: (
         <div
           className={cn(
-            "w-56 h-8 flex items-center justify-center text-white bg-red-500",
-            "bg-blue-500"
+            "w-56 h-8 flex items-center justify-center text-foreground bg-danger",
+            "bg-accent-2"
           )}
         >
-          Blue wins
+          Accent-2 wins
         </div>
       ),
     },
@@ -594,7 +594,7 @@ export default function Page() {
           </div>
           {COLOR_TOKENS.map((c) => (
             <div key={c} className="flex flex-col items-center gap-2">
-              <span className="text-xs uppercase tracking-wide text-purple-300">{c}</span>
+              <span className="text-xs uppercase tracking-wide text-accent">{c}</span>
               <div
                 className="w-24 h-16 rounded-md border"
                 style={{ backgroundColor: `hsl(var(--${c}))` }}

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -24,6 +24,7 @@
   --glow: 292 80% 60%;
   --ring-muted: 248 20% 22%;
   --danger: 0 84% 60%;
+  --warning: 43 96% 56%;
   --muted: 248 26% 14%;
   --muted-foreground: 250 15% 70%;
   --surface: 248 24% 12%;
@@ -132,6 +133,7 @@ html.light {
   --glow: 292 80% 45%;
   --ring-muted: 240 9% 90%;
   --danger: 0 84% 55%;
+  --warning: 43 96% 51%;
   --muted: 240 6% 96%;
   --muted-foreground: 240 4% 35%;
   --surface: 240 7% 98%;

--- a/src/components/goals/DurationSelector.tsx
+++ b/src/components/goals/DurationSelector.tsx
@@ -34,11 +34,11 @@ export default function DurationSelector({
             className={cn(
               "inline-flex items-center justify-center h-9 px-3 rounded-full text-center text-sm",
               "border transition-colors",
-              "border-white/10 bg-white/5 text-white/70",
-              "hover:bg-white/10 hover:text-white/70",
+              "border-foreground/10 bg-foreground/5 text-foreground/70",
+              "hover:bg-foreground/10 hover:text-foreground/70",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
               active &&
-                "border-purple-400/60 bg-purple-500/20 text-white/70 font-semibold"
+                "border-accent/60 bg-accent/20 text-foreground/70 font-semibold"
             )}
           >
             {m}m

--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -30,13 +30,13 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
     <SectionCard className="card-neo-soft">
       <SectionCard.Header title={<h2 className="text-lg font-semibold">Goal Queue</h2>} />
       <SectionCard.Body className="grid gap-6">
-          <ul className="divide-y divide-white/10">
+          <ul className="divide-y divide-foreground/10">
             {items.length === 0 ? (
               <li className="py-3 text-sm text-[hsl(var(--muted-foreground))]">No queued goals</li>
             ) : (
               items.map((it) => (
                 <li key={it.id} className="group flex items-center gap-2 py-3">
-                  <span className="h-1.5 w-1.5 rounded-full bg-white/40" aria-hidden />
+                  <span className="h-1.5 w-1.5 rounded-full bg-foreground/40" aria-hidden />
                   <p className="flex-1 truncate text-sm">{it.text}</p>
                   <time
                     className="text-xs text-[hsl(var(--muted-foreground))] opacity-0 group-hover:opacity-100"
@@ -63,7 +63,7 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
           </ul>
 
           <form onSubmit={submit} className="flex items-center gap-2 pt-3">
-            <span className="h-1.5 w-1.5 rounded-full bg-white/40" aria-hidden />
+            <span className="h-1.5 w-1.5 rounded-full bg-foreground/40" aria-hidden />
             <Input
               tone="default"
               className="flex-1 h-9 text-sm"

--- a/src/components/prompts/demoData.ts
+++ b/src/components/prompts/demoData.ts
@@ -4,6 +4,7 @@ export const colorTokens = [
   "bg-accent-2",
   "bg-lavDeep",
   "bg-danger",
+  "bg-warning",
   "bg-success",
   "bg-glow",
 ];

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -665,7 +665,7 @@ export default function ReviewEditor({
               <div
                 className={cn(
                   "py-2 text-center",
-                  result === "Win" ? "text-white/70" : "text-[hsl(var(--muted-foreground))]"
+                  result === "Win" ? "text-foreground/70" : "text-[hsl(var(--muted-foreground))]"
                 )}
               >
                 Win
@@ -673,7 +673,7 @@ export default function ReviewEditor({
               <div
                 className={cn(
                   "py-2 text-center",
-                  result === "Loss" ? "text-white/70" : "text-[hsl(var(--muted-foreground))]"
+                  result === "Loss" ? "text-foreground/70" : "text-[hsl(var(--muted-foreground))]"
                 )}
               >
                 Loss
@@ -898,7 +898,7 @@ export default function ReviewEditor({
               />
             ) : (
               <span
-                className="inline-flex h-10 items-center justify-center gap-2 rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 text-sm text-white/70"
+                className="inline-flex h-10 items-center justify-center gap-2 rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 text-sm text-foreground/70"
                 style={{ width: "calc(5ch + 1.5rem)" }}
                 title="Timestamp disabled"
               >

--- a/src/components/reviews/ReviewPanel.tsx
+++ b/src/components/reviews/ReviewPanel.tsx
@@ -5,7 +5,7 @@ export default function ReviewPanel({ className, ...props }: HTMLAttributes<HTML
   return (
     <div
       className={cn(
-        "max-w-[880px] w-full rounded-xl p-5 bg-[hsl(var(--card)/0.6)] ring-1 ring-white/5 shadow-[0_0_40px_-12px_hsl(var(--glow-soft))]",
+        "max-w-[880px] w-full rounded-xl p-5 bg-[hsl(var(--card)/0.6)] ring-1 ring-foreground/5 shadow-[0_0_40px_-12px_hsl(var(--glow-soft))]",
         className
       )}
       {...props}

--- a/src/components/reviews/ReviewSummary.tsx
+++ b/src/components/reviews/ReviewSummary.tsx
@@ -289,8 +289,8 @@ export default function ReviewSummary({ review, onEdit, className }: Props) {
         <div className="grid w-full grid-cols-[1fr_auto] items-center gap-4">
           {/* Left: Title */}
           <div className="min-w-0">
-            <div className="mb-0.5 text-xs text-white/25">Title</div>
-            <div className="truncate text-lg font-medium leading-7 text-white/70">
+            <div className="mb-0.5 text-xs text-foreground/25">Title</div>
+            <div className="truncate text-lg font-medium leading-7 text-foreground/70">
               {laneTitle || "Untitled review"}
             </div>
           </div>
@@ -377,7 +377,7 @@ export default function ReviewSummary({ review, onEdit, className }: Props) {
             <div className="mt-4 space-y-1.5">
               <div className="mb-2 flex items-center gap-2" aria-label="Focus">
                 <NeonIcon kind="brain" on={true} size={32} staticGlow />
-                <div className="h-px flex-1 bg-gradient-to-r from-white/20 via-white/5 to-transparent" />
+                <div className="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
               </div>
 
               <div className="relative h-12 rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-4">
@@ -427,7 +427,7 @@ export default function ReviewSummary({ review, onEdit, className }: Props) {
           <div className="mb-2 flex items-center gap-2" aria-label="Timestamps">
             <NeonIcon kind="clock" on={!!hasTimed} size={32} staticGlow />
             <NeonIcon kind="file" on={!!hasNoteOnly} size={32} staticGlow />
-            <div className="h-px flex-1 bg-gradient-to-r from-white/20 via-white/5 to-transparent" />
+            <div className="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
           </div>
 
           {!markers.length ? (
@@ -465,7 +465,7 @@ export default function ReviewSummary({ review, onEdit, className }: Props) {
         {review.notes ? (
           <div>
             <SectionLabel>Notes</SectionLabel>
-            <div className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-3 text-sm leading-6 text-white/70">
+            <div className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-3 text-sm leading-6 text-foreground/70">
               {review.notes}
             </div>
           </div>

--- a/src/components/reviews/SectionLabel.tsx
+++ b/src/components/reviews/SectionLabel.tsx
@@ -4,8 +4,8 @@ import * as React from "react";
 export default function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
     <div className="mb-2 flex items-center gap-2">
-      <div className="text-xs tracking-wide text-white/20">{children}</div>
-      <div className="h-px flex-1 bg-gradient-to-r from-white/20 via-white/5 to-transparent" />
+      <div className="text-xs tracking-wide text-foreground/20">{children}</div>
+      <div className="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
     </div>
   );
 }

--- a/src/components/reviews/reviewData.ts
+++ b/src/components/reviews/reviewData.ts
@@ -57,10 +57,10 @@ export function scoreIcon(score: number): {
   Icon: ComponentType<{ className?: string }>;
   cls: string;
 } {
-  if (score <= 3) return { Icon: Skull, cls: "text-rose-400" };
-  if (score <= 6) return { Icon: Meh, cls: "text-amber-400" };
-  if (score >= 9) return { Icon: Trophy, cls: "text-emerald-400" };
-  return { Icon: Smile, cls: "text-emerald-300" };
+  if (score <= 3) return { Icon: Skull, cls: "text-danger" };
+  if (score <= 6) return { Icon: Meh, cls: "text-warning" };
+  if (score >= 9) return { Icon: Trophy, cls: "text-auroraG" };
+  return { Icon: Smile, cls: "text-auroraGLight" };
 }
 
 /** Short quips for performance score 0..10 (5 per tier) */

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -155,7 +155,7 @@ export default function TabBar({
                   "relative inline-flex items-center select-none rounded-full transition-[color,opacity,text-shadow] duration-200",
                   "bg-transparent border-0",
                   s.h, s.px, s.text, size === "lg" ? "font-medium" : "font-normal",
-                  "text-white/70 hover:text-white/70 data-[active=true]:text-white/70",
+                  "text-foreground/70 hover:text-foreground/70 data-[active=true]:text-foreground/70",
                   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] focus-visible:ring-offset-0",
                   item.disabled && "opacity-40 pointer-events-none",
                   item.className
@@ -166,7 +166,7 @@ export default function TabBar({
                 {item.icon && <span className={cn("mr-2 grid place-items-center", size !== "lg" ? "[&>svg]:h-4 [&>svg]:w-4" : "[&>svg]:h-5 [&>svg]:w-5")}>{item.icon}</span>}
                 <span className="truncate">{item.label}</span>
                 {item.badge != null && (
-                  <span className="ml-2 inline-flex items-center justify-center rounded-full text-[10px] leading-none px-2 py-1 bg-[hsl(var(--primary-soft))] text-white/70">
+                  <span className="ml-2 inline-flex items-center justify-center rounded-full text-[10px] leading-none px-2 py-1 bg-[hsl(var(--primary-soft))] text-foreground/70">
                     {item.badge}
                   </span>
                 )}

--- a/src/components/ui/league/SideSelector.tsx
+++ b/src/components/ui/league/SideSelector.tsx
@@ -92,7 +92,7 @@ export default function SideSelector({
         <div
           className={cn(
             "py-2 text-center transition-colors",
-            !isRight ? "text-white/70" : "text-[hsl(var(--muted-foreground))]"
+            !isRight ? "text-foreground/70" : "text-[hsl(var(--muted-foreground))]"
           )}
           style={{ textShadow: !isRight ? "0 0 10px hsl(200 100% 60% / .35)" : undefined }}
         >
@@ -101,7 +101,7 @@ export default function SideSelector({
         <div
           className={cn(
             "py-2 text-center transition-colors",
-            isRight ? "text-white/70" : "text-[hsl(var(--muted-foreground))]"
+            isRight ? "text-foreground/70" : "text-[hsl(var(--muted-foreground))]"
           )}
           style={{ textShadow: isRight ? "0 0 10px hsl(0 85% 60% / .35)" : undefined }}
         >

--- a/src/components/ui/selects/AnimatedSelect.tsx
+++ b/src/components/ui/selects/AnimatedSelect.tsx
@@ -345,7 +345,7 @@ export default function AnimatedSelect({
                           disabledItem ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
                           active
                             ? "bg-[hsl(var(--primary)/.14)] text-[hsl(var(--primary-foreground))]"
-                            : "hover:bg-white/5",
+                            : "hover:bg-foreground/5",
                           "focus:[outline:none] focus-visible:[outline:none] focus:ring-2 focus:ring-[--theme-ring] focus:ring-offset-0",
                           it.className ?? "",
                         ].join(" ")}

--- a/src/components/ui/toggles/toggle.tsx
+++ b/src/components/ui/toggles/toggle.tsx
@@ -65,7 +65,7 @@ export default function Toggle({
       <span
         className={cn(
           "relative z-10 flex-1 text-center font-mono text-sm transition-colors",
-          !isRight ? "text-white/70" : "text-[hsl(var(--muted-foreground))]"
+          !isRight ? "text-foreground/70" : "text-[hsl(var(--muted-foreground))]"
         )}
         style={{ textShadow: !isRight ? "0 0 10px hsl(200 100% 60% / .35)" : undefined }}
       >
@@ -74,7 +74,7 @@ export default function Toggle({
       <span
         className={cn(
           "relative z-10 flex-1 text-center font-mono text-sm transition-colors",
-          isRight ? "text-white/70" : "text-[hsl(var(--muted-foreground))]"
+          isRight ? "text-foreground/70" : "text-[hsl(var(--muted-foreground))]"
         )}
         style={{ textShadow: isRight ? "0 0 10px hsl(0 85% 60% / .35)" : undefined }}
       >

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -33,6 +33,7 @@ export const COLOR_TOKENS = [
   "surface-vhs",
   "surface-streak",
   "danger",
+  "warning",
   "success",
   "glow-strong",
   "glow-soft",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -25,6 +25,7 @@ const config: Config = {
         glow: "hsl(var(--glow))",
         ringMuted: "hsl(var(--ring-muted))",
         danger: "hsl(var(--danger))",
+        warning: "hsl(var(--warning))",
         success: {
           DEFAULT: "hsl(var(--success))",
           glow: "hsl(var(--success-glow))"


### PR DESCRIPTION
## Summary
- replace hard-coded Tailwind classes with theme tokens
- add `--warning` color token and Tailwind mapping
- document new color mappings and demo token on prompts page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bebe757e6c832ca4584e96c6cd4fe3