### PR TITLE
Refactor planner hooks into modular store

### DIFF
--- a/docs/planner-modules.md
+++ b/docs/planner-modules.md
@@ -1,0 +1,10 @@
+# Planner Modules
+
+This directory splits the planner logic into focused modules:
+
+- `plannerStore.ts` – React context with persistent planner data (`days`, `focus`, and selection). Wrap planner pages with `PlannerProvider` and consume the raw store via `usePlannerStore`.
+- `plannerCrud.ts` – Factory for project and task CRUD helpers. Given a day ISO string and an `upsertDay` function, it returns operations like `addProject` and `toggleTask`.
+- `usePlanner.ts` – Hook exposing high-level planner state for the current focus day. It wires the store with CRUD helpers and also exports selection hooks.
+- `useDay.ts` – Hook returning a convenient view of any day. It derives task counts and reuses `plannerCrud` to mutate the targeted day.
+
+Together these modules provide a clearer entry point for new contributors and eliminate duplicated CRUD code.

--- a/src/components/planner/DayCard.tsx
+++ b/src/components/planner/DayCard.tsx
@@ -10,11 +10,11 @@
 import "./style.css";
 import * as React from "react";
 import {
-  useDay,
   useSelectedProject,
   useSelectedTask,
   type ISODate,
 } from "./usePlanner";
+import { useDay } from "./useDay";
 import Input from "@/components/ui/primitives/Input";
 import { cn } from "@/lib/utils";
 import DayCardHeader from "./DayCardHeader";

--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -16,7 +16,8 @@ import WeekNotes from "./WeekNotes";
 import WeekPicker from "./WeekPicker";
 import DayRow from "./DayRow";
 import ScrollTopFloatingButton from "./ScrollTopFloatingButton";
-import { PlannerProvider, useFocusDate, useWeek, type ISODate } from "./usePlanner";
+import { useFocusDate, useWeek, type ISODate } from "./usePlanner";
+import { PlannerProvider } from "./plannerStore";
 
 /* ───────── Page body under provider ───────── */
 

--- a/src/components/planner/TodayHero.tsx
+++ b/src/components/planner/TodayHero.tsx
@@ -8,7 +8,8 @@
 
 import { useMemo, useRef, useState, useEffect } from "react";
 import { toISODate, cn } from "@/lib/utils";
-import { useFocusDate, useDay, useSelectedProject, useSelectedTask, type ISODate } from "./usePlanner";
+import { useFocusDate, useSelectedProject, useSelectedTask, type ISODate } from "./usePlanner";
+import { useDay } from "./useDay";
 import CheckCircle from "@/components/ui/toggles/CheckCircle";
 import Input from "@/components/ui/primitives/Input";
 import IconButton from "@/components/ui/primitives/IconButton";

--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -11,7 +11,8 @@
 import * as React from "react";
 import Hero2 from "@/components/ui/layout/Hero2";
 import Button from "@/components/ui/primitives/Button";
-import { useFocusDate, useDay, type ISODate } from "./usePlanner";
+import { useFocusDate, type ISODate } from "./usePlanner";
+import { useDay } from "./useDay";
 import { cn } from "@/lib/utils";
 import { CalendarDays, ChevronLeft, ChevronRight, ArrowUpToLine } from "lucide-react";
 import { isoToDate, toISO, addDays, mondayStartOfWeek } from "@/lib/date";

