### PR TITLE
Sanitize champion names in MyComps

### DIFF
--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -28,6 +28,7 @@ import {
   NotebookPen,
   Plus,
 } from "lucide-react";
+import { sanitizeText } from "@/lib/utils";
 
 /* ───────────── Types ───────────── */
 
@@ -157,18 +158,19 @@ function ChampChips({
 
   function setAt(i: number, next: string) {
     const arr = [...champs];
-    arr[i] = next;
-    onChange(arr.filter(s => s.trim().length));
+    arr[i] = sanitizeText(next);
+    onChange(arr.map(sanitizeText).filter(s => s.trim().length));
   }
   function insertAfter(i: number) {
     const arr = [...champs];
     arr.splice(i + 1, 0, "");
-    onChange(arr.length ? arr : [""]);
+    const nextArr = arr.length ? arr : [""];
+    onChange(nextArr.map(sanitizeText));
   }
   function removeAt(i: number) {
     const arr = [...champs];
     arr.splice(i, 1);
-    onChange(arr);
+    onChange(arr.map(sanitizeText));
   }
 
   return (


### PR DESCRIPTION
## Summary
- sanitize champion inputs in MyComps to strip unsafe markup before saving

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf930bb3d8832ca0a40f5bd39bfc79