### PR TITLE
feat: set default Hero2 top offset

### DIFF
--- a/src/components/team/JungleClears.tsx
+++ b/src/components/team/JungleClears.tsx
@@ -128,6 +128,7 @@ export default function JungleClears() {
       {/* Top: Hero2 header with pill search (round) */}
       <Hero2
         sticky={false}
+        topClassName="top-0"
         rail
         heading="Clear Speed Buckets"
         dividerTint="primary"

--- a/src/components/ui/layout/Hero2.tsx
+++ b/src/components/ui/layout/Hero2.tsx
@@ -63,7 +63,7 @@ export default function Hero2({
   right,
   children,
   sticky = true,
-  topClassName,
+  topClassName = "top-8",
   barClassName,
   bodyClassName,
   rail = true,


### PR DESCRIPTION
## Summary
- default Hero2 topClassName to `top-8`
- ensure non-sticky JungleClears hero uses `top-0`

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bec67b622c832ca5b17c88db3886a5