### PR TITLE
feat: improve TabBar contrast

### DIFF
--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -36,8 +36,8 @@ export type TabBarProps = {
 };
 
 const sizeMap: Record<Size, { h: string; px: string; text: string }> = {
-  sm: { h: "h-8",  px: "px-3", text: "text-sm"  },
-  md: { h: "h-10", px: "px-4", text: "text-sm"  },
+  sm: { h: "h-8", px: "px-3", text: "text-sm" },
+  md: { h: "h-10", px: "px-4", text: "text-sm" },
   lg: { h: "h-11", px: "px-5", text: "text-base" },
 };
 
@@ -57,7 +57,7 @@ export default function TabBar({
   const [internal, setInternal] = React.useState<string>(() => {
     if (value !== undefined) return value;
     if (defaultValue) return defaultValue;
-    return items.find(i => !i.disabled)?.key ?? items[0]?.key ?? "";
+    return items.find((i) => !i.disabled)?.key ?? items[0]?.key ?? "";
   });
 
   const activeKey = isControlled ? (value as string) : internal;
@@ -66,14 +66,20 @@ export default function TabBar({
   const tabRefs = React.useRef(new Map<string, HTMLButtonElement | null>());
   const indicatorRef = React.useRef<HTMLDivElement | null>(null);
 
-  const setTabRef = React.useCallback((key: string) => (el: HTMLButtonElement | null) => {
-    tabRefs.current.set(key, el);
-  }, []);
+  const setTabRef = React.useCallback(
+    (key: string) => (el: HTMLButtonElement | null) => {
+      tabRefs.current.set(key, el);
+    },
+    [],
+  );
 
-  const commitValue = React.useCallback((next: string) => {
-    if (!isControlled) setInternal(next);
-    onValueChange?.(next);
-  }, [isControlled, onValueChange]);
+  const commitValue = React.useCallback(
+    (next: string) => {
+      if (!isControlled) setInternal(next);
+      onValueChange?.(next);
+    },
+    [isControlled, onValueChange],
+  );
 
   const recalcIndicator = React.useCallback(() => {
     const el = tabRefs.current.get(activeKey);
@@ -92,7 +98,9 @@ export default function TabBar({
     bar.style.opacity = "1";
   }, [activeKey]);
 
-  React.useEffect(() => { recalcIndicator(); }, [activeKey, recalcIndicator, items.length]);
+  React.useEffect(() => {
+    recalcIndicator();
+  }, [activeKey, recalcIndicator, items.length]);
   React.useEffect(() => {
     const onResize = () => recalcIndicator();
     window.addEventListener("resize", onResize);
@@ -103,8 +111,8 @@ export default function TabBar({
     if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(e.key)) return;
     e.preventDefault();
 
-    const enabled = items.filter(i => !i.disabled);
-    const curIndex = enabled.findIndex(i => i.key === activeKey);
+    const enabled = items.filter((i) => !i.disabled);
+    const curIndex = enabled.findIndex((i) => i.key === activeKey);
     if (enabled.length === 0) return;
 
     if (e.key === "Home") return commitValue(enabled[0].key);
@@ -138,8 +146,12 @@ export default function TabBar({
     >
       <div className={cn("flex items-center", justify, "gap-3")}>
         {/* Tabs group */}
-        <div role="tablist" aria-orientation="horizontal" className="relative flex items-center flex-wrap gap-1.5">
-          {items.map(item => {
+        <div
+          role="tablist"
+          aria-orientation="horizontal"
+          className="relative flex items-center flex-wrap gap-1.5"
+        >
+          {items.map((item) => {
             const active = item.key === activeKey;
             return (
               <button
@@ -154,19 +166,37 @@ export default function TabBar({
                 className={cn(
                   "relative inline-flex items-center select-none rounded-full transition-[color,opacity,text-shadow] duration-200",
                   "bg-transparent border-0",
-                  s.h, s.px, s.text, size === "lg" ? "font-medium" : "font-normal",
-                  "text-[hsl(var(--foreground)/0.7)] hover:text-[hsl(var(--foreground)/0.7)] data-[active=true]:text-[hsl(var(--foreground)/0.7)]",
+                  s.h,
+                  s.px,
+                  s.text,
+                  size === "lg" ? "font-medium" : "font-normal",
+                  "text-foreground hover:text-foreground data-[active=true]:text-foreground",
                   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] focus-visible:ring-offset-0",
                   item.disabled && "opacity-40 pointer-events-none",
-                  item.className
+                  item.className,
                 )}
                 data-active={active || undefined}
-                style={active ? { textShadow: "0 0 10px hsl(var(--ring))" } : undefined}
+                style={
+                  active
+                    ? { textShadow: "0 0 10px hsl(var(--ring))" }
+                    : undefined
+                }
               >
-                {item.icon && <span className={cn("mr-2 grid place-items-center", size !== "lg" ? "[&>svg]:h-4 [&>svg]:w-4" : "[&>svg]:h-5 [&>svg]:w-5")}>{item.icon}</span>}
+                {item.icon && (
+                  <span
+                    className={cn(
+                      "mr-2 grid place-items-center",
+                      size !== "lg"
+                        ? "[&>svg]:h-4 [&>svg]:w-4"
+                        : "[&>svg]:h-5 [&>svg]:w-5",
+                    )}
+                  >
+                    {item.icon}
+                  </span>
+                )}
                 <span className="truncate">{item.label}</span>
                 {item.badge != null && (
-                  <span className="ml-2 inline-flex items-center justify-center rounded-full text-[10px] leading-none px-2 py-1 bg-[hsl(var(--primary-soft))] text-[hsl(var(--foreground)/0.7)]">
+                  <span className="ml-2 inline-flex items-center justify-center rounded-full text-xs leading-none px-2 py-1 bg-[hsl(var(--primary-soft))] text-foreground">
                     {item.badge}
                   </span>
                 )}
@@ -182,13 +212,15 @@ export default function TabBar({
               "pointer-events-none absolute -bottom-1 h-[2px] rounded-full opacity-0",
               "[background:var(--seg-active-grad,linear-gradient(90deg,hsl(var(--primary))_0%,hsl(var(--accent))_100%))]",
               "transition-[transform,width,opacity] duration-200 ease-out",
-              "shadow-ring"
+              "shadow-ring",
             )}
           />
         </div>
 
         {/* Right slot */}
-        {right && <div className="ml-auto flex items-center gap-2">{right}</div>}
+        {right && (
+          <div className="ml-auto flex items-center gap-2">{right}</div>
+        )}
       </div>
 
       {/* Optional baseline divider */}


### PR DESCRIPTION
## Summary
- increase TabBar default text contrast and ensure hover and active states remain accessible
- bump TabBar badge text to 12px for better legibility

## Testing
- `npm run regen-ui`
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68beff8458b8832cbc25f7afd470f1e4