### PR TITLE
refactor: use tailwind text tokens

### DIFF
--- a/src/components/planner/index.ts
+++ b/src/components/planner/index.ts
@@ -20,12 +20,15 @@ export {
   PlannerProvider,
   todayISO,
   ensureDay,
-  type ISODate,
-  type DayRecord,
-  type Project,
-  type DayTask,
 } from "./plannerStore";
+export type {
+  ISODate,
+  DayRecord,
+  Project,
+  DayTask,
+  Selection,
+} from "./plannerStore";
+export { usePlannerStore } from "./usePlannerStore";
 export * from "./useDay";
-export * from "./usePlannerStore";
 export * from "./useFocusDate";
 export * from "./useSelection";

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -11,19 +11,19 @@ export const buttonSizes = {
   sm: {
     height: "h-9",
     padding: "px-4",
-    text: "text-[14px]",
+    text: "text-sm",
     gap: "gap-2",
   },
   md: {
     height: "h-10",
     padding: "px-5",
-    text: "text-[16px]",
+    text: "text-base",
     gap: "gap-2",
   },
   lg: {
     height: "h-11",
     padding: "px-6",
-    text: "text-[18px]",
+    text: "text-lg",
     gap: "gap-2",
   },
 } as const;


### PR DESCRIPTION
## Summary
- replace pixel-based font sizes in button sizes with Tailwind tokens
- expose planner store helpers while keeping type exports

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf32bcf528832c9dd1848748e5bc5c