### PR TITLE
refactor: simplify hero bar alignment

### DIFF
--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -66,7 +66,7 @@ export default function Hero({
       {/* Top bar */}
       <div
         className={cx(
-          "relative flex items-center justify-between gap-3",
+          "relative flex items-center",
           "px-3 sm:px-4 py-2 min-h-12",
           barClassName
         )}
@@ -101,7 +101,7 @@ export default function Hero({
         </div>
 
         {/* Right slot */}
-        {right ? <div className="shrink-0">{right}</div> : <div className="shrink-0" />}
+        {right ? <div className="ml-auto shrink-0">{right}</div> : null}
       </div>
 
       {/* Body under the bar */}


### PR DESCRIPTION
## Summary
- streamline Hero bar container with flex items-center alignment
- remove placeholder when no right slot content

## Testing
- `npm test` *(fails: require() of ES Module vite not supported)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bee49d21d0832cbd6bde6ed0b67ffa