### PR TITLE
test: add prompts component tests

### DIFF
--- a/tests/prompts/prompts-compose-panel.test.tsx
+++ b/tests/prompts/prompts-compose-panel.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import PromptsComposePanel from '@/components/prompts/PromptsComposePanel';
+
+afterEach(cleanup);
+
+describe('PromptsComposePanel', () => {
+  it('renders fields and handles changes', () => {
+    const handleTitle = vi.fn();
+    const handleText = vi.fn();
+    render(
+      <PromptsComposePanel
+        title="Title"
+        onTitleChange={handleTitle}
+        text="Text"
+        onTextChange={handleText}
+      />
+    );
+
+    const titleInput = screen.getByPlaceholderText('Title');
+    const textarea = screen.getByPlaceholderText('Write your prompt or snippet…');
+    expect(titleInput).toHaveValue('Title');
+    expect(textarea).toHaveValue('Text');
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+
+    fireEvent.change(titleInput, { target: { value: 'New' } });
+    expect(handleTitle).toHaveBeenCalledWith('New');
+    fireEvent.change(textarea, { target: { value: 'Body' } });
+    expect(handleText).toHaveBeenCalledWith('Body');
+  });
+});
+

--- a/tests/prompts/prompts-demos.test.tsx
+++ b/tests/prompts/prompts-demos.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import PromptsDemos from '@/components/prompts/PromptsDemos';
+
+afterEach(cleanup);
+
+describe('PromptsDemos', () => {
+  it('renders key demo sections', () => {
+    render(<PromptsDemos />);
+    expect(
+      screen.getByRole('button', { name: 'Focus me to see the glow' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Input' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Select' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Textarea' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Scroll to top' })
+    ).toBeInTheDocument();
+  });
+});
+

--- a/tests/prompts/prompts-header.test.tsx
+++ b/tests/prompts/prompts-header.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import PromptsHeader from '@/components/prompts/PromptsHeader';
+
+afterEach(cleanup);
+
+describe('PromptsHeader', () => {
+  it('renders count, search input, and disabled save button', () => {
+    const handleQuery = vi.fn();
+    const handleSave = vi.fn();
+    render(
+      <PromptsHeader
+        count={2}
+        query="hello"
+        onQueryChange={handleQuery}
+        onSave={handleSave}
+        disabled
+      />
+    );
+
+    expect(screen.getByText('Prompts')).toBeInTheDocument();
+    expect(screen.getByText('2 saved')).toBeInTheDocument();
+    const search = screen.getByPlaceholderText('Search prompts…') as HTMLInputElement;
+    expect(search.value).toBe('hello');
+    const save = screen.getByRole('button', { name: 'Save' });
+    expect(save).toBeDisabled();
+
+    fireEvent.change(search, { target: { value: 'changed' } });
+    expect(handleQuery).toHaveBeenCalledWith('changed');
+  });
+
+  it('calls onSave when save button clicked', () => {
+    const handleSave = vi.fn();
+    render(
+      <PromptsHeader
+        count={0}
+        query=""
+        onQueryChange={() => {}}
+        onSave={handleSave}
+        disabled={false}
+      />
+    );
+    const save = screen.getByRole('button', { name: 'Save' });
+    fireEvent.click(save);
+    expect(handleSave).toHaveBeenCalled();
+  });
+});
+

--- a/tests/prompts/prompts-page.test.tsx
+++ b/tests/prompts/prompts-page.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, beforeEach, expect, afterEach } from 'vitest';
+import PromptsPage from '@/components/prompts/PromptsPage';
+import { resetLocalStorage } from '../setup';
+
+afterEach(cleanup);
+
+describe('PromptsPage', () => {
+  beforeEach(() => {
+    resetLocalStorage();
+  });
+
+  it('saves prompts and filters results', async () => {
+    render(<PromptsPage />);
+
+    const titleInput = screen.getByPlaceholderText('Title');
+    const textArea = screen.getByPlaceholderText('Write your prompt or snippet…');
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+
+    fireEvent.change(titleInput, { target: { value: 'First' } });
+    fireEvent.change(textArea, { target: { value: 'one' } });
+    fireEvent.click(saveButton);
+    await screen.findByText('First');
+    expect(screen.getByText('1 saved')).toBeInTheDocument();
+
+    fireEvent.change(titleInput, { target: { value: '' } });
+    fireEvent.change(textArea, { target: { value: 'Second line\nmore' } });
+    fireEvent.click(saveButton);
+    await screen.findByText('Second line');
+    expect(screen.getByText('2 saved')).toBeInTheDocument();
+
+    const search = screen.getByPlaceholderText('Search prompts…');
+    fireEvent.change(search, { target: { value: 'second' } });
+    expect(screen.getByText('Second line')).toBeInTheDocument();
+    expect(screen.queryByText('First')).not.toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: 'zzz' } });
+    expect(
+      screen.getByText('Nothing matches your search. Typical.')
+    ).toBeInTheDocument();
+  });
+
+  it('ignores empty saves', async () => {
+    render(<PromptsPage />);
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    expect(saveButton).toBeDisabled();
+    fireEvent.click(saveButton);
+    await waitFor(() => expect(screen.getByText('0 saved')).toBeInTheDocument());
+    expect(
+      screen.getByText('Nothing matches your search. Typical.')
+    ).toBeInTheDocument();
+  });
+});
+

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,1 +1,5 @@
 import '@testing-library/jest-dom/vitest';
+
+export function resetLocalStorage() {
+  window.localStorage.clear();
+}


### PR DESCRIPTION
## Summary
- add tests for prompts header, compose panel, demos, and page
- export resetLocalStorage test utility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bed2218ee8832cb6b69225ad769df2