### PR TITLE
refactor: memoize task addition

### DIFF
--- a/src/components/planner/TaskList.tsx
+++ b/src/components/planner/TaskList.tsx
@@ -32,13 +32,13 @@ export default function TaskList({
     [tasks, selectedProjectId],
   );
 
-  function addTaskCommit() {
+  const addTaskCommit = React.useCallback(() => {
     const v = draftTask.trim();
     if (!v || !selectedProjectId) return;
     const id = addTask(v, selectedProjectId);
     setDraftTask("");
     if (id) setSelectedTaskId(id);
-  }
+  }, [draftTask, selectedProjectId, addTask, setSelectedTaskId]);
 
   return (
     <div className="flex flex-col gap-3 min-w-0">


### PR DESCRIPTION
## Summary
- memoize task addition handler in TaskList

## Testing
- `npm run regen-ui`
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf8f1f6a8c832ca27d52f7ea57258d