### PR TITLE
fix: use 4px spacing in Hero layout

### DIFF
--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -117,7 +117,7 @@ export default function Hero({
         <span aria-hidden className="hero2-noise" />
 
         <div
-          className={cx("relative z-[2] flex items-center gap-3", barClassName)}
+          className={cx("relative z-[2] flex items-center gap-4", barClassName)}
         >
           {rail ? <span aria-hidden className="rail" /> : null}
           {icon ? <div className="opacity-90">{icon}</div> : null}
@@ -148,7 +148,7 @@ export default function Hero({
         </div>
 
         {children || bottomNode ? (
-          <div className="relative z-[2] mt-3 flex flex-col gap-3">
+          <div className="relative z-[2] mt-4 flex flex-col gap-4">
             {children ? (
               <div className={cx(bodyClassName)}>{children}</div>
             ) : null}


### PR DESCRIPTION
## Summary
- use 4px gap for Hero top bar
- increase Hero body margin & gap to 4px spacing

## Testing
- `node - <<'NODE'
const { MultiBar, Presets } = require("cli-progress");
const { spawn } = require("child_process");

const tasks = [
  { name: "regen-ui", cmd: ["npm", ["run", "regen-ui"]] },
  { name: "test", cmd: ["npm", ["test"]] },
  { name: "lint", cmd: ["npm", ["run", "lint"]] },
  { name: "typecheck", cmd: ["npm", ["run", "typecheck"]] },
];

const bars = new MultiBar({ clearOnComplete: false, hideCursor: true }, Presets.shades_grey);

function runTask(i) {
  if (i >= tasks.length) {
    bars.stop();
    return;
  }
  const task = tasks[i];
  const bar = bars.create(100, 0);
  const child = spawn(task.cmd[0], task.cmd[1], { stdio: "inherit" });
  let progress = 0;
  const timer = setInterval(() => {
    progress = Math.min(progress + 5, 100);
    bar.update(progress);
  }, 1000);
  child.on("close", (code) => {
    clearInterval(timer);
    bar.update(100);
    bar.stop();
    runTask(i + 1);
  });
}
runTask(0);
NODE`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68bf295c1964832c946de0a4f2fff52f