### PR TITLE
refactor: replace #000 gradients

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -289,8 +289,8 @@ html.bg-intense body::after {
     border-radius: calc(var(--_r) + 1px);
     background: var(--edge-iris);
     mask:
-      linear-gradient(#000 0 0) content-box,
-      linear-gradient(#000 0 0);
+      linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+      linear-gradient(hsl(var(--foreground)) 0 0);
     -webkit-mask-composite: xor;
     mask-composite: exclude;
     opacity: 0.45;
@@ -695,11 +695,11 @@ html.bg-intense body::after {
       hsl(262 83% 58% / 0)
     );
     -webkit-mask:
-      linear-gradient(#000 0 0) content-box,
-      linear-gradient(#000 0 0);
+      linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+      linear-gradient(hsl(var(--foreground)) 0 0);
     mask:
-      linear-gradient(#000 0 0) content-box,
-      linear-gradient(#000 0 0);
+      linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+      linear-gradient(hsl(var(--foreground)) 0 0);
     -webkit-mask-composite: xor;
     mask-composite: exclude;
     pointer-events: none;
@@ -995,8 +995,8 @@ html.bg-intense body::after {
     hsl(262 83% 58% / 0)
   );
   mask:
-    linear-gradient(#000 0 0) content-box,
-    linear-gradient(#000 0 0);
+    linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+    linear-gradient(hsl(var(--foreground)) 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
   opacity: 0.55;
@@ -1201,11 +1201,11 @@ textarea:-webkit-autofill {
   );
   background-size: 300% 100%;
   -webkit-mask:
-    linear-gradient(#000 0 0) content-box,
-    linear-gradient(#000 0 0);
+    linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+    linear-gradient(hsl(var(--foreground)) 0 0);
   mask:
-    linear-gradient(#000 0 0) content-box,
-    linear-gradient(#000 0 0);
+    linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+    linear-gradient(hsl(var(--foreground)) 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
   animation: lg-holo 12s linear infinite;
@@ -1611,8 +1611,8 @@ textarea:-webkit-autofill {
     transparent 100%
   );
   mask:
-    linear-gradient(#000 0 0) content-box,
-    linear-gradient(#000 0 0);
+    linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+    linear-gradient(hsl(var(--foreground)) 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
   opacity: 0.85;

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -625,9 +625,9 @@ html.bg-intense body::after  { filter: blur(2px) saturate(120%); }
     hsl(262 83% 58% / 0)
   );
   /* mask to only show the ring, not fill the card */
-  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask: linear-gradient(hsl(var(--foreground)) 0 0) content-box, linear-gradient(hsl(var(--foreground)) 0 0);
   -webkit-mask-composite: xor;
-          mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+          mask: linear-gradient(hsl(var(--foreground)) 0 0) content-box, linear-gradient(hsl(var(--foreground)) 0 0);
           mask-composite: exclude;
   opacity: .55;
   animation:

--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -69,8 +69,8 @@
   inset: 1px;
   border-radius: calc(var(--radius-lg, 12px) - 2px);
   background: var(--edge-iris, linear-gradient(90deg, hsl(var(--accent)), hsl(var(--primary))));
-  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
-          mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask: linear-gradient(hsl(var(--foreground)) 0 0) content-box, linear-gradient(hsl(var(--foreground)) 0 0);
+          mask: linear-gradient(hsl(var(--foreground)) 0 0) content-box, linear-gradient(hsl(var(--foreground)) 0 0);
   -webkit-mask-composite: xor;
           mask-composite: exclude;
   pointer-events: none;
@@ -247,8 +247,8 @@
     hsl(var(--accent) / .45),
     hsl(var(--primary) / .55)
   );
-  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
-          mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask: linear-gradient(hsl(var(--foreground)) 0 0) content-box, linear-gradient(hsl(var(--foreground)) 0 0);
+          mask: linear-gradient(hsl(var(--foreground)) 0 0) content-box, linear-gradient(hsl(var(--foreground)) 0 0);
   -webkit-mask-composite: xor;
           mask-composite: exclude;
   opacity: 0;

--- a/src/components/reviews/style.css
+++ b/src/components/reviews/style.css
@@ -23,7 +23,7 @@
 :where(.reviews-scope, [data-scope="reviews"]) .review-tile::after{
   content:""; position:absolute; inset:2px; padding:1px; border-radius: calc(var(--radius-lg) - 1px);
   pointer-events:none; background: var(--edge-iris);
-  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  mask: linear-gradient(hsl(var(--foreground)) 0 0) content-box, linear-gradient(hsl(var(--foreground)) 0 0);
   -webkit-mask-composite: xor; mask-composite: exclude;
   opacity:0; transition: opacity var(--dur-quick) var(--ease-out), filter var(--dur-quick) var(--ease-out);
 }

--- a/src/components/ui/selects/AnimatedSelect.tsx
+++ b/src/components/ui/selects/AnimatedSelect.tsx
@@ -493,8 +493,8 @@ function GlitchStyles() {
           hsl(262 83% 58% / 0)
         );
         -webkit-mask:
-          linear-gradient(#000 0 0) content-box,
-          linear-gradient(#000 0 0);
+          linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+          linear-gradient(hsl(var(--foreground)) 0 0);
         -webkit-mask-composite: xor;
         mask-composite: exclude;
         opacity: 0.32;
@@ -518,8 +518,8 @@ function GlitchStyles() {
           hsl(var(--primary) / 0)
         );
         -webkit-mask:
-          linear-gradient(#000 0 0) content-box,
-          linear-gradient(#000 0 0);
+          linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+          linear-gradient(hsl(var(--foreground)) 0 0);
         -webkit-mask-composite: xor;
         mask-composite: exclude;
         mix-blend-mode: screen;
@@ -601,8 +601,8 @@ function GlitchStyles() {
       .gb-scan {
         padding: 1px;
         -webkit-mask:
-          linear-gradient(#000 0 0) content-box,
-          linear-gradient(#000 0 0);
+          linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+          linear-gradient(hsl(var(--foreground)) 0 0);
         -webkit-mask-composite: xor;
         mask-composite: exclude;
         background: repeating-linear-gradient(

--- a/src/components/ui/toggles/CheckCircle.tsx
+++ b/src/components/ui/toggles/CheckCircle.tsx
@@ -200,7 +200,7 @@ export default function CheckCircle({
               background: `linear-gradient(90deg, ${pink}, hsl(var(--accent)), ${pink})`,
               backgroundSize: "200% 100%",
               WebkitMask:
-                "linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)",
+                "linear-gradient(hsl(var(--foreground)) 0 0) content-box, linear-gradient(hsl(var(--foreground)) 0 0)",
               WebkitMaskComposite: "xor",
               maskComposite: "exclude",
               animation:
@@ -376,7 +376,7 @@ export default function CheckCircle({
             hsl(320 85% 60% / .6),
             hsl(262 83% 58% / .0)
           );
-          -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+          -webkit-mask: linear-gradient(hsl(var(--foreground)) 0 0) content-box, linear-gradient(hsl(var(--foreground)) 0 0);
           -webkit-mask-composite: xor; mask-composite: exclude;
           opacity: .5;
           animation: ccxHue 6s linear infinite, ccxJit 2s steps(6,end) infinite;


### PR DESCRIPTION
## Summary
- replace hard-coded #000 mask/gradient colors with `hsl(var(--foreground))`
- update planner and review component styles to use foreground token
- align UI components AnimatedSelect and CheckCircle with theme tokens

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf2c5c5e0c832cb665f88f5216b06e