### PR TITLE
Add ReviewsPage tests and fix React imports

### DIFF
--- a/src/components/reviews/ReviewPanel.tsx
+++ b/src/components/reviews/ReviewPanel.tsx
@@ -1,5 +1,5 @@
+import React, { type HTMLAttributes } from "react";
 import { cn } from "@/lib/utils";
-import type { HTMLAttributes } from "react";
 
 export default function ReviewPanel({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   return (

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 import "./style.css";
 
-import { useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import type { Review } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import ReviewList from "./ReviewList";

--- a/tests/reviews/ReviewsPage.test.tsx
+++ b/tests/reviews/ReviewsPage.test.tsx
@@ -1,0 +1,134 @@
+import React from "react";
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  within,
+} from "@testing-library/react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { ReviewsPage } from "@/components/reviews";
+import type { Review } from "@/lib/types";
+
+afterEach(cleanup);
+
+const baseReviews: Review[] = [
+  { id: "1", title: "Alpha", tags: [], pillars: [], createdAt: 3000 },
+  { id: "2", title: "Beta", tags: [], pillars: [], createdAt: 1000 },
+  { id: "3", title: "Gamma", tags: [], pillars: [], createdAt: 2000 },
+];
+
+describe("ReviewsPage", () => {
+  it("renders default state", () => {
+    const { container } = render(
+      <ReviewsPage
+        reviews={baseReviews}
+        selectedId={null}
+        onSelect={() => {}}
+        onCreate={() => {}}
+        onRename={() => {}}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it("filters reviews by search query", () => {
+    render(
+      <ReviewsPage
+        reviews={baseReviews}
+        selectedId={null}
+        onSelect={() => {}}
+        onCreate={() => {}}
+        onRename={() => {}}
+      />,
+    );
+
+    const search = screen.getByRole("searchbox");
+    fireEvent.change(search, { target: { value: "Gamma" } });
+    expect(screen.getByText("Gamma")).toBeInTheDocument();
+    expect(screen.queryByText("Alpha")).toBeNull();
+    expect(screen.queryByText("Beta")).toBeNull();
+  });
+
+  it("sorts reviews by title", () => {
+    render(
+      <ReviewsPage
+        reviews={baseReviews}
+        selectedId={null}
+        onSelect={() => {}}
+        onCreate={() => {}}
+        onRename={() => {}}
+      />,
+    );
+
+    const list = screen.getAllByRole("list")[0];
+    const getTitles = () =>
+      within(list)
+        .getAllByRole("button")
+        .map((b) => b.getAttribute("aria-label")?.replace("Open review: ", ""));
+
+    expect(getTitles()).toEqual(["Alpha", "Gamma", "Beta"]);
+
+    const sortBtn = screen.getByRole("button", { name: "Select option" });
+    fireEvent.click(sortBtn);
+    fireEvent.click(screen.getByRole("option", { name: "Title" }));
+
+    expect(getTitles()).toEqual(["Alpha", "Beta", "Gamma"]);
+  });
+
+  it("creates a new review and opens editor", () => {
+    function Harness({ onCreate }: { onCreate: () => void }) {
+      const [reviews, setReviews] = React.useState<Review[]>(baseReviews);
+      const [selectedId, setSelectedId] = React.useState<string | null>(null);
+      return (
+        <ReviewsPage
+          reviews={reviews}
+          selectedId={selectedId}
+          onSelect={setSelectedId}
+          onCreate={() => {
+            onCreate();
+            const next: Review = {
+              id: "4",
+              title: "New Review",
+              tags: [],
+              pillars: [],
+              createdAt: 4000,
+            };
+            setReviews((r) => [...r, next]);
+            setSelectedId(next.id);
+          }}
+          onRename={() => {}}
+        />
+      );
+    }
+
+    const createSpy = vi.fn();
+    render(<Harness onCreate={createSpy} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "New Review" }));
+    expect(createSpy).toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+  });
+
+  it("toggles between summary and edit panels", () => {
+    function Harness() {
+      const [selectedId, setSelectedId] = React.useState<string>("1");
+      return (
+        <ReviewsPage
+          reviews={baseReviews}
+          selectedId={selectedId}
+          onSelect={setSelectedId}
+          onCreate={() => {}}
+          onRename={() => {}}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit review" }));
+    expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+    expect(screen.getByRole("button", { name: "Edit review" })).toBeInTheDocument();
+  });
+});

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -1,0 +1,921 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ReviewsPage > renders default state 1`] = `
+<div>
+  <main
+    class="page-shell py-6 space-y-6"
+  >
+    <header
+      class="sticky top-8 z-[999] relative isolate rounded-2xl bg-[hsl(var(--card))]/70 backdrop-blur-md shadow-[0_0_18px_hsl(var(--ring)/.35),0_0_32px_hsl(var(--accent)/.25)] overflow-hidden"
+    >
+      <div
+        class="relative flex items-center px-3 sm:px-4 py-3 sm:py-4 min-h-12"
+      >
+        <div
+          aria-hidden="true"
+          class="header-rail pointer-events-none absolute left-0 top-1 bottom-1 w-2 rounded-l-2xl"
+        />
+        <div
+          class="flex min-w-0 items-center gap-2 sm:gap-3"
+        >
+          <div
+            class="min-w-0"
+          >
+            <div
+              class="flex min-w-0 items-baseline gap-2"
+            >
+              <h1
+                class="truncate text-base leading-tight text-[hsl(var(--foreground))] sm:text-lg title-glow"
+              >
+                Reviews
+              </h1>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+    <section>
+      <style>
+        
+      /* === Hero2: header background layers =============================== */
+      .hero2-frame {
+        --hero2-c1: hsl(var(--accent));
+        --hero2-c2: hsl(var(--primary));
+        --hero2-bloom: hsl(var(--shadow-color) / 0.85);
+        box-shadow:
+          0 10px 40px -18px var(--hero2-bloom),
+          inset 0 0 0 1px hsl(var(--border) / 0.55);
+        background:
+          radial-gradient(
+            120% 120% at 0% 0%,
+            hsl(var(--accent) / 0.14) 0%,
+            transparent 55%
+          ),
+          radial-gradient(
+            120% 120% at 100% 0%,
+            hsl(var(--primary) / 0.12) 0%,
+            transparent 55%
+          ),
+          linear-gradient(
+            0deg,
+            hsl(var(--card) / 0.82),
+            hsl(var(--card) / 0.82)
+          );
+      }
+      .hero2-beams {
+        position: absolute;
+        inset: -2px;
+        border-radius: var(--radius-2xl, 24px);
+        z-index: 0;
+        pointer-events: none;
+        background:
+          linear-gradient(
+              100deg,
+              transparent 0%,
+              hsl(var(--primary) / 0.18) 10%,
+              transparent 22%
+            )
+            0 0/100% 100%,
+          linear-gradient(
+              260deg,
+              transparent 0%,
+              hsl(var(--accent) / 0.2) 8%,
+              transparent 20%
+            )
+            0 0/100% 100%;
+        mix-blend-mode: screen;
+        animation: hero2-beam-pan 7s linear infinite;
+      }
+      @keyframes hero2-beam-pan {
+        0% {
+          transform: translateX(-3%);
+        }
+        50% {
+          transform: translateX(3%);
+        }
+        100% {
+          transform: translateX(-3%);
+        }
+      }
+      .hero2-scanlines {
+        position: absolute;
+        inset: 0;
+        z-index: 1;
+        pointer-events: none;
+        background:
+          linear-gradient(
+            transparent 94%,
+            hsl(var(--foreground) / 0.5) 96%,
+            transparent 98%
+          ),
+          linear-gradient(
+            90deg,
+            transparent 94%,
+            hsl(var(--foreground) / 0.4) 96%,
+            transparent 98%
+          );
+        background-size:
+          100% 14px,
+          14px 100%;
+        opacity: 0.07;
+        animation: hero2-scan-move 6s linear infinite;
+      }
+      @keyframes hero2-scan-move {
+        0% {
+          background-position:
+            0 0,
+            0 0;
+        }
+        100% {
+          background-position:
+            0 14px,
+            14px 0;
+        }
+      }
+      .hero2-noise {
+        position: absolute;
+        inset: 0;
+        z-index: 1;
+        pointer-events: none;
+        opacity: 0.08;
+        mix-blend-mode: overlay;
+        background-image: url("data:image/svg+xml;utf8,        &lt;svg xmlns='http://www.w3.org/2000/svg' width='140' height='140' viewBox='0 0 140 140'&gt;          &lt;filter id='n'&gt;&lt;feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/&gt;&lt;/filter&gt;          &lt;rect width='100%' height='100%' filter='url(%23n)' opacity='0.38'/&gt;&lt;/svg&gt;");
+        background-size: 280px 280px;
+        animation: hero2-noise-shift 1.8s steps(2, end) infinite;
+      }
+      @keyframes hero2-noise-shift {
+        50% {
+          background-position: 50% 50%;
+        }
+      }
+
+      /* === Glitch title ================================================== */
+      .hero2-title {
+        position: relative;
+        text-shadow:
+          -0.02em 0 hsl(var(--accent-2) / 0.65),
+          0.02em 0 hsl(var(--lav-deep) / 0.65),
+          0 0 0.25em hsl(var(--foreground) / 0.35);
+      }
+      .hero2-title::before,
+      .hero2-title::after {
+        content: attr(data-text);
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        clip-path: inset(0 0 0 0);
+        opacity: 0.75;
+      }
+      .hero2-title::before {
+        transform: translate(0.5px, -0.5px);
+        color: hsl(var(--accent-2) / 0.85);
+        mix-blend-mode: screen;
+        animation: hero2-glitch-a 2.4s infinite steps(8, end);
+      }
+      .hero2-title::after {
+        transform: translate(-0.5px, 0.5px);
+        color: hsl(var(--lav-deep) / 0.85);
+        mix-blend-mode: screen;
+        animation: hero2-glitch-b 2.4s infinite steps(9, end);
+      }
+      @keyframes hero2-glitch-a {
+        0% {
+          clip-path: inset(0);
+        }
+        10% {
+          clip-path: inset(0 0 8% 0);
+        }
+        20% {
+          clip-path: inset(60% 0 0 0);
+        }
+        40% {
+          clip-path: inset(30% 0 40% 0);
+        }
+        80% {
+          clip-path: inset(10% 0 70% 0);
+        }
+        100% {
+          clip-path: inset(0);
+        }
+      }
+      @keyframes hero2-glitch-b {
+        0% {
+          clip-path: inset(0);
+        }
+        15% {
+          clip-path: inset(70% 0 10% 0);
+        }
+        55% {
+          clip-path: inset(0 0 60% 0);
+        }
+        95% {
+          clip-path: inset(20% 0 30% 0);
+        }
+        100% {
+          clip-path: inset(0);
+        }
+      }
+
+      /* === HUD Tabs container (legacy hook, optional) ==================== */
+      .tabs-hud {
+        background: transparent;
+        box-shadow: none;
+      }
+
+      /* === Neon divider (unchanged) ===================================== */
+      .neon-primary {
+        --neon: var(--primary);
+      }
+      .neon-life {
+        --neon: var(--accent);
+      }
+      .hero2-sep {
+        position: relative;
+        padding-top: var(--space-4);
+      }
+      .hero2-neon-line {
+        position: absolute;
+        left: calc(-1 * var(--space-2));
+        right: calc(-1 * var(--space-2));
+        top: 0;
+        height: 1px;
+        pointer-events: none;
+        background: linear-gradient(
+          90deg,
+          transparent,
+          hsl(var(--neon)),
+          transparent
+        );
+        box-shadow:
+          0 0 4px hsl(var(--neon) / 0.55),
+          0 0 10px hsl(var(--neon) / 0.35),
+          0 0 18px hsl(var(--neon) / 0.2);
+        animation: neon-flicker 3.4s infinite;
+        opacity: 0.95;
+      }
+      .hero2-sep-row {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        justify-content: space-between;
+      }
+      @keyframes neon-flicker {
+        0%,
+        17%,
+        22%,
+        26%,
+        52%,
+        100% {
+          opacity: 1;
+        }
+        18% {
+          opacity: 0.72;
+        }
+        24% {
+          opacity: 0.55;
+        }
+        54% {
+          opacity: 0.78;
+        }
+        70% {
+          opacity: 0.62;
+        }
+        74% {
+          opacity: 1;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .hero2-beams,
+        .hero2-scanlines,
+        .hero2-noise,
+        .hero2-title::before,
+        .hero2-title::after,
+        .hero2-neon-line {
+          animation: none !important;
+          transition: none !important;
+        }
+      }
+    
+      </style>
+      <div
+        class="sticky-blur hero2-frame relative overflow-hidden rounded-2xl px-4 sm:px-5 py-4 top-20"
+      >
+        <span
+          aria-hidden="true"
+          class="hero2-beams"
+        />
+        <span
+          aria-hidden="true"
+          class="hero2-scanlines"
+        />
+        <span
+          aria-hidden="true"
+          class="hero2-noise"
+        />
+        <div
+          class="relative z-[2] flex items-center gap-4"
+        >
+          <span
+            aria-hidden="true"
+            class="rail"
+          />
+          <div
+            class="min-w-0"
+          >
+            <div
+              class="flex items-baseline gap-2"
+            >
+              <h2
+                class="hero2-title title-glow text-xl sm:text-2xl truncate"
+              >
+                <div
+                  class="flex items-center gap-2"
+                >
+                  <h2
+                    class="title-glow"
+                  >
+                    Reviews
+                  </h2>
+                  <span
+                    class="pill"
+                  >
+                    Total 
+                    3
+                  </span>
+                </div>
+              </h2>
+            </div>
+          </div>
+          <div
+            class="ml-auto"
+          />
+        </div>
+        <div
+          class="relative z-[2] mt-4 flex flex-col gap-4"
+        >
+          <div
+            class="relative hero2-sep neon-primary"
+          >
+            <span
+              aria-hidden="true"
+              class="hero2-neon-line"
+            />
+            <div
+              class="hero2-sep-row"
+            >
+              <form
+                class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 w-full max-w-[640px] flex-1"
+                role="search"
+              >
+                <div
+                  class="relative min-w-0"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="lucide lucide-search pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-muted-foreground"
+                    fill="none"
+                    height="18"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    viewBox="0 0 24 24"
+                    width="18"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <circle
+                      cx="11"
+                      cy="11"
+                      r="8"
+                    />
+                    <path
+                      d="m21 21-4.3-4.3"
+                    />
+                  </svg>
+                  <div
+                    class="relative inline-flex items-center rounded-xl border backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] w-full border-[hsl(var(--border))] bg-[hsl(var(--input))]"
+                    style="--theme-ring: hsl(var(--ring)); --control-h: 2.5rem;"
+                  >
+                    <input
+                      autocapitalize="none"
+                      autocomplete="off"
+                      autocorrect="off"
+                      class="w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] pl-7"
+                      id=":r0:"
+                      name=":r0:"
+                      placeholder="Search title, tags, opponent, patch…"
+                      spellcheck="false"
+                      type="search"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </form>
+              <div
+                class="flex items-center gap-3"
+              >
+                <div
+                  class="hidden sm:flex items-center gap-2 text-xs text-muted-foreground"
+                >
+                  <span>
+                    Sort
+                  </span>
+                  <div
+                    class="glitch-wrap "
+                  >
+                    <div
+                      class="group inline-flex rounded-full border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0"
+                    >
+                      <button
+                        aria-controls=":r1:-listbox"
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-label="Select option"
+                        class="glitch-trigger relative flex items-center rounded-full px-3 overflow-hidden bg-[hsl(var(--muted)/.12)] hover:bg-[hsl(var(--muted)/.18)] focus:[outline:none] focus-visible:[outline:none] transition h-10 px-4"
+                        data-lit="true"
+                        data-open="false"
+                        type="button"
+                      >
+                        <span
+                          class="font-medium glitch-text text-[hsl(var(--foreground))] group-hover:text-[hsl(var(--foreground))]"
+                        >
+                          Newest
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          class="caret ml-auto size-4 shrink-0 opacity-75 "
+                          viewBox="0 0 20 20"
+                        >
+                          <path
+                            d="M5 7l5 6 5-6"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                          />
+                        </svg>
+                        <span
+                          aria-hidden="true"
+                          class="gb-iris"
+                        />
+                        <span
+                          aria-hidden="true"
+                          class="gb-chroma"
+                        />
+                        <span
+                          aria-hidden="true"
+                          class="gb-flicker"
+                        />
+                        <span
+                          aria-hidden="true"
+                          class="gb-scan"
+                        />
+                      </button>
+                    </div>
+                    <style>
+                      
+      /* caret jitter */
+      .caret {
+        transition:
+          transform 0.18s var(--ease-out),
+          filter 0.18s var(--ease-out);
+      }
+      .caret-open {
+        transform: rotate(180deg);
+      }
+      .glitch-trigger:hover .caret {
+        animation: caret-jitter 0.9s steps(2, end) infinite;
+        filter: drop-shadow(0 0 4px hsl(var(--ring) / 0.55));
+      }
+      @keyframes caret-jitter {
+        0%,
+        100% {
+          transform: translateX(0) rotate(var(--rot, 0deg));
+        }
+        50% {
+          transform: translateX(0.6px) rotate(var(--rot, 0deg));
+        }
+      }
+
+      /* ── border stack pieces (masked to border) ── */
+
+      .gb-iris,
+      .gb-chroma,
+      .gb-flicker,
+      .gb-scan {
+        position: absolute;
+        inset: -1px;
+        border-radius: var(--radius-2xl, 1.5rem);
+        pointer-events: none;
+      }
+
+      /* Base iris sheen with subtle rotation */
+      .gb-iris {
+        padding: 1px;
+        background: conic-gradient(
+          from 180deg,
+          hsl(262 83% 58% / 0),
+          hsl(262 83% 58% / 0.55),
+          hsl(192 90% 50% / 0.55),
+          hsl(320 85% 60% / 0.55),
+          hsl(262 83% 58% / 0)
+        );
+        -webkit-mask:
+          linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+          linear-gradient(hsl(var(--foreground)) 0 0);
+        -webkit-mask-composite: xor;
+        mask-composite: exclude;
+        opacity: 0.32;
+        animation: iris-rotate 10s linear infinite;
+      }
+      @keyframes iris-rotate {
+        to {
+          filter: hue-rotate(360deg);
+        }
+      }
+
+      /* Stronger chroma jitter (RGB split feel) */
+      .gb-chroma {
+        padding: 1px;
+        background: conic-gradient(
+          from 90deg,
+          hsl(var(--primary) / 0),
+          hsl(var(--primary) / 0.7),
+          hsl(var(--accent-2) / 0.65),
+          hsl(var(--accent) / 0.65),
+          hsl(var(--primary) / 0)
+        );
+        -webkit-mask:
+          linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+          linear-gradient(hsl(var(--foreground)) 0 0);
+        -webkit-mask-composite: xor;
+        mask-composite: exclude;
+        mix-blend-mode: screen;
+        opacity: 0.28;
+        animation: chroma-jitter 2.1s steps(6, end) infinite;
+      }
+      @keyframes chroma-jitter {
+        0%,
+        100% {
+          transform: translate(0, 0);
+        }
+        20% {
+          transform: translate(0.25px, -0.25px);
+        }
+        40% {
+          transform: translate(-0.25px, 0.25px);
+        }
+        60% {
+          transform: translate(0.15px, 0.15px);
+        }
+        80% {
+          transform: translate(-0.15px, -0.1px);
+        }
+      }
+
+      /* Flickery aura hugging the border */
+      .gb-flicker {
+        inset: -2px;
+        border-radius: var(--radius-2xl, 1.5rem);
+        background: radial-gradient(
+          120% 120% at 50% 50%,
+          hsl(var(--ring) / 0.18),
+          transparent 60%
+        );
+        filter: blur(7px) saturate(1.06);
+        mix-blend-mode: screen;
+        opacity: 0.18;
+        animation:
+          border-flicker 3.2s steps(24, end) infinite,
+          border-pulse 6s ease-in-out infinite alternate;
+      }
+      @keyframes border-flicker {
+        0%,
+        7%,
+        9%,
+        100% {
+          opacity: 0.16;
+        }
+        8% {
+          opacity: 0.46;
+        }
+        31% {
+          opacity: 0.22;
+        }
+        33% {
+          opacity: 0.4;
+        }
+        54% {
+          opacity: 0.2;
+        }
+        55% {
+          opacity: 0.46;
+        }
+        78% {
+          opacity: 0.24;
+        }
+      }
+      @keyframes border-pulse {
+        0%,
+        100% {
+          filter: blur(7px) saturate(1.02);
+        }
+        50% {
+          filter: blur(8px) saturate(1.18);
+        }
+      }
+
+      /* Thin scanlines constrained to the edge */
+      .gb-scan {
+        padding: 1px;
+        -webkit-mask:
+          linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+          linear-gradient(hsl(var(--foreground)) 0 0);
+        -webkit-mask-composite: xor;
+        mask-composite: exclude;
+        background: repeating-linear-gradient(
+          0deg,
+          hsl(var(--foreground) / 0.1) 0 1px,
+          transparent 2px 4px
+        );
+        mix-blend-mode: soft-light;
+        opacity: 0.2;
+        animation: scan-move 5.2s linear infinite;
+      }
+      @keyframes scan-move {
+        0% {
+          transform: translateY(-10%);
+        }
+        100% {
+          transform: translateY(10%);
+        }
+      }
+
+      /* Light up when selected or open */
+      .glitch-trigger[data-lit="true"] .gb-iris,
+      .glitch-trigger[data-open="true"] .gb-iris {
+        opacity: 0.45;
+      }
+      .glitch-trigger[data-lit="true"] .gb-chroma,
+      .glitch-trigger[data-open="true"] .gb-chroma {
+        opacity: 0.48;
+      }
+      .glitch-trigger[data-lit="true"] .gb-flicker,
+      .glitch-trigger[data-open="true"] .gb-flicker {
+        opacity: 0.28;
+      }
+
+      /* Menu also glows a bit stronger */
+      [data-open="true"] .gb-iris {
+        opacity: 0.38;
+      }
+      [data-open="true"] .gb-chroma {
+        opacity: 0.42;
+      }
+      [data-open="true"] .gb-flicker {
+        opacity: 0.26;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .gb-iris,
+        .gb-chroma,
+        .gb-flicker,
+        .gb-scan,
+        .glitch-trigger:hover .caret {
+          animation: none;
+        }
+      }
+
+      /* subtle label RGB split on hover */
+      .glitch-text:hover {
+        text-shadow:
+          0.6px 0 hsl(210 100% 60% / 0.45),
+          -0.6px 0 hsl(330 100% 60% / 0.45);
+      }
+    
+                    </style>
+                  </div>
+                </div>
+                <button
+                  class="relative inline-flex items-center justify-center rounded-2xl border border-[--theme-ring] font-medium transition-all duration-200 focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--theme-ring] h-10 text-base gap-2 px-4 whitespace-nowrap bg-panel/85 overflow-hidden shadow-neo text-[hsl(var(--foreground))]"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="absolute inset-0 pointer-events-none rounded-2xl"
+                    style="background: linear-gradient(90deg, hsl(var(--foreground)/.18), hsl(var(--foreground)/.18));"
+                  />
+                  <span
+                    class="relative z-10 inline-flex items-center gap-2"
+                  >
+                    <svg
+                      class="lucide lucide-plus size-4"
+                      fill="none"
+                      height="24"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M5 12h14"
+                      />
+                      <path
+                        d="M12 5v14"
+                      />
+                    </svg>
+                    <span>
+                      New Review
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          aria-hidden="true"
+          class="absolute inset-0 rounded-2xl ring-1 ring-inset ring-[hsl(var(--border)/0.55)]"
+        />
+      </div>
+    </section>
+    <div
+      class="grid items-start gap-6 md:grid-cols-12"
+    >
+      <aside
+        class="md:col-span-5 md:w-72 lg:col-span-4 lg:w-80"
+      >
+        <div
+          class="card-neo-soft overflow-hidden bg-card/50 shadow-neo-strong"
+        >
+          <div
+            class="section-b"
+          >
+            <div
+              class="mb-2 text-sm text-muted-foreground"
+            >
+              3
+               shown
+            </div>
+            <div
+              class="rounded-xl border border-[hsl(var(--border)/0.25)] bg-[hsl(var(--card)/0.6)] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] w-full mx-auto backdrop-blur-sm max-h-screen overflow-auto p-2"
+            >
+              <ul
+                class="flex flex-col gap-3"
+              >
+                <li>
+                  <div
+                    data-scope="reviews"
+                  >
+                    <button
+                      aria-label="Open review: Alpha"
+                      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
+                      type="button"
+                    >
+                      <div
+                        class="grid grid-cols-[20px_1fr_auto] gap-3"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-[hsl(var(--muted-foreground))]"
+                        />
+                        <div
+                          class="min-w-0 flex flex-col gap-1"
+                        >
+                          <div
+                            class="truncate font-medium text-base"
+                          >
+                            Alpha
+                          </div>
+                          <div
+                            class="flex items-center gap-2 text-sm text-muted-foreground"
+                          />
+                        </div>
+                        <span
+                          class="self-start text-xs text-muted-foreground whitespace-nowrap"
+                        >
+                          1/1/1970
+                        </span>
+                      </div>
+                    </button>
+                  </div>
+                </li>
+                <li>
+                  <div
+                    data-scope="reviews"
+                  >
+                    <button
+                      aria-label="Open review: Gamma"
+                      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
+                      type="button"
+                    >
+                      <div
+                        class="grid grid-cols-[20px_1fr_auto] gap-3"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-[hsl(var(--muted-foreground))]"
+                        />
+                        <div
+                          class="min-w-0 flex flex-col gap-1"
+                        >
+                          <div
+                            class="truncate font-medium text-base"
+                          >
+                            Gamma
+                          </div>
+                          <div
+                            class="flex items-center gap-2 text-sm text-muted-foreground"
+                          />
+                        </div>
+                        <span
+                          class="self-start text-xs text-muted-foreground whitespace-nowrap"
+                        >
+                          1/1/1970
+                        </span>
+                      </div>
+                    </button>
+                  </div>
+                </li>
+                <li>
+                  <div
+                    data-scope="reviews"
+                  >
+                    <button
+                      aria-label="Open review: Beta"
+                      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
+                      type="button"
+                    >
+                      <div
+                        class="grid grid-cols-[20px_1fr_auto] gap-3"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-[hsl(var(--muted-foreground))]"
+                        />
+                        <div
+                          class="min-w-0 flex flex-col gap-1"
+                        >
+                          <div
+                            class="truncate font-medium text-base"
+                          >
+                            Beta
+                          </div>
+                          <div
+                            class="flex items-center gap-2 text-sm text-muted-foreground"
+                          />
+                        </div>
+                        <span
+                          class="self-start text-xs text-muted-foreground whitespace-nowrap"
+                        >
+                          1/1/1970
+                        </span>
+                      </div>
+                    </button>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </aside>
+      <div
+        class="md:col-span-7 lg:col-span-8 flex justify-center"
+      >
+        <div
+          class="max-w-[880px] w-full rounded-xl p-5 bg-[hsl(var(--card)/0.6)] ring-1 ring-[hsl(var(--ring)/0.05)] shadow-[0_0_40px_-12px_hsl(var(--glow-soft))] flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground"
+        >
+          <svg
+            class="lucide lucide-ghost h-6 w-6 opacity-60"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M9 10h.01"
+            />
+            <path
+              d="M15 10h.01"
+            />
+            <path
+              d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z"
+            />
+          </svg>
+          <p>
+            Select a review from the list or create a new one.
+          </p>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+`;


### PR DESCRIPTION
## Summary
- add comprehensive tests for ReviewsPage covering search filtering, sorting, new review creation, and panel toggling
- fix missing React imports in ReviewsPage and ReviewPanel components

## Testing
- `npm run regen-ui`
- `npm test -- -u`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf8b385020832c9cf6b2cd4a7da554