### PR TITLE
refactor: use Plus icon in reminders

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import * as React from "react";
-import { TabBar, Header, Hero, Button, type TabItem, Input } from "@/components/ui";
+import { TabBar, Header, Hero, Button, IconButton, type TabItem, Input } from "@/components/ui";
 import Banner from "@/components/chrome/Banner";
 import { GoalsProgress } from "@/components/goals";
 import { RoleSelector, NeonIcon } from "@/components/reviews";
 import { ComponentGallery, ColorGallery } from "@/components/prompts";
 import { ROLE_OPTIONS } from "@/components/reviews/reviewData";
 import type { Role } from "@/lib/types";
+import { Plus } from "lucide-react";
 
 type View = "components" | "colors";
 
@@ -81,6 +82,11 @@ export default function Page() {
         <Button tone="danger" variant="primary">
           Danger primary
         </Button>
+      </div>
+      <div className="mb-8 flex gap-2">
+        <IconButton aria-label="Add item" title="Add item">
+          <Plus size={16} aria-hidden />
+        </IconButton>
       </div>
       <p className="mb-4 text-xs text-danger">Example error message</p>
       <div className="mb-8">

--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -34,6 +34,7 @@ import {
   Gamepad2,
   GraduationCap,
   Pencil,
+  Plus,
 } from "lucide-react";
 
 /* ───────── Types & seeds ───────── */
@@ -283,7 +284,7 @@ export default function RemindersTab() {
                 className="flex-1"
               />
               <IconButton title="Add quick" aria-label="Add quick" type="submit" size="md" variant="solid">
-                <svg width="16" height="16" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round"/></svg>
+                <Plus size={16} aria-hidden />
               </IconButton>
               <div className={neonClass}>
                 <p className="neon-note text-xs italic">Stop procrastinating, do it now if you have time</p>


### PR DESCRIPTION
## Summary
- replace inline SVG with `Plus` icon in reminders quick-add
- showcase `IconButton` usage in prompts gallery

## Testing
- `npm run regen-ui`
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`
- `npm run verify-prompts`

------
https://chatgpt.com/codex/tasks/task_e_68bf955e128c832c9cbd9a366cefe5b9