### PR TITLE
Use Header component on planner page

### DIFF
--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -19,6 +19,7 @@ import ScrollTopFloatingButton from "./ScrollTopFloatingButton";
 import { useFocusDate, useWeek } from "./useFocusDate";
 import type { ISODate } from "./plannerStore";
 import { PlannerProvider } from "./plannerStore";
+import Header from "@/components/ui/layout/Header";
 
 /* ───────── Page body under provider ───────── */
 
@@ -38,12 +39,10 @@ function Inner() {
     <>
       <main
         className="page-shell py-6 space-y-6"
-        aria-labelledby="planner-week-heading"
+        aria-labelledby="planner-header"
       >
       {/* Week header (range, nav, totals, day chips) */}
-      <h1 id="planner-week-heading" className="sr-only">
-        Weekly planner
-      </h1>
+      <Header id="planner-header" heading="Planner" />
       <WeekPicker />
 
       {/* Today + Side column */}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -15,7 +15,6 @@ export * from "./layout/Header";
 export { default as Hero2 } from "./layout/Hero2";
 export * from "./layout/Hero2";
 export { default as SectionCard } from "./layout/SectionCard";
-export * from "./layout/SectionCard";
 export { default as Split } from "./layout/Split";
 export { default as TabBar } from "./layout/TabBar";
 export * from "./layout/TabBar";


### PR DESCRIPTION
## Summary
- Use shared Header on PlannerPage and drop redundant screen-reader heading
- Simplify UI index to avoid duplicate HeaderProps export

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf1cf3f2c8832cb8b7f938333059fe