### PR TITLE
Wrap prompt updates in list

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -34,50 +34,51 @@ export default function Page() {
           />
         </div>
       </div>
-      <p className="mb-4 text-sm text-muted-foreground">
-        Global styles are now modularized into <code>animations.css</code>,
-        <code>overlays.css</code>, and <code>utilities.css</code>.
-      </p>
-      <p className="mb-4 text-sm text-muted-foreground">
-        Control height token <code>--control-h</code> now snaps to 44px to align
-        with the 4px spacing grid.
-      </p>
-      <p className="mb-4 text-sm text-muted-foreground">
-        Buttons now default to the 40px <code>md</code> size and follow a
-        36/40/44px scale.
-      </p>
-      <p className="mb-4 text-sm text-muted-foreground">
-        WeekPicker scrolls horizontally with snap points, showing 2–3 days at
-        a time on smaller screens.
-      </p>
-        <p className="mb-4 text-sm text-muted-foreground">
+      <ul className="mb-4 space-y-4">
+        <li className="text-sm text-muted-foreground">
+          Global styles are now modularized into <code>animations.css</code>,
+          <code>overlays.css</code>, and <code>utilities.css</code>.
+        </li>
+        <li className="text-sm text-muted-foreground">
+          Control height token <code>--control-h</code> now snaps to 44px to
+          align with the 4px spacing grid.
+        </li>
+        <li className="text-sm text-muted-foreground">
+          Buttons now default to the 40px <code>md</code> size and follow a
+          36/40/44px scale.
+        </li>
+        <li className="text-sm text-muted-foreground">
+          WeekPicker scrolls horizontally with snap points, showing 2–3 days at
+          a time on smaller screens.
+        </li>
+        <li className="text-sm text-muted-foreground">
           Review status dots blink to highlight wins and losses.
-        </p>
-        <p className="mb-4 text-sm text-muted-foreground">
+        </li>
+        <li className="text-sm text-muted-foreground">
           Hero dividers now use <code>var(--space-4)</code> top padding and
           tokenized side offsets via <code>var(--space-2)</code>.
-        </p>
-        <div className="mb-8 flex flex-wrap gap-2">
-          <Button tone="primary">Primary tone</Button>
-          <Button tone="accent">Accent tone</Button>
-          <Button tone="info" variant="ghost">
-            Info ghost
-          </Button>
-          <Button tone="danger" variant="primary">
-            Danger primary
-          </Button>
-        </div>
-        <p className="mb-4 text-xs text-danger">Example error message</p>
-        <div className="mb-8">
-          <TabBar
-            items={viewTabs}
-            value={view}
-            onValueChange={(k) => setView(k)}
-            ariaLabel="Prompts gallery view"
-          />
-        </div>
+        </li>
+      </ul>
+      <div className="mb-8 flex flex-wrap gap-2">
+        <Button tone="primary">Primary tone</Button>
+        <Button tone="accent">Accent tone</Button>
+        <Button tone="info" variant="ghost">
+          Info ghost
+        </Button>
+        <Button tone="danger" variant="primary">
+          Danger primary
+        </Button>
+      </div>
+      <p className="mb-4 text-xs text-danger">Example error message</p>
+      <div className="mb-8">
+        <TabBar
+          items={viewTabs}
+          value={view}
+          onValueChange={(k) => setView(k)}
+          ariaLabel="Prompts gallery view"
+        />
+      </div>
       {view === "components" ? <ComponentGallery /> : <ColorGallery />}
     </main>
   );
 }
-


### PR DESCRIPTION
## Summary
- Replace standalone update paragraphs on the prompts page with a spaced bullet list
- Drop redundant margin classes from each list item

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf89b14f4c832cb25de480af88e27d