### PR TITLE
refactor: persistent state hooks

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -27,7 +27,7 @@ import GoalsTabs, { FilterKey } from "./GoalsTabs";
 import GoalForm, { GoalFormHandle } from "./GoalForm";
 import GoalsProgress from "./GoalsProgress";
 
-import { useLocalDB, uid } from "@/lib/db";
+import { usePersistentState, uid } from "@/lib/db";
 import type { Goal, Pillar } from "@/lib/types";
 import { shortDate } from "@/lib/date";
 
@@ -69,11 +69,11 @@ const ACTIVE_CAP = 3;
 /* ====================================================================== */
 
 export default function GoalsPage() {
-  const [tab, setTab] = useLocalDB<Tab>("goals.tab.v2", "goals");
+  const [tab, setTab] = usePersistentState<Tab>("goals.tab.v2", "goals");
 
   // stores
-  const [goals, setGoals] = useLocalDB<Goal[]>("goals.v2", []);
-  const [filter, setFilter] = useLocalDB<FilterKey>("goals.filter.v1", "All");
+  const [goals, setGoals] = usePersistentState<Goal[]>("goals.v2", []);
+  const [filter, setFilter] = usePersistentState<FilterKey>("goals.filter.v1", "All");
 
   // add form
   const [title, setTitle] = React.useState("");

--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -3,7 +3,7 @@
 
 /**
  * Team Reminders (Lavender-Glitch, neon-outlined)
- * - Local-first via useLocalDB("team.reminders.v1")
+ * - Local-first via usePersistentState("team.reminders.v1")
  * - Search + group chips + pinned toggle
  * - Add / duplicate / delete / reset curated seeds
  * - Inline edit (Enter saves, Esc cancels)
@@ -19,7 +19,7 @@ import Textarea from "@/components/ui/primitives/Textarea";
 import Badge from "@/components/ui/primitives/Badge";
 import IconButton from "@/components/ui/primitives/IconButton";
 import TabBar from "@/components/ui/layout/TabBar";
-import { uid, useLocalDB } from "@/lib/db";
+import { uid, usePersistentState } from "@/lib/db";
 import {
   Search,
   Plus,
@@ -96,7 +96,7 @@ const GROUP_TABS: Array<{ key: Group | "all"; label: string }> = [
 /* ---------- component ---------- */
 
 export default function Reminders() {
-  const [items, setItems] = useLocalDB<Reminder[]>(STORE_KEY, SEEDS);
+  const [items, setItems] = usePersistentState<Reminder[]>(STORE_KEY, SEEDS);
   const [query, setQuery] = React.useState("");
   const [onlyPinned, setOnlyPinned] = React.useState(false);
   const [group, setGroup] = React.useState<Group | "all">("all");

--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -23,7 +23,7 @@ import Button from "@/components/ui/primitives/Button";
 import IconButton from "@/components/ui/primitives/IconButton";
 import Hero2, { Hero2SearchBar } from "@/components/ui/layout/Hero2";
 import TabBar from "@/components/ui/layout/TabBar";
-import { uid, useLocalDB } from "@/lib/db";
+import { uid, usePersistentState } from "@/lib/db";
 import {
   Search,
   SlidersHorizontal,
@@ -143,12 +143,21 @@ const cap = (s: string) => s.slice(0, 1).toUpperCase() + s.slice(1);
 /* ───────── Page ───────── */
 
 export default function RemindersTab() {
-  const [items, setItems] = useLocalDB<Reminder[]>(STORE_KEY, SEEDS);
+  const [items, setItems] = usePersistentState<Reminder[]>(STORE_KEY, SEEDS);
   const [query, setQuery] = React.useState("");
   const [onlyPinned, setOnlyPinned] = React.useState(false);
-  const [domain, setDomain] = useLocalDB<Domain>("goals.reminders.domain.v2", "League");
-  const [group, setGroup] = useLocalDB<Group>("goals.reminders.group.v1", "quick");
-  const [source, setSource] = useLocalDB<Source | "all">("goals.reminders.source.v1", "all");
+  const [domain, setDomain] = usePersistentState<Domain>(
+    "goals.reminders.domain.v2",
+    "League",
+  );
+  const [group, setGroup] = usePersistentState<Group>(
+    "goals.reminders.group.v1",
+    "quick",
+  );
+  const [source, setSource] = usePersistentState<Source | "all">(
+    "goals.reminders.source.v1",
+    "all",
+  );
   const [quickAdd, setQuickAdd] = React.useState("");
   const [showFilters, setShowFilters] = React.useState(false);
 

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -17,7 +17,7 @@ import {
   Play, Pause, RotateCcw, Plus, Minus,
   BookOpen, Brush, Code2, User,
 } from "lucide-react";
-import { useLocalDB } from "@/lib/db";
+import { usePersistentState } from "@/lib/db";
 import DurationSelector from "./DurationSelector";
 
 /* profiles */
@@ -47,19 +47,25 @@ const parseMmSs = (v: string) => {
 };
 
 export default function TimerTab() {
-  const [profile, setProfile] = useLocalDB<ProfileKey>("goals.timer.profile.v1", "study");
-  const [personalMinutes, setPersonalMinutes] = useLocalDB<number>("goals.timer.personalMin.v1", 25);
+  const [profile, setProfile] = usePersistentState<ProfileKey>(
+    "goals.timer.profile.v1",
+    "study",
+  );
+  const [personalMinutes, setPersonalMinutes] = usePersistentState<number>(
+    "goals.timer.personalMin.v1",
+    25,
+  );
 
   const profileDef = React.useMemo(() => PROFILES.find(p => p.key === profile)!, [profile]);
   const isPersonal = profile === "personal";
   const minutes = isPersonal ? personalMinutes : profileDef.defaultMin;
 
   // remaining time
-  const [remaining, setRemaining] = useLocalDB<number>(
+  const [remaining, setRemaining] = usePersistentState<number>(
     "goals.timer.remaining.v1",
     minutes * 60_000,
   );
-  const [running, setRunning] = useLocalDB<boolean>(
+  const [running, setRunning] = usePersistentState<boolean>(
     "goals.timer.running.v1",
     false,
   );

--- a/src/components/planner/FocusPanel.tsx
+++ b/src/components/planner/FocusPanel.tsx
@@ -21,7 +21,7 @@ type Props = { iso: ISODate };
 export default function FocusPanel({ iso }: Props) {
   const { focus, setFocus, day, setNotes } = usePlanner();
 
-  // Initialize from current day.notes; safe because useLocalDB returns initial on first render.
+  // Initialize from current day.notes; safe because usePersistentState returns initial on first render.
   const [value, setValue] = React.useState<string>(day.notes ?? "");
 
   // Keep global focus aligned with the visible iso without causing loops.

--- a/src/components/planner/usePlanner.ts
+++ b/src/components/planner/usePlanner.ts
@@ -8,7 +8,7 @@
 
 import "./style.css";
 import * as React from "react";
-import { useLocalDB, uid } from "@/lib/db";
+import { usePersistentState, uid } from "@/lib/db";
 import { toISO, addDays, weekRangeFromISO } from "@/lib/date";
 import {
   addProject as dayAddProject,
@@ -71,12 +71,15 @@ type PlannerState = {
 const PlannerCtx = React.createContext<PlannerState | null>(null);
 
 export function PlannerProvider({ children }: { children: React.ReactNode }) {
-  const [days, setDays] = useLocalDB<Record<ISODate, DayRecord>>(
+  const [days, setDays] = usePersistentState<Record<ISODate, DayRecord>>(
     "planner:days",
     {},
   );
-  const [focus, setFocus] = useLocalDB<ISODate>("planner:focus", todayISO());
-  const [selected, setSelected] = useLocalDB<Record<ISODate, Selection>>(
+  const [focus, setFocus] = usePersistentState<ISODate>(
+    "planner:focus",
+    todayISO(),
+  );
+  const [selected, setSelected] = usePersistentState<Record<ISODate, Selection>>(
     "planner:selected",
     {},
   );

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -8,7 +8,7 @@
 
 import * as React from "react";
 import { SectionCard, Card } from "@/components/ui";
-import { useLocalDB, uid } from "@/lib/db";
+import { usePersistentState, uid } from "@/lib/db";
 import { LOCALE } from "@/lib/utils";
 import PromptsHeader from "./PromptsHeader";
 import PromptsComposePanel from "./PromptsComposePanel";
@@ -23,7 +23,7 @@ type Prompt = {
 
 export default function PromptsPage() {
   // Storage
-  const [prompts, setPrompts] = useLocalDB<Prompt[]>("prompts.v1", []);
+  const [prompts, setPrompts] = usePersistentState<Prompt[]>("prompts.v1", []);
 
   // Drafts
   const [titleDraft, setTitleDraft] = React.useState("");

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -23,7 +23,7 @@ import {
   Brain,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { uid, useLocalDB } from "@/lib/db";
+import { uid, usePersistentState } from "@/lib/db";
 import {
   ALL_PILLARS,
   LAST_ROLE_KEY,
@@ -356,9 +356,15 @@ export default function ReviewEditor({
     Array.isArray(review.pillars) ? review.pillars : []
   );
 
-  const [lastRole, setLastRole] = useLocalDB<Role>(LAST_ROLE_KEY, "MID");
-  const [lastMarkerMode, setLastMarkerMode] = useLocalDB<boolean>(LAST_MARKER_MODE_KEY, true);
-  const [lastMarkerTime, setLastMarkerTime] = useLocalDB<string>(LAST_MARKER_TIME_KEY, "");
+  const [lastRole, setLastRole] = usePersistentState<Role>(LAST_ROLE_KEY, "MID");
+  const [lastMarkerMode, setLastMarkerMode] = usePersistentState<boolean>(
+    LAST_MARKER_MODE_KEY,
+    true,
+  );
+  const [lastMarkerTime, setLastMarkerTime] = usePersistentState<string>(
+    LAST_MARKER_TIME_KEY,
+    "",
+  );
   const ext0 = getExt(review);
   const initialRole: Role = ext0.role ?? lastRole ?? "MID";
   const [role, setRole] = React.useState<Role>(initialRole);

--- a/src/components/reviews/ReviewPage.tsx
+++ b/src/components/reviews/ReviewPage.tsx
@@ -3,15 +3,15 @@ import "./style.css";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Review } from "@/lib/types";
-import { useLocalDB, uid } from "@/lib/db";
+import { usePersistentState, uid } from "@/lib/db";
 import ReviewsPage from "./ReviewsPage";
 
 /**
  * ReviewPage — container with local-first persistence.
- * Hydration-safe: useLocalDB returns initial value on first render, then loads.
- */
+ * Hydration-safe: usePersistentState returns initial value on first render, then loads.
+*/
 export default function ReviewPage() {
-  const [reviews, setReviews] = useLocalDB<Review[]>("reviews.v1", []);
+  const [reviews, setReviews] = usePersistentState<Review[]>("reviews.v1", []);
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
   // After local DB hydration, select the first review if none is chosen

--- a/src/components/team/Builder.tsx
+++ b/src/components/team/Builder.tsx
@@ -4,7 +4,7 @@ import "./style.css";
 
 /**
  * Builder — Allies vs Enemies with a center divider
- * - Local storage via useLocalDB
+ * - Local storage via usePersistentState
  * - Icon-only actions with tooltips (Swap / Copy)
  * - Glitch-styled titles and subtle neon rail
  * - Center spine shows on md+ only
@@ -26,7 +26,7 @@ import {
   Info,
   Copy,
 } from "lucide-react";
-import { useLocalDB } from "@/lib/db";
+import { usePersistentState } from "@/lib/db";
 import { copyText } from "@/lib/clipboard";
 
 /* ───────────────── types & constants ───────────────── */
@@ -90,7 +90,7 @@ function stringify(s: TeamState) {
 /* ───────────────── component ───────────────── */
 
 export default function Builder() {
-  const [state, setState] = useLocalDB<TeamState>(TEAM_KEY, {
+  const [state, setState] = usePersistentState<TeamState>(TEAM_KEY, {
     allies: { ...EMPTY_TEAM },
     enemies: { ...EMPTY_TEAM },
   });

--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -10,7 +10,7 @@ import "./style.css";
  */
 
 import * as React from "react";
-import { useLocalDB } from "@/lib/db";
+import { usePersistentState } from "@/lib/db";
 import IconButton from "@/components/ui/primitives/IconButton";
 import Textarea from "@/components/ui/primitives/Textarea";
 import { Pencil, Check } from "lucide-react";
@@ -396,7 +396,10 @@ export default function CheatSheet({
   data = DEFAULT_SHEET,
   query = "",
 }: CheatSheetProps) {
-  const [sheet, setSheet] = useLocalDB<Archetype[]>("team:cheatsheet.v2", data);
+  const [sheet, setSheet] = usePersistentState<Archetype[]>(
+    "team:cheatsheet.v2",
+    data,
+  );
   const [editingId, setEditingId] = React.useState<string | null>(null);
 
   const filtered = React.useMemo(() => {

--- a/src/components/team/CheatSheetTabs.tsx
+++ b/src/components/team/CheatSheetTabs.tsx
@@ -4,7 +4,7 @@ import "./style.css";
 
 import * as React from "react";
 import { BookOpen, Users2 } from "lucide-react";
-import { useLocalDB } from "@/lib/db";
+import { usePersistentState } from "@/lib/db";
 import Hero2 from "@/components/ui/layout/Hero2";
 import CheatSheet from "./CheatSheet";
 import MyComps from "./MyComps";
@@ -16,8 +16,8 @@ const TAB_KEY = "team:cheatsheet:activeSubTab.v1";
 const QUERY_KEY = "team:cheatsheet:query.v1";
 
 export default function CheatSheetTabs() {
-  const [tab, setTab] = useLocalDB<SubTab>(TAB_KEY, "sheet");
-  const [query, setQuery] = useLocalDB<string>(QUERY_KEY, "");
+  const [tab, setTab] = usePersistentState<SubTab>(TAB_KEY, "sheet");
+  const [query, setQuery] = usePersistentState<string>(QUERY_KEY, "");
 
   const tabs = React.useMemo(
     () => [

--- a/src/components/team/JungleClears.tsx
+++ b/src/components/team/JungleClears.tsx
@@ -16,7 +16,7 @@ import Hero2 from "@/components/ui/layout/Hero2";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import IconButton from "@/components/ui/primitives/IconButton";
 import Input from "@/components/ui/primitives/Input";
-import { useLocalDB, uid } from "@/lib/db";
+import { usePersistentState, uid } from "@/lib/db";
 import { Timer, Pencil, Trash2, Check, X, Plus } from "lucide-react";
 import { JUNGLE_ROWS, SPEED_HINT, type ClearSpeed } from "./data";
 
@@ -41,7 +41,7 @@ const SPEED_TIME: Record<ClearSpeed, string> = {
 };
 
 export default function JungleClears() {
-  const [items, setItems] = useLocalDB<JunglerRow[]>(STORE_KEY, SEEDS);
+  const [items, setItems] = usePersistentState<JunglerRow[]>(STORE_KEY, SEEDS);
   const [query, setQuery] = useState("");
   const [editing, setEditing] = useState<{
     id: string;

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -6,14 +6,14 @@
  * - One SectionCard: header + add bar + cards grid inside the same panel
  * - Add comp (title), edit per-role champs (inline chips), notes
  * - Hover-only actions: Copy / Edit / Delete; Save when editing
- * - Local-first via useLocalDB("team:mycomps.v1")
+ * - Local-first via usePersistentState("team:mycomps.v1")
  * - Scoped with data-scope="team" so glitch effects don't bleed globally
  */
 
 import "./style.css";
 
 import * as React from "react";
-import { useLocalDB, uid } from "@/lib/db";
+import { usePersistentState, uid } from "@/lib/db";
 import { copyText } from "@/lib/clipboard";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import IconButton from "@/components/ui/primitives/IconButton";
@@ -205,7 +205,7 @@ export type MyCompsProps = { query?: string };
 
 export default function MyComps({ query = "" }: MyCompsProps) {
   // Load and normalize so old/bad records don't break the UI.
-  const [raw, setRaw] = useLocalDB<TeamComp[]>(DB_KEY, SEEDS);
+  const [raw, setRaw] = usePersistentState<TeamComp[]>(DB_KEY, SEEDS);
   const items = React.useMemo(() => normalize(raw as unknown[]), [raw]);
   const filtered = React.useMemo(() => {
     const q = query.trim().toLowerCase();

--- a/src/components/ui/AnimationToggle.tsx
+++ b/src/components/ui/AnimationToggle.tsx
@@ -2,13 +2,13 @@
 
 import * as React from "react";
 import { Zap, ZapOff } from "lucide-react";
-import { useLocalDB, readLocal, writeLocal } from "@/lib/db";
+import { usePersistentState, readLocal, writeLocal } from "@/lib/db";
 import { cn } from "@/lib/utils";
 
 const KEY = "ui:animations";
 
 export default function AnimationToggle() {
-  const [enabled, setEnabled] = useLocalDB<boolean>(KEY, true);
+  const [enabled, setEnabled] = usePersistentState<boolean>(KEY, true);
   const [showNotice, setShowNotice] = React.useState(false);
 
   React.useEffect(() => {

--- a/src/components/ui/theme/ThemeToggle.tsx
+++ b/src/components/ui/theme/ThemeToggle.tsx
@@ -4,7 +4,7 @@
 import * as React from "react";
 import { Sun, Moon, Image as ImageIcon } from "lucide-react";
 import AnimatedSelect, { DropItem } from "@/components/ui/selects/AnimatedSelect";
-import { useLocalDB } from "@/lib/db";
+import { usePersistentState } from "@/lib/db";
 import {
   applyTheme,
   defaultTheme,
@@ -32,7 +32,10 @@ export default function ThemeToggle({
   const aria = ariaLabel ?? ariaLabelAttr ?? "Theme";
 
   const [mounted, setMounted] = React.useState(false);
-  const [state, setState] = useLocalDB<ThemeState>(THEME_STORAGE_KEY, defaultTheme());
+  const [state, setState] = usePersistentState<ThemeState>(
+    THEME_STORAGE_KEY,
+    defaultTheme(),
+  );
   const { variant, mode } = state;
 
   React.useEffect(() => {

--- a/tests/lib/db.test.ts
+++ b/tests/lib/db.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
-import { readLocal, writeLocal, removeLocal, useLocalDB, uid } from '@/lib/db';
+import { readLocal, writeLocal, removeLocal, usePersistentState, uid } from '@/lib/db';
 
 // Tests for localStorage helpers
 
@@ -48,9 +48,9 @@ describe('localStorage helpers', () => {
   });
 });
 
-// Tests for useLocalDB hook
+// Tests for usePersistentState hook
 
-describe('useLocalDB', () => {
+describe('usePersistentState', () => {
   beforeEach(() => {
     window.localStorage.clear();
   });
@@ -58,13 +58,13 @@ describe('useLocalDB', () => {
   it('hydrates state from localStorage after mount', async () => {
     window.localStorage.setItem('13lr:state', JSON.stringify('stored'));
     const getSpy = vi.spyOn(window.localStorage.__proto__, 'getItem');
-    const { result } = renderHook(() => useLocalDB('state', 'initial'));
+    const { result } = renderHook(() => usePersistentState('state', 'initial'));
     await waitFor(() => expect(result.current[0]).toBe('stored'));
     expect(getSpy).toHaveBeenCalledWith('noxis-planner:state');
   });
 
   it('syncs state across tabs via storage events', async () => {
-    const { result } = renderHook(() => useLocalDB('sync', 'a'));
+    const { result } = renderHook(() => usePersistentState('sync', 'a'));
     await waitFor(() =>
       expect(window.localStorage.getItem('noxis-planner:sync')).toBe(
         JSON.stringify('a')
@@ -83,7 +83,7 @@ describe('useLocalDB', () => {
   });
 
   it('resets state to initial when storage key is removed', async () => {
-    const { result } = renderHook(() => useLocalDB('remove', 'init'));
+    const { result } = renderHook(() => usePersistentState('remove', 'init'));
     await waitFor(() =>
       expect(window.localStorage.getItem('noxis-planner:remove')).toBe(
         JSON.stringify('init')

--- a/tests/planner/usePlanner.test.tsx
+++ b/tests/planner/usePlanner.test.tsx
@@ -6,7 +6,7 @@ vi.mock("@/lib/db", async () => {
   const actual: any = await vi.importActual("@/lib/db");
   return {
     ...actual,
-    useLocalDB: <T,>(key: string, initial: T) => React.useState(initial),
+    usePersistentState: <T,>(key: string, initial: T) => React.useState(initial),
   };
 });
 


### PR DESCRIPTION
## Summary
- extract storage key handling and migration into `createStorageKey`
- add `useStorageSync` and `usePersistentState` hooks
- replace `useLocalDB` with new persistent state primitives and tests

## Testing
- `npm run lint` *(fails: missing Node environment)*
- `npm test` *(fails: missing Node environment)*
- `npm run typecheck` *(fails: missing Node environment)*

------
https://chatgpt.com/codex/tasks/task_e_68bf06e2c488832c8a9fa7a51f3385fe