### PR TITLE
feat: label prompts tab bar

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -63,7 +63,12 @@ export default function Page() {
         </div>
         <p className="mb-4 text-xs text-danger">Example error message</p>
         <div className="mb-8">
-          <TabBar items={viewTabs} value={view} onValueChange={setView} />
+          <TabBar
+            items={viewTabs}
+            value={view}
+            onValueChange={setView}
+            ariaLabel="Prompts gallery view"
+          />
         </div>
       {view === "components" ? <ComponentGallery /> : <ColorGallery />}
     </main>

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -141,13 +141,13 @@ export default function TabBar({
     <div
       className={cn("relative w-full", className)}
       ref={containerRef}
-      aria-label={ariaLabel}
       onKeyDown={onKeyDown}
     >
       <div className={cn("flex items-center", justify, "gap-3")}>
         {/* Tabs group */}
         <div
           role="tablist"
+          aria-label={ariaLabel}
           aria-orientation="horizontal"
           className="relative flex items-center flex-wrap gap-2"
         >

--- a/tests/ui/tab-bar.test.tsx
+++ b/tests/ui/tab-bar.test.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import { TabBar } from "@/components/ui";
+
+afterEach(cleanup);
+
+describe("TabBar", () => {
+  it("announces aria label", () => {
+    render(
+      <TabBar
+        items={[
+          { key: "components", label: "Components" },
+          { key: "colors", label: "Colors" },
+        ]}
+        ariaLabel="Prompts gallery view"
+      />
+    );
+    expect(
+      screen.getByRole("tablist", { name: "Prompts gallery view" }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add descriptive ariaLabel to prompts page TabBar
- ensure TabBar applies aria-label to its tablist element
- test TabBar label accessibility

## Testing
- `node --input-type=module <<'NODE'
import { MultiBar, Presets } from 'cli-progress';
import { execSync } from 'node:child_process';
const tasks = [
  { cmd: 'npm test -- --run', label: 'test' },
  { cmd: 'npm run lint', label: 'lint' },
  { cmd: 'npm run typecheck', label: 'typecheck' },
];
const bars = new MultiBar({ clearOnComplete: false, hideCursor: true }, Presets.shades_grey);
const bar = bars.create(tasks.length, 0);
for (let i = 0; i < tasks.length; i++) {
  const t = tasks[i];
  console.log(`Running ${t.label}...`);
  try {
    execSync(t.cmd, { stdio: 'inherit' });
  } catch {
    console.error(`${t.label} failed`);
    process.exit(1);
  }
  bar.update(i + 1);
}
bars.stop();
NODE`
- `npm run regen-ui`

------
https://chatgpt.com/codex/tasks/task_e_68bf7169f134832ca626c0985872ab33