### PR TITLE
feat: make SectionCard headers offset-aware

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -533,7 +533,7 @@ export default function Page() {
       label: "Prompts Header",
       element: (
         <SectionCard className="w-full">
-          <SectionCard.Header>
+          <SectionCard.Header sticky topClassName="top-8">
             <PromptsHeader
               count={0}
               query=""

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -204,7 +204,11 @@ export default function GoalsPage() {
                 />
               ) : (
                 <SectionCard className="card-neo-soft">
-                  <SectionCard.Header sticky className="flex items-center justify-between">
+                  <SectionCard.Header
+                    sticky
+                    topClassName="top-0"
+                    className="flex items-center justify-between"
+                  >
                     <div className="flex items-center gap-2 sm:gap-4">
                       <h2 className="text-lg font-semibold">Your Goals</h2>
                       <GoalsProgress total={totalCount} pct={pctDone} />

--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -164,7 +164,7 @@ export default function Reminders() {
   return (
     <div className="grid gap-2.5">
       <SectionCard className="card-neo-soft">
-        <SectionCard.Header sticky>
+        <SectionCard.Header sticky topClassName="top-0">
           {/* header row (no Quick Add here anymore) */}
           <div className="flex flex-wrap items-center gap-2 sm:gap-3 w-full">
             {/* search */}

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -161,7 +161,7 @@ export default function TimerTab() {
 
   return (
     <SectionCard className="goal-card no-hover">
-      <SectionCard.Header sticky>
+      <SectionCard.Header sticky topClassName="top-0">
         <TabBar
           items={tabItems}
           value={profile}

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -70,7 +70,7 @@ export default function PromptsPage() {
 
   return (
     <SectionCard>
-      <SectionCard.Header sticky className="gap-3">
+      <SectionCard.Header sticky topClassName="top-8" className="gap-3">
         <PromptsHeader
           count={prompts.length}
           query={query}

--- a/src/components/ui/layout/SectionCard.tsx
+++ b/src/components/ui/layout/SectionCard.tsx
@@ -2,11 +2,13 @@
 "use client";
 
 import * as React from "react";
+import clsx from "clsx";
 import { cn } from "@/lib/utils";
 
 type RootProps = React.HTMLAttributes<HTMLDivElement>;
 export type HeaderProps = {
   sticky?: boolean;
+  topClassName?: string; // sticky top offset
   className?: string;
   children?: React.ReactNode; // if provided, we render this and ignore title/actions
   title?: React.ReactNode; // optional convenience API
@@ -25,9 +27,22 @@ function Root({ className, children, ...props }: RootProps) {
   );
 }
 
-function Header({ sticky, className, children, title, actions }: HeaderProps) {
+function Header({
+  sticky,
+  topClassName = "top-8",
+  className,
+  children,
+  title,
+  actions,
+}: HeaderProps) {
   return (
-    <div className={cn("section-h", sticky && "sticky", className)}>
+    <div
+      className={cn(
+        "section-h",
+        sticky && clsx("sticky", topClassName),
+        className
+      )}
+    >
       {children ?? (
         <div className="flex w-full items-center justify-between">
           <div>{title}</div>


### PR DESCRIPTION
## Summary
- extend SectionCard.Header with optional `topClassName` to control sticky offset
- update sticky header call sites to specify their desired `top-*` class
- show sticky SectionCard header usage on the Prompts gallery page

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bed0909f00832caa8df21253551a38