### PR TITLE
feat: show goal caps in overview

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -205,7 +205,7 @@ export default function GoalsPage() {
       <Hero
         eyebrow="Guide"
         heading="Overview"
-        subtitle="Track up to 3 active goals, pin quick cues, and focus with the timer."
+        subtitle={`Cap ${ACTIVE_CAP}, ${remaining} remaining (${activeCount} active, ${doneCount} done)`}
         sticky={false}
       />
 

--- a/tests/goals/goals-page.test.tsx
+++ b/tests/goals/goals-page.test.tsx
@@ -18,6 +18,13 @@ describe("GoalsPage", () => {
     window.localStorage.clear();
   });
 
+  it("renders dynamic subtitle with counts", () => {
+    render(<GoalsPage />);
+    expect(
+      screen.getByText("Cap 3, 3 remaining (0 active, 0 done)"),
+    ).toBeInTheDocument();
+  });
+
   it("handles adding goals, cap enforcement, completion toggles, and undo", async () => {
     render(<GoalsPage />);
 


### PR DESCRIPTION
## Summary
- display active goal cap and counts in Goals overview
- verify dynamic subtitle via unit test

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf72cb56f4832c875f96af0f95562e