### PR TITLE
Expand timer input width

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -23,6 +23,14 @@ export default function Page() {
         <div className="flex justify-center">
           <GoalsProgress total={5} pct={60} />
         </div>
+        <div className="flex justify-center">
+          <input
+            aria-label="Timer demo"
+            defaultValue="25:00"
+            className="btn-like-segmented btn-glitch w-[5ch] text-center"
+            type="text"
+          />
+        </div>
       </div>
       <p className="mb-4 text-sm text-muted-foreground">
         Global styles are now modularized into <code>animations.css</code>,

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -159,7 +159,7 @@ export default function TimerTab() {
         onKeyDown={(e) => e.key === "Enter" && commitEdit()}
         placeholder="mm:ss"
         disabled={running}
-          className="btn-like-segmented btn-glitch w-8 text-center"
+        className="btn-like-segmented btn-glitch w-[5ch] text-center"
         type="text"
       />
     </div>


### PR DESCRIPTION
## Summary
- widen timer input for clearer entry and centered text
- add matching timer input demo on prompts page

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf3587f2b0832c8df11ad6db320d20