### PR TITLE
feat: incremental typecheck with progress bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ web_modules/
 
 # TypeScript cache
 *.tsbuildinfo
+/.cache/
 
 # Optional npm cache directory
 .npm

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "npm run regen-ui && npm run regen-feature && next build",
     "start": "next start -p 3000",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "ts-node scripts/typecheck.ts",
     "test": "vitest",
     "format": "prettier --write .",
     "check-prompts": "ts-node scripts/check-prompts-updated.ts",


### PR DESCRIPTION
## Summary
- run typecheck via a custom script using incremental `tsc` and stored build info in `.cache`
- ignore `.cache` folder and create it automatically
- show a cli-progress bar during type checking

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf126c41ec832cb9519e04a5ea5adc