### PR TITLE
refactor: centralize design tokens

### DIFF
--- a/src/components/prompts/demoData.ts
+++ b/src/components/prompts/demoData.ts
@@ -1,20 +1,15 @@
-export const colorTokens = [
-  "bg-ring",
-  "bg-accent",
-  "bg-accent-2",
-  "bg-lavDeep",
-  "bg-danger",
-  "bg-success",
-  "bg-glow",
-];
+import { colorTokens, spacingTokens, radiusTokens } from "@/lib/tokens";
 
-export const spacingTokens = [4, 8, 12, 16, 24, 32, 48, 64];
+export { colorTokens, spacingTokens, radiusTokens };
 
 export const glowTokens = ["--glow-strong", "--glow-soft"];
 
 export const focusRingToken = "--theme-ring";
-
-export const radiusTokens = ["--radius-md", "--radius-lg", "--radius-xl", "--radius-2xl"];
-export const radiusClasses = ["rounded-md", "rounded-lg", "rounded-xl", "rounded-2xl"];
+export const radiusClasses = [
+  "rounded-md",
+  "rounded-lg",
+  "rounded-xl",
+  "rounded-2xl",
+];
 
 export const typeRamp = ["eyebrow", "title", "subtitle", "body", "caption"];

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -1,0 +1,18 @@
+export const colorTokens = [
+  "bg-ring",
+  "bg-accent",
+  "bg-accent-2",
+  "bg-lavDeep",
+  "bg-danger",
+  "bg-success",
+  "bg-glow",
+];
+
+export const spacingTokens = [4, 8, 12, 16, 24, 32, 48, 64];
+
+export const radiusTokens = [
+  "--radius-md",
+  "--radius-lg",
+  "--radius-xl",
+  "--radius-2xl",
+];

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,6 +2,7 @@
 // - TypeScript config; works with Tailwind 3.4+
 // - Dark mode by class; colors map to CSS variables in globals.css
 import type { Config } from "tailwindcss";
+import { spacingTokens, radiusTokens } from "./src/lib/tokens";
 
 const config: Config = {
   darkMode: ["class"],
@@ -18,71 +19,78 @@ const config: Config = {
         primary: {
           DEFAULT: "hsl(var(--primary))",
           foreground: "hsl(var(--primary-foreground))",
-          soft: "hsl(var(--primary-soft))"
+          soft: "hsl(var(--primary-soft))",
         },
-        accent: { DEFAULT: "hsl(var(--accent))", soft: "hsl(var(--accent-soft))" },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          soft: "hsl(var(--accent-soft))",
+        },
         "accent-2": "hsl(var(--accent-2))",
         glow: "hsl(var(--glow))",
         ringMuted: "hsl(var(--ring-muted))",
         danger: "hsl(var(--danger))",
         success: {
           DEFAULT: "hsl(var(--success))",
-          glow: "hsl(var(--success-glow))"
+          glow: "hsl(var(--success-glow))",
         },
         auroraG: "hsl(var(--aurora-g))",
         auroraGLight: "hsl(var(--aurora-g-light))",
         auroraP: "hsl(var(--aurora-p))",
         auroraPLight: "hsl(var(--aurora-p-light))",
-        muted: { DEFAULT: "hsl(var(--muted))", foreground: "hsl(var(--muted-foreground))" },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
         lavDeep: "hsl(var(--lav-deep))",
         surfaceVhs: "hsl(var(--surface-vhs))",
-        surfaceStreak: "hsl(var(--surface-streak))"
+        surfaceStreak: "hsl(var(--surface-streak))",
       },
       borderRadius: {
-        md: "var(--radius-md)",
-        lg: "var(--radius-lg)",
-        xl: "var(--radius-xl)",
-        "2xl": "var(--radius-2xl)"
+        md: `var(${radiusTokens[0]})`,
+        lg: `var(${radiusTokens[1]})`,
+        xl: `var(${radiusTokens[2]})`,
+        "2xl": `var(${radiusTokens[3]})`,
       },
       boxShadow: {
         "neo-sm":
           "4px 4px 8px hsl(var(--panel)/0.72), -4px -4px 8px hsl(var(--foreground)/0.06)",
-        neo:
-          "12px 12px 24px hsl(var(--panel)/0.72), -12px -12px 24px hsl(var(--foreground)/0.06)",
+        neo: "12px 12px 24px hsl(var(--panel)/0.72), -12px -12px 24px hsl(var(--foreground)/0.06)",
         "neo-strong":
           "14px 14px 28px hsl(var(--panel)/0.72), -14px -14px 28px hsl(var(--foreground)/0.06)",
         "neo-inset":
           "inset 4px 4px 10px hsl(var(--panel)/0.85), inset -4px -4px 10px hsl(var(--foreground)/0.08)",
         ring: "0 0 12px hsl(var(--ring))",
-        neoSoft: "0 3px 12px -4px hsl(var(--shadow-color))"
+        neoSoft: "0 3px 12px -4px hsl(var(--shadow-color))",
       },
       transitionTimingFunction: {
         out: "cubic-bezier(0.16, 1, 0.3, 1)",
-        snap: "var(--ease-snap)"
+        snap: "var(--ease-snap)",
       },
