### PR TITLE
refactor: use main tag for layout wrapper

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,9 +34,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body className="min-h-screen bg-[hsl(var(--background))] text-[hsl(var(--foreground))] glitch-root">
         <SiteChrome />
-        <div className="relative z-10">
+        <main className="relative z-10">
           {children}
-        </div>
+        </main>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- use semantic `main` for layout content wrapper

## Testing
- `npm run regen-ui` *(fails: ts-node: not found)*
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: ts-node: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1a4baee0832ca10b3243c4030598