### PR TITLE
refactor: remove result badge

### DIFF
--- a/src/components/reviews/ReviewListItem.tsx
+++ b/src/components/reviews/ReviewListItem.tsx
@@ -47,7 +47,6 @@ export default function ReviewListItem({
   const untitled = !review?.title?.trim();
   const subline = review?.notes?.trim() || "";
   const score = review?.score;
-  const resultTag = review?.result ? review.result[0] : undefined;
   const dateStr = review?.createdAt
     ? shortDate.format(new Date(review.createdAt))
     : "";
@@ -86,18 +85,10 @@ export default function ReviewListItem({
             >
               {title}
             </div>
-            <div className="flex items-center gap-1 text-sm text-muted-foreground">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
               {typeof score === "number" ? (
                 <Badge variant="accent" aria-label={`Rating ${score} out of 10`}>
                   {score}/10
-                </Badge>
-              ) : null}
-              {resultTag ? (
-                <Badge
-                  variant="neutral"
-                  className="px-1.5 py-0.5 text-[10px] tracking-wide rounded-md"
-                >
-                  {resultTag}
                 </Badge>
               ) : null}
               {subline ? (

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`ReviewListItem > renders default state 1`] = `
             Sample Review
           </div>
           <div
-            class="flex items-center gap-1 text-sm text-muted-foreground"
+            class="flex items-center gap-2 text-sm text-muted-foreground"
           >
             <span
               aria-label="Rating 9 out of 10"
@@ -34,11 +34,6 @@ exports[`ReviewListItem > renders default state 1`] = `
             >
               9
               /10
-            </span>
-            <span
-              class="inline-flex items-center font-medium border bg-[hsl(var(--muted)/0.25)] border-[hsl(var(--border)/0.2)] text-[hsl(var(--muted-foreground))] px-1.5 py-0.5 text-[10px] tracking-wide rounded-md"
-            >
-              W
             </span>
             <span
               class="line-clamp-1 truncate"
@@ -101,7 +96,7 @@ exports[`ReviewListItem > renders selected state 1`] = `
             Sample Review
           </div>
           <div
-            class="flex items-center gap-1 text-sm text-muted-foreground"
+            class="flex items-center gap-2 text-sm text-muted-foreground"
           >
             <span
               aria-label="Rating 9 out of 10"
@@ -109,11 +104,6 @@ exports[`ReviewListItem > renders selected state 1`] = `
             >
               9
               /10
-            </span>
-            <span
-              class="inline-flex items-center font-medium border bg-[hsl(var(--muted)/0.25)] border-[hsl(var(--border)/0.2)] text-[hsl(var(--muted-foreground))] px-1.5 py-0.5 text-[10px] tracking-wide rounded-md"
-            >
-              W
             </span>
             <span
               class="line-clamp-1 truncate"
@@ -160,7 +150,7 @@ exports[`ReviewListItem > renders untitled state 1`] = `
             Untitled Review
           </div>
           <div
-            class="flex items-center gap-1 text-sm text-muted-foreground"
+            class="flex items-center gap-2 text-sm text-muted-foreground"
           >
             <span
               aria-label="Rating 9 out of 10"
@@ -168,11 +158,6 @@ exports[`ReviewListItem > renders untitled state 1`] = `
             >
               9
               /10
-            </span>
-            <span
-              class="inline-flex items-center font-medium border bg-[hsl(var(--muted)/0.25)] border-[hsl(var(--border)/0.2)] text-[hsl(var(--muted-foreground))] px-1.5 py-0.5 text-[10px] tracking-wide rounded-md"
-            >
-              W
             </span>
             <span
               class="line-clamp-1 truncate"


### PR DESCRIPTION
## Summary
- drop Win/Loss badge from review list items and tighten layout spacing
- update snapshots to match revised markup

## Testing
- `npm run regen-ui`
- `npm test -- --run -u`
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf3f582730832ca275a19467d467b7