### PR TITLE
fix: adjust hero offsets

### DIFF
--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -471,7 +471,7 @@ export default function ComponentGallery() {
       element: (
         <div className="w-56 h-56 overflow-auto space-y-6">
           <Header heading="Stacked" />
-          <Hero heading="Stacked" topClassName="top-24" />
+          <Hero heading="Stacked" topClassName="top-20" />
           <div className="h-96" />
         </div>
       ),

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -96,7 +96,7 @@ export default function ReviewsPage({
     <main className="page-shell py-6 space-y-6">
       <Header heading="Reviews" />
       <Hero
-        topClassName="top-24"
+        topClassName="top-20"
         heading={
           <div className="flex items-center gap-2">
             <h2 className="title-glow">Reviews</h2>


### PR DESCRIPTION
## Summary
- align hero and header offsets by replacing unsupported `top-24` with `top-20`

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf50858308832c8b19116ff336e5d3