### PR TITLE
refactor: use crypto UUID for goal ids

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -27,7 +27,7 @@ import GoalsTabs, { FilterKey } from "./GoalsTabs";
 import GoalForm, { GoalFormHandle } from "./GoalForm";
 import GoalsProgress from "./GoalsProgress";
 
-import { usePersistentState, uid } from "@/lib/db";
+import { usePersistentState } from "@/lib/db";
 import type { Goal, Pillar } from "@/lib/types";
 import { shortDate } from "@/lib/date";
 
@@ -123,7 +123,7 @@ export default function GoalsPage() {
       return setErr("Cap reached. Mark something done first.");
 
     const g: Goal = {
-      id: uid("goal"),
+      id: crypto.randomUUID(),
       title: title.trim(),
       ...(pillar ? { pillar } : {}),
       metric: metric.trim() || undefined,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -183,18 +183,11 @@ export function usePersistentState<T>(
 }
 
 /**
- * Tiny uid helper.
- * Uses `crypto.randomUUID` when available; falls back to `Math.random`.
- * Example: "review_123e4567e89b12d3"
+ * Generates a unique identifier using `crypto.randomUUID`.
+ * If a prefix is provided, it is prepended followed by an underscore.
  */
-export function uid(prefix = "id"): string {
-  const id =
-    typeof globalThis.crypto?.randomUUID === "function"
-      ? globalThis.crypto.randomUUID().replace(/-/g, "").slice(0, 16)
-      : (
-          Math.random().toString(36).slice(2) +
-          Math.random().toString(36).slice(2)
-        ).slice(0, 16);
-  return `${prefix}_${id}`;
+export function uid(prefix = ""): string {
+  const id = crypto.randomUUID();
+  return prefix ? `${prefix}_${id}` : id;
 }
 


### PR DESCRIPTION
## Summary
- use `crypto.randomUUID()` when adding goals
- wrap `crypto.randomUUID()` in `uid` helper for consistent ID generation

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf900e5d88832cba92752156cdecca