### PR TITLE
refactor: use barrel exports for review components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 // Root: "/" → Reviews
-import ReviewPage from "@/components/reviews/ReviewPage";
+import { ReviewPage } from "@/components/reviews";
 
 export default function Page() {
   return <ReviewPage />;

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -4,7 +4,10 @@ import * as React from "react";
 import { TabBar, Header, Hero, Button, type TabItem } from "@/components/ui";
 import Banner from "@/components/chrome/Banner";
 import { GoalsProgress } from "@/components/goals";
+import { RoleSelector } from "@/components/reviews";
 import { ComponentGallery, ColorGallery } from "@/components/prompts";
+import { ROLE_OPTIONS } from "@/components/reviews/reviewData";
+import type { Role } from "@/lib/types";
 
 type View = "components" | "colors";
 
@@ -15,6 +18,7 @@ export default function Page() {
   ];
 
   const [view, setView] = React.useState<View>("components");
+  const [role, setRole] = React.useState<Role>(ROLE_OPTIONS[0].value);
 
   return (
     <main className="page-shell py-6">
@@ -24,6 +28,9 @@ export default function Page() {
         <Banner title="Banner" actions={<Button size="sm">Action</Button>} />
         <div className="flex justify-center">
           <GoalsProgress total={5} pct={60} />
+        </div>
+        <div className="flex justify-center">
+          <RoleSelector value={role} onChange={setRole} />
         </div>
         <div className="flex justify-center">
           <input

--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -1,5 +1,5 @@
 // src/app/reviews/page.tsx
-import ReviewPage from "@/components/reviews/ReviewPage";
+import { ReviewPage } from "@/components/reviews";
 
 export default function ReviewsRoute() {
   return <ReviewPage />;

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -2,7 +2,7 @@
 
 // Full Review Editor with icon-only header actions and RoleSelector rail control.
 import "./style.css";
-import RoleSelector from "@/components/reviews/RoleSelector";
+import { RoleSelector } from "@/components/reviews";
 import SectionLabel from "@/components/reviews/SectionLabel";
 
 import * as React from "react";

--- a/src/components/reviews/index.ts
+++ b/src/components/reviews/index.ts
@@ -1,7 +1,9 @@
 // src/components/reviews/index.ts
+export { default as ReviewPage } from "./ReviewPage";
 export { default as ReviewsPage } from "./ReviewsPage";
 export { default as ReviewEditor } from "./ReviewEditor";
 export { default as ReviewList } from "./ReviewList";
 export { default as ReviewSummary } from "./ReviewSummary";
+export { default as RoleSelector } from "./RoleSelector";
 export { default as StatsStrip } from "./StatsStrip";
 export { default as ReviewPanel } from "./ReviewPanel";


### PR DESCRIPTION
## Summary
- re-export `ReviewPage` and `RoleSelector` from the reviews barrel
- update imports to consume barrel exports and demo `RoleSelector` on prompts page

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bf8b0af0fc832c8868c322809ee733