### PR TITLE
fix: adjust spacing tokens in reminders

### DIFF
--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -162,7 +162,7 @@ export default function Reminders() {
   }
 
   return (
-    <div className="grid gap-2.5">
+    <div className="grid gap-3">
       <SectionCard className="card-neo-soft">
         <SectionCard.Header sticky topClassName="top-0">
           {/* header row (no Quick Add here anymore) */}
@@ -173,7 +173,7 @@ export default function Reminders() {
               <Input
                 aria-label="Search reminders"
                 placeholder="Search title, text, tags…"
-                className="pl-10"
+                className="pl-6"
                 value={query}
                 onChange={(e) => setQuery(e.currentTarget.value)}
               />
@@ -211,7 +211,7 @@ export default function Reminders() {
         </SectionCard.Header>
 
         {/* Panel body now holds Quick Add + neon quote + cards grid */}
-        <SectionCard.Body className="grid gap-2.5">
+        <SectionCard.Body className="grid gap-3">
           {/* Quick Add row (in the SAME panel as cards) */}
           <div className="sm:p-4 flex items-center gap-4">
             <Input

--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -266,7 +266,7 @@ export default function RemindersTab() {
 
       <SectionCard className="goal-card">
         <SectionCard.Body>
-          <div className="grid gap-2.5">
+          <div className="grid gap-3">
             {/* Quick Add row — now INSIDE the same panel as the cards */}
             <form
               onSubmit={(e) => {


### PR DESCRIPTION
## Summary
- normalize reminder layouts to use `gap-3`
- replace hard-coded `pl-10` with spacing token `pl-6`
- update reminders tab spacing for consistency

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf372fe938832ca7f72cc60e8d9272