### PR TITLE
chore: unify top-level page spacing

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -152,7 +152,11 @@ export default function GoalsPage() {
       : "Pick a duration and focus.";
 
   return (
-    <main id="goals-main" role="main" className="page-shell grid gap-6 py-6">
+    <main
+      id="goals-main"
+      role="main"
+      className="page-shell py-6 space-y-6"
+    >
       {/* ======= HERO ======= */}
       <Hero
         eyebrow="Goals"

--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -89,7 +89,10 @@ function Inner() {
 
   return (
     <>
-      <main className="page-shell py-6 space-y-6" aria-labelledby="planner-week-heading">
+      <main
+        className="page-shell py-6 space-y-6"
+        aria-labelledby="planner-week-heading"
+      >
       {/* Week header (range, nav, totals, day chips) */}
       <h1 id="planner-week-heading" className="sr-only">
         Weekly planner

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -92,7 +92,7 @@ export default function ReviewsPage({
   const active = base.find((r) => r.id === selectedId) || null;
 
   return (
-    <main className="page-shell space-y-6 py-6">
+    <main className="page-shell py-6 space-y-6">
       <Hero2
         heading={
           <div className="flex items-center gap-2">

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -35,7 +35,7 @@ export default function TeamCompPage() {
   const [tab, setTab] = useState<Tab>("cheat");
 
   return (
-    <main className="page-shell grid gap-4 py-6">
+    <main className="page-shell py-6 space-y-6">
       <Hero
         eyebrow="Comps"
         heading="Today"


### PR DESCRIPTION
## Summary
- standardize top-level page spacing using `space-y-6` with `py-6`
- adjust Planner, Reviews, Goals, and Team Comp pages for consistent layout

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`
- `npm run build`
- `curl -s http://localhost:3000/planner | grep -o 'page-shell[^"<]*'`
- `curl -s http://localhost:3000/reviews | grep -o 'page-shell[^"<]*'`
- `curl -s http://localhost:3000/goals | grep -o 'page-shell[^"<]*'`
- `curl -s http://localhost:3000/comps | grep -o 'page-shell[^"<]*'`


------
https://chatgpt.com/codex/tasks/task_e_68bebf6e6e1c832c901c4fa7151fdcfe