### PR TITLE
Focus day row after week picker scroll

### DIFF
--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -150,6 +150,7 @@ export default function WeekPicker() {
     const el = document.getElementById(`day-${d}`);
     if (el) {
       el.scrollIntoView({ behavior: "smooth", block: "start", inline: "nearest" });
+      el.focus({ preventScroll: true });
       setShowTop(true);
     }
   };


### PR DESCRIPTION
## Summary
- focus day row after scrolling from week picker while preventing extra scroll

## Testing
- `npm run regen-ui && npm test && npm run lint && npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf31c4eb78832c8ff2355a64a20d31