### PR TITLE
Add server-safe not-found handling

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+import { Button } from "@/components/ui";
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-[50vh] flex-col items-center justify-center gap-4 p-6 text-center">
+      <h2 className="text-xl font-semibold">Page not found</h2>
+      <p className="text-sm text-muted-foreground">
+        The page you are looking for does not exist.
+      </p>
+      <Link href="/"><Button>Go home</Button></Link>
+    </main>
+  );
+}

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,9 +1,13 @@
-import { createStorageKey } from "./db";
 import {
   readLocal,
   writeLocal,
   localBootstrapScript,
 } from "./local-bootstrap";
+
+const STORAGE_PREFIX = "noxis-planner:";
+function createStorageKey(key: string): string {
+  return `${STORAGE_PREFIX}${key}`;
+}
 
 export type Mode = "dark" | "light";
 export type Variant = "lg" | "aurora" | "citrus" | "noir" | "ocean" | "rose" | "hardstuck";


### PR DESCRIPTION
## Summary
- implement custom 404 page
- avoid client-only import for theme storage key

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bf0e7b0cac832ca92c58d99436418f