### PR TITLE
fix: trim className spaces in RemindersTab

### DIFF
--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -273,7 +273,7 @@ export default function RemindersTab() {
                 e.preventDefault();
                 if (quickAdd.trim()) addNew(quickAdd);
               }}
-              className=" rounded-card flex items-center gap-6 glitch"
+              className="rounded-card flex items-center gap-6 glitch"
             >
               <Input
                 aria-label="Quick add reminder"
@@ -459,7 +459,7 @@ function RemTile({
           )}
         </div>
 
-        <div className=" flex items-center gap-1">
+        <div className="flex items-center gap-1">
           <IconButton
             title="Edit"
             aria-label="Edit"


### PR DESCRIPTION
## Summary
- remove stray leading spaces from RemindersTab class strings

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf90c90274832c9bcb6b689e124fef