### PR TITLE
Improve DayCard responsive grid

### DIFF
--- a/src/components/planner/DayCard.tsx
+++ b/src/components/planner/DayCard.tsx
@@ -63,7 +63,7 @@ export default function DayCard({ iso, isToday }: Props) {
       className={cn(
         "daycard relative overflow-hidden card-neo-soft rounded-2xl border card-pad",
         "grid gap-4 lg:gap-6",
-        "grid-cols-1 lg:grid-cols-[340px_1px_1fr]",
+        "grid-cols-1 lg:grid-cols-[minmax(260px,320px)_1px_1fr]",
         isToday && "ring-1 ring-[hsl(var(--ring)/0.65)] title-glow",
         "before:pointer-events-none before:absolute before:inset-x-4 before:top-0 before:h-px before:bg-gradient-to-r",
         "before:from-transparent before:via-[hsl(var(--ring)/.45)] before:to-transparent",


### PR DESCRIPTION
## Summary
- refine DayCard grid to allow project column between 260px and 320px on large screens

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf35410740832cbd1a3a6bf19823f7