### PR TITLE
Cache legacy storage migration

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -22,9 +22,12 @@ const OLD_STORAGE_PREFIX = "13lr:";
 /** SSR guard */
 const isBrowser = typeof window !== "undefined";
 
+// Track whether legacy keys have been migrated
+let migrated = false;
+
 // Migrate any legacy keys from older builds
 function ensureMigration() {
-  if (!isBrowser) return;
+  if (!isBrowser || migrated) return;
   try {
     const legacyKeys: string[] = [];
     for (let i = 0; i < window.localStorage.length; i++) {
@@ -42,6 +45,7 @@ function ensureMigration() {
   } catch {
     // ignore
   }
+  migrated = true;
 }
 
 /** Build a fully namespaced key and ensure migrations */

--- a/tests/lib/db.migration.test.ts
+++ b/tests/lib/db.migration.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Ensure legacy key migration runs only once
+
+describe("ensureMigration", () => {
+  it("migrates legacy keys only once", async () => {
+    vi.resetModules();
+    const original = window.localStorage;
+    const store: Record<string, string> = { "13lr:legacy": "value" };
+    const mockStorage: Storage = {
+      getItem: vi.fn((key: string) => (key in store ? store[key] : null)),
+      setItem: vi.fn((key: string, value: string) => {
+        store[key] = value;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete store[key];
+      }),
+      clear: vi.fn(() => {
+        for (const k of Object.keys(store)) delete store[k];
+      }),
+      key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+      get length() {
+        return Object.keys(store).length;
+      },
+    } as unknown as Storage;
+
+    Object.defineProperty(window, "localStorage", {
+      value: mockStorage,
+      configurable: true,
+    });
+
+    const { createStorageKey } = await import("@/lib/db");
+    const keySpy = vi.spyOn(window.localStorage, "key");
+
+    expect(createStorageKey("legacy")).toBe("noxis-planner:legacy");
+    expect(window.localStorage.getItem("noxis-planner:legacy")).toBe("value");
+    expect(window.localStorage.getItem("13lr:legacy")).toBeNull();
+    const calls = keySpy.mock.calls.length;
+
+    createStorageKey("another");
+    expect(keySpy.mock.calls.length).toBe(calls);
+
+    Object.defineProperty(window, "localStorage", { value: original });
+  });
+});


### PR DESCRIPTION
## Summary
- track and cache whether legacy localStorage keys have been migrated
- ensure `ensureMigration` only runs once via a module-level flag
- add regression test confirming migration executes once

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf8bf8aa28832c8c276a2775b86393