--- a/src/components/planner/dayCrud.ts
+++ b/src/components/planner/dayCrud.ts
@@ -1,4 +1,4 @@
-import type { DayRecord } from "./usePlanner";
+import type { DayRecord } from "./plannerStore";
 
 export function addProject(day: DayRecord, id: string, name: string) {
   const title = name.trim();

--- a/src/components/planner/index.ts
+++ b/src/components/planner/index.ts
@@ -15,4 +15,7 @@ export { default as WeekNotes } from "./WeekNotes";
 export { default as WeekPicker } from "./WeekPicker";
 export { default as WeekSummary } from "./WeekSummary";
 export * from "./dayCrud";
+export * from "./plannerCrud";
+export * from "./plannerStore";
+export * from "./useDay";
 export * from "./usePlanner";

--- a/src/components/planner/plannerCrud.ts
+++ b/src/components/planner/plannerCrud.ts
@@ -1,0 +1,64 @@
+import { uid } from "@/lib/db";
+import {
+  addProject as dayAddProject,
+  renameProject as dayRenameProject,
+  toggleProject as dayToggleProject,
+  removeProject as dayRemoveProject,
+  addTask as dayAddTask,
+  renameTask as dayRenameTask,
+  toggleTask as dayToggleTask,
+  removeTask as dayRemoveTask,
+} from "./dayCrud";
+import type { ISODate, DayRecord } from "./plannerStore";
+
+export type UpsertDay = (
+  iso: ISODate,
+  fn: (d: DayRecord) => DayRecord,
+) => void;
+
+export function makeCrud(iso: ISODate, upsertDay: UpsertDay) {
+  const addProject = (name: string) => {
+    const id = uid("proj");
+    upsertDay(iso, (d) => dayAddProject(d, id, name));
+    return id;
+  };
+
+  const renameProject = (id: string, name: string) =>
+    upsertDay(iso, (d) => dayRenameProject(d, id, name));
+
+  const toggleProject = (id: string) =>
+    upsertDay(iso, (d) => dayToggleProject(d, id));
+
+  const removeProject = (id: string) =>
+    upsertDay(iso, (d) => dayRemoveProject(d, id));
+
+  const addTask = (title: string, projectId?: string) => {
+    const id = uid("task");
+    upsertDay(iso, (d) => dayAddTask(d, id, title, projectId));
+    return id;
+  };
+
+  const renameTask = (id: string, next: string) =>
+    upsertDay(iso, (d) => dayRenameTask(d, id, next));
+
+  const toggleTask = (id: string) =>
+    upsertDay(iso, (d) => dayToggleTask(d, id));
+
+  const removeTask = (id: string) =>
+    upsertDay(iso, (d) => dayRemoveTask(d, id));
+
+  const setNotes = (notes: string) =>
+    upsertDay(iso, (d) => ({ ...d, notes }));
+
+  return {
+    addProject,
+    renameProject,
+    toggleProject,
+    removeProject,
+    addTask,
+    renameTask,
+    toggleTask,
+    removeTask,
+    setNotes,
+  } as const;
+}

--- a/src/components/planner/plannerStore.ts
+++ b/src/components/planner/plannerStore.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import "./style.css";
+import * as React from "react";
+import { usePersistentState } from "@/lib/db";
+import { toISO } from "@/lib/date";
+
+export type ISODate = string;
+
+export type Project = {
+  id: string;
+  name: string;
+  done: boolean;
+  createdAt: number;
+};
+
+export type DayTask = {
+  id: string;
+  title: string;
+  done: boolean;
+  projectId?: string;
+  createdAt: number;
+};
+
+export type DayRecord = {
+  projects: Project[];
+  tasks: DayTask[];
+  focus?: string;
+  notes?: string;
+};
+
+export type Selection = {
+  projectId?: string;
+  taskId?: string;
+};
+
+export function todayISO(): ISODate {
+  return toISO(new Date());
+}
+
+export function ensureDay(map: Record<ISODate, DayRecord>, date: ISODate) {
+  return map[date] ?? { projects: [], tasks: [] };
+}
+
+type PlannerState = {
+  days: Record<ISODate, DayRecord>;
+  setDays: React.Dispatch<React.SetStateAction<Record<ISODate, DayRecord>>>;
+  focus: ISODate;
+  setFocus: (iso: ISODate) => void;
+  selected: Record<ISODate, Selection>;
+  setSelected: React.Dispatch<React.SetStateAction<Record<ISODate, Selection>>>;
+};
+
+const PlannerCtx = React.createContext<PlannerState | null>(null);
+
+export function PlannerProvider({ children }: { children: React.ReactNode }) {
+  const [days, setDays] = usePersistentState<Record<ISODate, DayRecord>>(
+    "planner:days",
+    {},
+  );
+  const [focus, setFocus] = usePersistentState<ISODate>(
+    "planner:focus",
+    todayISO(),
+  );
+  const [selected, setSelected] = usePersistentState<Record<ISODate, Selection>>(
+    "planner:selected",
+    {},
+  );
+
+  const value = React.useMemo<PlannerState>(
+    () => ({ days, setDays, focus, setFocus, selected, setSelected }),
+    [days, focus, selected, setDays, setFocus, setSelected],
+  );
+
+  return React.createElement(
+    PlannerCtx.Provider,
+    { value },
+    children as React.ReactNode,
+  );
+}
+
+export function usePlannerStore(): PlannerState {
+  const ctx = React.useContext(PlannerCtx);
+  if (!ctx)
+    throw new Error(
+      "PlannerProvider is missing. Wrap your planner page with <PlannerProvider>.",
+    );
+  return ctx;
+}

--- a/src/components/planner/useDay.ts
+++ b/src/components/planner/useDay.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import * as React from "react";
+import { ensureDay, type ISODate } from "./plannerStore";
+import { makeCrud } from "./plannerCrud";
+import { usePlanner } from "./usePlanner";
+
+export function useDay(iso: ISODate) {
+  const { days, upsertDay } = usePlanner();
+
+  const rec = React.useMemo(() => ensureDay(days, iso), [days, iso]);
+
+  const tasks = React.useMemo(
+    () =>
+      rec.tasks.map((t) => ({
+        id: t.id,
+        title: t.title,
+        text: t.title,
+        done: t.done,
+        projectId: t.projectId,
+        createdAt: t.createdAt,
+      })),
+    [rec.tasks],
+  );
+
+  const crud = React.useMemo(() => makeCrud(iso, upsertDay), [iso, upsertDay]);
+
+  const doneTasks = React.useMemo(
+    () => tasks.filter((t) => t.done).length,
+    [tasks],
+  );
+  const totalTasks = tasks.length;
+
+  return {
+    projects: rec.projects,
+    tasks,
+    addProject: crud.addProject,
+    renameProject: crud.renameProject,
+    deleteProject: crud.removeProject,
+    toggleProject: crud.toggleProject,
+    addTask: crud.addTask,
+    renameTask: crud.renameTask,
+    deleteTask: crud.removeTask,
+    toggleTask: crud.toggleTask,
+    doneTasks,
+    totalTasks,
+  } as const;
+}

--- a/src/components/planner/usePlanner.ts
+++ b/src/components/planner/usePlanner.ts
@@ -1,109 +1,17 @@
 "use client";
 
-/**
- * Planner store (Lavender-Glitch)
- * - Central day data + per-day selection state (projectId | taskId)
- * - Single source of truth for cross-component selection
- */
-
-import "./style.css";
 import * as React from "react";
-import { usePersistentState, uid } from "@/lib/db";
-import { toISO, addDays, weekRangeFromISO } from "@/lib/date";
+import { addDays, toISO, weekRangeFromISO } from "@/lib/date";
 import {
-  addProject as dayAddProject,
-  renameProject as dayRenameProject,
-  toggleProject as dayToggleProject,
-  removeProject as dayRemoveProject,
-  addTask as dayAddTask,
-  renameTask as dayRenameTask,
-  toggleTask as dayToggleTask,
-  removeTask as dayRemoveTask,
-} from "./dayCrud";
+  ensureDay,
+  todayISO,
+  usePlannerStore,
+  type DayRecord,
+  type ISODate,
+} from "./plannerStore";
+import { makeCrud } from "./plannerCrud";
 
