### PR TITLE
feat: enforce semantic color tokens

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,13 +1,20 @@
 # Design System Usage
 
-This project ships with a small design system based on Tailwind CSS and CSS variables. This guide summarizes how to use it when building new features.
+This project ships with a small design system based on Tailwind CSS and CSS variables. This guide summarizes how to use it when
+building new features.
 
 ## Tokens
 - Color, radius, shadows and transitions are defined as CSS variables in `tailwind.config.ts` and `src/app/themes.css`.
 - Use semantic classes like `bg-background`, `text-foreground` and `ring` instead of hard-coded values.
 - If you need to introduce a new static color, map it to a token in [`COLOR_MAPPINGS.md`](../COLOR_MAPPINGS.md).
+- A custom ESLint rule (`semantic-tokens/no-raw-colors`) flags Tailwind classes that use unknown tokens or unmapped raw colors.
 - Name color tokens in kebab-case with hyphenated numeric variants (e.g. `accent-2`).
 - Input elements use `--control-radius` (16px) for consistent corner rounding.
+
+### Adding new colors
+1. Add the raw color and its replacement token to [`COLOR_MAPPINGS.md`](../COLOR_MAPPINGS.md).
+2. Define the token under `theme.extend.colors` in `tailwind.config.ts`.
+3. Use the new token in your components (`bg-your-token`, `text-your-token`, etc.).
 
 ### Effects tokens
 - `--edge-iris` – iridescent conic gradient for edges and focus rings. Defined in the dark base and re-colored for the Aurora theme ([themes.css](../src/app/themes.css#L69-L76), [Aurora override](../src/app/themes.css#L171-L178)).
@@ -94,4 +101,3 @@ export function Demo() {
   );
 }
 ```
-

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,10 @@
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { FlatCompat } from "@eslint/eslintrc";
+import { register } from "ts-node";
+
+register({ transpileOnly: true });
+const semanticTokensRule = (await import("./scripts/eslint-semantic-tokens.ts")).default;
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -9,11 +13,18 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
 
-
-
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript", "prettier"),
+  {
+    plugins: {
+      "semantic-tokens": {
+        rules: { "no-raw-colors": semanticTokensRule },
+      },
+    },
+    rules: {
+      "semantic-tokens/no-raw-colors": "error",
+    },
+  },
 ];
-
 
 export default eslintConfig;

--- a/scripts/eslint-semantic-tokens.ts
+++ b/scripts/eslint-semantic-tokens.ts
@@ -1,0 +1,107 @@
+import { readFileSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import tailwindConfig from "../tailwind.config";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function collectTokens(obj: Record<string, any>, prefix = ""): string[] {
+  const tokens: string[] = [];
+  for (const [key, value] of Object.entries(obj)) {
+    if (typeof value === "string") {
+      tokens.push(prefix + key);
+    } else if (typeof value === "object" && value) {
+      tokens.push(...collectTokens(value as Record<string, any>, `${prefix + key}-`));
+    }
+  }
+  return tokens;
+}
+
+const tailwindTokens = new Set(
+  collectTokens((tailwindConfig.theme?.extend as any)?.colors ?? {}),
+);
+
+const mappingsRaw = readFileSync(
+  path.resolve(__dirname, "../COLOR_MAPPINGS.md"),
+  "utf8",
+);
+const colorMappings = new Set<string>();
+for (const line of mappingsRaw.split("\n")) {
+  const match = line.match(/\| `([^`]+)` \|/);
+  if (match) {
+    colorMappings.add(match[1]);
+  }
+}
+
+const prefixes = [
+  "bg",
+  "text",
+  "border",
+  "from",
+  "to",
+  "via",
+  "ring",
+  "stroke",
+  "fill",
+  "shadow",
+];
+
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "enforce semantic color tokens or mapped raw colors",
+    },
+    messages: {
+      unknownToken: "Color token \"{{token}}\" not found in tailwind.config.ts.",
+      unmappedColor:
+        "Color value \"{{color}}\" is not mapped in COLOR_MAPPINGS.md.",
+    },
+    schema: [],
+  },
+  create(context: any) {
+    return {
+      JSXAttribute(node: any) {
+        if (
+          (node.name as any).name !== "class" &&
+          (node.name as any).name !== "className"
+        ) {
+          return;
+        }
+        if (!node.value) {
+          return;
+        }
+        if (node.value.type !== "Literal" || typeof node.value.value !== "string") {
+          return;
+        }
+        const classes = node.value.value.split(/\s+/);
+        for (const cls of classes) {
+          const prefix = prefixes.find((p) => cls.startsWith(`${p}-`));
+          if (!prefix) continue;
+          const rest = cls.slice(prefix.length + 1);
+          const base = rest.split("/")[0];
+          if (base.startsWith("[")) {
+            const raw = base.slice(1, -1);
+            if (!colorMappings.has(raw)) {
+              context.report({
+                node: node.value,
+                messageId: "unmappedColor",
+                data: { color: raw },
+              });
+            }
+          } else if (!tailwindTokens.has(base)) {
+            context.report({
+              node: node.value,
+              messageId: "unknownToken",
+              data: { token: base },
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/src/components/ui/layout/SectionCard.tsx
+++ b/src/components/ui/layout/SectionCard.tsx
@@ -6,7 +6,7 @@ import clsx from "clsx";
 import { cn } from "@/lib/utils";
 
 type RootProps = React.HTMLAttributes<HTMLDivElement>;
-export type HeaderProps = {
+export type SectionHeaderProps = {
   sticky?: boolean;
   topClassName?: string; // sticky top offset
   className?: string;
@@ -34,7 +34,7 @@ function Header({
   children,
   title,
   actions,
-}: HeaderProps) {
+}: SectionHeaderProps) {
   return (
     <div
       className={cn(


### PR DESCRIPTION
## Summary
- add custom ESLint rule to ensure Tailwind colors use tokens or COLOR_MAPPINGS
- register rule in ESLint config and document color mapping process
- rename SectionCard header props to avoid type conflicts

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf1f3a39dc832cbaf0134a94866baf