### PR TITLE
feat: add glow IconButton variant

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -100,6 +100,9 @@ export default function Page() {
         <IconButton aria-label="Add item" title="Add item">
           <Plus size={16} aria-hidden />
         </IconButton>
+        <IconButton variant="glow" aria-label="Add item glow" title="Add item glow">
+          <Plus size={16} aria-hidden />
+        </IconButton>
       </div>
       <p className="mb-4 text-xs text-danger">Example error message</p>
       <div className="mb-8">

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -122,6 +122,14 @@ export default function ComponentGallery() {
         ),
       },
       {
+        label: "IconButton Glow",
+        element: (
+          <IconButton variant="glow" size="md" aria-label="Star" title="Star">
+            <Star />
+          </IconButton>
+        ),
+      },
+      {
         label: "Segmented",
         element: (
           <GlitchSegmentedGroup value={seg} onChange={setSeg} className="w-56">

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -35,7 +35,7 @@ const sizeMap: Record<IconButtonSize, string> = {
 const variantBase: Record<Variant, string> = {
   ring: "border bg-transparent hover:bg-panel/45",
   solid: "border",
-  glow: "border bg-transparent hover:bg-panel/45",
+  glow: "border bg-transparent hover:bg-panel/45 shadow-[0_0_8px_currentColor]",
 };
 
 const toneClasses: Record<Variant, Record<Tone, string>> = {
@@ -61,13 +61,13 @@ const toneClasses: Record<Variant, Record<Tone, string>> = {
   },
   glow: {
     primary:
-      "border-[hsl(var(--foreground)/0.35)] text-[hsl(var(--foreground))] shadow-[0_0_8px_hsl(var(--foreground)/0.3)]",
+      "border-[hsl(var(--foreground)/0.35)] text-[hsl(var(--foreground))]",
     accent:
-      "border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))] shadow-[0_0_8px_hsl(var(--accent)/0.3)]",
+      "border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))]",
     info:
-      "border-[hsl(var(--accent-2)/0.35)] text-[hsl(var(--accent-2))] shadow-[0_0_8px_hsl(var(--accent-2)/0.3)]",
+      "border-[hsl(var(--accent-2)/0.35)] text-[hsl(var(--accent-2))]",
     danger:
-      "border-[hsl(var(--danger)/0.35)] text-[hsl(var(--danger))] shadow-[0_0_8px_hsl(var(--danger)/0.3)]",
+      "border-[hsl(var(--danger)/0.35)] text-[hsl(var(--danger))]",
   },
 };
 

--- a/tests/primitives/icon-button.test.tsx
+++ b/tests/primitives/icon-button.test.tsx
@@ -88,9 +88,11 @@ describe("IconButton", () => {
       <IconButton variant="glow" tone="info" aria-label="gi" />,
     );
     const classes = getByRole("button").className;
-    expect(classes).toContain("border bg-transparent hover:bg-panel/45");
     expect(classes).toContain(
-      "border-[hsl(var(--accent-2)/0.35)] text-[hsl(var(--accent-2))] shadow-[0_0_8px_hsl(var(--accent-2)/0.3)]",
+      "border bg-transparent hover:bg-panel/45 shadow-[0_0_8px_currentColor]",
+    );
+    expect(classes).toContain(
+      "border-[hsl(var(--accent-2)/0.35)] text-[hsl(var(--accent-2))]",
     );
   });
 
@@ -103,5 +105,6 @@ describe("IconButton", () => {
     expect(classes).toContain(
       "border-[hsl(var(--danger)/0.35)] text-[hsl(var(--danger))]",
     );
+    expect(classes).not.toContain("shadow-[0_0_8px_currentColor]");
   });
 });


### PR DESCRIPTION
## Summary
- add distinctive glow shadow to IconButton variant
- demo glow variant in ComponentGallery and prompts page
- test glow variant class list

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf9bd1182c832c829283811e5a2a4b