### PR TITLE
Add hero pre-header to team comp page

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -50,7 +50,7 @@ import {
 } from "@/components/planner";
 import type { Pillar, Review } from "@/lib/types";
 import type { GameSide } from "@/components/ui/league/SideSelector";
-import { Search as SearchIcon, Star, Plus, Sun } from "lucide-react";
+import { Search as SearchIcon, Star, Plus, Sun, Users2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { COLOR_TOKENS } from "@/lib/theme";
 
@@ -483,9 +483,27 @@ export default function Page() {
     {
       label: "Hero + Hero2",
       element: (
-        <div className="w-56 space-y-4">
-          <Hero heading="Hero" eyebrow="Top" sticky={false} />
-          <Hero2 heading="Hero2" eyebrow="Bottom" sticky={false} />
+        <div className="w-56 space-y-2">
+          <Hero
+            eyebrow="Comps"
+            heading="Today"
+            subtitle="Readable. Fast. On brand."
+            icon={<Users2 className="opacity-80" />}
+            sticky={false}
+          />
+          <Hero2
+            eyebrow="Comps"
+            heading="Today"
+            subtitle="Readable. Fast. On brand."
+            icon={<Users2 className="opacity-80" />}
+            sticky={false}
+            tabs={{
+              items: tabs,
+              value: "one",
+              onChange: () => {},
+              align: "end",
+            }}
+          />
         </div>
       ),
     },

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -14,6 +14,7 @@ import "./style.css";
 
 import { useState } from "react";
 import { Users2, BookOpenText, Hammer, Timer } from "lucide-react";
+import Hero from "@/components/ui/layout/Hero";
 import Hero2 from "@/components/ui/layout/Hero2";
 import Builder from "./Builder";
 import JungleClears from "./JungleClears";
@@ -22,9 +23,24 @@ import CheatSheetTabs from "./CheatSheetTabs";
 type Tab = "cheat" | "builder" | "clears";
 
 const TABS = [
-  { key: "cheat", label: "Cheat Sheet", hint: "Archetypes, counters, examples", icon: <BookOpenText /> },
-  { key: "builder", label: "Builder", hint: "Fill allies vs enemies", icon: <Hammer /> },
-  { key: "clears", label: "Jungle Clears", hint: "Relative buckets by speed", icon: <Timer /> },
+  {
+    key: "cheat",
+    label: "Cheat Sheet",
+    hint: "Archetypes, counters, examples",
+    icon: <BookOpenText />,
+  },
+  {
+    key: "builder",
+    label: "Builder",
+    hint: "Fill allies vs enemies",
+    icon: <Hammer />,
+  },
+  {
+    key: "clears",
+    label: "Jungle Clears",
+    hint: "Relative buckets by speed",
+    icon: <Timer />,
+  },
 ] as const;
 
 export default function TeamCompPage() {
@@ -32,21 +48,33 @@ export default function TeamCompPage() {
 
   return (
     <main className="page-shell py-6 space-y-6">
-      <Hero2
-        eyebrow="Comps"
-        heading="Today"
-        subtitle="Readable. Fast. On brand."
-        icon={<Users2 className="opacity-80" />}
-        tabs={{
-          items: TABS.map((t) => ({ key: t.key, label: t.label, icon: t.icon })),
-          value: tab,
-          onChange: (k) => setTab(k as Tab),
-          align: "end",
-          className: "px-2",
-        }}
-        className="mb-1"
-        barClassName="gap-2 items-baseline"
-      />
+      <div className="space-y-2">
+        <Hero
+          eyebrow="Comps"
+          heading="Today"
+          subtitle="Readable. Fast. On brand."
+          icon={<Users2 className="opacity-80" />}
+        />
+        <Hero2
+          eyebrow="Comps"
+          heading="Today"
+          subtitle="Readable. Fast. On brand."
+          icon={<Users2 className="opacity-80" />}
+          tabs={{
+            items: TABS.map((t) => ({
+              key: t.key,
+              label: t.label,
+              icon: t.icon,
+            })),
+            value: tab,
+            onChange: (k) => setTab(k as Tab),
+            align: "end",
+            className: "px-2",
+          }}
+          className="mb-1"
+          barClassName="gap-2 items-baseline"
+        />
+      </div>
 
       <section className="grid gap-4">
         <div role="tabpanel" hidden={tab !== "cheat"}>

--- a/tests/lib/db.test.ts
+++ b/tests/lib/db.test.ts
@@ -1,10 +1,16 @@
-import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
-import { renderHook, waitFor, act } from '@testing-library/react';
-import { readLocal, writeLocal, removeLocal, usePersistentState, uid } from '@/lib/db';
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import {
+  readLocal,
+  writeLocal,
+  removeLocal,
+  usePersistentState,
+  uid,
+} from "@/lib/db";
 
 // Tests for localStorage helpers
 
-describe('localStorage helpers', () => {
+describe("localStorage helpers", () => {
   const original = window.localStorage;
   const store: Record<string, string> = {};
   const mockStorage: Storage = {
@@ -27,106 +33,114 @@ describe('localStorage helpers', () => {
   beforeEach(() => {
     mockStorage.clear();
     vi.clearAllMocks();
-    Object.defineProperty(window, 'localStorage', { value: mockStorage, configurable: true });
+    Object.defineProperty(window, "localStorage", {
+      value: mockStorage,
+      configurable: true,
+    });
   });
 
   afterAll(() => {
-    Object.defineProperty(window, 'localStorage', { value: original });
+    Object.defineProperty(window, "localStorage", { value: original });
   });
 
-  it('writes and reads namespaced values', () => {
-    writeLocal('foo', { bar: 1 });
-    expect(mockStorage.setItem).toHaveBeenCalledWith('noxis-planner:foo', JSON.stringify({ bar: 1 }));
-    expect(readLocal<{ bar: number }>('foo')).toEqual({ bar: 1 });
+  it("writes and reads namespaced values", () => {
+    writeLocal("foo", { bar: 1 });
+    expect(mockStorage.setItem).toHaveBeenCalledWith(
+      "noxis-planner:foo",
+      JSON.stringify({ bar: 1 }),
+    );
+    expect(readLocal<{ bar: number }>("foo")).toEqual({ bar: 1 });
   });
 
-  it('removes values', () => {
-    writeLocal('foo', 'baz');
-    removeLocal('foo');
-    expect(mockStorage.removeItem).toHaveBeenCalledWith('noxis-planner:foo');
-    expect(readLocal('foo')).toBeNull();
+  it("removes values", () => {
+    writeLocal("foo", "baz");
+    removeLocal("foo");
+    expect(mockStorage.removeItem).toHaveBeenCalledWith("noxis-planner:foo");
+    expect(readLocal("foo")).toBeNull();
   });
 });
 
 // Tests for usePersistentState hook
 
-describe('usePersistentState', () => {
+describe("usePersistentState", () => {
   beforeEach(() => {
     window.localStorage.clear();
   });
 
-  it('hydrates state from localStorage after mount', async () => {
-    window.localStorage.setItem('13lr:state', JSON.stringify('stored'));
-    const getSpy = vi.spyOn(window.localStorage.__proto__, 'getItem');
-    const { result } = renderHook(() => usePersistentState('state', 'initial'));
-    await waitFor(() => expect(result.current[0]).toBe('stored'));
-    expect(getSpy).toHaveBeenCalledWith('noxis-planner:state');
+  it("hydrates state from localStorage after mount", async () => {
+    window.localStorage.setItem(
+      "noxis-planner:state",
+      JSON.stringify("stored"),
+    );
+    const getSpy = vi.spyOn(window.localStorage.__proto__, "getItem");
+    const { result } = renderHook(() => usePersistentState("state", "initial"));
+    await waitFor(() => expect(result.current[0]).toBe("stored"));
+    expect(getSpy).toHaveBeenCalledWith("noxis-planner:state");
   });
 
-  it('syncs state across tabs via storage events', async () => {
-    const { result } = renderHook(() => usePersistentState('sync', 'a'));
+  it("syncs state across tabs via storage events", async () => {
+    const { result } = renderHook(() => usePersistentState("sync", "a"));
     await waitFor(() =>
-      expect(window.localStorage.getItem('noxis-planner:sync')).toBe(
-        JSON.stringify('a')
-      )
+      expect(window.localStorage.getItem("noxis-planner:sync")).toBe(
+        JSON.stringify("a"),
+      ),
     );
     await act(async () => {
       window.dispatchEvent(
-        new StorageEvent('storage', {
-          key: 'noxis-planner:sync',
-          newValue: JSON.stringify('b'),
+        new StorageEvent("storage", {
+          key: "noxis-planner:sync",
+          newValue: JSON.stringify("b"),
           storageArea: window.localStorage,
-        })
+        }),
       );
     });
-    expect(result.current[0]).toBe('b');
+    expect(result.current[0]).toBe("b");
   });
 
-  it('resets state to initial when storage key is removed', async () => {
-    const { result } = renderHook(() => usePersistentState('remove', 'init'));
+  it("resets state to initial when storage key is removed", async () => {
+    const { result } = renderHook(() => usePersistentState("remove", "init"));
     await waitFor(() =>
-      expect(window.localStorage.getItem('noxis-planner:remove')).toBe(
-        JSON.stringify('init')
-      )
+      expect(window.localStorage.getItem("noxis-planner:remove")).toBe(
+        JSON.stringify("init"),
+      ),
     );
 
     // Change state so it differs from the initial value
-    act(() => result.current[1]('changed'));
+    act(() => result.current[1]("changed"));
     await waitFor(() =>
-      expect(window.localStorage.getItem('noxis-planner:remove')).toBe(
-        JSON.stringify('changed')
-      )
+      expect(window.localStorage.getItem("noxis-planner:remove")).toBe(
+        JSON.stringify("changed"),
+      ),
     );
 
     // Simulate another tab removing the key
     await act(async () => {
-      window.localStorage.removeItem('noxis-planner:remove');
+      window.localStorage.removeItem("noxis-planner:remove");
       window.dispatchEvent(
-        new StorageEvent('storage', {
-          key: 'noxis-planner:remove',
+        new StorageEvent("storage", {
+          key: "noxis-planner:remove",
           newValue: null,
           storageArea: window.localStorage,
-        })
+        }),
       );
     });
 
-    expect(result.current[0]).toBe('init');
+    expect(result.current[0]).toBe("init");
   });
 });
 
 // Tests for uid
 
-describe('uid', () => {
-  it('generates unique identifiers of sufficient length', () => {
+describe("uid", () => {
+  it("generates unique identifiers of sufficient length", () => {
     const ids = new Set<string>();
     for (let i = 0; i < 100; i++) {
-      ids.add(uid('test'));
+      ids.add(uid("test"));
     }
     expect(ids.size).toBe(100);
 
-    const sample = uid('test');
-    expect(sample.startsWith('test_')).toBe(true);
-    expect(sample.slice('test_'.length).length).toBeGreaterThanOrEqual(16);
+    const sample = uid("test");
+    expect(sample.startsWith("test_")).toBe(true);
+    expect(sample.slice("test_".length).length).toBeGreaterThanOrEqual(16);
   });
 });
-


### PR DESCRIPTION
## Summary
- Add top Hero component before tabbed Hero2 on Team comp page
- Document combined Hero + Hero2 header in prompts gallery
- Fix persistence test to use current storage prefix

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf04dd3b34832cb0863fb34a85754d