### PR TITLE
feat: add horizontal scroll to week picker

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -36,6 +36,10 @@ export default function Page() {
         Buttons now default to the 40px <code>md</code> size and follow a
         36/40/44px scale.
       </p>
+      <p className="mb-4 text-sm text-muted-foreground">
+        WeekPicker scrolls horizontally with snap points, showing 2–3 days at
+        a time on smaller screens.
+      </p>
         <div className="mb-8 flex flex-wrap gap-2">
           <Button tone="primary">Primary tone</Button>
           <Button tone="accent">Accent tone</Button>

--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -78,7 +78,7 @@ function DayChip({
       aria-label={`Select ${iso}. Completed ${done} of ${total}. ${selected ? "Double-click to jump." : ""}`}
       title={selected ? "Double-click to jump" : "Click to focus"}
       className={cn(
-        "chip relative w-full rounded-2xl border text-left px-3 py-2 transition",
+        "chip relative flex-none min-w-[min(160px,40%)] rounded-2xl border text-left px-3 py-2 transition snap-start",
         // default border is NOT white; use card hairline tint
         "border-[hsl(var(--card-hairline))] bg-[hsl(var(--card)/0.75)]",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
@@ -213,7 +213,7 @@ export default function WeekPicker() {
           </div>
 
           {/* Day chips */}
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3 lg:grid-cols-7">
+          <div className="flex gap-3 overflow-x-auto snap-x snap-mandatory lg:overflow-visible">
             {days.map((d, i) => (
               <DayChip
                 key={d}


### PR DESCRIPTION
## Summary
- allow WeekPicker days to scroll horizontally with snapping
- size day chips so only a few are visible at once
- document WeekPicker updates in prompts page

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf337e112c832c9ab30b1ca74e2750