### PR TITLE
feat: improve planner header

### DIFF
--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -20,12 +20,15 @@ import { useFocusDate, useWeek } from "./useFocusDate";
 import type { ISODate } from "./plannerStore";
 import { PlannerProvider } from "./plannerStore";
 import Header from "@/components/ui/layout/Header";
+import Button from "@/components/ui/primitives/Button";
+import { CalendarDays, ChevronLeft, ChevronRight } from "lucide-react";
+import { addDays, toISODate } from "@/lib/date";
 
 /* ───────── Page body under provider ───────── */
 
 function Inner() {
-  const { iso, today } = useFocusDate();
-  const { days } = useWeek(iso);
+  const { iso, today, setIso } = useFocusDate();
+  const { start, days } = useWeek(iso);
 
   // Derive once per week change; keeps list stable during edits elsewhere
   const dayItems = React.useMemo<Array<{ iso: ISODate; isToday: boolean }>>(
@@ -33,7 +36,37 @@ function Inner() {
     [days, today]
   );
 
+  const prevWeek = () => setIso(toISODate(addDays(start, -7)));
+  const nextWeek = () => setIso(toISODate(addDays(start, 7)));
+  const jumpToday = () => setIso(today);
+
   const heroRef = React.useRef<HTMLDivElement>(null);
+
+  const right = (
+    <div className="flex items-center gap-2">
+      <Button
+        variant="ghost"
+        size="sm"
+        aria-label="Previous week"
+        onClick={prevWeek}
+      >
+        <ChevronLeft className="size-4" />
+        <span>Prev</span>
+      </Button>
+      <Button size="sm" aria-label="Jump to today" onClick={jumpToday}>
+        Today
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        aria-label="Next week"
+        onClick={nextWeek}
+      >
+        <span>Next</span>
+        <ChevronRight className="size-4" />
+      </Button>
+    </div>
+  );
 
   return (
     <>
@@ -41,31 +74,44 @@ function Inner() {
         className="page-shell py-6 space-y-6"
         aria-labelledby="planner-header"
       >
-      {/* Week header (range, nav, totals, day chips) */}
-      <Header id="planner-header" heading="Planner" />
-      <WeekPicker />
-
-      {/* Today + Side column */}
-      <section
-        aria-label="Today and weekly panels"
-        className="grid grid-cols-1 gap-6 lg:grid-cols-12"
-      >
-        <div className="lg:col-span-8" ref={heroRef}>
-          <TodayHero iso={iso} />
+        {/* Week header (range, nav, totals, day chips) */}
+        <div className="space-y-2">
+          <Header
+            id="planner-header"
+            eyebrow="Planner"
+            heading="Today"
+            subtitle="Plan your week"
+            icon={<CalendarDays className="opacity-80" />}
+            right={right}
+          />
+          <WeekPicker />
         </div>
 
-        {/* Sticky only on large so it doesn’t eat the viewport on mobile */}
-          <aside className="lg:col-span-4 space-y-6 lg:sticky lg:top-8">
-          <WeekNotes iso={iso} />
-        </aside>
-      </section>
+        {/* Today + Side column */}
+        <section
+          aria-label="Today and weekly panels"
+          className="grid grid-cols-1 gap-6 lg:grid-cols-12"
+        >
+          <div className="lg:col-span-8" ref={heroRef}>
+            <TodayHero iso={iso} />
+          </div>
 
-      {/* Week list (Mon→Sun) — anchors used by WeekPicker’s selectAndScroll */}
-      <section role="list" aria-label="Week days (Monday to Sunday)" className="flex flex-col gap-4">
-        {dayItems.map(item => (
-          <DayRow key={item.iso} iso={item.iso} isToday={item.isToday} />
-        ))}
-      </section>
+          {/* Sticky only on large so it doesn’t eat the viewport on mobile */}
+          <aside className="lg:col-span-4 space-y-6 lg:sticky lg:top-8">
+            <WeekNotes iso={iso} />
+          </aside>
+        </section>
+
+        {/* Week list (Mon→Sun) — anchors used by WeekPicker’s selectAndScroll */}
+        <section
+          role="list"
+          aria-label="Week days (Monday to Sunday)"
+          className="flex flex-col gap-4"
+        >
+          {dayItems.map(item => (
+            <DayRow key={item.iso} iso={item.iso} isToday={item.isToday} />
+          ))}
+        </section>
       </main>
       <ScrollTopFloatingButton watchRef={heroRef} />
     </>

--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -15,7 +15,7 @@ import { useFocusDate } from "./useFocusDate";
 import type { ISODate } from "./plannerStore";
 import { useDay } from "./useDay";
 import { cn } from "@/lib/utils";
-import { CalendarDays, ChevronLeft, ChevronRight, ArrowUpToLine } from "lucide-react";
+import { CalendarDays, ArrowUpToLine } from "lucide-react";
 import { fromISODate, toISODate, addDays, mondayStartOfWeek } from "@/lib/date";
 
 /* ───────── date helpers ───────── */
@@ -115,15 +115,12 @@ function DayChip({
 export default function WeekPicker() {
   const { iso, setIso, today } = useFocusDate();
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { start, end, heading, rangeLabel, isoStart, isoEnd, days } = React.useMemo(() => {
+  const { heading, rangeLabel, isoStart, isoEnd, days } = React.useMemo(() => {
     const base = fromISODate(iso) ?? new Date();
     const s = mondayStartOfWeek(base);
     const e = addDays(s, 6);
     const list: ISODate[] = Array.from({ length: 7 }, (_, i) => toISODate(addDays(s, i)) as ISODate);
     return {
-      start: s,
-      end: e,
       heading: `${dmy.format(s)} — ${dmy.format(e)}`,
       rangeLabel: `${dmy.format(s)} → ${dmy.format(e)}`,
       isoStart: toISODate(s),
@@ -131,10 +128,6 @@ export default function WeekPicker() {
       days: list,
     };
   }, [iso]);
-
-  const prevWeek = () => setIso(toISODate(addDays(start, -7)));
-  const nextWeek = () => setIso(toISODate(addDays(start, 7)));
-  const jumpToday = () => setIso(today);
 
   const { per, weekDone, weekTotal } = useWeekStats(days);
 
@@ -168,49 +161,20 @@ export default function WeekPicker() {
     }
   };
 
-  /* Top-right controls go in Hero.right */
-  const right = (
-    <div className="flex items-center gap-2">
+  /* Top button goes in Hero.right when applicable */
+  const right =
+    showTop ? (
       <Button
-        variant="ghost"
+        variant="primary"
         size="sm"
-        aria-label="Previous week"
-        onClick={prevWeek}
+        aria-label="Jump to top"
+        onClick={jumpToTop}
+        title="Jump to top"
       >
-        <ChevronLeft className="size-4" />
-        <span>Prev</span>
+        <ArrowUpToLine className="size-4" />
+        <span>Top</span>
       </Button>
-      <Button
-        size="sm"
-        aria-label="Jump to today"
-        onClick={jumpToday}
-      >
-        Today
-      </Button>
-      <Button
-        variant="ghost"
-        size="sm"
-        aria-label="Next week"
-        onClick={nextWeek}
-      >
-        <span>Next</span>
-        <ChevronRight className="size-4" />
-      </Button>
-
-      {showTop && (
-        <Button
-          variant="primary"
-          size="sm"
-          aria-label="Jump to top"
-          onClick={jumpToTop}
-          title="Jump to top"
-        >
-          <ArrowUpToLine className="size-4" />
-          <span>Top</span>
-        </Button>
-      )}
-    </div>
-  );
+    ) : undefined;
 
   return (
     <Hero


### PR DESCRIPTION
## Summary
- enhance planner header with eyebrow, subtitle, icon, and week navigation buttons
- simplify week picker to focus on range stats and day chips with optional top button

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf25dc715c832cbdf89d1027600e69