### PR TITLE
Use local CSS imports for review and team components

### DIFF
--- a/src/components/reviews/ReviewCard.tsx
+++ b/src/components/reviews/ReviewCard.tsx
@@ -1,5 +1,5 @@
 "use client";
-import "../reviews/style.css";
+import "./style.css";
 
 import type { Review } from "@/lib/types";
 import { cn } from "@/lib/utils";

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 // Full Review Editor with icon-only header actions and RoleSelector rail control.
-import "../reviews/style.css";
+import "./style.css";
 import RoleSelector from "@/components/reviews/RoleSelector";
 import SectionLabel from "@/components/reviews/SectionLabel";
 

--- a/src/components/reviews/ReviewSummary.tsx
+++ b/src/components/reviews/ReviewSummary.tsx
@@ -1,6 +1,6 @@
 // src/components/reviews/ReviewSummary.tsx
 "use client";
-import "../reviews/style.css";
+import "./style.css";
 
 import * as React from "react";
 import type { Review, Pillar, Role, ReviewMarker } from "@/lib/types";

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -1,5 +1,5 @@
 "use client";
-import "../reviews/style.css";
+import "./style.css";
 
 import { useMemo, useState } from "react";
 import type { Review } from "@/lib/types";

--- a/src/components/reviews/StatsStrip.tsx
+++ b/src/components/reviews/StatsStrip.tsx
@@ -1,5 +1,5 @@
 "use client";
-import "../reviews/style.css";
+import "./style.css";
 
 export default function StatsStrip({
   total,

--- a/src/components/team/Builder.tsx
+++ b/src/components/team/Builder.tsx
@@ -1,6 +1,6 @@
 // src/components/team/Builder.tsx
 "use client";
-import "../team/style.css";
+import "./style.css";
 
 /**
  * Builder — Allies vs Enemies with a center divider

--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -1,6 +1,6 @@
 // src/components/team/CheatSheet.tsx
 "use client";
-import "../team/style.css";
+import "./style.css";
 
 /**
  * CheatSheet — hover-only edit per card, write-through persistence.

--- a/src/components/team/CheatSheetTabs.tsx
+++ b/src/components/team/CheatSheetTabs.tsx
@@ -1,6 +1,6 @@
 // src/components/team/CheatSheetTabs.tsx
 "use client";
-import "../team/style.css";
+import "./style.css";
 
 import * as React from "react";
 import { BookOpen, Users2 } from "lucide-react";

--- a/src/components/team/JungleClears.tsx
+++ b/src/components/team/JungleClears.tsx
@@ -1,6 +1,6 @@
 // src/components/team/JungleClears.tsx
 "use client";
-import "../team/style.css";
+import "./style.css";
 
 /**
  * JungleClears

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -10,7 +10,7 @@
  * - Scoped with data-scope="team" so glitch effects don't bleed globally
  */
 
-import "../team/style.css";
+import "./style.css";
 
 import * as React from "react";
 import { useLocalDB, uid } from "@/lib/db";

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -10,7 +10,7 @@
  * Uses Hero (v1) + HeroTabs for the main header.
  * The Cheat Sheet tab itself renders a nested Hero2 internally.
  */
-import "../team/style.css";
+import "./style.css";
 
 import { useState } from "react";
 import { Users2, BookOpenText, Hammer, Timer } from "lucide-react";


### PR DESCRIPTION
## Summary
- refactor: import local `style.css` in review and team components
- chore: verify Next.js build and tests pass

## Testing
- `npm run build`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68beda29d09c832cb7db6632e4847f4b