### PR TITLE
feat(goals): make progress bar responsive

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { TabBar, Header, Hero, Button } from "@/components/ui";
 import Banner from "@/components/chrome/Banner";
+import { GoalsProgress } from "@/components/goals";
 import { ComponentGallery, ColorGallery } from "@/components/prompts";
 
 export default function Page() {
@@ -19,6 +20,9 @@ export default function Page() {
         <Header heading="Header" sticky={false} />
         <Hero heading="Hero" sticky={false} />
         <Banner title="Banner" actions={<Button size="sm">Action</Button>} />
+        <div className="flex justify-center">
+          <GoalsProgress total={5} pct={60} />
+        </div>
       </div>
       <p className="mb-4 text-sm text-muted-foreground">
         Global styles are now modularized into <code>animations.css</code>,

--- a/src/components/goals/GoalsProgress.tsx
+++ b/src/components/goals/GoalsProgress.tsx
@@ -7,9 +7,10 @@ interface GoalsProgressProps {
   total: number;
   pct: number; // 0..100
   onAddFirst?: () => void;
+  maxWidth?: number | string;
 }
 
-export default function GoalsProgress({ total, pct, onAddFirst }: GoalsProgressProps) {
+export default function GoalsProgress({ total, pct, onAddFirst, maxWidth }: GoalsProgressProps) {
   if (total === 0) {
     return (
       <div className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] p-6 text-center">
@@ -24,9 +25,18 @@ export default function GoalsProgress({ total, pct, onAddFirst }: GoalsProgressP
   }
 
   const v = Math.max(0, Math.min(100, Math.round(pct)));
+  const style = maxWidth
+    ? ({
+        "--progress-max":
+          typeof maxWidth === "number" ? `${maxWidth}px` : maxWidth,
+      } as React.CSSProperties)
+    : undefined;
   return (
     <div className="flex min-w-[120px] items-center gap-2" aria-label="Progress">
-      <div className="h-1.5 w-28 overflow-hidden rounded-full bg-[hsl(var(--fg)/0.1)]">
+      <div
+        className="h-1.5 w-full flex-1 max-w-[var(--progress-max,160px)] overflow-hidden rounded-full bg-[hsl(var(--fg)/0.1)]"
+        style={style}
+      >
         <div
           className="h-1.5 rounded-full bg-[hsl(var(--accent))] transition-[width]"
           style={{ width: `${v}%` }}

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -33,7 +33,7 @@ import {
   Label,
 } from "@/components/ui";
 import BadgePrimitive from "@/components/ui/primitives/Badge";
-import { GoalsTabs, type FilterKey } from "@/components/goals";
+import { GoalsTabs, GoalsProgress, type FilterKey } from "@/components/goals";
 import PromptsHeader from "./PromptsHeader";
 import PromptsComposePanel from "./PromptsComposePanel";
 import PromptsDemos from "./PromptsDemos";
@@ -224,6 +224,10 @@ export default function ComponentGallery() {
           <Progress value={50} />
         </div>
       ),
+    },
+    {
+      label: "GoalsProgress",
+      element: <GoalsProgress total={5} pct={60} maxWidth={200} />,
     },
     {
       label: "Spinner",


### PR DESCRIPTION
## Summary
- make GoalsProgress width flexible with optional maxWidth prop
- demo GoalsProgress in prompts gallery
- showcase GoalsProgress on prompts page

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf2bfad880832cb2d57abb642330b4