### PR TITLE
chore: expand color tokens

### DIFF
--- a/src/components/prompts/demoData.ts
+++ b/src/components/prompts/demoData.ts
@@ -1,5 +1,6 @@
 import { colorTokens, spacingTokens, radiusTokens } from "@/lib/tokens";
 
+// Re-export tokens for demo components
 export { colorTokens, spacingTokens, radiusTokens };
 
 export const glowTokens = ["--glow-strong", "--glow-soft"];

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -1,11 +1,26 @@
 export const colorTokens = [
+  "bg-border",
+  "bg-input",
   "bg-ring",
+  "bg-background",
+  "bg-foreground",
+  "bg-card",
+  "bg-panel",
+  "bg-primary",
   "bg-accent",
   "bg-accent-2",
-  "bg-lavDeep",
+  "bg-glow",
+  "bg-ringMuted",
   "bg-danger",
   "bg-success",
-  "bg-glow",
+  "bg-auroraG",
+  "bg-auroraGLight",
+  "bg-auroraP",
+  "bg-auroraPLight",
+  "bg-muted",
+  "bg-lavDeep",
+  "bg-surfaceVhs",
+  "bg-surfaceStreak",
 ];
 
 export const spacingTokens = [4, 8, 12, 16, 24, 32, 48, 64];

--- a/tests/prompts/demo-tokens.test.ts
+++ b/tests/prompts/demo-tokens.test.ts
@@ -22,7 +22,7 @@ describe("demo tokens", () => {
 
   it("use colors defined in tailwind config", () => {
     const colors = (config as any).theme?.extend?.colors ?? {};
-    const expected = colorTokens.map((c) => c.replace(/^bg-/, ""));
-    expect(expected.every((name) => colors[name])).toBe(true);
+    const expected = Object.keys(colors).map((name) => `bg-${name}`);
+    expect(colorTokens.sort()).toEqual(expected.sort());
   });
 });


### PR DESCRIPTION
## Summary
- sync colorTokens with all Tailwind color variables for semantic demo tokens
- verify color tokens match Tailwind config in tests
- document token re-exports for prompt demos

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf2f8d6e38832c9c32920e0f366599