### PR TITLE
chore: run checks in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,5 @@
-#!/usr/bin/env sh
-npx lint-staged
+npm test -- --run &&
+npm run lint &&
+npm run typecheck &&
+npm run regen-ui
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,19 @@ After running the script, add a demo of the new component to `src/app/prompts/pa
 
 `npm run build` runs the regeneration step automatically, but running it manually keeps the index and prompts page current during development.
 
+## Git hooks
+
+Running `npm install` triggers the `prepare` script, which installs a Husky pre-commit hook. The hook blocks commits unless the following commands succeed:
+
+```bash
+npm test
+npm run lint
+npm run typecheck
+npm run regen-ui
+```
+
+Ensure these checks pass before committing.
+
 ## Branch workflow
 
 ### Feature branch naming


### PR DESCRIPTION
## Summary
- run tests, lint, typecheck and UI regeneration on pre-commit
- document Git hooks and mention automatic installation via `prepare`

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`
- `npm run regen-ui`


------
https://chatgpt.com/codex/tasks/task_e_68bf051f8d28832cbb621b18cb33b318