### PR TITLE
feat: expand icon button sizes

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -119,6 +119,9 @@ export default function Page() {
           <IconButton variant="glow" size="md" aria-label="Search" title="Search">
             <SearchIcon />
           </IconButton>
+          <IconButton variant="ring" size="xl" aria-label="Search" title="Search">
+            <SearchIcon />
+          </IconButton>
         </div>
       ),
     },
@@ -413,6 +416,9 @@ export default function Page() {
           </IconButton>
           <IconButton size="lg" aria-label="Toggle theme" title="Toggle theme">
             <Sun />
+          </IconButton>
+          <IconButton size="xl" aria-label="Search" title="Search">
+            <SearchIcon />
           </IconButton>
         </div>
       ),

--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -317,27 +317,63 @@ function ReminderCard({
         )}
 
         <div className="card-neo flex items-center gap-1">
-          <IconButton title={value.pinned ? "Unpin" : "Pin"} aria-label={value.pinned ? "Unpin" : "Pin"} onClick={() => onChange({ pinned: !value.pinned })}>
+          <IconButton
+            title={value.pinned ? "Unpin" : "Pin"}
+            aria-label={value.pinned ? "Unpin" : "Pin"}
+            onClick={() => onChange({ pinned: !value.pinned })}
+            size="sm"
+            iconSize="sm"
+          >
             {value.pinned ? <PinOff /> : <Pin />}
           </IconButton>
-          <IconButton title="Duplicate" aria-label="Duplicate" onClick={onDuplicate}>
+          <IconButton
+            title="Duplicate"
+            aria-label="Duplicate"
+            onClick={onDuplicate}
+            size="sm"
+            iconSize="sm"
+          >
             <Copy />
           </IconButton>
           {editing ? (
             <>
-              <IconButton title="Save (Enter)" aria-label="Save" onClick={save}>
+              <IconButton
+                title="Save (Enter)"
+                aria-label="Save"
+                onClick={save}
+                size="sm"
+                iconSize="sm"
+              >
                 <Check />
               </IconButton>
-              <IconButton title="Cancel (Esc)" aria-label="Cancel" onClick={cancel}>
+              <IconButton
+                title="Cancel (Esc)"
+                aria-label="Cancel"
+                onClick={cancel}
+                size="sm"
+                iconSize="sm"
+              >
                 <X />
               </IconButton>
             </>
           ) : (
             <>
-              <IconButton title="Edit" aria-label="Edit" onClick={() => setEditing(true)}>
+              <IconButton
+                title="Edit"
+                aria-label="Edit"
+                onClick={() => setEditing(true)}
+                size="sm"
+                iconSize="sm"
+              >
                 <Pencil />
               </IconButton>
-              <IconButton title="Delete" aria-label="Delete" onClick={onDelete}>
+              <IconButton
+                title="Delete"
+                aria-label="Delete"
+                onClick={onDelete}
+                size="sm"
+                iconSize="sm"
+              >
                 <Trash2 />
               </IconButton>
             </>

--- a/src/components/prompts/PromptsDemos.tsx
+++ b/src/components/prompts/PromptsDemos.tsx
@@ -124,7 +124,7 @@ export default function PromptsDemos() {
       <Card className="mt-8 space-y-4">
         <h3 className="type-title">IconButton</h3>
         <div className="space-x-3">
-          <IconButton aria-label="Scroll to top">
+          <IconButton aria-label="Scroll to top" size="md">
             <ArrowUp />
           </IconButton>
         </div>

--- a/src/components/team/Builder.tsx
+++ b/src/components/team/Builder.tsx
@@ -161,6 +161,8 @@ export default function Builder() {
                 title="Swap Allies ↔ Enemies"
                 aria-label="Swap Allies and Enemies"
                 onClick={swapSides}
+                size="sm"
+                iconSize="sm"
               >
                 <Shuffle />
               </IconButton>
@@ -168,6 +170,8 @@ export default function Builder() {
                 title="Copy both sides"
                 aria-label="Copy both sides"
                 onClick={() => copy("all")}
+                size="sm"
+                iconSize="sm"
               >
                 {copied === "all" ? <ClipboardCheck /> : <Clipboard />}
               </IconButton>
@@ -288,6 +292,8 @@ function SideEditor(props: {
             aria-label={`Clear ${title}`}
             variant="ring"
             onClick={onClear}
+            size="sm"
+            iconSize="sm"
           >
             <Eraser />
           </IconButton>
@@ -295,6 +301,8 @@ function SideEditor(props: {
             title={`Copy ${title}`}
             aria-label={`Copy ${title}`}
             onClick={onCopy}
+            size="sm"
+            iconSize="sm"
           >
             <Copy />
           </IconButton>

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -4,29 +4,32 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 import type { ButtonSize } from "./Button";
 
-type Icon = "xs" | "sm" | "md" | "lg";
+type IconButtonSize = ButtonSize | "xl";
+type Icon = "xs" | "sm" | "md" | "lg" | "xl";
 
 type Tone = "primary" | "accent" | "info" | "danger";
 type Variant = "ring" | "glow" | "solid";
 
 export type IconButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  size?: ButtonSize;
+  size?: IconButtonSize;
   iconSize?: Icon;
   tone?: Tone;
   variant?: Variant;
 };
 
 const iconMap: Record<Icon, string> = {
-  xs: "[&>svg]:h-3.5 [&>svg]:w-3.5",
-  sm: "[&>svg]:h-4 [&>svg]:w-4",
-  md: "[&>svg]:h-5 [&>svg]:w-5",
-  lg: "[&>svg]:h-6 [&>svg]:w-6",
+  xs: "[&>svg]:h-5 [&>svg]:w-5",
+  sm: "[&>svg]:h-6 [&>svg]:w-6",
+  md: "[&>svg]:h-7 [&>svg]:w-7",
+  lg: "[&>svg]:h-8 [&>svg]:w-8",
+  xl: "[&>svg]:h-9 [&>svg]:w-9",
 };
 
-const sizeMap: Record<ButtonSize, string> = {
-  sm: "h-5 w-5",
-  md: "h-6 w-6",
-  lg: "h-7 w-7",
+const sizeMap: Record<IconButtonSize, string> = {
+  sm: "h-9 w-9",
+  md: "h-10 w-10",
+  lg: "h-11 w-11",
+  xl: "h-12 w-12",
 };
 
 const variantBase: Record<Variant, string> = {
@@ -70,7 +73,7 @@ const toneClasses: Record<Variant, Record<Tone, string>> = {
 
 const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
   (
-    { size = "sm", iconSize = size as Icon, className, tone = "primary", variant = "ring", ...props },
+    { size = "md", iconSize = size as Icon, className, tone = "primary", variant = "ring", ...props },
     ref
   ) => {
     const sizeClass = sizeMap[size];


### PR DESCRIPTION
## Summary
- enlarge `IconButton` default sizing and add optional `xl`
- scale icons to match new button sizes
- document new `IconButton` size on prompts page and update consumers relying on small buttons

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bef69ecf4c832cbdd53833728a8ea8