### PR TITLE
refactor: streamline goals stats

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -174,7 +174,7 @@ export default function GoalsPage() {
 
   return (
     <main id="goals-main" role="main" className="page-shell py-6 space-y-6">
-      {/* ======= HERO ======= */}
+      {/* ======= HEADER ======= */}
       <Header
         eyebrow="Goals"
         heading={
@@ -203,9 +203,9 @@ export default function GoalsPage() {
       />
 
       <Hero
-        eyebrow="Stats"
+        eyebrow="Guide"
         heading="Overview"
-        subtitle={summary}
+        subtitle="Track up to 3 active goals, pin quick cues, and focus with the timer."
         sticky={false}
       />
 


### PR DESCRIPTION
## Summary
- avoid duplicate stats on Goals page by moving summary solely into header
- repurpose hero to offer guidance copy instead of repeating numbers

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf26fe81c0832c8cb920344407d0c3