### PR TITLE
chore: add prompt coverage check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,1 +1,22 @@
+name: CI
 
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm run check-prompts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,14 @@ When adding a new UI component or style under `src/components/ui`, run:
 
 ```bash
 npm run regen-ui
+npm run check-prompts
 ```
 
-This regenerates `src/components/ui/index.ts` so pages can import the component from `@/components/ui`.
+`regen-ui` regenerates `src/components/ui/index.ts` so pages can import the component from `@/components/ui`.
 
-After running the script, add a demo of the new component to `src/app/prompts/page.tsx` so it appears in the prompts gallery.
+`check-prompts` verifies that every component in `src/components/ui` and `src/components/prompts` has a corresponding entry in `src/app/prompts/page.tsx` or `src/components/prompts/PromptsDemos.tsx`.
+
+After running the scripts, add a demo of the new component to `src/app/prompts/page.tsx` so it appears in the prompts gallery.
 
 `npm run build` runs the regeneration step automatically, but running it manually keeps the index and prompts page current during development.
 

--- a/cli-progress.d.ts
+++ b/cli-progress.d.ts
@@ -1,0 +1,8 @@
+declare module "cli-progress" {
+  export class MultiBar {
+    constructor(options?: any, preset?: any);
+    create(total: number, startValue?: number): any;
+    stop(): void;
+  }
+  export const Presets: any;
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest",
     "format": "prettier --write .",
+    "check-prompts": "ts-node scripts/check-prompts-updated.ts",
     "postinstall": "npm run regen-ui && npm run regen-feature",
     "prepare": "husky"
   },

--- a/scripts/check-prompts-updated.ts
+++ b/scripts/check-prompts-updated.ts
@@ -1,0 +1,93 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { MultiBar, Presets } from "cli-progress";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const uiDir = path.resolve(__dirname, "../src/components/ui");
+const promptsDir = path.resolve(__dirname, "../src/components/prompts");
+const pageFile = path.resolve(__dirname, "../src/app/prompts/page.tsx");
+const demosFile = path.resolve(
+  __dirname,
+  "../src/components/prompts/PromptsDemos.tsx",
+);
+
+const ignore = new Set(["Split"]);
+
+function toComponentName(file: string): string {
+  const base = path.basename(file).replace(/\.(tsx|ts)$/, "");
+  return base
+    .replace(/[-_](.)/g, (_, c) => c.toUpperCase())
+    .replace(/^(.)/, (c) => c.toUpperCase());
+}
+
+async function getTsxFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await getTsxFiles(full)));
+    } else if (entry.isFile() && entry.name.endsWith(".tsx")) {
+      const base = path.basename(entry.name, ".tsx");
+      if (base === "index" || base.endsWith("Page")) {
+        continue;
+      }
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+async function collectComponents(): Promise<string[]> {
+  const files = [
+    ...(await getTsxFiles(uiDir)),
+    ...(await getTsxFiles(promptsDir)),
+  ];
+  const names = new Set<string>();
+  for (const file of files) {
+    const content = await fs.readFile(file, "utf8");
+    const defMatch = content.match(
+      /export\s+default\s+function\s+([A-Z][A-Za-z0-9_]*)/,
+    );
+    if (defMatch) {
+      names.add(defMatch[1]);
+    } else if (/export\s+default/.test(content)) {
+      names.add(toComponentName(file));
+    }
+  }
+  return [...names].filter((n) => !ignore.has(n));
+}
+
+async function main() {
+  const components = await collectComponents();
+  const bars = new MultiBar(
+    { clearOnComplete: false, hideCursor: true },
+    Presets.shades_grey,
+  );
+  const bar = bars.create(components.length, 0);
+  const page = await fs.readFile(pageFile, "utf8");
+  const demos = await fs.readFile(demosFile, "utf8");
+  const missing: string[] = [];
+  components.forEach((name, idx) => {
+    if (!page.includes(name) && !demos.includes(name)) {
+      missing.push(name);
+    }
+    bar.update(idx + 1);
+  });
+  bars.stop();
+  if (missing.length) {
+    console.error(
+      "Missing prompt demos for components:\n" + missing.join("\n"),
+    );
+    process.exit(1);
+  }
+  console.log("All components have prompt demos.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add script to ensure components have prompt demos
- document prompt check in contributing guide
- run prompt check in CI

## Testing
- `npm run check-prompts`
- `npm test` *(fails: expected 'stored' to be 'stored')*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf0a761e80832cb940fe29eb3403b7