### PR TITLE
refactor: extract planner utilities

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -47,6 +47,9 @@ import {
   TaskList,
   TaskRow,
   EmptyRow,
+  DayRow,
+  ScrollTopFloatingButton,
+  PlannerProvider,
 } from "@/components/planner";
 import type { Pillar, Review } from "@/lib/types";
 import type { GameSide } from "@/components/ui/league/SideSelector";
@@ -748,6 +751,24 @@ export default function Page() {
         />
       ),
       className: "sm:col-span-2 md:col-span-3",
+    },
+    {
+      label: "DayRow",
+      element: (
+        <PlannerProvider>
+          <DayRow iso="2024-01-01" isToday={false} />
+        </PlannerProvider>
+      ),
+      className: "sm:col-span-2 md:col-span-3 w-full",
+    },
+    {
+      label: "ScrollTopFloatingButton",
+      element: (
+        <ScrollTopFloatingButton
+          watchRef={React.createRef<HTMLElement>()}
+          forceVisible
+        />
+      ),
     },
   ];
 

--- a/src/components/planner/DayRow.tsx
+++ b/src/components/planner/DayRow.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import DayCard from "./DayCard";
+import type { ISODate } from "./usePlanner";
+
+type DayRowProps = { iso: ISODate; isToday: boolean };
+
+const DayRow = React.memo(
+  function DayRow({ iso, isToday }: DayRowProps) {
+    return (
+      <section
+        id={`day-${iso}`}
+        role="listitem"
+        aria-label={`Day ${iso}${isToday ? " (Today)" : ""}`}
+        className="w-full scroll-m-24"
+        tabIndex={-1}
+      >
+        <DayCard iso={iso} isToday={isToday} />
+      </section>
+    );
+  },
+  (a: Readonly<DayRowProps>, b: Readonly<DayRowProps>) => a.iso === b.iso && a.isToday === b.isToday,
+);
+
+export default DayRow;

--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -12,66 +12,11 @@ import "./style.css";
 
 import * as React from "react";
 import TodayHero from "./TodayHero";
-import DayCard from "./DayCard";
 import WeekNotes from "./WeekNotes";
 import WeekPicker from "./WeekPicker";
+import DayRow from "./DayRow";
+import ScrollTopFloatingButton from "./ScrollTopFloatingButton";
 import { PlannerProvider, useFocusDate, useWeek, type ISODate } from "./usePlanner";
-import IconButton from "@/components/ui/primitives/IconButton";
-import { ArrowUp } from "lucide-react";
-
-/* ───────── Row (memo) ───────── */
-
-type DayRowProps = { iso: ISODate; isToday: boolean };
-
-const DayRow = React.memo(
-  function DayRow({ iso, isToday }: DayRowProps) {
-    return (
-      <section
-        id={`day-${iso}`}
-        role="listitem"
-        aria-label={`Day ${iso}${isToday ? " (Today)" : ""}`}
-        className="w-full scroll-m-24"
-        tabIndex={-1}
-      >
-        <DayCard iso={iso} isToday={isToday} />
-      </section>
-    );
-  },
-  (a: Readonly<DayRowProps>, b: Readonly<DayRowProps>) => a.iso === b.iso && a.isToday === b.isToday
-);
-
-/* ───────── Scroll-to-top button ───────── */
-function ScrollTopFloatingButton({ watchRef }: { watchRef: React.RefObject<HTMLElement> }) {
-  const [visible, setVisible] = React.useState(false);
-
-  React.useEffect(() => {
-    const target = watchRef.current;
-    if (!target) return;
-    const obs = new IntersectionObserver(entries => {
-      entries.forEach(e => setVisible(!e.isIntersecting));
-    });
-    obs.observe(target);
-    return () => obs.disconnect();
-  }, [watchRef]);
-
-  const scrollTop = () => {
-    if (typeof window !== "undefined") {
-      window.scrollTo({ top: 0, behavior: "smooth" });
-    }
-  };
-
-  if (!visible) return null;
-
-  return (
-    <IconButton
-      aria-label="Scroll to top"
-      onClick={scrollTop}
-        className="fixed bottom-8 right-2 z-50"
-    >
-      <ArrowUp />
-    </IconButton>
-  );
-}
 
 /* ───────── Page body under provider ───────── */
 

