### PR TITLE
ci: use Node 22 in Next.js workflow

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary
- use Node.js 22 in Next.js GitHub Actions workflow

## Testing
- `node --version`
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bf825d958c832ca96c16073aee04ff