### PR TITLE
feat(theme): matrix green hardstuck palette

### DIFF
--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -292,36 +292,38 @@ html.theme-kitten {
 
 /* ---------- Hardstuck ---------- */
 html.theme-hardstuck {
-  --background: 165 60% 3%;
-  --foreground: 160 12% 95%;
+  --background: 120 60% 2%;
+  --foreground: 120 100% 70%;
   --text: var(--foreground);
-  --card: 165 55% 7%;
+  --card: 120 55% 5%;
   --panel: var(--card);
-  --border: 165 40% 22%;
+  --border: 120 40% 20%;
   --line: var(--border);
-  --input: 165 45% 10%;
-  --ring: 160 100% 60%;
+  --input: 120 45% 8%;
+  --ring: 120 100% 60%;
   --theme-ring: hsl(var(--ring));
-  --primary: 160 100% 60%;
-  --primary-foreground: 0 0% 100%;
-  --primary-soft: 160 100% 24%;
-  --accent: 284 100% 24%;
-  --accent-2: 160 100% 20%;
-  --accent-foreground: 0 0% 100%;
-  --accent-soft: 284 100% 10%;
-  --glow: 160 100% 60%;
-  --ring-muted: 165 30% 20%;
+  --primary: 120 100% 60%;
+  --primary-foreground: 0 0% 0%;
+  --primary-soft: 120 100% 24%;
+  --accent: 120 100% 60%;
+  --accent-2: 120 100% 20%;
+  --accent-foreground: 0 0% 0%;
+  --text-on-accent: hsl(var(--background));
+  --accent-soft: 120 100% 12%;
+  --glow: 120 100% 60%;
+  --ring-muted: 120 30% 20%;
   --danger: 0 84% 60%;
-  --muted: 165 35% 14%;
-  --muted-foreground: 165 15% 70%;
-  --surface: 165 32% 12%;
-  --surface-2: 165 32% 16%;
-  --surface-vhs: 210 27% 6%;
-  --surface-streak: 240 16% 12%;
-  --shadow-color: 160 100% 40%;
-  --lav-deep: 300 90% 60%;
-  --success: 150 70% 50%;
-  --success-glow: 150 70% 40% / 0.6;
+  --muted: 120 35% 10%;
+  --muted-foreground: 120 15% 70%;
+  --surface: 120 32% 8%;
+  --surface-2: 120 32% 12%;
+  --surface-vhs: 120 27% 4%;
+  --surface-streak: 120 16% 10%;
+  --shadow-color: 120 100% 40%;
+  --lav-deep: 120 100% 50%;
+  --icon-fg: 120 100% 60%;
+  --success: 120 100% 50%;
+  --success-glow: 120 100% 40% / 0.6;
 }
 
 /* =========================================================
@@ -487,22 +489,22 @@ html.theme-kitten body::after {
 /* Hardstuck backdrop */
 html.theme-hardstuck body {
   background-image:
-    radial-gradient(1000px 520px at 20% -10%, hsl(160 100% 60% / 0.15), transparent 60%),
-    radial-gradient(900px 520px at 110% 15%, hsl(300 90% 60% / 0.12), transparent 60%),
+    radial-gradient(1000px 520px at 20% -10%, hsl(120 100% 60% / 0.15), transparent 60%),
+    radial-gradient(900px 520px at 110% 15%, hsl(120 80% 40% / 0.12), transparent 60%),
     linear-gradient(180deg, hsl(var(--card) / 0.9), hsl(var(--background)));
   background-attachment: fixed, fixed, fixed;
 }
 html.theme-hardstuck body::before {
   content:""; position:fixed; inset:0; pointer-events:none; z-index:0;
-  background: repeating-linear-gradient(0deg, hsl(160 100% 60% / 0.05) 0 1px, transparent 1px 3px);
+  background: repeating-linear-gradient(0deg, hsl(120 100% 60% / 0.05) 0 1px, transparent 1px 3px);
   mix-blend-mode: screen; opacity:0.2; animation: hardstuck-scan 14s linear infinite;
 }
 html.theme-hardstuck body::after {
   content:""; position:fixed; inset:-12%; pointer-events:none; z-index:0;
   background:
-    radial-gradient(80% 60% at 50% 120%, hsl(160 90% 6% / 0.45), transparent 70%),
-    radial-gradient(40% 25% at 6% 4%,  hsl(160 100% 60% / 0.15), transparent 60%),
-    radial-gradient(40% 25% at 94% 10%, hsl(300 80% 60% / 0.12), transparent 60%);
+    radial-gradient(80% 60% at 50% 120%, hsl(120 90% 6% / 0.45), transparent 70%),
+    radial-gradient(40% 25% at 6% 4%,  hsl(120 100% 60% / 0.15), transparent 60%),
+    radial-gradient(40% 25% at 94% 10%, hsl(120 80% 40% / 0.12), transparent 60%);
   filter: blur(1.5px) saturate(110%); opacity:0.9; animation: hardstuck-drift 26s ease-in-out infinite alternate;
 }
 @keyframes hardstuck-scan { 0%{background-position-y:0} 100%{background-position-y:100%} }


### PR DESCRIPTION
## Summary
- restyle Hardstuck theme tokens and backdrop to neon Matrix green

## Testing
- `npm run regen-ui`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68bf9c7a55a0832cb911939582f9bb86