--- a/src/components/planner/ScrollTopFloatingButton.tsx
+++ b/src/components/planner/ScrollTopFloatingButton.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import IconButton from "@/components/ui/primitives/IconButton";
+import { ArrowUp } from "lucide-react";
+
+type ScrollTopFloatingButtonProps = {
+  watchRef: React.RefObject<HTMLElement>;
+  forceVisible?: boolean;
+};
+
+export default function ScrollTopFloatingButton({
+  watchRef,
+  forceVisible = false,
+}: ScrollTopFloatingButtonProps) {
+  const [visible, setVisible] = React.useState(false);
+
+  React.useEffect(() => {
+    const target = watchRef.current;
+    if (!target) return;
+    const obs = new IntersectionObserver(entries => {
+      entries.forEach(e => setVisible(!e.isIntersecting));
+    });
+    obs.observe(target);
+    return () => obs.disconnect();
+  }, [watchRef]);
+
+  const scrollTop = () => {
+    if (typeof window !== "undefined") {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  };
+
+  if (!visible && !forceVisible) return null;
+
+  return (
+    <IconButton
+      aria-label="Scroll to top"
+      onClick={scrollTop}
+      className="fixed bottom-8 right-2 z-50"
+    >
+      <ArrowUp />
+    </IconButton>
+  );
+}

--- a/src/components/planner/index.ts
+++ b/src/components/planner/index.ts
@@ -2,10 +2,12 @@
 // Do not edit directly.
 export { default as DayCard } from "./DayCard";
 export { default as DayCardHeader } from "./DayCardHeader";
+export { default as DayRow } from "./DayRow";
 export { default as EmptyRow } from "./EmptyRow";
 export { default as FocusPanel } from "./FocusPanel";
 export { default as PlannerPage } from "./PlannerPage";
 export { default as ProjectList } from "./ProjectList";
+export { default as ScrollTopFloatingButton } from "./ScrollTopFloatingButton";
 export { default as TaskList } from "./TaskList";
 export { default as TaskRow } from "./TaskRow";
 export { default as TodayHero } from "./TodayHero";

--- a/src/stories/planner/DayRow.stories.tsx
+++ b/src/stories/planner/DayRow.stories.tsx
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { DayRow, PlannerProvider } from "@/components/planner";
+
+const meta: Meta<typeof DayRow> = {
+  title: "Planner/DayRow",
+  component: DayRow,
+  decorators: [
+    (Story) => (
+      <PlannerProvider>
+        <Story />
+      </PlannerProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof DayRow>;
+
+export const Default: Story = {
+  args: {
+    iso: "2024-01-01",
+    isToday: false,
+  },
+};

--- a/src/stories/planner/ScrollTopFloatingButton.stories.tsx
+++ b/src/stories/planner/ScrollTopFloatingButton.stories.tsx
@@ -1,0 +1,20 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import ScrollTopFloatingButton from "@/components/planner/ScrollTopFloatingButton";
+
+const meta: Meta<typeof ScrollTopFloatingButton> = {
+  title: "Planner/ScrollTopFloatingButton",
+  component: ScrollTopFloatingButton,
+};
+export default meta;
+
+type Story = StoryObj<typeof ScrollTopFloatingButton>;
+
+export const Visible: Story = {
+  render: () => {
+    const ref = React.createRef<HTMLElement>();
+    return <ScrollTopFloatingButton watchRef={ref} forceVisible />;
+  },
+};

--- a/tests/planner/DayRow.test.tsx
+++ b/tests/planner/DayRow.test.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { DayRow, PlannerProvider } from "@/components/planner";
+
+describe("DayRow", () => {
+  it("renders day section with aria label", () => {
+    render(
+      <PlannerProvider>
+        <DayRow iso="2024-01-01" isToday={false} />
+      </PlannerProvider>,
+    );
+    expect(
+      screen.getByRole("listitem", { name: "Day 2024-01-01" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/planner/ScrollTopFloatingButton.test.tsx
+++ b/tests/planner/ScrollTopFloatingButton.test.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import ScrollTopFloatingButton from "@/components/planner/ScrollTopFloatingButton";
+
+describe("ScrollTopFloatingButton", () => {
+  beforeEach(() => {
+    (window as any).IntersectionObserver = class {
+      observe() {}
+      disconnect() {}
+    };
+  });
+
+  it("scrolls to top when clicked", () => {
+    const scrollTo = vi.fn();
+    (window as any).scrollTo = scrollTo;
+    const ref = React.createRef<HTMLElement>();
+    const { getByRole } = render(
+      <ScrollTopFloatingButton watchRef={ref} forceVisible />,
+    );
+    fireEvent.click(getByRole("button", { name: "Scroll to top" }));
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "smooth" });
+  });
+});


### PR DESCRIPTION
## Summary
- extract DayRow and ScrollTopFloatingButton into standalone planner components
- wire new components into PlannerPage and prompts gallery
- add tests and Storybook stories for DayRow and ScrollTopFloatingButton

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf0b2225a0832c99e033f503cb86e7