### PR TITLE
refactor planner CRUD helpers

### DIFF
--- a/src/components/planner/dayCrud.ts
+++ b/src/components/planner/dayCrud.ts
@@ -1,0 +1,77 @@
+import type { DayRecord } from "./usePlanner";
+
+export function addProject(day: DayRecord, id: string, name: string) {
+  const title = name.trim();
+  if (!title) return day;
+  const createdAt = Date.now();
+  const projects = [
+    ...day.projects,
+    { id, name: title, done: false, createdAt },
+  ];
+  return { ...day, projects };
+}
+
+export function renameProject(day: DayRecord, id: string, name: string) {
+  return {
+    ...day,
+    projects: day.projects.map((p) => (p.id === id ? { ...p, name } : p)),
+  };
+}
+
+export function toggleProject(day: DayRecord, id: string) {
+  const wasDone = day.projects.find((p) => p.id === id)?.done ?? false;
+  const projects = day.projects.map((p) =>
+    p.id === id ? { ...p, done: !wasDone } : p,
+  );
+  const tasks = day.tasks.map((t) =>
+    t.projectId === id ? { ...t, done: !wasDone } : t,
+  );
+  return { ...day, projects, tasks };
+}
+
+export function removeProject(day: DayRecord, id: string) {
+  return {
+    ...day,
+    projects: day.projects.filter((p) => p.id !== id),
+    tasks: day.tasks.filter((t) => t.projectId !== id),
+  };
+}
+
+export function addTask(
+  day: DayRecord,
+  id: string,
+  title: string,
+  projectId?: string,
+) {
+  const name = title.trim();
+  if (!name) return day;
+  const createdAt = Date.now();
+  const tasks = [
+    ...day.tasks,
+    { id, title: name, done: false, projectId, createdAt },
+  ];
+  return { ...day, tasks };
+}
+
+export function renameTask(day: DayRecord, id: string, next: string) {
+  const title = next.trim();
+  if (!title) return day;
+  return {
+    ...day,
+    tasks: day.tasks.map((t) => (t.id === id ? { ...t, title } : t)),
+  };
+}
+
+export function toggleTask(day: DayRecord, id: string) {
+  return {
+    ...day,
+    tasks: day.tasks.map((t) => (t.id === id ? { ...t, done: !t.done } : t)),
+  };
+}
+
+export function removeTask(day: DayRecord, id: string) {
+  return {
+    ...day,
+    tasks: day.tasks.filter((t) => t.id !== id),
+  };
+}

--- a/src/components/planner/usePlanner.ts
+++ b/src/components/planner/usePlanner.ts
@@ -10,6 +10,16 @@ import "./style.css";
 import * as React from "react";
 import { useLocalDB, uid } from "@/lib/db";
 import { toISO, addDays, weekRangeFromISO } from "@/lib/date";
+import {
+  addProject as dayAddProject,
+  renameProject as dayRenameProject,
+  toggleProject as dayToggleProject,
+  removeProject as dayRemoveProject,
+  addTask as dayAddTask,
+  renameTask as dayRenameTask,
+  toggleTask as dayToggleTask,
+  removeTask as dayRemoveTask,
+} from "./dayCrud";
 
 /* ───────────────── Types ───────────────── */
 export type ISODate = string;
