### PR TITLE
Remove redundant background styling from prompts page

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -573,7 +573,7 @@ export default function Page() {
   ];
 
   return (
-    <main className="page-shell py-6 bg-background text-foreground">
+    <main className="page-shell py-6">
       <p className="mb-4 text-sm text-muted-foreground">
         Global styles are now modularized into <code>animations.css</code>,<code>overlays.css</code>, and <code>utilities.css</code>.
       </p>


### PR DESCRIPTION
## Summary
- rely on global layout's body classes for background and foreground
- clean up prompts page main element

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bedc919968832cb1562812675c1ce9