### PR TITLE
refactor: unify date helpers

### DIFF
--- a/src/components/planner/TodayHero.tsx
+++ b/src/components/planner/TodayHero.tsx
@@ -7,7 +7,8 @@
  */
 
 import { useMemo, useRef, useState, useEffect } from "react";
-import { toISODate, cn } from "@/lib/utils";
+import { cn } from "@/lib/utils";
+import { toISODate } from "@/lib/date";
 import { useFocusDate, useSelectedProject, useSelectedTask, type ISODate } from "./usePlanner";
 import { useDay } from "./useDay";
 import CheckCircle from "@/components/ui/toggles/CheckCircle";

--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -15,7 +15,7 @@ import { useFocusDate, type ISODate } from "./usePlanner";
 import { useDay } from "./useDay";
 import { cn } from "@/lib/utils";
 import { CalendarDays, ChevronLeft, ChevronRight, ArrowUpToLine } from "lucide-react";
-import { isoToDate, toISO, addDays, mondayStartOfWeek } from "@/lib/date";
+import { fromISODate, toISODate, addDays, mondayStartOfWeek } from "@/lib/date";
 
 /* ───────── date helpers ───────── */
 
@@ -116,23 +116,23 @@ export default function WeekPicker() {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { start, end, heading, rangeLabel, isoStart, isoEnd, days } = React.useMemo(() => {
-    const base = isoToDate(iso);
+    const base = fromISODate(iso) ?? new Date();
     const s = mondayStartOfWeek(base);
     const e = addDays(s, 6);
-    const list: ISODate[] = Array.from({ length: 7 }, (_, i) => toISO(addDays(s, i)) as ISODate);
+    const list: ISODate[] = Array.from({ length: 7 }, (_, i) => toISODate(addDays(s, i)) as ISODate);
     return {
       start: s,
       end: e,
       heading: `${dmy.format(s)} — ${dmy.format(e)}`,
       rangeLabel: `${dmy.format(s)} → ${dmy.format(e)}`,
-      isoStart: toISO(s),
-      isoEnd: toISO(e),
+      isoStart: toISODate(s),
+      isoEnd: toISODate(e),
       days: list,
     };
   }, [iso]);
 
-  const prevWeek = () => setIso(toISO(addDays(start, -7)));
-  const nextWeek = () => setIso(toISO(addDays(start, 7)));
+  const prevWeek = () => setIso(toISODate(addDays(start, -7)));
+  const nextWeek = () => setIso(toISODate(addDays(start, 7)));
   const jumpToday = () => setIso(today);
 
   const { per, weekDone, weekTotal } = useWeekStats(days);

--- a/src/components/planner/plannerStore.ts
+++ b/src/components/planner/plannerStore.ts
@@ -3,7 +3,7 @@
 import "./style.css";
 import * as React from "react";
 import { usePersistentState } from "@/lib/db";
-import { toISO } from "@/lib/date";
+import { toISODate } from "@/lib/date";
 
 export type ISODate = string;
 
@@ -35,7 +35,7 @@ export type Selection = {
 };
 
 export function todayISO(): ISODate {
-  return toISO(new Date());
+  return toISODate(new Date());
 }
 
 export function ensureDay(map: Record<ISODate, DayRecord>, date: ISODate) {

--- a/src/components/planner/usePlanner.ts
+++ b/src/components/planner/usePlanner.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { addDays, toISO, weekRangeFromISO } from "@/lib/date";
+import { addDays, toISODate, weekRangeFromISO } from "@/lib/date";
 import {
   ensureDay,
   todayISO,
@@ -24,7 +24,7 @@ export function useWeek(iso: ISODate) {
   return React.useMemo(() => {
     const { start, end } = weekRangeFromISO(iso);
     const days: ISODate[] = [];
-    for (let i = 0; i < 7; i++) days.push(toISO(addDays(start, i)));
+    for (let i = 0; i < 7; i++) days.push(toISODate(addDays(start, i)));
     const today = todayISO();
     const isToday = (d: ISODate) => d === today;
     return { start, end, days, isToday } as const;

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -9,16 +9,46 @@ export const shortDate = new Intl.DateTimeFormat(LOCALE, {
   year: "numeric",
 });
 
-export function toISO(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
+/** Predicate for "YYYY-MM-DD" */
+export function isISODate(v: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(v);
 }
 
-export function isoToDate(iso: string): Date {
-  const [y, m, d] = iso.split("-").map(Number);
-  return new Date(y, m - 1, d);
+/** Parse "YYYY-MM-DD" into a Date at local midnight. Returns null if invalid. */
+export function fromISODate(iso: string): Date | null {
+  if (!isISODate(iso)) return null;
+  const [y, m, d] = iso.split("-").map((x) => parseInt(x, 10));
+  const dt = new Date(y, m - 1, d, 0, 0, 0, 0);
+  if (!Number.isFinite(dt.getTime())) return null;
+  return dt.getFullYear() === y && dt.getMonth() === m - 1 && dt.getDate() === d
+    ? dt
+    : null;
+}
+
+/** Normalize various inputs to a valid Date (fallback = now). */
+export function normalizeDate(src?: Date | number | string): Date {
+  let dt: Date;
+  if (src instanceof Date) {
+    dt = new Date(src);
+  } else if (typeof src === "number") {
+    dt = new Date(src);
+  } else if (typeof src === "string") {
+    const maybeISO = isISODate(src) ? fromISODate(src) : null;
+    dt = maybeISO ?? new Date(src);
+  } else {
+    dt = new Date();
+  }
+  if (!Number.isFinite(dt.getTime())) dt = new Date();
+  return dt;
+}
+
+/** toISODate — Returns local date in "YYYY-MM-DD". */
+export function toISODate(d?: Date | number | string): string {
+  const date = normalizeDate(d);
+  const y = date.getFullYear();
+  const m = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${y}-${m}-${day}`;
 }
 
 export function addDays(date: Date, n: number): Date {
@@ -43,6 +73,6 @@ export function sundayEndOfWeek(d: Date): Date {
 }
 
 export function weekRangeFromISO(iso: string): { start: Date; end: Date } {
-  const d = isoToDate(iso);
+  const d = fromISODate(iso) ?? new Date();
   return { start: mondayStartOfWeek(d), end: sundayEndOfWeek(d) };
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -22,52 +22,7 @@ export function clamp(n: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, n));
 }
 
-/**
- * toISODate — Returns local date in "YYYY-MM-DD".
- * Accepts Date | timestamp | date-like string. Falls back to today on invalid.
- * Note: uses local time (planner/week UX expects local).
- */
-export function toISODate(d?: Date | number | string): string {
-  const date = normalizeDate(d);
-  const y = date.getFullYear();
-  const m = `${date.getMonth() + 1}`.padStart(2, "0");
-  const day = `${date.getDate()}`.padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
-
-/** Parse "YYYY-MM-DD" into a Date at local midnight. Returns null if invalid. */
-export function fromISODate(iso: string): Date | null {
-  if (!isISODate(iso)) return null;
-  const [y, m, d] = iso.split("-").map((x) => parseInt(x, 10));
-  const dt = new Date(y, m - 1, d, 0, 0, 0, 0);
-  if (!Number.isFinite(dt.getTime())) return null;
-  // Guard against JS Date rolling over invalid dates like "2023-02-31" -> Mar 3
-  return dt.getFullYear() === y && dt.getMonth() === m - 1 && dt.getDate() === d
-    ? dt
-    : null;
-}
-
-/** Predicate for "YYYY-MM-DD". */
-export function isISODate(v: string): boolean {
-  return /^\d{4}-\d{2}-\d{2}$/.test(v);
-}
-
-/** Normalize a variety of inputs to a valid Date (fallback = now). */
-export function normalizeDate(src?: Date | number | string): Date {
-  let dt: Date;
-  if (src instanceof Date) {
-    dt = new Date(src);
-  } else if (typeof src === "number") {
-    dt = new Date(src);
-  } else if (typeof src === "string") {
-    const maybeISO = isISODate(src) ? fromISODate(src) : null;
-    dt = maybeISO ?? new Date(src);
-  } else {
-    dt = new Date();
-  }
-  if (!Number.isFinite(dt.getTime())) dt = new Date();
-  return dt;
-}
+// Date helpers moved to ./date.ts
 
 /** Create a URL-friendly slug from a string. */
 export function slugify(s?: string): string {

--- a/tests/lib/date.test.ts
+++ b/tests/lib/date.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  addDays,
+  fromISODate,
+  toISODate,
+  normalizeDate,
+  weekRangeFromISO,
+} from '../../src/lib/date';
+
+describe('fromISODate', () => {
+  it('returns null for invalid dates', () => {
+    const valid = fromISODate('2024-02-29');
+    expect(
+      valid &&
+        valid.getFullYear() === 2024 &&
+        valid.getMonth() === 1 &&
+        valid.getDate() === 29,
+    ).toBe(true);
+    expect(fromISODate('2024-02-30')).toBeNull();
+    expect(fromISODate('not-a-date')).toBeNull();
+  });
+});
+
+describe('toISODate', () => {
+  it('formats dates and timestamps', () => {
+    const d = new Date('2024-02-29T12:00:00Z');
+    expect(toISODate(d)).toBe('2024-02-29');
+    const ts = Date.UTC(2024, 1, 29);
+    expect(toISODate(ts)).toBe('2024-02-29');
+  });
+
+  it('falls back to today for invalid values', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-02T00:00:00Z'));
+    expect(toISODate('not-a-date')).toBe('2024-01-02');
+    expect(toISODate(NaN)).toBe('2024-01-02');
+    vi.useRealTimers();
+  });
+
+  it('handles timezone offsets', () => {
+    const d = new Date('2024-02-29T23:00:00-02:00');
+    const expected = `${d.getFullYear()}-${`${d.getMonth() + 1}`.padStart(2, '0')}-${`${d.getDate()}`.padStart(2, '0')}`;
+    expect(toISODate(d)).toBe(expected);
+  });
+});
+
+describe('normalizeDate', () => {
+  it('parses various inputs', () => {
+    const d = new Date('2024-02-29T12:34:56Z');
+    expect(normalizeDate(d).getTime()).toBe(d.getTime());
+    const ts = Date.UTC(2024, 1, 29);
+    expect(normalizeDate(ts).getTime()).toBe(ts);
+  });
+
+  it('returns local midnight for ISO strings', () => {
+    const dt = normalizeDate('2024-02-29');
+    expect(dt.getHours()).toBe(0);
+    expect(dt.getMinutes()).toBe(0);
+    expect(dt.getSeconds()).toBe(0);
+  });
+
+  it('falls back to now on invalid values', () => {
+    vi.useFakeTimers();
+    const now = new Date('2024-06-15T00:00:00Z');
+    vi.setSystemTime(now);
+    expect(normalizeDate('not-a-date').getTime()).toBe(now.getTime());
+    expect(normalizeDate(NaN).getTime()).toBe(now.getTime());
+    vi.useRealTimers();
+  });
+
+  it('rolls over out-of-range ISO dates', () => {
+    const dt = normalizeDate('2024-02-30');
+    expect(dt.getFullYear()).toBe(2024);
+    expect(dt.getMonth()).toBe(2); // March
+    expect(dt.getDate()).toBe(1);
+  });
+});
+
+describe('addDays', () => {
+  it('adds days without mutating original', () => {
+    const d = new Date('2024-02-29T00:00:00Z');
+    const next = addDays(d, 1);
+    expect(toISODate(next)).toBe('2024-03-01');
+    expect(toISODate(d)).toBe('2024-02-29');
+  });
+});
+
+describe('weekRangeFromISO', () => {
+  it('returns week boundaries', () => {
+    const { start, end } = weekRangeFromISO('2024-06-15');
+    expect(toISODate(start)).toBe('2024-06-10');
+    expect(toISODate(end)).toBe('2024-06-16');
+  });
+});

--- a/tests/lib/utils.test.ts
+++ b/tests/lib/utils.test.ts
@@ -1,11 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import {
-  cn,
-  fromISODate,
-  slugify,
-  toISODate,
-  normalizeDate,
-} from '../../src/lib/utils';
+import { describe, it, expect } from 'vitest';
+import { cn, slugify } from '../../src/lib/utils';
 
 describe('cn', () => {
   it('handles strings', () => {
@@ -39,75 +33,6 @@ describe('cn', () => {
       0
     );
     expect(result).toBe('foo 1 bar baz qux corge');
-  });
-});
-
-describe('fromISODate', () => {
-  it('returns null for invalid dates', () => {
-    const valid = fromISODate('2024-02-29');
-    expect(
-      valid &&
-        valid.getFullYear() === 2024 &&
-        valid.getMonth() === 1 &&
-        valid.getDate() === 29
-    ).toBe(true);
-    expect(fromISODate('2024-02-30')).toBeNull();
-    expect(fromISODate('not-a-date')).toBeNull();
-  });
-});
-
-describe('toISODate', () => {
-  it('formats dates and timestamps', () => {
-    const d = new Date('2024-02-29T12:00:00Z');
-    expect(toISODate(d)).toBe('2024-02-29');
-    const ts = Date.UTC(2024, 1, 29);
-    expect(toISODate(ts)).toBe('2024-02-29');
-  });
-
-  it('falls back to today for invalid values', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2024-01-02T00:00:00Z'));
-    expect(toISODate('not-a-date')).toBe('2024-01-02');
-    expect(toISODate(NaN)).toBe('2024-01-02');
-    vi.useRealTimers();
-  });
-
-  it('handles timezone offsets', () => {
-    const d = new Date('2024-02-29T23:00:00-02:00');
-    const expected = `${d.getFullYear()}-${`${d.getMonth() + 1}`.padStart(2, '0')}-${`${d.getDate()}`.padStart(2, '0')}`;
-    expect(toISODate(d)).toBe(expected);
-  });
-});
-
-describe('normalizeDate', () => {
-  it('parses various inputs', () => {
-    const d = new Date('2024-02-29T12:34:56Z');
-    expect(normalizeDate(d).getTime()).toBe(d.getTime());
-    const ts = Date.UTC(2024, 1, 29);
-    expect(normalizeDate(ts).getTime()).toBe(ts);
-  });
-
-  it('returns local midnight for ISO strings', () => {
-    const dt = normalizeDate('2024-02-29');
-    expect(dt.getHours()).toBe(0);
-    expect(dt.getMinutes()).toBe(0);
-    expect(dt.getSeconds()).toBe(0);
-  });
-
-  it('falls back to now on invalid values', () => {
-    vi.useFakeTimers();
-    const now = new Date('2024-06-15T00:00:00Z');
-    vi.setSystemTime(now);
-    expect(normalizeDate('not-a-date').getTime()).toBe(now.getTime());
-    expect(normalizeDate(NaN).getTime()).toBe(now.getTime());
-    vi.useRealTimers();
-  });
-
-  it('rolls over out-of-range ISO dates', () => {
-    const dt = normalizeDate('2024-02-30');
-    expect(dt.getFullYear()).toBe(2024);
-    expect(dt.getMonth()).toBe(2); // March
-    expect(dt.getDate()).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- centralize date helpers in src/lib/date.ts
- remove duplicate utilities and update imports across planner components
- add tests for date helpers and prune utils tests

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf150552c4832c8b630bee46639cd3