### PR TITLE
feat: optimize tests with progress bar

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,14 @@ npm run regen-ui
 
 Ensure these checks pass before committing.
 
+## Testing
+
+`npm test` runs only the tests for files changed since the last commit. To execute the full test suite, run:
+
+```bash
+npm test -- --run
+```
+
 ## Branch workflow
 
 ### Feature branch naming

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "next start -p 3000",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "vitest",
+    "test": "vitest --changed",
     "format": "prettier --write .",
     "postinstall": "npm run regen-ui && npm run regen-feature",
     "prepare": "husky"

--- a/tests/lib/db.test.ts
+++ b/tests/lib/db.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
-import { renderHook, waitFor, act } from '@testing-library/react';
-import { readLocal, writeLocal, removeLocal, usePersistentState, uid } from '@/lib/db';
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { readLocal, writeLocal, removeLocal, uid } from "@/lib/db";
+let usePersistentState: typeof import("@/lib/db").usePersistentState;
 
 // Tests for localStorage helpers
 
-describe('localStorage helpers', () => {
+describe("localStorage helpers", () => {
   const original = window.localStorage;
   const store: Record<string, string> = {};
   const mockStorage: Storage = {
@@ -27,106 +28,113 @@ describe('localStorage helpers', () => {
   beforeEach(() => {
     mockStorage.clear();
     vi.clearAllMocks();
-    Object.defineProperty(window, 'localStorage', { value: mockStorage, configurable: true });
+    Object.defineProperty(window, "localStorage", {
+      value: mockStorage,
+      configurable: true,
+    });
   });
 
   afterAll(() => {
-    Object.defineProperty(window, 'localStorage', { value: original });
+    Object.defineProperty(window, "localStorage", { value: original });
   });
 
-  it('writes and reads namespaced values', () => {
-    writeLocal('foo', { bar: 1 });
-    expect(mockStorage.setItem).toHaveBeenCalledWith('noxis-planner:foo', JSON.stringify({ bar: 1 }));
-    expect(readLocal<{ bar: number }>('foo')).toEqual({ bar: 1 });
+  it("writes and reads namespaced values", () => {
+    writeLocal("foo", { bar: 1 });
+    expect(mockStorage.setItem).toHaveBeenCalledWith(
+      "noxis-planner:foo",
+      JSON.stringify({ bar: 1 }),
+    );
+    expect(readLocal<{ bar: number }>("foo")).toEqual({ bar: 1 });
   });
 
-  it('removes values', () => {
-    writeLocal('foo', 'baz');
-    removeLocal('foo');
-    expect(mockStorage.removeItem).toHaveBeenCalledWith('noxis-planner:foo');
-    expect(readLocal('foo')).toBeNull();
+  it("removes values", () => {
+    writeLocal("foo", "baz");
+    removeLocal("foo");
+    expect(mockStorage.removeItem).toHaveBeenCalledWith("noxis-planner:foo");
+    expect(readLocal("foo")).toBeNull();
   });
 });
 
 // Tests for usePersistentState hook
 
-describe('usePersistentState', () => {
-  beforeEach(() => {
+describe("usePersistentState", () => {
+  beforeEach(async () => {
     window.localStorage.clear();
+    vi.resetModules();
+    ({ usePersistentState } = await import("@/lib/db"));
   });
 
-  it('hydrates state from localStorage after mount', async () => {
-    window.localStorage.setItem('13lr:state', JSON.stringify('stored'));
-    const getSpy = vi.spyOn(window.localStorage.__proto__, 'getItem');
-    const { result } = renderHook(() => usePersistentState('state', 'initial'));
-    await waitFor(() => expect(result.current[0]).toBe('stored'));
-    expect(getSpy).toHaveBeenCalledWith('noxis-planner:state');
+  it("hydrates state from localStorage after mount", async () => {
+    window.localStorage.setItem("13lr:state", JSON.stringify("stored"));
+    const getSpy = vi.spyOn(window.localStorage.__proto__, "getItem");
+    const { result } = renderHook(() => usePersistentState("state", "initial"));
+    await waitFor(() => expect(result.current[0]).toBe("stored"));
+    expect(getSpy).toHaveBeenCalledWith("noxis-planner:state");
   });
 
-  it('syncs state across tabs via storage events', async () => {
-    const { result } = renderHook(() => usePersistentState('sync', 'a'));
+  it("syncs state across tabs via storage events", async () => {
+    const { result } = renderHook(() => usePersistentState("sync", "a"));
     await waitFor(() =>
-      expect(window.localStorage.getItem('noxis-planner:sync')).toBe(
-        JSON.stringify('a')
-      )
+      expect(window.localStorage.getItem("noxis-planner:sync")).toBe(
+        JSON.stringify("a"),
+      ),
     );
     await act(async () => {
       window.dispatchEvent(
-        new StorageEvent('storage', {
-          key: 'noxis-planner:sync',
-          newValue: JSON.stringify('b'),
+        new StorageEvent("storage", {
+          key: "noxis-planner:sync",
+          newValue: JSON.stringify("b"),
           storageArea: window.localStorage,
-        })
+        }),
       );
     });
-    expect(result.current[0]).toBe('b');
+    expect(result.current[0]).toBe("b");
   });
 
-  it('resets state to initial when storage key is removed', async () => {
-    const { result } = renderHook(() => usePersistentState('remove', 'init'));
+  it("resets state to initial when storage key is removed", async () => {
+    const { result } = renderHook(() => usePersistentState("remove", "init"));
     await waitFor(() =>
-      expect(window.localStorage.getItem('noxis-planner:remove')).toBe(
-        JSON.stringify('init')
-      )
+      expect(window.localStorage.getItem("noxis-planner:remove")).toBe(
+        JSON.stringify("init"),
+      ),
     );
 
     // Change state so it differs from the initial value
-    act(() => result.current[1]('changed'));
+    act(() => result.current[1]("changed"));
     await waitFor(() =>
-      expect(window.localStorage.getItem('noxis-planner:remove')).toBe(
-        JSON.stringify('changed')
-      )
+      expect(window.localStorage.getItem("noxis-planner:remove")).toBe(
+        JSON.stringify("changed"),
+      ),
     );
 
     // Simulate another tab removing the key
     await act(async () => {
-      window.localStorage.removeItem('noxis-planner:remove');
+      window.localStorage.removeItem("noxis-planner:remove");
       window.dispatchEvent(
-        new StorageEvent('storage', {
-          key: 'noxis-planner:remove',
+        new StorageEvent("storage", {
+          key: "noxis-planner:remove",
           newValue: null,
           storageArea: window.localStorage,
-        })
+        }),
       );
     });
 
-    expect(result.current[0]).toBe('init');
+    expect(result.current[0]).toBe("init");
   });
 });
 
 // Tests for uid
 
-describe('uid', () => {
-  it('generates unique identifiers of sufficient length', () => {
+describe("uid", () => {
+  it("generates unique identifiers of sufficient length", () => {
     const ids = new Set<string>();
     for (let i = 0; i < 100; i++) {
-      ids.add(uid('test'));
+      ids.add(uid("test"));
     }
     expect(ids.size).toBe(100);
 
-    const sample = uid('test');
-    expect(sample.startsWith('test_')).toBe(true);
-    expect(sample.slice('test_'.length).length).toBeGreaterThanOrEqual(16);
+    const sample = uid("test");
+    expect(sample.startsWith("test_")).toBe(true);
+    expect(sample.slice("test_".length).length).toBeGreaterThanOrEqual(16);
   });
 });
-

--- a/tests/progress-reporter.ts
+++ b/tests/progress-reporter.ts
@@ -1,0 +1,48 @@
+import type { Reporter, Vitest } from "vitest";
+import { MultiBar } from "cli-progress";
+
+export default function progressReporter(): Reporter {
+  let bars: any = null;
+  let startedBar: any = null;
+  let finishedBar: any = null;
+  let total = 0;
+  let started = 0;
+  let finished = 0;
+
+  return {
+    onInit(ctx: Vitest) {
+      const files = ctx.state.getFiles() as any[];
+      total = files.reduce(
+        (sum, file) => sum + (file.tasks?.length ?? 0),
+        0,
+      );
+      if (total > 0) {
+        bars = new MultiBar(
+          { clearOnComplete: false, hideCursor: true },
+          MultiBar.Presets.shades_grey,
+        );
+        startedBar = bars.create(total, 0, {
+          format: "{bar} Started {value}/{total}",
+        });
+        finishedBar = bars.create(total, 0, {
+          format: "{bar} Completed {value}/{total}",
+        });
+      }
+    },
+    onTestCaseReady() {
+      if (startedBar) {
+        started += 1;
+        startedBar.update(started);
+      }
+    },
+    onTestCaseResult() {
+      if (finishedBar) {
+        finished += 1;
+        finishedBar.update(finished);
+      }
+    },
+    onFinished() {
+      bars?.stop();
+    },
+  };
+}

--- a/types/cli-progress.d.ts
+++ b/types/cli-progress.d.ts
@@ -1,0 +1,1 @@
+declare module "cli-progress";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,16 +1,18 @@
-import path from 'path';
-import { defineConfig } from 'vitest/config';
+import path from "path";
+import { defineConfig } from "vitest/config";
+import progressReporter from "./tests/progress-reporter";
 
 export default defineConfig({
   test: {
-    environment: 'jsdom',
-    setupFiles: './tests/setup.ts',
-    include: ['tests/**/*.test.{ts,tsx}'],
-    exclude: ['**/node_modules/**', '**/dist/**'],
+    environment: "jsdom",
+    setupFiles: "./tests/setup.ts",
+    include: ["tests/**/*.test.{ts,tsx}"],
+    exclude: ["**/node_modules/**", "**/dist/**"],
+    reporters: ["default", progressReporter()],
   },
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, 'src'),
+      "@": path.resolve(__dirname, "src"),
     },
   },
 });


### PR DESCRIPTION
## Summary
- run vitest only on changed files
- add MultiBar reporter for suite progress
- document full test run command

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf0ad37364832c81ae74e0af217a84