### PR TITLE
fix: add button type attribute

### DIFF
--- a/src/components/prompts/OutlineGlowDemo.tsx
+++ b/src/components/prompts/OutlineGlowDemo.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 export default function OutlineGlowDemo() {
   return (
     <div className="mb-4">
-      <button className="p-2 rounded-md border">
+      <button type="button" className="p-2 rounded-md border">
         Focus me to see the glow
       </button>
     </div>


### PR DESCRIPTION
## Summary
- add explicit `type="button"` to `OutlineGlowDemo` demo button

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bef9bdf448832c8b2b48a7496bb2ec