### PR TITLE
refactor: remove IconButton circleSize prop

### DIFF
--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -14,8 +14,6 @@ export type IconButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   iconSize?: Icon;
   tone?: Tone;
   variant?: Variant;
-  /** @deprecated use size */
-  circleSize?: ButtonSize;
 };
 
 const iconMap: Record<Icon, string> = {
@@ -72,19 +70,10 @@ const toneClasses: Record<Variant, Record<Tone, string>> = {
 
 const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
   (
-    {
-      size = "sm",
-      circleSize,
-      iconSize = size as Icon,
-      className,
-      tone = "primary",
-      variant = "ring",
-      ...props
-    },
+    { size = "sm", iconSize = size as Icon, className, tone = "primary", variant = "ring", ...props },
     ref
   ) => {
-    const finalSize = circleSize ?? size;
-    const sizeClass = sizeMap[finalSize];
+    const sizeClass = sizeMap[size];
     return (
       <button
         ref={ref}


### PR DESCRIPTION
## Summary
- remove deprecated `circleSize` prop from `IconButton`
- rely on `size` for button dimensions

## Testing
- `npm test`
- `npm run typecheck`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bec6185ba4832cbcd7a3dddddb7345