### PR TITLE
Skip ts-node during postinstall on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "format": "prettier --write .",
     "verify-prompts": "ts-node scripts/verify-prompts.ts",
     "check-prompts": "ts-node scripts/check-prompts-updated.ts",
-    "postinstall": "ts-node scripts/regen-if-needed.ts",
+    "postinstall": "node scripts/regen-if-needed.js",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/regen-if-needed.js
+++ b/scripts/regen-if-needed.js
@@ -1,0 +1,11 @@
+if (process.env.CI === "true") {
+  process.exit(0);
+}
+
+(async () => {
+  await import("ts-node/esm");
+  await import("./regen-if-needed.ts");
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- run postinstall via a small Node wrapper
- load ts-node only when not in CI

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf7da5bbd8832c842b6687736115df