### PR TITLE
refactor: remove fractional spacing tokens

### DIFF
--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -36,7 +36,7 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
             ) : (
               items.map((it) => (
                 <li key={it.id} className="group flex items-center gap-2 py-3">
-                  <span className="h-1.5 w-1.5 rounded-full bg-[hsl(var(--foreground)/0.4)]" aria-hidden />
+                  <span className="h-2 w-2 rounded-full bg-[hsl(var(--foreground)/0.4)]" aria-hidden />
                   <p className="flex-1 truncate text-sm">{it.text}</p>
                   <time
                     className="text-xs text-[hsl(var(--muted-foreground))] opacity-0 group-hover:opacity-100"
@@ -63,7 +63,7 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
           </ul>
 
           <form onSubmit={submit} className="flex items-center gap-2 pt-3">
-            <span className="h-1.5 w-1.5 rounded-full bg-[hsl(var(--foreground)/0.4)]" aria-hidden />
+            <span className="h-2 w-2 rounded-full bg-[hsl(var(--foreground)/0.4)]" aria-hidden />
             <Input
               tone="default"
               className="flex-1 h-9 text-sm"

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -258,7 +258,7 @@ export default function GoalsPage() {
                           >
                             <span
                               aria-hidden
-                              className="absolute inset-y-4 left-0 w-0.5 rounded-full bg-gradient-to-b from-[hsl(var(--primary))] via-[hsl(var(--accent))] to-transparent opacity-60"
+                              className="absolute inset-y-4 left-0 w-1 rounded-full bg-gradient-to-b from-[hsl(var(--primary))] via-[hsl(var(--accent))] to-transparent opacity-60"
                             />
                             <header className="flex items-start justify-between gap-2">
                               <h3 className="font-semibold leading-tight pr-6 line-clamp-2">

--- a/src/components/goals/GoalsProgress.tsx
+++ b/src/components/goals/GoalsProgress.tsx
@@ -34,11 +34,11 @@ export default function GoalsProgress({ total, pct, onAddFirst, maxWidth }: Goal
   return (
     <div className="flex min-w-[120px] items-center gap-2" aria-label="Progress">
       <div
-        className="h-1.5 w-full flex-1 max-w-[var(--progress-max,160px)] overflow-hidden rounded-full bg-[hsl(var(--fg)/0.1)]"
+        className="h-2 w-full flex-1 max-w-[var(--progress-max,160px)] overflow-hidden rounded-full bg-[hsl(var(--fg)/0.1)]"
         style={style}
       >
         <div
-          className="h-1.5 rounded-full bg-[hsl(var(--accent))] transition-[width]"
+          className="h-2 rounded-full bg-[hsl(var(--accent))] transition-[width]"
           style={{ width: `${v}%` }}
         />
       </div>

--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -381,7 +381,7 @@ function ReminderCard({
         </div>
       </div>
 
-      <div className="space-y-2.5">
+      <div className="space-y-3">
         {editing ? (
           <>
             <Textarea

--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -500,7 +500,7 @@ function RemTile({
       </div>
 
       {/* Body + meta */}
-      <div className="mt-2 space-y-2.5">
+      <div className="mt-2 space-y-3">
         {editing ? (
           <>
             <label className="text-xs opacity-70">Note</label>

--- a/src/components/planner/ProjectList.tsx
+++ b/src/components/planner/ProjectList.tsx
@@ -48,7 +48,7 @@ export default function ProjectList({
           <EmptyRow text="No projects yet." />
         ) : (
           <ul
-            className="w-full space-y-2 [&>li:first-child]:mt-1.5 [&>li:last-child]:mb-1.5"
+            className="w-full space-y-2 [&>li:first-child]:mt-2 [&>li:last-child]:mb-2"
             role="radiogroup"
             aria-label="Projects"
           >
@@ -102,7 +102,7 @@ export default function ProjectList({
                     )}
                   >
                     <span
-                      className="shrink-0 ml-0.5"
+                      className="shrink-0 ml-1"
                       onMouseDown={(e) => e.stopPropagation()}
                       onClick={(e) => e.stopPropagation()}
                     >

--- a/src/components/planner/TaskList.tsx
+++ b/src/components/planner/TaskList.tsx
@@ -59,7 +59,7 @@ export default function TaskList({
           <EmptyRow text="No tasks selected." />
         ) : (
           <ul
-            className="space-y-2 [&>li:first-child]:mt-1.5 [&>li:last-child]:mb-1.5"
+            className="space-y-2 [&>li:first-child]:mt-2 [&>li:last-child]:mb-2"
             aria-label="Tasks"
           >
             {tasksForSelected.map((t) => (

--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -52,7 +52,7 @@ export default function TaskRow({
         )}
         onClick={onSelect}
       >
-        <div className="shrink-0 ml-0.5">
+        <div className="shrink-0 ml-1">
           <CheckCircle
             checked={task.done}
             onChange={() => !editing && onToggle()}

--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -195,7 +195,7 @@ export default function WeekPicker() {
           <div className="flex items-center justify-between gap-3">
             <span
               className={cn(
-                "inline-flex items-center gap-2 rounded-2xl px-3 py-1.5 text-sm",
+                "inline-flex items-center gap-2 rounded-2xl px-3 py-2 text-sm",
                 "bg-[hsl(var(--card)/0.72)] ring-1 ring-[hsl(var(--border)/0.55)] backdrop-blur"
               )}
               aria-label={`Week range ${rangeLabel}`}

--- a/src/components/planner/index.ts
+++ b/src/components/planner/index.ts
@@ -16,19 +16,8 @@ export { default as WeekPicker } from "./WeekPicker";
 export { default as WeekSummary } from "./WeekSummary";
 export * from "./dayCrud";
 export * from "./plannerCrud";
-export {
-  PlannerProvider,
-  todayISO,
-  ensureDay,
-} from "./plannerStore";
-export type {
-  ISODate,
-  DayRecord,
-  Project,
-  DayTask,
-  Selection,
-} from "./plannerStore";
-export { usePlannerStore } from "./usePlannerStore";
+export * from "./plannerStore";
 export * from "./useDay";
 export * from "./useFocusDate";
+export { usePlannerStore } from "./usePlannerStore";
 export * from "./useSelection";

--- a/src/components/prompts/PromptsComposePanel.tsx
+++ b/src/components/prompts/PromptsComposePanel.tsx
@@ -19,7 +19,7 @@ export default function PromptsComposePanel({
 }: PromptsComposePanelProps) {
   const titleId = React.useId();
   return (
-    <div className="space-y-2.5">
+    <div className="space-y-3">
       <Input
         id={titleId}
         placeholder="Title"

--- a/src/components/reviews/ReviewCard.tsx
+++ b/src/components/reviews/ReviewCard.tsx
@@ -48,7 +48,7 @@ export default function ReviewCard({
           </div>
 
           {Array.isArray(review.tags) && review.tags.length > 0 && (
-            <div className="mt-2 flex flex-wrap gap-1.5">
+            <div className="mt-2 flex flex-wrap gap-2">
               {review.tags.slice(0, 6).map((t) => (
                 <Badge key={t} variant="pill">
                   {t}

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -964,7 +964,7 @@ export default function ReviewEditor({
                       <FileText size={14} className="opacity-80" />
                     </span>
                   ) : (
-                    <span className="pill h-7 min-w-[60px] px-2.5 text-[11px] font-mono tabular-nums text-center">
+                    <span className="pill h-7 min-w-[60px] px-3 text-[11px] font-mono tabular-nums text-center">
                       {m.time}
                     </span>
                   )}
@@ -1030,7 +1030,7 @@ export default function ReviewEditor({
                 <button
                   key={t}
                   type="button"
-                  className="chip h-9 px-3.5 text-sm group inline-flex items-center gap-1"
+                  className="chip h-9 px-4 text-sm group inline-flex items-center gap-1"
                   title="Remove tag"
                   onClick={() => removeTag(t)}
                 >

--- a/src/components/reviews/ReviewSummary.tsx
+++ b/src/components/reviews/ReviewSummary.tsx
@@ -289,7 +289,7 @@ export default function ReviewSummary({ review, onEdit, className }: Props) {
         <div className="grid w-full grid-cols-[1fr_auto] items-center gap-4">
           {/* Left: Title */}
           <div className="min-w-0">
-            <div className="mb-0.5 text-xs text-[hsl(var(--foreground)/0.25)]">Title</div>
+            <div className="mb-1 text-xs text-[hsl(var(--foreground)/0.25)]">Title</div>
             <div className="truncate text-lg font-medium leading-7 text-[hsl(var(--foreground)/0.7)]">
               {laneTitle || "Untitled review"}
             </div>
@@ -300,7 +300,7 @@ export default function ReviewSummary({ review, onEdit, className }: Props) {
             {role ? (
               <span
                 className={cn(
-                  "inline-flex h-10 items-center gap-1.5 rounded-2xl border border-[hsl(var(--border))]",
+                  "inline-flex h-10 items-center gap-2 rounded-2xl border border-[hsl(var(--border))]",
                   "bg-[hsl(var(--card))] px-3 text-sm font-semibold"
                 )}
                 title={roleLabel}
@@ -374,7 +374,7 @@ export default function ReviewSummary({ review, onEdit, className }: Props) {
 
           {/* Focus */}
           {focusOn && (
-            <div className="mt-4 space-y-1.5">
+            <div className="mt-4 space-y-2">
               <div className="mb-2 flex items-center gap-2" aria-label="Focus">
                 <NeonIcon kind="brain" on={true} size={32} staticGlow />
                 <div className="h-px flex-1 bg-gradient-to-r from-[hsl(var(--foreground)/0.20)] via-[hsl(var(--foreground)/0.05)] to-transparent" />

--- a/src/components/team/Builder.tsx
+++ b/src/components/team/Builder.tsx
@@ -156,7 +156,7 @@ export default function Builder() {
             </div>
           }
           actions={
-            <div className="flex items-center gap-1.5">
+            <div className="flex items-center gap-2">
               <IconButton
                 title="Swap Allies ↔ Enemies"
                 aria-label="Swap Allies and Enemies"
@@ -252,7 +252,7 @@ function SideEditor(props: {
         </span>
       </header>
 
-      <div className="grid gap-2.5">
+      <div className="grid gap-3">
         {LANES.map(({ key, label }) => (
           <div key={key} className="grid grid-cols-[88px_1fr] items-center gap-3">
             <label
@@ -270,7 +270,7 @@ function SideEditor(props: {
           </div>
         ))}
 
-        <div className="grid gap-2.5">
+        <div className="grid gap-3">
           <label className="text-xs text-[hsl(var(--muted-foreground))] inline-flex items-center gap-2">
             <NotebookPen className="opacity-80" /> Notes
           </label>
@@ -286,7 +286,7 @@ function SideEditor(props: {
         </div>
 
         {/* side actions: icon-only, same behavior */}
-        <div className="mt-1 flex items-center gap-1.5 justify-end">
+        <div className="mt-1 flex items-center gap-2 justify-end">
           <IconButton
             title={`Clear ${title}`}
             aria-label={`Clear ${title}`}

--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -361,7 +361,7 @@ function ChampPillsEdit({
   }
 
   return (
-    <div className="champ-badges mt-1 flex flex-wrap gap-1.5">
+    <div className="champ-badges mt-1 flex flex-wrap gap-2">
       {(list.length ? list : [""]).map((c, i) => (
         <span key={i} className="champ-badge text-xs">
           <i className="dot" />

--- a/src/components/team/JungleClears.tsx
+++ b/src/components/team/JungleClears.tsx
@@ -183,7 +183,7 @@ export default function JungleClears() {
               />
               <SectionCard.Body>
                 <div className="mb-2 flex flex-wrap items-center gap-2">
-                  <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-2 py-0.5 text-[10px] tracking-wide uppercase">
+                  <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-2 py-1 text-[10px] tracking-wide uppercase">
                     {SPEED_PERSONA[bucket].tag}
                   </span>
                   <span className="text-sm text-[hsl(var(--muted-foreground))]">
@@ -272,7 +272,7 @@ export default function JungleClears() {
                           >
                             <td className="py-2 pr-3 font-medium">{r.champ}</td>
                             <td className="py-2 pr-3">
-                              <div className="flex flex-wrap gap-1.5">
+                              <div className="flex flex-wrap gap-2">
                                 {(r.type ?? []).map((t) => (
                                   <span key={t} className="pill pill-compact text-xs">
                                     {t}

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -144,7 +144,7 @@ function ChampChips({
 
   if (!editing) {
     return (
-      <div className="champ-badges mt-1 flex flex-wrap gap-1.5">
+      <div className="champ-badges mt-1 flex flex-wrap gap-2">
         {(champs.length ? champs : ["-"]).map((c, i) => (
           <span key={i} className="champ-badge glitch-pill text-xs">
             <i className="dot" />
@@ -172,7 +172,7 @@ function ChampChips({
   }
 
   return (
-    <div className="champ-badges mt-1 flex flex-wrap gap-1.5">
+    <div className="champ-badges mt-1 flex flex-wrap gap-2">
       {(champs.length ? champs : [""]).map((c, i) => (
         <span key={i} className="champ-badge glitch-pill text-xs">
           <i className="dot" />
@@ -357,7 +357,7 @@ export default function MyComps({ query = "" }: MyCompsProps) {
                   </header>
 
                   {/* roles */}
-                  <div className="grid gap-2.5">
+                  <div className="grid gap-3">
                     {ROLES.map(r => {
                       const list = c.roles[r] ?? [];
                       const setList = (next: string[]) =>

--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -73,7 +73,7 @@ export default function Header({
       >
         {rail ? (
           <div
-            className="header-rail pointer-events-none absolute left-0 top-1 bottom-1 w-1.5 rounded-l-2xl"
+            className="header-rail pointer-events-none absolute left-0 top-1 bottom-1 w-2 rounded-l-2xl"
             aria-hidden
           />
         ) : null}
@@ -83,7 +83,7 @@ export default function Header({
           {icon ? <span className="shrink-0 opacity-90">{icon}</span> : null}
           <div className="min-w-0">
             {eyebrow ? (
-              <div className="mb-0.5 truncate text-[0.6875rem] uppercase tracking-wide text-[hsl(var(--muted-foreground))]">
+              <div className="mb-1 truncate text-[0.6875rem] uppercase tracking-wide text-[hsl(var(--muted-foreground))]">
                 {eyebrow}
               </div>
             ) : null}
@@ -172,7 +172,7 @@ export function HeaderTabs<Key extends string = string>({
     <nav
       role="tablist"
       aria-label={ariaLabel ?? "Page sections"}
-      className="flex items-center gap-1 sm:gap-1.5"
+      className="flex items-center gap-1 sm:gap-2"
       onKeyDown={onKeyDown}
     >
       {tabs.map((t, i) => {

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -149,7 +149,7 @@ export default function TabBar({
         <div
           role="tablist"
           aria-orientation="horizontal"
-          className="relative flex items-center flex-wrap gap-1.5"
+          className="relative flex items-center flex-wrap gap-2"
         >
           {items.map((item) => {
             const active = item.key === activeKey;

--- a/src/components/ui/layout/TitleBar.tsx
+++ b/src/components/ui/layout/TitleBar.tsx
@@ -9,7 +9,7 @@ type Props = {
 export default function TitleBar({ label, idText = "ID:0x13LG" }: Props) {
   return (
     <>
-      <div className="term-mini flex items-center gap-2 px-2 py-1.5 rounded-full">
+      <div className="term-mini flex items-center gap-2 px-2 py-2 rounded-full">
         <span className="term-mini__text">{label}</span>
         <span className="pill pill--pulse ml-auto">{idText}</span>
       </div>

--- a/src/components/ui/league/pillars/PillarBadge.tsx
+++ b/src/components/ui/league/pillars/PillarBadge.tsx
@@ -52,8 +52,8 @@ export default function PillarBadge({
     size === "lg"
       ? "h-10 px-4 text-base gap-2"
       : size === "sm"
-      ? "h-8 px-3 text-[13px] gap-1.5"
-      : "h-9 px-3.5 text-sm gap-2";
+      ? "h-8 px-3 text-[13px] gap-2"
+      : "h-9 px-4 text-sm gap-2";
 
   // Default element: "button" if interactive, else "span".
   const Tag: AsTag = as ?? (interactive ? "button" : "span");

--- a/src/components/ui/league/pillars/PillarSelector.tsx
+++ b/src/components/ui/league/pillars/PillarSelector.tsx
@@ -30,7 +30,7 @@ export default function PillarSelector({
   return (
     <div className={cn("w-full", className)}>
       <div className="overline mb-2">{label}</div>
-      <div className="flex flex-wrap gap-1.5">
+      <div className="flex flex-wrap gap-2">
         {ORDER.map((p) => {
           const active = set.has(p);
           return (

--- a/src/components/ui/primitives/Badge.tsx
+++ b/src/components/ui/primitives/Badge.tsx
@@ -28,7 +28,7 @@ export type BadgeProps<T extends React.ElementType = "span"> = BadgeOwnProps<T> 
 
 const sizeMap: Record<Size, string> = {
   xs: "px-2 py-1 text-xs leading-none",
-  sm: "px-2.5 py-2 text-xs leading-none",
+  sm: "px-3 py-2 text-xs leading-none",
 };
 
 const toneBorder: Record<Tone, string> = {

--- a/src/components/ui/primitives/GlitchSegmented.tsx
+++ b/src/components/ui/primitives/GlitchSegmented.tsx
@@ -68,7 +68,7 @@ export const GlitchSegmentedGroup = ({
       role="tablist"
       aria-label={ariaLabel}
       className={cn(
-        "inline-flex rounded-full bg-[var(--btn-bg)] p-0.5 gap-0.5",
+        "inline-flex rounded-full bg-[var(--btn-bg)] p-1 gap-1",
         className,
       )}
       onKeyDown={onKeyDown}

--- a/src/components/ui/selects/AnimatedSelect.tsx
+++ b/src/components/ui/selects/AnimatedSelect.tsx
@@ -352,7 +352,7 @@ export default function AnimatedSelect({
                   "relative pointer-events-auto rounded-2xl overflow-hidden",
                   "bg-[hsl(var(--card))]/92 backdrop-blur-xl",
                   "shadow-[0_12px_40px_hsl(var(--shadow-color)/0.55)] ring-1 ring-[hsl(var(--ring)/.18)]",
-                  "p-1.5",
+                  "p-2",
                   "max-h-[60vh] min-w-[220px] overflow-y-auto scrollbar-thin",
                   "scrollbar-thumb-[hsl(var(--foreground)/.12)] scrollbar-track-transparent",
                   dropdownClassName,
@@ -379,7 +379,7 @@ export default function AnimatedSelect({
                         onClick={() => selectByIndex(idx)}
                         onFocus={() => setActiveIndex(idx)}
                         className={[
-                          "group relative w-full rounded-xl px-3.5 py-2.5 text-left transition",
+                          "group relative w-full rounded-xl px-4 py-3 text-left transition",
                           disabledItem
                             ? "opacity-50 cursor-not-allowed"
                             : "cursor-pointer",

--- a/src/components/ui/toggles/CheckCircle.tsx
+++ b/src/components/ui/toggles/CheckCircle.tsx
@@ -22,7 +22,7 @@ type CCVars = React.CSSProperties & {
 
 type Size = "sm" | "md" | "lg";
 const SIZE: Record<Size, string> = {
-  sm: "h-6 w-6 [&_svg]:h-3.5 [&_svg]:w-3.5",
+  sm: "h-6 w-6 [&_svg]:h-4 [&_svg]:w-4",
   md: "h-7 w-7 [&_svg]:h-4   [&_svg]:w-4",
   lg: "h-9 w-9 [&_svg]:h-5   [&_svg]:w-5",
 };
@@ -193,7 +193,7 @@ export default function CheckCircle({
           <span
             aria-hidden
             className={cn(
-              "absolute inset-0 rounded-full p-[1.5px] pointer-events-none transition-opacity",
+              "absolute inset-0 rounded-full p-[2px] pointer-events-none transition-opacity",
               lit ? "opacity-100" : "opacity-0"
             )}
             style={{
@@ -313,7 +313,7 @@ export default function CheckCircle({
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
             )}
           >
-            <svg viewBox="0 0 18 18" className="h-3.5 w-3.5" aria-hidden>
+            <svg viewBox="0 0 18 18" className="h-4 w-4" aria-hidden>
               <path
                 d="M4 4l10 10M14 4L4 14"
                 stroke="currentColor"


### PR DESCRIPTION
## Summary
- replace fractional spacing utilities (gap/p/m/space) with whole-number tokens
- eliminate ambiguous planner export by explicitly re-exporting `usePlannerStore`
- standardize padding, gap, and badge sizes across components

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf43c4091c832c82425c4736bb65a6