### PR TITLE
chore: run checks concurrently

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "next lint",
     "typecheck": "ts-node scripts/typecheck.ts",
     "test": "vitest",
-    "check": "npm test && npm run lint && npm run typecheck",
+    "check": "concurrently \"npm test -- --run\" \"npm run lint\" \"npm run typecheck\"",
     "check-all": "concurrently \"npm test -- --run\" \"npm run lint\" \"npm run typecheck\"",
     "format": "prettier --write .",
     "verify-prompts": "ts-node scripts/verify-prompts.ts",


### PR DESCRIPTION
## Summary
- replace `check` script with `concurrently` to run tests, lint, and typecheck in parallel

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bf32a04984832c83563cf38139aadd