-      transitionDuration: { 140: "140ms", 200: "200ms", 220: "220ms", 420: "420ms" },
-      spacing: {
-        1: "4px",
-        2: "8px",
-        3: "12px",
-        4: "16px",
-        5: "24px",
-        6: "32px",
-        7: "48px",
-        8: "64px"
+      transitionDuration: {
+        140: "140ms",
+        200: "200ms",
+        220: "220ms",
+        420: "420ms",
       },
+      spacing: spacingTokens.reduce(
+        (acc, token, idx) => {
+          acc[idx + 1] = `${token}px`;
+          return acc;
+        },
+        {} as Record<number, string>,
+      ),
       keyframes: {
         shimmer: {
           "0%": { transform: "translateX(-100%)" },
-          "100%": { transform: "translateX(100%)" }
-        }
+          "100%": { transform: "translateX(100%)" },
+        },
       },
       animation: {
-        shimmer: "shimmer 120ms linear"
-      }
-    }
+        shimmer: "shimmer 120ms linear",
+      },
+    },
   },
-  plugins: []
+  plugins: [],
 };
 
 export default config;

--- a/tests/prompts/demo-tokens.test.ts
+++ b/tests/prompts/demo-tokens.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import config from "../../tailwind.config";
+import { colorTokens, spacingTokens, radiusTokens } from "../../src/lib/tokens";
+
+describe("demo tokens", () => {
+  it("match tailwind spacing config", () => {
+    const spacing = (config as any).theme?.extend?.spacing ?? {};
+    const spacingFromConfig = Object.values(spacing).map((v) =>
+      parseInt(String(v)),
+    );
+    expect(spacingTokens).toEqual(spacingFromConfig);
+  });
+
+  it("match tailwind radius config", () => {
+    const radius = (config as any).theme?.extend?.borderRadius ?? {};
+    const radiusFromConfig = Object.values(radius).map((v) => {
+      const match = String(v).match(/var\(([^)]+)\)/);
+      return match ? match[1] : v;
+    });
+    expect(radiusTokens).toEqual(radiusFromConfig);
+  });
+
+  it("use colors defined in tailwind config", () => {
+    const colors = (config as any).theme?.extend?.colors ?? {};
+    const expected = colorTokens.map((c) => c.replace(/^bg-/, ""));
+    expect(expected.every((name) => colors[name])).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- centralize color, spacing, and radius tokens in `src/lib/tokens.ts`
- use shared tokens in Tailwind config and prompt demo data
- add tests to ensure demo tokens stay in sync with Tailwind config

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf07f685d0832cb9874b0f96855001