### PR TITLE
feat: improve champion input accessibility

### DIFF
--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -380,6 +380,8 @@ function ChampPillsEdit({
                 removeAt(i);
               }
             }}
+            aria-label="Champion name"
+            autoComplete="off"
             className="bg-transparent border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] w-24"
           />
         </span>

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -193,6 +193,8 @@ function ChampChips({
                 removeAt(i);
               }
             }}
+            aria-label="Champion name"
+            autoComplete="off"
             className="bg-transparent border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] w-24"
           />
         </span>


### PR DESCRIPTION
## Summary
- add descriptive labels and disable autocomplete for champion inputs in cheat sheet and my comps

## Testing
- `npm run regen-ui`
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf977bd42c832c864d6f2261db26df