### PR TITLE
feat: add panel color token

### DIFF
--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -348,7 +348,7 @@ export default function ComponentGallery() {
       label: "Review Layout",
       element: (
         <div className="grid w-full gap-4 md:grid-cols-12">
-          <div className="md:col-span-4 md:w-[240px] bg-[hsl(var(--panel))] h-10 rounded" />
+          <div className="md:col-span-4 md:w-[240px] bg-panel h-10 rounded" />
           <div className="md:col-span-8 bg-muted h-10 rounded" />
         </div>
       ),

--- a/src/components/prompts/PromptsDemos.tsx
+++ b/src/components/prompts/PromptsDemos.tsx
@@ -132,10 +132,10 @@ export default function PromptsDemos() {
       <Card className="mt-8 space-y-4">
         <h3 className="type-title">Shadows</h3>
         <div className="flex flex-wrap gap-4">
-          <div className="size-16 rounded-2xl bg-[hsl(var(--panel)/0.8)] shadow-neo" />
-          <div className="size-16 rounded-2xl bg-[hsl(var(--panel)/0.8)] shadow-neo-strong" />
-          <div className="size-16 rounded-2xl bg-[hsl(var(--panel)/0.8)] shadow-neo-inset" />
-          <div className="size-16 rounded-2xl bg-[hsl(var(--panel)/0.8)] shadow-ring" />
+          <div className="size-16 rounded-2xl bg-panel/80 shadow-neo" />
+          <div className="size-16 rounded-2xl bg-panel/80 shadow-neo-strong" />
+          <div className="size-16 rounded-2xl bg-panel/80 shadow-neo-inset" />
+          <div className="size-16 rounded-2xl bg-panel/80 shadow-ring" />
         </div>
       </Card>
       <Card className="mt-8 space-y-4">
@@ -181,7 +181,7 @@ export default function PromptsDemos() {
             {radiusClasses.map((cls) => (
               <div
                 key={cls}
-                className={`size-6 bg-[hsl(var(--panel)/0.8)] ${cls}`}
+                className={`size-6 bg-panel/80 ${cls}`}
               />
             ))}
           </div>

--- a/src/components/ui/feedback/Progress.tsx
+++ b/src/components/ui/feedback/Progress.tsx
@@ -10,7 +10,7 @@ export default function Progress({ value, label }: { value: number; label?: stri
       aria-label={label}
     >
       <div
-        className="h-full w-full overflow-hidden rounded-full bg-[hsl(var(--panel)/0.9)] shadow-neo-inset"
+        className="h-full w-full overflow-hidden rounded-full bg-panel/90 shadow-neo-inset"
       >
         <span
           className="block h-full rounded-full bg-[linear-gradient(90deg,hsl(var(--accent)),hsl(var(--accent-2)))] transition-[width] shadow-neo-sm"

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -69,7 +69,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       }
     > = {
       primary: {
-        className: "bg-[hsl(var(--panel)/0.85)] overflow-hidden shadow-neo",
+        className: "bg-panel/85 overflow-hidden shadow-neo",
         whileHover: {
           scale: 1.03,
           boxShadow:
@@ -91,7 +91,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         contentClass: "relative z-10 inline-flex items-center gap-2",
       },
       secondary: {
-        className: "bg-[hsl(var(--panel)/0.8)] shadow-neo",
+        className: "bg-panel/80 shadow-neo",
         whileHover: { scale: 1.02, boxShadow: neuRaised(15) },
         whileTap: {
           scale: 0.97,
@@ -99,7 +99,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         },
       },
       ghost: {
-        className: "bg-transparent hover:bg-[hsl(var(--panel)/0.45)]",
+        className: "bg-transparent hover:bg-panel/45",
         whileTap: { scale: 0.97 },
       },
     } as const;

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -33,9 +33,9 @@ const sizeMap: Record<IconButtonSize, string> = {
 };
 
 const variantBase: Record<Variant, string> = {
-  ring: "border bg-transparent hover:bg-[hsl(var(--panel)/0.45)]",
+  ring: "border bg-transparent hover:bg-panel/45",
   solid: "border",
-  glow: "border bg-transparent hover:bg-[hsl(var(--panel)/0.45)]",
+  glow: "border bg-transparent hover:bg-panel/45",
 };
 
 const toneClasses: Record<Variant, Record<Tone, string>> = {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -16,6 +16,7 @@ const config: Config = {
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
         card: { DEFAULT: "hsl(var(--card))" },
+        panel: { DEFAULT: "hsl(var(--panel))" },
         primary: {
           DEFAULT: "hsl(var(--primary))",
           foreground: "hsl(var(--primary-foreground))",


### PR DESCRIPTION
## Summary
- extend Tailwind theme with `panel` color token
- use `bg-panel` utilities in Button, IconButton, Progress, and demos

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf2a4fb278832c92cc7eb30c6d4b73