### PR TITLE
refactor: standardize ReviewEditor padding

### DIFF
--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -569,7 +569,7 @@ export default function ReviewEditor({
                       go(opponentRef);
                     }
                   }}
-                  className="pl-10"
+                  className="pl-6"
                   placeholder="Ashe/Lulu"
                   aria-label="Lane (used as Title)"
                 />
@@ -592,7 +592,7 @@ export default function ReviewEditor({
                     }
                   }}
                   placeholder="Draven/Thresh"
-                  className="pl-10"
+                  className="pl-6"
                   aria-label="Opponent"
                 />
               </div>
@@ -996,7 +996,7 @@ export default function ReviewEditor({
                 value={draftTag}
                 onChange={(e) => setDraftTag(e.target.value)}
                 placeholder="Add tag and press Enter"
-                className="pl-10"
+                className="pl-6"
                 onKeyDown={(e) => {
                   if (e.key === "Enter") {
                     e.preventDefault();


### PR DESCRIPTION
## Summary
- replace `pl-10` padding with design-token `pl-6` in ReviewEditor inputs

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf85a91018832c93b9f79211b72c5e