### PR TITLE
feat: add tone variants to Button

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -36,6 +36,16 @@ export default function Page() {
         Buttons now default to the 40px <code>md</code> size and follow a
         36/40/44px scale.
       </p>
+      <div className="mb-8 flex flex-wrap gap-2">
+        <Button tone="primary">Primary tone</Button>
+        <Button tone="accent">Accent tone</Button>
+        <Button tone="info" variant="ghost">
+          Info ghost
+        </Button>
+        <Button tone="danger" variant="primary">
+          Danger primary
+        </Button>
+      </div>
       <div className="mb-8">
         <TabBar items={viewTabs} value={view} onValueChange={setView} />
       </div>

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -30,9 +30,12 @@ export const buttonSizes = {
 
 export type ButtonSize = keyof typeof buttonSizes;
 
+type Tone = "primary" | "accent" | "info" | "danger";
+
 export type ButtonProps = React.ComponentProps<typeof motion.button> & {
   size?: ButtonSize;
   variant?: "primary" | "secondary" | "ghost";
+  tone?: Tone;
 };
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
@@ -41,6 +44,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       className,
       size = "md",
       variant = "secondary",
+      tone = "primary",
       children,
       type = "button",
       ...rest
@@ -54,9 +58,46 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       s.padding,
       s.text,
       s.gap,
-      "text-[hsl(var(--foreground))]",
       className
     );
+
+    const colorVar: Record<Tone, string> = {
+      primary: "--foreground",
+      accent: "--accent",
+      info: "--accent-2",
+      danger: "--danger",
+    };
+
+    const toneClasses: Record<
+      NonNullable<ButtonProps["variant"]>,
+      Record<Tone, string>
+    > = {
+      primary: {
+        primary: "text-[hsl(var(--foreground))]",
+        accent: "text-[hsl(var(--accent))]",
+        info: "text-[hsl(var(--accent-2))]",
+        danger: "text-[hsl(var(--danger))]",
+      },
+      secondary: {
+        primary: "text-[hsl(var(--foreground))]",
+        accent:
+          "text-[hsl(var(--accent))] bg-[hsl(var(--accent)/0.15)] hover:bg-[hsl(var(--accent)/0.25)]",
+        info:
+          "text-[hsl(var(--accent-2))] bg-[hsl(var(--accent-2)/0.15)] hover:bg-[hsl(var(--accent-2)/0.25)]",
+        danger:
+          "text-[hsl(var(--danger))] bg-[hsl(var(--danger)/0.15)] hover:bg-[hsl(var(--danger)/0.25)]",
+      },
+      ghost: {
+        primary:
+          "text-[hsl(var(--foreground))] hover:bg-[hsl(var(--foreground)/0.1)]",
+        accent:
+          "text-[hsl(var(--accent))] hover:bg-[hsl(var(--accent)/0.1)]",
+        info:
+          "text-[hsl(var(--accent-2))] hover:bg-[hsl(var(--accent-2)/0.1)]",
+        danger:
+          "text-[hsl(var(--danger))] hover:bg-[hsl(var(--danger)/0.1)]",
+      },
+    };
 
     const variants: Record<
       NonNullable<ButtonProps["variant"]>,
@@ -70,24 +111,10 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     > = {
       primary: {
         className: "bg-panel/85 overflow-hidden shadow-neo",
-        whileHover: {
-          scale: 1.03,
-          boxShadow:
-            `${neuRaised(16)},0 0 8px hsl(var(--accent)/.3)` as CSSProperties["boxShadow"],
-        },
         whileTap: {
           scale: 0.96,
           boxShadow: neuInset(10) as CSSProperties["boxShadow"],
         },
-        overlay: (
-          <span
-            className="absolute inset-0 pointer-events-none rounded-2xl"
-            style={{
-              background:
-                "linear-gradient(90deg, hsl(var(--accent)/.18), hsl(var(--accent-2)/.18))",
-            }}
-          />
-        ),
         contentClass: "relative z-10 inline-flex items-center gap-2",
       },
       secondary: {
@@ -99,7 +126,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         },
       },
       ghost: {
-        className: "bg-transparent hover:bg-panel/45",
+        className: "bg-transparent",
         whileTap: { scale: 0.97 },
       },
     } as const;
@@ -111,12 +138,28 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       <motion.button
         ref={ref}
         type={type}
-        className={cn(base, variantClass)}
-        whileHover={whileHover}
+        className={cn(base, variantClass, toneClasses[variant][tone])}
+        whileHover={
+          variant === "primary"
+            ? {
+                scale: 1.03,
+                boxShadow: `${neuRaised(16)},0 0 8px hsl(var(${colorVar[tone]})/.3)`,
+              }
+            : whileHover
+        }
         whileTap={whileTap}
         {...rest}
       >
-        {overlay}
+        {variant === "primary" ? (
+          <span
+            className="absolute inset-0 pointer-events-none rounded-2xl"
+            style={{
+              background: `linear-gradient(90deg, hsl(var(${colorVar[tone]})/.18), hsl(var(${colorVar[tone]})/.18))`,
+            }}
+          />
+        ) : (
+          overlay
+        )}
         {contentClass ? (
           <span className={contentClass}>{children as React.ReactNode}</span>
         ) : (


### PR DESCRIPTION
## Summary
- support primary, accent, info, and danger tones on Button
- map tone-specific styles across primary, secondary, and ghost variants
- document tone usage on prompts page

## Testing
- `node -e "const { MultiBar, Presets } = require('cli-progress'); const { spawn } = require('child_process'); const bars = new MultiBar({ clearOnComplete: false, hideCursor: true }, Presets.shades_grey); const tasks=['npm run regen-ui','npm test -- --run','npm run lint','npm run typecheck']; const bar=bars.create(tasks.length,0); (async()=>{for(let i=0;i<tasks.length;i++){await new Promise((resolve,reject)=>{const p=spawn(tasks[i],{shell:true,stdio:'inherit'});p.on('exit',c=>{if(c===0){bar.update(i+1);resolve();}else{bars.stop();reject(new Error('failed'));}});});}bars.stop();})();"`

------
https://chatgpt.com/codex/tasks/task_e_68bf2d7c095c832caa49ba529d3a61d8