### PR TITLE
refactor: rename chrome header to banner

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/components/prompts";
 import ReviewPanel from "@/components/reviews/ReviewPanel";
 import ReviewListItem from "@/components/reviews/ReviewListItem";
+import Banner from "@/components/chrome/Banner";
 import {
   DayCardHeader,
   ProjectList,
@@ -313,6 +314,14 @@ export default function Page() {
       element: (
         <div className="w-56">
           <TitleBar label="Navigation" />
+        </div>
+      ),
+    },
+    {
+      label: "Banner",
+      element: (
+        <div className="w-56">
+          <Banner title="Banner" actions={<Button size="sm">Action</Button>} />
         </div>
       ),
     },

--- a/src/components/chrome/Banner.tsx
+++ b/src/components/chrome/Banner.tsx
@@ -1,10 +1,10 @@
-// src/components/chrome/Header.tsx
+// src/components/chrome/Banner.tsx
 "use client";
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-export type HeaderProps = {
+export type BannerProps = {
   sticky?: boolean;
   title?: React.ReactNode;
   actions?: React.ReactNode;
@@ -13,17 +13,17 @@ export type HeaderProps = {
 };
 
 /**
- * Header — simple page header row.
+ * Banner — simple page header row.
  * - sticky uses .sticky-blur surface and a hairline.
  * - no mystery CSS variables; uses theme tokens.
  */
-export default function Header({
+export default function Banner({
   sticky = false,
   title,
   actions,
   children,
   className,
-}: HeaderProps) {
+}: BannerProps) {
   return (
     <header
       className={cn(


### PR DESCRIPTION
## Summary
- rename chrome Header component to Banner
- add Banner demo to prompts gallery

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf158a56e4832c84377ad17b4d0fd6