@@ -38,11 +48,13 @@ export type DayRecord = {
 
 type Selection = {
   projectId?: string; // if present, taskId must be undefined
-  taskId?: string;    // if present, projectId is auto-derived for that task
+  taskId?: string; // if present, projectId is auto-derived for that task
 };
 
 /* ───────────────── Date helpers ───────────────── */
-function todayISO(): ISODate { return toISO(new Date()); }
+function todayISO(): ISODate {
+  return toISO(new Date());
+}
 
 /* ───────────────── Context ───────────────── */
 type PlannerState = {
@@ -59,21 +71,34 @@ type PlannerState = {
 const PlannerCtx = React.createContext<PlannerState | null>(null);
 
 export function PlannerProvider({ children }: { children: React.ReactNode }) {
-  const [days, setDays] = useLocalDB<Record<ISODate, DayRecord>>("planner:days", {});
+  const [days, setDays] = useLocalDB<Record<ISODate, DayRecord>>(
+    "planner:days",
+    {},
+  );
   const [focus, setFocus] = useLocalDB<ISODate>("planner:focus", todayISO());
-  const [selected, setSelected] = useLocalDB<Record<ISODate, Selection>>("planner:selected", {});
+  const [selected, setSelected] = useLocalDB<Record<ISODate, Selection>>(
+    "planner:selected",
+    {},
+  );
 
   const value = React.useMemo<PlannerState>(
     () => ({ days, setDays, focus, setFocus, selected, setSelected }),
-    [days, focus, selected, setDays, setFocus, setSelected]
+    [days, focus, selected, setDays, setFocus, setSelected],
   );
 
-  return React.createElement(PlannerCtx.Provider, { value }, children as React.ReactNode);
+  return React.createElement(
+    PlannerCtx.Provider,
+    { value },
+    children as React.ReactNode,
+  );
 }
 
 function usePlannerStore(): PlannerState {
   const ctx = React.useContext(PlannerCtx);
-  if (!ctx) throw new Error("PlannerProvider is missing. Wrap your planner page with <PlannerProvider>.");
+  if (!ctx)
+    throw new Error(
+      "PlannerProvider is missing. Wrap your planner page with <PlannerProvider>.",
+    );
   return ctx;
 }
 
@@ -98,12 +123,18 @@ export function useWeek(iso: ISODate) {
 function ensureDay(map: Record<ISODate, DayRecord>, date: ISODate) {
   return map[date] ?? { projects: [], tasks: [] };
 }
-function writeThroughLegacy(storage: Storage, days: Record<ISODate, DayRecord>, iso: ISODate) {
+function writeThroughLegacy(
+  storage: Storage,
+  days: Record<ISODate, DayRecord>,
+  iso: ISODate,
+) {
   try {
     const cur = days[iso] ?? { projects: [], tasks: [] };
     storage.setItem("planner:projects", JSON.stringify(cur.projects));
     storage.setItem("planner:tasks", JSON.stringify(cur.tasks));
-  } catch { /* ignore */ }
+  } catch {
+    /* ignore */
+  }
 }
 
 /* ───────────────── High-level API ───────────────── */
@@ -111,119 +142,99 @@ export function usePlanner() {
   const { days, setDays, focus, setFocus } = usePlannerStore();
 
   const setDaysAndMirror = React.useCallback(
-    (date: ISODate, updater: (prev: Record<ISODate, DayRecord>) => Record<ISODate, DayRecord>) => {
-      setDays(prev => {
+    (
+      date: ISODate,
+      updater: (prev: Record<ISODate, DayRecord>) => Record<ISODate, DayRecord>,
+    ) => {
+      setDays((prev) => {
         const nextMap = updater(prev);
         queueMicrotask(() => {
-          if (typeof window !== "undefined") writeThroughLegacy(window.localStorage, nextMap, date);
+          if (typeof window !== "undefined")
+            writeThroughLegacy(window.localStorage, nextMap, date);
         });
         return nextMap;
       });
     },
-    [setDays]
+    [setDays],
   );
 
   const upsertDay = React.useCallback(
     (date: ISODate, fn: (d: DayRecord) => DayRecord) => {
-      setDaysAndMirror(date, prev => {
+      setDaysAndMirror(date, (prev) => {
         const base = ensureDay(prev, date);
         const next = fn(base);
         return { ...prev, [date]: next };
       });
     },
-    [setDaysAndMirror]
+    [setDaysAndMirror],
   );
 
-  const getDay = React.useCallback((date: ISODate): DayRecord => ensureDay(days, date), [days]);
+  const getDay = React.useCallback(
+    (date: ISODate): DayRecord => ensureDay(days, date),
+    [days],
+  );
 
   const setDay = React.useCallback(
     (date: ISODate, next: DayRecord) => {
-      setDaysAndMirror(date, prev => ({ ...prev, [date]: next }));
+      setDaysAndMirror(date, (prev) => ({ ...prev, [date]: next }));
     },
-    [setDaysAndMirror]
+    [setDaysAndMirror],
   );
 
   // Focus-scoped CRUD
   const addProject = React.useCallback(
     (name: string) => {
       const id = uid("proj");
-      const title = name.trim();
-      if (!title) return id;
-      const createdAt = Date.now();
-      upsertDay(focus, d => ({
-        ...d,
-        projects: [...d.projects, { id, name: title, done: false, createdAt }],
-      }));
+      upsertDay(focus, (d) => dayAddProject(d, id, name));
       return id;
     },
-    [focus, upsertDay]
+    [focus, upsertDay],
   );
 
   const renameProject = React.useCallback(
     (id: string, name: string) =>
-      upsertDay(focus, d => ({ ...d, projects: d.projects.map(p => (p.id === id ? { ...p, name } : p)) })),
-    [focus, upsertDay]
+      upsertDay(focus, (d) => dayRenameProject(d, id, name)),
+    [focus, upsertDay],
   );
 
   const toggleProject = React.useCallback(
-    (id: string) =>
-      upsertDay(focus, d => {
-        const wasDone = d.projects.find(p => p.id === id)?.done ?? false;
-        const projects = d.projects.map(p => (p.id === id ? { ...p, done: !wasDone } : p));
-        const tasks = d.tasks.map(t => (t.projectId === id ? { ...t, done: !wasDone } : t));
-        return { ...d, projects, tasks };
-      }),
-    [focus, upsertDay]
+    (id: string) => upsertDay(focus, (d) => dayToggleProject(d, id)),
+    [focus, upsertDay],
   );
 
   const removeProject = React.useCallback(
-    (id: string) =>
-      upsertDay(focus, d => ({
-        ...d,
-        projects: d.projects.filter(p => p.id !== id),
-        tasks: d.tasks.filter(t => t.projectId !== id),
-      })),
-    [focus, upsertDay]
+    (id: string) => upsertDay(focus, (d) => dayRemoveProject(d, id)),
+    [focus, upsertDay],
   );
 
   const addTask = React.useCallback(
     (title: string, projectId?: string) => {
       const id = uid("task");
-      const name = title.trim();
-      if (!name) return id;
-      const createdAt = Date.now();
-      upsertDay(focus, d => ({
-        ...d,
-        tasks: [...d.tasks, { id, title: name, done: false, projectId, createdAt }],
-      }));
+      upsertDay(focus, (d) => dayAddTask(d, id, title, projectId));
       return id;
     },
-    [focus, upsertDay]
+    [focus, upsertDay],
   );
 
   const renameTask = React.useCallback(
-    (id: string, next: string) => {
-      const title = next.trim(); if (!title) return;
-      upsertDay(focus, d => ({ ...d, tasks: d.tasks.map(t => (t.id === id ? { ...t, title } : t)) }));
-    },
-    [focus, upsertDay]
+    (id: string, next: string) =>
+      upsertDay(focus, (d) => dayRenameTask(d, id, next)),
+    [focus, upsertDay],
   );
 
   const toggleTask = React.useCallback(
-    (id: string) =>
-      upsertDay(focus, d => ({ ...d, tasks: d.tasks.map(t => (t.id === id ? { ...t, done: !t.done } : t)) })),
-    [focus, upsertDay]
+    (id: string) => upsertDay(focus, (d) => dayToggleTask(d, id)),
+    [focus, upsertDay],
   );
 
   const removeTask = React.useCallback(
-    (id: string) =>
-      upsertDay(focus, d => ({ ...d, tasks: d.tasks.filter(t => t.id !== id) })),
-    [focus, upsertDay]
+    (id: string) => upsertDay(focus, (d) => dayRemoveTask(d, id)),
+    [focus, upsertDay],
   );
 
   const setNotes = React.useCallback(
-    (notes: string) => upsertDay(focus, d => ({ ...d, notes })),
-    [focus, upsertDay]
+    (notes: string) => upsertDay(focus, (d) => ({ ...d, notes })),
+    [focus, upsertDay],
   );
 
   return {
@@ -259,7 +270,7 @@ export function useDay(iso: ISODate) {
 
   const tasks = React.useMemo(
     () =>
-      rec.tasks.map(t => ({
+      rec.tasks.map((t) => ({
         id: t.id,
         title: t.title,
         text: t.title, // adapter for UIs expecting `text`
@@ -267,57 +278,43 @@ export function useDay(iso: ISODate) {
         projectId: t.projectId,
         createdAt: t.createdAt,
       })),
-    [rec.tasks]
+    [rec.tasks],
   );
 
   const addProject = (name: string) => {
     const id = uid("proj");
-    const title = name.trim();
-    if (!title) return id;
-    const createdAt = Date.now();
-    upsertDay(iso, d => ({ ...d, projects: [...d.projects, { id, name: title, done: false, createdAt }] }));
+    upsertDay(iso, (d) => dayAddProject(d, id, name));
     return id;
   };
 
   const renameProject = (id: string, name: string) =>
-    upsertDay(iso, d => ({ ...d, projects: d.projects.map(p => (p.id === id ? { ...p, name } : p)) }));
+    upsertDay(iso, (d) => dayRenameProject(d, id, name));
 
   const toggleProject = (id: string) =>
-    upsertDay(iso, d => {
-      const wasDone = d.projects.find(p => p.id === id)?.done ?? false;
-      const projects = d.projects.map(p => (p.id === id ? { ...p, done: !wasDone } : p));
-      const tasks2 = d.tasks.map(t => (t.projectId === id ? { ...t, done: !wasDone } : t));
-      return { ...d, projects, tasks: tasks2 };
-    });
+    upsertDay(iso, (d) => dayToggleProject(d, id));
 
   const deleteProject = (id: string) =>
-    upsertDay(iso, d => ({
-      ...d,
-      projects: d.projects.filter(p => p.id !== id),
-      tasks: d.tasks.filter(t => t.projectId !== id),
-    }));
+    upsertDay(iso, (d) => dayRemoveProject(d, id));
 
   const addTask = (title: string, projectId?: string) => {
     const id = uid("task");
-    const name = title.trim();
-    if (!name) return id;
-    const createdAt = Date.now();
-    upsertDay(iso, d => ({ ...d, tasks: [...d.tasks, { id, title: name, done: false, projectId, createdAt }] }));
+    upsertDay(iso, (d) => dayAddTask(d, id, title, projectId));
     return id;
   };
 
-  const renameTask = (id: string, next: string) => {
-    const title = next.trim(); if (!title) return;
-    upsertDay(iso, d => ({ ...d, tasks: d.tasks.map(t => (t.id === id ? { ...t, title } : t)) }));
-  };
+  const renameTask = (id: string, next: string) =>
+    upsertDay(iso, (d) => dayRenameTask(d, id, next));
 
   const toggleTask = (id: string) =>
-    upsertDay(iso, d => ({ ...d, tasks: d.tasks.map(t => (t.id === id ? { ...t, done: !t.done } : t)) }));
+    upsertDay(iso, (d) => dayToggleTask(d, id));
 
   const deleteTask = (id: string) =>
-    upsertDay(iso, d => ({ ...d, tasks: d.tasks.filter(t => t.id !== id) }));
+    upsertDay(iso, (d) => dayRemoveTask(d, id));
 
-  const doneTasks = React.useMemo(() => tasks.filter(t => t.done).length, [tasks]);
+  const doneTasks = React.useMemo(
+    () => tasks.filter((t) => t.done).length,
+    [tasks],
+  );
   const totalTasks = tasks.length;
 
   return {
@@ -343,12 +340,12 @@ export function useSelectedProject(iso: ISODate) {
   const current = selected[iso]?.projectId ?? "";
   const set = React.useCallback(
     (projectId: string) => {
-      setSelected(prev => ({
+      setSelected((prev) => ({
         ...prev,
         [iso]: projectId ? { projectId } : {}, // clears taskId implicitly
       }));
     },
-    [iso, setSelected]
+    [iso, setSelected],
   );
   return [current, set] as const;
 }
@@ -360,17 +357,17 @@ export function useSelectedTask(iso: ISODate) {
   const set = React.useCallback(
     (taskId: string) => {
       if (!taskId) {
-        setSelected(prev => ({ ...prev, [iso]: {} }));
+        setSelected((prev) => ({ ...prev, [iso]: {} }));
         return;
       }
       const rec = ensureDay(days, iso);
-      const projectId = rec.tasks.find(t => t.id === taskId)?.projectId;
-      setSelected(prev => ({
+      const projectId = rec.tasks.find((t) => t.id === taskId)?.projectId;
+      setSelected((prev) => ({
         ...prev,
         [iso]: { taskId, projectId }, // selecting a task auto-selects its project
       }));
     },
-    [iso, setSelected, days]
+    [iso, setSelected, days],
   );
 
   return [current, set] as const;


### PR DESCRIPTION
## Summary
- add shared dayCrud utilities for project and task operations
- refactor usePlanner and useDay to consume dayCrud helpers

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68befde16748832c9f665cf0d8adee93