### PR TITLE
refactor: rename planner store hook

### DIFF
--- a/docs/planner-modules.md
+++ b/docs/planner-modules.md
@@ -2,7 +2,7 @@
 
 This directory splits the planner logic into focused modules:
 
-- `plannerStore.ts` – React context with persistent planner data (`days`, `focus`, and selection). Wrap planner pages with `PlannerProvider` and consume the raw store via `usePlannerStore`.
+- `plannerStore.ts` – React context with persistent planner data (`days`, `focus`, and selection). Wrap planner pages with `PlannerProvider` and consume the raw store via `usePlannerContext`.
 - `plannerCrud.ts` – Factory for project and task CRUD helpers. Given a day ISO string and an `upsertDay` function, it returns operations like `addProject` and `toggleTask`.
 - `usePlannerStore.ts` – Hook exposing persistent planner state and CRUD helpers for the current focus day.
 - `useFocusDate.ts` – Hooks for managing the focused date and deriving week information.

--- a/src/components/planner/plannerStore.ts
+++ b/src/components/planner/plannerStore.ts
@@ -79,7 +79,7 @@ export function PlannerProvider({ children }: { children: React.ReactNode }) {
   );
 }
 
-export function usePlannerStore(): PlannerState {
+export function usePlannerContext(): PlannerState {
   const ctx = React.useContext(PlannerCtx);
   if (!ctx)
     throw new Error(

--- a/src/components/planner/useFocusDate.ts
+++ b/src/components/planner/useFocusDate.ts
@@ -2,14 +2,14 @@
 
 import * as React from "react";
 import { addDays, toISODate, weekRangeFromISO } from "@/lib/date";
-import { todayISO, usePlannerStore, type ISODate } from "./plannerStore";
+import { todayISO, usePlannerContext, type ISODate } from "./plannerStore";
 
 /**
  * Exposes the currently focused ISO date and helper to update it.
  * @returns Current focus ISO date, setter, and today's ISO string.
  */
 export function useFocusDate() {
-  const { focus, setFocus } = usePlannerStore();
+  const { focus, setFocus } = usePlannerContext();
   const today = todayISO();
   return { iso: focus, setIso: setFocus, today } as const;
 }

--- a/src/components/planner/usePlannerStore.ts
+++ b/src/components/planner/usePlannerStore.ts
@@ -3,7 +3,7 @@
 import * as React from "react";
 import {
   ensureDay,
-  usePlannerStore as useStore,
+  usePlannerContext as useStore,
   type DayRecord,
   type ISODate,
 } from "./plannerStore";

--- a/src/components/planner/useSelection.ts
+++ b/src/components/planner/useSelection.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { ensureDay, usePlannerStore, type ISODate } from "./plannerStore";
+import { ensureDay, usePlannerContext, type ISODate } from "./plannerStore";
 
 /**
  * Manages the selected project for a given day.
@@ -10,7 +10,7 @@ import { ensureDay, usePlannerStore, type ISODate } from "./plannerStore";
  * @returns Tuple of current project ID and setter.
  */
 export function useSelectedProject(iso: ISODate) {
-  const { selected, setSelected } = usePlannerStore();
+  const { selected, setSelected } = usePlannerContext();
   const current = selected[iso]?.projectId ?? "";
   const set = React.useCallback(
     (projectId: string) => {
@@ -31,7 +31,7 @@ export function useSelectedProject(iso: ISODate) {
  * @returns Tuple of current task ID and setter.
  */
 export function useSelectedTask(iso: ISODate) {
-  const { selected, setSelected, days } = usePlannerStore();
+  const { selected, setSelected, days } = usePlannerContext();
   const current = selected[iso]?.taskId ?? "";
 
   const set = React.useCallback(


### PR DESCRIPTION
## Summary
- rename base planner store hook to `usePlannerContext` to avoid export conflicts
- update selection and focus hooks to use the new context hook
- document the new `usePlannerContext` entry point

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf5a3dcdb8832c91bb285e73d5c811