### PR TITLE
chore: improve postinstall regeneration

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "vitest",
     "format": "prettier --write .",
     "check-prompts": "ts-node scripts/check-prompts-updated.ts",
-    "postinstall": "npm run regen-ui && npm run regen-feature",
+    "postinstall": "ts-node scripts/postinstall.ts",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -1,0 +1,46 @@
+import { execSync } from "node:child_process";
+import { MultiBar, Presets } from "cli-progress";
+
+function hasComponentChanges(): boolean {
+  try {
+    const diff = execSync("git diff --name-only HEAD -- src/components")
+      .toString()
+      .trim();
+    return diff !== "";
+  } catch {
+    return true;
+  }
+}
+
+function run(cmd: string): void {
+  execSync(cmd, { stdio: "inherit" });
+}
+
+async function main() {
+  if (process.env.CI === "true" || !hasComponentChanges()) {
+    console.log("Skipping UI and feature regeneration");
+    return;
+  }
+
+  const bars = new MultiBar(
+    {
+      clearOnComplete: false,
+      hideCursor: true,
+    },
+    Presets.shades_grey,
+  );
+  const taskBar = bars.create(2, 0);
+
+  run("npm run regen-ui");
+  taskBar.update(1);
+
+  run("npm run regen-feature");
+  taskBar.update(2);
+
+  bars.stop();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- skip UI/feature regeneration when running in CI or when components haven't changed
- show a progress bar when regeneration runs

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf0dccbbdc832cb97e285d01704425