### PR TITLE
Rename comps route to team

### DIFF
--- a/src/app/comps/page.tsx
+++ b/src/app/comps/page.tsx
@@ -1,8 +1,0 @@
-import type { Metadata } from "next";
-import TeamCompPage from "@/components/team/TeamCompPage";
-
-export const metadata: Metadata = { title: "Comps · 13 League Review" };
-
-export default function Page() {
-  return <TeamCompPage />;
-}

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import TeamCompPage from "@/components/team/TeamCompPage";
+
+export const metadata: Metadata = { title: "Team · 13 League Review" };
+
+export default function Page() {
+  return <TeamCompPage />;
+}

--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -15,7 +15,7 @@ const ITEMS = [
   { href: "/reviews", label: "Reviews" },
   { href: "/planner", label: "Planner" },
   { href: "/goals", label: "Goals" },
-  { href: "/comps", label: "Comps" },
+  { href: "/team", label: "Comps" },
   { href: "/prompts", label: "Prompts" },
 ];
 


### PR DESCRIPTION
## Summary
- rename `src/app/comps` to `src/app/team`
- update navbar links from `/comps` to `/team`

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf15d0e2f8832cb4bcb3431f892e0c