### PR TITLE
test: cover GoalsPage hero heading

### DIFF
--- a/tests/goals/goals-page.test.tsx
+++ b/tests/goals/goals-page.test.tsx
@@ -18,6 +18,16 @@ describe("GoalsPage", () => {
     window.localStorage.clear();
   });
 
+  it("renders hero heading and subtitle", () => {
+    render(<GoalsPage />);
+    expect(
+      screen.getByRole("heading", { name: "Overview" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Cap 3, 3 remaining (0 active, 0 done)"),
+    ).toBeInTheDocument();
+  });
+
   it("renders dynamic subtitle with counts", () => {
     render(<GoalsPage />);
     expect(


### PR DESCRIPTION
## Summary
- add test ensuring GoalsPage hero heading "Overview" and subtitle text render

## Testing
- `node -e "const { MultiBar, Presets } = require('cli-progress'); const { execSync } = require('child_process'); const bars = new MultiBar({ clearOnComplete: false, hideCursor: true }, Presets.shades_grey); const total = 3; const bar = bars.create(total, 0); execSync('npm test -- --run', { stdio: 'inherit' }); bar.update(1); execSync('npm run lint', { stdio: 'inherit' }); bar.update(2); execSync('npm run typecheck', { stdio: 'inherit' }); bar.update(3); bars.stop();"`

------
https://chatgpt.com/codex/tasks/task_e_68bf7d6e97f0832cb6ea5ab1145187f0