### PR TITLE
refactor: remove hardcoded white colors

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -151,6 +151,14 @@ export default function Page() {
       ),
     },
     {
+      label: "Foreground Overlay Box",
+      element: (
+        <div className="w-56 h-6 flex items-center justify-center rounded border border-[hsl(var(--border)/0.1)] bg-[hsl(var(--foreground)/0.05)] text-[hsl(var(--foreground)/0.7)]">
+          FG Overlay
+        </div>
+      ),
+    },
+    {
       label: "Surface",
       element: (
         <div className="w-56 h-6 flex items-center justify-center rounded bg-[hsl(var(--surface))]">

--- a/src/components/goals/DurationSelector.tsx
+++ b/src/components/goals/DurationSelector.tsx
@@ -34,11 +34,11 @@ export default function DurationSelector({
             className={cn(
               "inline-flex items-center justify-center h-9 px-3 rounded-full text-center text-sm",
               "border transition-colors",
-              "border-white/10 bg-white/5 text-white/70",
-              "hover:bg-white/10 hover:text-white/70",
+              "border-[hsl(var(--border)/0.1)] bg-[hsl(var(--foreground)/0.05)] text-[hsl(var(--foreground)/0.7)]",
+              "hover:bg-[hsl(var(--foreground)/0.10)] hover:text-[hsl(var(--foreground)/0.70)]",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
               active &&
-                "border-purple-400/60 bg-purple-500/20 text-white/70 font-semibold"
+                "border-purple-400/60 bg-purple-500/20 text-[hsl(var(--foreground)/0.70)] font-semibold"
             )}
           >
             {m}m

--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -30,13 +30,13 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
     <SectionCard className="card-neo-soft">
       <SectionCard.Header title={<h2 className="text-lg font-semibold">Goal Queue</h2>} />
       <SectionCard.Body className="grid gap-6">
-          <ul className="divide-y divide-white/10">
+          <ul className="divide-y divide-[hsl(var(--border)/0.1)]">
             {items.length === 0 ? (
               <li className="py-3 text-sm text-[hsl(var(--muted-foreground))]">No queued goals</li>
             ) : (
               items.map((it) => (
                 <li key={it.id} className="group flex items-center gap-2 py-3">
-                  <span className="h-1.5 w-1.5 rounded-full bg-white/40" aria-hidden />
+                  <span className="h-1.5 w-1.5 rounded-full bg-[hsl(var(--foreground)/0.4)]" aria-hidden />
                   <p className="flex-1 truncate text-sm">{it.text}</p>
                   <time
                     className="text-xs text-[hsl(var(--muted-foreground))] opacity-0 group-hover:opacity-100"
@@ -63,7 +63,7 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
           </ul>
 
           <form onSubmit={submit} className="flex items-center gap-2 pt-3">
-            <span className="h-1.5 w-1.5 rounded-full bg-white/40" aria-hidden />
+            <span className="h-1.5 w-1.5 rounded-full bg-[hsl(var(--foreground)/0.4)]" aria-hidden />
             <Input
               tone="default"
               className="flex-1 h-9 text-sm"

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -665,7 +665,7 @@ export default function ReviewEditor({
               <div
                 className={cn(
                   "py-2 text-center",
-                  result === "Win" ? "text-white/70" : "text-[hsl(var(--muted-foreground))]"
+                  result === "Win" ? "text-[hsl(var(--foreground)/0.7)]" : "text-[hsl(var(--muted-foreground))]"
                 )}
               >
                 Win
@@ -673,7 +673,7 @@ export default function ReviewEditor({
               <div
                 className={cn(
                   "py-2 text-center",
-                  result === "Loss" ? "text-white/70" : "text-[hsl(var(--muted-foreground))]"
+                  result === "Loss" ? "text-[hsl(var(--foreground)/0.7)]" : "text-[hsl(var(--muted-foreground))]"
                 )}
               >
                 Loss
@@ -898,7 +898,7 @@ export default function ReviewEditor({
               />
             ) : (
               <span
-                className="inline-flex h-10 items-center justify-center gap-2 rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 text-sm text-white/70"
+                className="inline-flex h-10 items-center justify-center gap-2 rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 text-sm text-[hsl(var(--foreground)/0.7)]"
                 style={{ width: "calc(5ch + 1.5rem)" }}
                 title="Timestamp disabled"
               >

--- a/src/components/reviews/ReviewSummary.tsx
+++ b/src/components/reviews/ReviewSummary.tsx
@@ -289,8 +289,8 @@ export default function ReviewSummary({ review, onEdit, className }: Props) {
         <div className="grid w-full grid-cols-[1fr_auto] items-center gap-4">
           {/* Left: Title */}
           <div className="min-w-0">
-            <div className="mb-0.5 text-xs text-white/25">Title</div>
-            <div className="truncate text-lg font-medium leading-7 text-white/70">
+            <div className="mb-0.5 text-xs text-[hsl(var(--foreground)/0.25)]">Title</div>
+            <div className="truncate text-lg font-medium leading-7 text-[hsl(var(--foreground)/0.7)]">
               {laneTitle || "Untitled review"}
             </div>
           </div>
@@ -377,7 +377,7 @@ export default function ReviewSummary({ review, onEdit, className }: Props) {
             <div className="mt-4 space-y-1.5">
               <div className="mb-2 flex items-center gap-2" aria-label="Focus">
                 <NeonIcon kind="brain" on={true} size={32} staticGlow />
-                <div className="h-px flex-1 bg-gradient-to-r from-white/20 via-white/5 to-transparent" />
+                <div className="h-px flex-1 bg-gradient-to-r from-[hsl(var(--foreground)/0.20)] via-[hsl(var(--foreground)/0.05)] to-transparent" />
               </div>
 
               <div className="relative h-12 rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-4">
@@ -427,7 +427,7 @@ export default function ReviewSummary({ review, onEdit, className }: Props) {
           <div className="mb-2 flex items-center gap-2" aria-label="Timestamps">
             <NeonIcon kind="clock" on={!!hasTimed} size={32} staticGlow />
             <NeonIcon kind="file" on={!!hasNoteOnly} size={32} staticGlow />
-            <div className="h-px flex-1 bg-gradient-to-r from-white/20 via-white/5 to-transparent" />
+            <div className="h-px flex-1 bg-gradient-to-r from-[hsl(var(--foreground)/0.20)] via-[hsl(var(--foreground)/0.05)] to-transparent" />
           </div>
 
           {!markers.length ? (
@@ -465,7 +465,7 @@ export default function ReviewSummary({ review, onEdit, className }: Props) {
         {review.notes ? (
           <div>
             <SectionLabel>Notes</SectionLabel>
-            <div className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-3 text-sm leading-6 text-white/70">
+            <div className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-3 text-sm leading-6 text-[hsl(var(--foreground)/0.7)]">
               {review.notes}
             </div>
           </div>

--- a/src/components/reviews/SectionLabel.tsx
+++ b/src/components/reviews/SectionLabel.tsx
@@ -4,8 +4,8 @@ import * as React from "react";
 export default function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
     <div className="mb-2 flex items-center gap-2">
-      <div className="text-xs tracking-wide text-white/20">{children}</div>
-      <div className="h-px flex-1 bg-gradient-to-r from-white/20 via-white/5 to-transparent" />
+      <div className="text-xs tracking-wide text-[hsl(var(--foreground)/0.2)]">{children}</div>
+      <div className="h-px flex-1 bg-gradient-to-r from-[hsl(var(--foreground)/0.20)] via-[hsl(var(--foreground)/0.05)] to-transparent" />
     </div>
   );
 }

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -155,7 +155,7 @@ export default function TabBar({
                   "relative inline-flex items-center select-none rounded-full transition-[color,opacity,text-shadow] duration-200",
                   "bg-transparent border-0",
                   s.h, s.px, s.text, size === "lg" ? "font-medium" : "font-normal",
-                  "text-white/70 hover:text-white/70 data-[active=true]:text-white/70",
+                  "text-[hsl(var(--foreground)/0.7)] hover:text-[hsl(var(--foreground)/0.7)] data-[active=true]:text-[hsl(var(--foreground)/0.7)]",
                   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] focus-visible:ring-offset-0",
                   item.disabled && "opacity-40 pointer-events-none",
                   item.className
@@ -166,7 +166,7 @@ export default function TabBar({
                 {item.icon && <span className={cn("mr-2 grid place-items-center", size !== "lg" ? "[&>svg]:h-4 [&>svg]:w-4" : "[&>svg]:h-5 [&>svg]:w-5")}>{item.icon}</span>}
                 <span className="truncate">{item.label}</span>
                 {item.badge != null && (
-                  <span className="ml-2 inline-flex items-center justify-center rounded-full text-[10px] leading-none px-2 py-1 bg-[hsl(var(--primary-soft))] text-white/70">
+                  <span className="ml-2 inline-flex items-center justify-center rounded-full text-[10px] leading-none px-2 py-1 bg-[hsl(var(--primary-soft))] text-[hsl(var(--foreground)/0.7)]">
                     {item.badge}
                   </span>
                 )}

--- a/src/components/ui/league/SideSelector.tsx
+++ b/src/components/ui/league/SideSelector.tsx
@@ -92,7 +92,7 @@ export default function SideSelector({
         <div
           className={cn(
             "py-2 text-center transition-colors",
-            !isRight ? "text-white/70" : "text-[hsl(var(--muted-foreground))]"
+            !isRight ? "text-[hsl(var(--foreground)/0.7)]" : "text-[hsl(var(--muted-foreground))]"
           )}
           style={{ textShadow: !isRight ? "0 0 10px hsl(200 100% 60% / .35)" : undefined }}
         >
@@ -101,7 +101,7 @@ export default function SideSelector({
         <div
           className={cn(
             "py-2 text-center transition-colors",
-            isRight ? "text-white/70" : "text-[hsl(var(--muted-foreground))]"
+            isRight ? "text-[hsl(var(--foreground)/0.7)]" : "text-[hsl(var(--muted-foreground))]"
           )}
           style={{ textShadow: isRight ? "0 0 10px hsl(0 85% 60% / .35)" : undefined }}
         >

--- a/src/components/ui/selects/AnimatedSelect.tsx
+++ b/src/components/ui/selects/AnimatedSelect.tsx
@@ -345,7 +345,7 @@ export default function AnimatedSelect({
                           disabledItem ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
                           active
                             ? "bg-[hsl(var(--primary)/.14)] text-[hsl(var(--primary-foreground))]"
-                            : "hover:bg-white/5",
+                            : "hover:bg-[hsl(var(--foreground)/0.05)]",
                           "focus:[outline:none] focus-visible:[outline:none] focus:ring-2 focus:ring-[--theme-ring] focus:ring-offset-0",
                           it.className ?? "",
                         ].join(" ")}

--- a/src/components/ui/toggles/toggle.tsx
+++ b/src/components/ui/toggles/toggle.tsx
@@ -65,7 +65,7 @@ export default function Toggle({
       <span
         className={cn(
           "relative z-10 flex-1 text-center font-mono text-sm transition-colors",
-          !isRight ? "text-white/70" : "text-[hsl(var(--muted-foreground))]"
+          !isRight ? "text-[hsl(var(--foreground)/0.7)]" : "text-[hsl(var(--muted-foreground))]"
         )}
         style={{ textShadow: !isRight ? "0 0 10px hsl(200 100% 60% / .35)" : undefined }}
       >
@@ -74,7 +74,7 @@ export default function Toggle({
       <span
         className={cn(
           "relative z-10 flex-1 text-center font-mono text-sm transition-colors",
-          isRight ? "text-white/70" : "text-[hsl(var(--muted-foreground))]"
+          isRight ? "text-[hsl(var(--foreground)/0.7)]" : "text-[hsl(var(--muted-foreground))]"
         )}
         style={{ textShadow: isRight ? "0 0 10px hsl(0 85% 60% / .35)" : undefined }}
       >


### PR DESCRIPTION
## Summary
- replace white utility classes with theme variables across goal, review, and UI components
- document foreground overlay style on prompts page

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bec06ffbc0832cb3deb245dd039025