### PR TITLE
feat: showcase stacked hero headers

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -50,7 +50,7 @@ import {
 } from "@/components/planner";
 import type { Pillar, Review } from "@/lib/types";
 import type { GameSide } from "@/components/ui/league/SideSelector";
-import { Search as SearchIcon, Star, Plus, Sun, Users2 } from "lucide-react";
+import { Search as SearchIcon, Star, Plus, Sun } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { COLOR_TOKENS } from "@/lib/theme";
 
@@ -483,27 +483,10 @@ export default function Page() {
     {
       label: "Hero + Hero2",
       element: (
-        <div className="w-56 space-y-2">
-          <Hero
-            eyebrow="Comps"
-            heading="Today"
-            subtitle="Readable. Fast. On brand."
-            icon={<Users2 className="opacity-80" />}
-            sticky={false}
-          />
-          <Hero2
-            eyebrow="Comps"
-            heading="Today"
-            subtitle="Readable. Fast. On brand."
-            icon={<Users2 className="opacity-80" />}
-            sticky={false}
-            tabs={{
-              items: tabs,
-              value: "one",
-              onChange: () => {},
-              align: "end",
-            }}
-          />
+        <div className="w-56 h-56 overflow-auto space-y-6">
+          <Hero heading="Stacked" />
+          <Hero2 heading="Stacked" topClassName="top-24" />
+          <div className="h-96" />
         </div>
       ),
     },

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -13,6 +13,7 @@ import { Ghost, Plus } from "lucide-react";
 import Button from "@/components/ui/primitives/Button";
 // ⬇️ use the new AnimatedSelect location
 import AnimatedSelect from "@/components/ui/selects/AnimatedSelect";
+import Hero from "@/components/ui/layout/Hero";
 import Hero2, { Hero2SearchBar } from "@/components/ui/layout/Hero2";
 
 type SortKey = "newest" | "oldest" | "title";
@@ -93,7 +94,9 @@ export default function ReviewsPage({
 
   return (
     <main className="page-shell py-6 space-y-6">
+      <Hero heading="Reviews" />
       <Hero2
+        topClassName="top-24"
         heading={
           <div className="flex items-center gap-2">
             <h2 className="title-glow">Reviews</h2>


### PR DESCRIPTION
## Summary
- add Hero above Reviews page filters and offset Hero2 to avoid sticky overlap
- demo stacked Hero + Hero2 in prompts gallery

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf0ba2a484832cb8e7eaced9051cf5