### PR TITLE
Validate review timestamp input

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -36,19 +36,20 @@ export default function Page() {
         Buttons now default to the 40px <code>md</code> size and follow a
         36/40/44px scale.
       </p>
-      <div className="mb-8 flex flex-wrap gap-2">
-        <Button tone="primary">Primary tone</Button>
-        <Button tone="accent">Accent tone</Button>
-        <Button tone="info" variant="ghost">
-          Info ghost
-        </Button>
-        <Button tone="danger" variant="primary">
-          Danger primary
-        </Button>
-      </div>
-      <div className="mb-8">
-        <TabBar items={viewTabs} value={view} onValueChange={setView} />
-      </div>
+        <div className="mb-8 flex flex-wrap gap-2">
+          <Button tone="primary">Primary tone</Button>
+          <Button tone="accent">Accent tone</Button>
+          <Button tone="info" variant="ghost">
+            Info ghost
+          </Button>
+          <Button tone="danger" variant="primary">
+            Danger primary
+          </Button>
+        </div>
+        <p className="mb-4 text-xs text-danger">Example error message</p>
+        <div className="mb-8">
+          <TabBar items={viewTabs} value={view} onValueChange={setView} />
+        </div>
       {view === "components" ? <ComponentGallery /> : <ColorGallery />}
     </main>
   );

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -493,10 +493,13 @@ export default function ReviewEditor({
     onChangeTags?.(next);
   }
 
-  const canAddMarker = (useTimestamp ? parseTime(tTime) !== null : true) && tNote.trim().length > 0;
+  const parsedTime = parseTime(tTime);
+  const timeError = useTimestamp && parsedTime === null;
+  const canAddMarker = (useTimestamp ? parsedTime !== null : true) &&
+    tNote.trim().length > 0;
 
   function addMarker() {
-    const s = useTimestamp ? parseTime(tTime) : 0;
+    const s = useTimestamp ? parsedTime : 0;
     const safeS = s === null ? 0 : s;
     const m: Marker = {
       id: uid("mark"),
@@ -891,6 +894,8 @@ export default function ReviewEditor({
                 aria-label="Timestamp time in mm:ss"
                 inputMode="numeric"
                 pattern="^[0-9]?\d:[0-5]\d$"
+                aria-invalid={timeError ? "true" : undefined}
+                aria-describedby={timeError ? "tTime-error" : undefined}
                 style={{ width: "calc(5ch + 1.7rem)" }}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" && canAddMarker) {
@@ -939,6 +944,11 @@ export default function ReviewEditor({
               <Plus />
             </IconButton>
           </div>
+          {timeError && (
+            <p id="tTime-error" className="mt-1 text-xs text-danger">
+              Enter time as mm:ss
+            </p>
+          )}
 
           {sortedMarkers.length === 0 ? (
             <div className="mt-2 text-sm text-muted-foreground">No timestamps yet.</div>


### PR DESCRIPTION
## Summary
- validate review timestamp input and show inline errors
- document error style on prompts page

## Testing
- `npm run regen-ui`
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf317db35c832cba4f2c286e59f100