### PR TITLE
feat: add xs icon button size

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -85,6 +85,9 @@ export default function Page() {
           Hero dividers now use <code>var(--space-4)</code> top padding and
           tokenized side offsets via <code>var(--space-2)</code>.
         </li>
+        <li className="text-sm text-muted-foreground">
+          IconButton adds a compact <code>xs</code> size.
+        </li>
       </ul>
       <div className="mb-8 flex flex-wrap gap-2">
         <Button tone="primary">Primary tone</Button>
@@ -97,6 +100,9 @@ export default function Page() {
         </Button>
       </div>
       <div className="mb-8 flex gap-2">
+        <IconButton size="xs" aria-label="Add item xs" title="Add item xs">
+          <Plus size={16} aria-hidden />
+        </IconButton>
         <IconButton aria-label="Add item" title="Add item">
           <Plus size={16} aria-hidden />
         </IconButton>

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -188,6 +188,9 @@ export default function ComponentGallery() {
         label: "Icon Button",
         element: (
           <div className="w-56 flex justify-center gap-2">
+            <IconButton size="xs" aria-label="Add" title="Add">
+              <Plus />
+            </IconButton>
             <IconButton aria-label="Add" title="Add">
               <Plus />
             </IconButton>

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 import type { ButtonSize } from "./Button";
 
-type IconButtonSize = ButtonSize | "xl";
+export type IconButtonSize = ButtonSize | "xl" | "xs";
 type Icon = "xs" | "sm" | "md" | "lg" | "xl";
 
 type Tone = "primary" | "accent" | "info" | "danger";
@@ -26,6 +26,7 @@ const iconMap: Record<Icon, string> = {
 };
 
 const sizeMap: Record<IconButtonSize, string> = {
+  xs: "h-8 w-8",
   sm: "h-9 w-9",
   md: "h-10 w-10",
   lg: "h-11 w-11",

--- a/tests/primitives/icon-button.test.tsx
+++ b/tests/primitives/icon-button.test.tsx
@@ -29,6 +29,7 @@ describe("IconButton", () => {
   });
 
   const sizeCases = [
+    ["xs", "h-8 w-8"],
     ["sm", "h-9 w-9"],
     ["md", "h-10 w-10"],
     ["lg", "h-11 w-11"],


### PR DESCRIPTION
## Summary
- extend IconButton to support new `xs` size
- document `xs` IconButton in prompts gallery
- cover `xs` size in IconButton tests

## Testing
- `node -e "const cliProgress = require('cli-progress'); const { MultiBar, Presets } = cliProgress; const { execSync } = require('child_process'); const tasks = ['npm run regen-ui', 'npm test -- --run', 'npm run lint', 'npm run typecheck']; const bars = new MultiBar({ clearOnComplete: false, hideCursor: true }, Presets.shades_grey); const bar = bars.create(tasks.length, 0); for (const cmd of tasks) { execSync(cmd, { stdio: 'inherit' }); bar.increment(); } bars.stop();"`


------
https://chatgpt.com/codex/tasks/task_e_68bf9e509320832c80cf000d657d6866