### PR TITLE
feat: add check script for pre-commit checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,6 @@ This file provides instructions for all contributors.
 - A future `npm run regen-feature` will update feature scaffolding; run it once available.
 
 ## Testing
-- Before committing, run and fix:
-  - `npm test`
-  - `npm run lint`
-  - `npm run typecheck`
+- Run `npm run check` before committing; it runs `npm test`, `npm run lint`, and `npm run typecheck`.
 - Only commit when all checks pass.
 

--- a/README.md
+++ b/README.md
@@ -47,5 +47,6 @@ Learn more about the components and guidelines in the [Design System](docs/desig
 
 ## Contributing
 
+- Run `npm run check` before committing to run tests, lint, and typecheck.
 - Run `npm run format` before committing to ensure code style consistency.
 - When introducing new styles or components, add them to the prompts page (`src/app/prompts/page.tsx`) so they can be previewed.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint": "next lint",
     "typecheck": "ts-node scripts/typecheck.ts",
     "test": "vitest",
+    "check": "npm test && npm run lint && npm run typecheck",
     "check-all": "concurrently \"npm test -- --run\" \"npm run lint\" \"npm run typecheck\"",
     "format": "prettier --write .",
     "check-prompts": "ts-node scripts/check-prompts-updated.ts",


### PR DESCRIPTION
## Summary
- add `check` script to run tests, lint, and typecheck sequentially
- document `npm run check` as the standard pre-commit check

## Testing
- `CI=1 npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bf265662b8832c98ad05a4747efe89