-/* ───────────────── Types ───────────────── */
-export type ISODate = string;
-
-export type Project = {
-  id: string;
-  name: string;
-  done: boolean;
-  createdAt: number;
-};
-
-export type DayTask = {
-  id: string;
-  title: string;
-  done: boolean;
-  projectId?: string;
-  createdAt: number;
-};
-
-export type DayRecord = {
-  projects: Project[];
-  tasks: DayTask[];
-  focus?: string;
-  notes?: string;
-};
-
-type Selection = {
-  projectId?: string; // if present, taskId must be undefined
-  taskId?: string; // if present, projectId is auto-derived for that task
-};
-
-/* ───────────────── Date helpers ───────────────── */
-function todayISO(): ISODate {
-  return toISO(new Date());
-}
-
-/* ───────────────── Context ───────────────── */
-type PlannerState = {
-  days: Record<ISODate, DayRecord>;
-  setDays: React.Dispatch<React.SetStateAction<Record<ISODate, DayRecord>>>;
-  focus: ISODate;
-  setFocus: (iso: ISODate) => void;
-
-  // NEW: per-day selection map (projectId | taskId)
-  selected: Record<ISODate, Selection>;
-  setSelected: React.Dispatch<React.SetStateAction<Record<ISODate, Selection>>>;
-};
-
-const PlannerCtx = React.createContext<PlannerState | null>(null);
-
-export function PlannerProvider({ children }: { children: React.ReactNode }) {
-  const [days, setDays] = usePersistentState<Record<ISODate, DayRecord>>(
-    "planner:days",
-    {},
-  );
-  const [focus, setFocus] = usePersistentState<ISODate>(
-    "planner:focus",
-    todayISO(),
-  );
-  const [selected, setSelected] = usePersistentState<Record<ISODate, Selection>>(
-    "planner:selected",
-    {},
-  );
-
-  const value = React.useMemo<PlannerState>(
-    () => ({ days, setDays, focus, setFocus, selected, setSelected }),
-    [days, focus, selected, setDays, setFocus, setSelected],
-  );
-
-  return React.createElement(
-    PlannerCtx.Provider,
-    { value },
-    children as React.ReactNode,
-  );
-}
-
-function usePlannerStore(): PlannerState {
-  const ctx = React.useContext(PlannerCtx);
-  if (!ctx)
-    throw new Error(
-      "PlannerProvider is missing. Wrap your planner page with <PlannerProvider>.",
-    );
-  return ctx;
-}
+export type { ISODate, DayRecord, Project, DayTask } from "./plannerStore";
 
 /* ───────────────── Public week + focus ───────────────── */
 export function useFocusDate() {
@@ -111,6 +19,7 @@ export function useFocusDate() {
   const today = todayISO();
   return { iso: focus, setIso: setFocus, today } as const;
 }
+
 export function useWeek(iso: ISODate) {
   return React.useMemo(() => {
     const { start, end } = weekRangeFromISO(iso);
@@ -122,10 +31,6 @@ export function useWeek(iso: ISODate) {
   }, [iso]);
 }
 
-/* ───────────────── Internals ───────────────── */
-function ensureDay(map: Record<ISODate, DayRecord>, date: ISODate) {
-  return map[date] ?? { projects: [], tasks: [] };
-}
 function writeThroughLegacy(
   storage: Storage,
   days: Record<ISODate, DayRecord>,
@@ -184,160 +89,21 @@ export function usePlanner() {
     [setDaysAndMirror],
   );
 
-  // Focus-scoped CRUD
-  const addProject = React.useCallback(
-    (name: string) => {
-      const id = uid("proj");
-      upsertDay(focus, (d) => dayAddProject(d, id, name));
-      return id;
-    },
-    [focus, upsertDay],
-  );
-
-  const renameProject = React.useCallback(
-    (id: string, name: string) =>
-      upsertDay(focus, (d) => dayRenameProject(d, id, name)),
-    [focus, upsertDay],
-  );
-
-  const toggleProject = React.useCallback(
-    (id: string) => upsertDay(focus, (d) => dayToggleProject(d, id)),
-    [focus, upsertDay],
-  );
-
-  const removeProject = React.useCallback(
-    (id: string) => upsertDay(focus, (d) => dayRemoveProject(d, id)),
-    [focus, upsertDay],
-  );
-
-  const addTask = React.useCallback(
-    (title: string, projectId?: string) => {
-      const id = uid("task");
-      upsertDay(focus, (d) => dayAddTask(d, id, title, projectId));
-      return id;
-    },
-    [focus, upsertDay],
-  );
-
-  const renameTask = React.useCallback(
-    (id: string, next: string) =>
-      upsertDay(focus, (d) => dayRenameTask(d, id, next)),
-    [focus, upsertDay],
-  );
-
-  const toggleTask = React.useCallback(
-    (id: string) => upsertDay(focus, (d) => dayToggleTask(d, id)),
-    [focus, upsertDay],
-  );
-
-  const removeTask = React.useCallback(
-    (id: string) => upsertDay(focus, (d) => dayRemoveTask(d, id)),
-    [focus, upsertDay],
-  );
-
-  const setNotes = React.useCallback(
-    (notes: string) => upsertDay(focus, (d) => ({ ...d, notes })),
-    [focus, upsertDay],
-  );
+  const crud = React.useMemo(() => makeCrud(focus, upsertDay), [focus, upsertDay]);
 
   return {
-    // raw store
     days,
     focus,
     setFocus,
-
-    // day accessors
     day: getDay(focus),
     getDay,
     setDay,
     upsertDay,
-
-    // focus-scoped CRUD
-    addProject,
-    renameProject,
-    toggleProject,
-    removeProject,
-    addTask,
-    renameTask,
-    toggleTask,
-    removeTask,
-    setNotes,
-  } as const;
-}
-
-/* ───────────────── Day-scoped view ───────────────── */
-export function useDay(iso: ISODate) {
-  const { days, upsertDay } = usePlanner();
-
-  const rec: DayRecord = React.useMemo(() => ensureDay(days, iso), [days, iso]);
-
-  const tasks = React.useMemo(
-    () =>
-      rec.tasks.map((t) => ({
-        id: t.id,
-        title: t.title,
-        text: t.title, // adapter for UIs expecting `text`
-        done: t.done,
-        projectId: t.projectId,
-        createdAt: t.createdAt,
-      })),
-    [rec.tasks],
-  );
-
-  const addProject = (name: string) => {
-    const id = uid("proj");
-    upsertDay(iso, (d) => dayAddProject(d, id, name));
-    return id;
-  };
-
-  const renameProject = (id: string, name: string) =>
-    upsertDay(iso, (d) => dayRenameProject(d, id, name));
-
-  const toggleProject = (id: string) =>
-    upsertDay(iso, (d) => dayToggleProject(d, id));
-
-  const deleteProject = (id: string) =>
-    upsertDay(iso, (d) => dayRemoveProject(d, id));
-
-  const addTask = (title: string, projectId?: string) => {
-    const id = uid("task");
-    upsertDay(iso, (d) => dayAddTask(d, id, title, projectId));
-    return id;
-  };
-
-  const renameTask = (id: string, next: string) =>
-    upsertDay(iso, (d) => dayRenameTask(d, id, next));
-
-  const toggleTask = (id: string) =>
-    upsertDay(iso, (d) => dayToggleTask(d, id));
-
-  const deleteTask = (id: string) =>
-    upsertDay(iso, (d) => dayRemoveTask(d, id));
-
-  const doneTasks = React.useMemo(
-    () => tasks.filter((t) => t.done).length,
-    [tasks],
-  );
-  const totalTasks = tasks.length;
-
-  return {
-    projects: rec.projects,
-    tasks,
-    addProject,
-    renameProject,
-    deleteProject,
-    toggleProject,
-    addTask,
-    renameTask,
-    deleteTask,
-    toggleTask,
-    doneTasks,
-    totalTasks,
+    ...crud,
   } as const;
 }
 
 /* ───────────────── Selection hooks (single-select per day) ───────────────── */
-
 export function useSelectedProject(iso: ISODate) {
   const { selected, setSelected } = usePlannerStore();
   const current = selected[iso]?.projectId ?? "";
@@ -345,7 +111,7 @@ export function useSelectedProject(iso: ISODate) {
     (projectId: string) => {
       setSelected((prev) => ({
         ...prev,
-        [iso]: projectId ? { projectId } : {}, // clears taskId implicitly
+        [iso]: projectId ? { projectId } : {},
       }));
     },
     [iso, setSelected],
@@ -367,7 +133,7 @@ export function useSelectedTask(iso: ISODate) {
       const projectId = rec.tasks.find((t) => t.id === taskId)?.projectId;
       setSelected((prev) => ({
         ...prev,
-        [iso]: { taskId, projectId }, // selecting a task auto-selects its project
+        [iso]: { taskId, projectId },
       }));
     },
     [iso, setSelected, days],


### PR DESCRIPTION
## Summary
- Extract `plannerStore` context provider and helpers
- Add `plannerCrud` factory and reuse in `usePlanner`/`useDay`
- Update planner components to import new hooks
- Document planner module responsibilities

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf1182af14832c9ff9702592db3d82