### PR TITLE
feat: organize color tokens into palettes

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -85,6 +85,10 @@ export default function Page() {
           Hero dividers now use <code>var(--space-4)</code> top padding and
           tokenized side offsets via <code>var(--space-2)</code>.
         </li>
+        <li className="text-sm text-muted-foreground">
+          Color gallery groups tokens into aurora, neutrals, and accents
+          palettes.
+        </li>
       </ul>
       <div className="mb-8 flex flex-wrap gap-2">
         <Button tone="primary">Primary tone</Button>

--- a/src/components/prompts/ColorGallery.tsx
+++ b/src/components/prompts/ColorGallery.tsx
@@ -1,33 +1,54 @@
 "use client";
 
 import * as React from "react";
-import { COLOR_TOKENS } from "@/lib/theme";
+import {
+  COLOR_PALETTES,
+  COLOR_PALETTE_TABS,
+  type ColorPalette,
+} from "@/lib/theme";
+import { TabBar, type TabItem } from "@/components/ui";
 
 export default function ColorGallery() {
+  const paletteTabs: TabItem<ColorPalette>[] = COLOR_PALETTE_TABS.map(
+    ({ id, label }) => ({ key: id, label }),
+  );
+  const [palette, setPalette] = React.useState<ColorPalette>("aurora");
+  const tokens = COLOR_PALETTES[palette];
+
   return (
-    <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
-      <div className="flex flex-col items-center gap-2 sm:col-span-2 md:col-span-3">
-        <span className="text-sm font-medium">Aurora Palette</span>
-        <div className="flex gap-2">
-          <div className="w-10 h-10 rounded bg-auroraG" />
-          <div className="w-10 h-10 rounded bg-auroraGLight" />
-          <div className="w-10 h-10 rounded bg-auroraP" />
-          <div className="w-10 h-10 rounded bg-auroraPLight" />
-        </div>
-        <p className="text-xs text-muted-foreground mt-2 text-center">
-          Use <code>auroraG</code>, <code>auroraGLight</code>, <code>auroraP</code>,
-          and<code>auroraPLight</code> Tailwind classes for aurora effects.
-        </p>
+    <div className="space-y-4">
+      <TabBar
+        items={paletteTabs}
+        value={palette}
+        onValueChange={(p) => setPalette(p)}
+        ariaLabel="Color palettes"
+      />
+      <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
+        {palette === "aurora" && (
+          <div className="flex flex-col items-center gap-2 sm:col-span-2 md:col-span-3">
+            <span className="text-sm font-medium">Aurora Palette</span>
+            <div className="flex gap-2">
+              <div className="w-10 h-10 rounded bg-auroraG" />
+              <div className="w-10 h-10 rounded bg-auroraGLight" />
+              <div className="w-10 h-10 rounded bg-auroraP" />
+              <div className="w-10 h-10 rounded bg-auroraPLight" />
+            </div>
+            <p className="text-xs text-muted-foreground mt-2 text-center">
+              Use <code>auroraG</code>, <code>auroraGLight</code>, <code>auroraP</code>,
+              and<code>auroraPLight</code> Tailwind classes for aurora effects.
+            </p>
+          </div>
+        )}
+        {tokens.map((c) => (
+          <div key={c} className="flex flex-col items-center gap-2">
+            <span className="text-xs uppercase tracking-wide text-accent">{c}</span>
+            <div
+              className="w-24 h-16 rounded-md border"
+              style={{ backgroundColor: `hsl(var(--${c}))` }}
+            />
+          </div>
+        ))}
       </div>
-      {COLOR_TOKENS.map((c) => (
-        <div key={c} className="flex flex-col items-center gap-2">
-          <span className="text-xs uppercase tracking-wide text-accent">{c}</span>
-          <div
-            className="w-24 h-16 rounded-md border"
-            style={{ backgroundColor: `hsl(var(--${c}))` }}
-          />
-        </div>
-      ))}
     </div>
   );
 }

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -62,6 +62,46 @@ export const COLOR_TOKENS = [
   "icon-fg",
 ] as const;
 
+export type ColorToken = typeof COLOR_TOKENS[number];
+export type ColorPalette = "aurora" | "neutrals" | "accents";
+
+export const COLOR_PALETTES: Record<ColorPalette, readonly ColorToken[]> = {
+  aurora: ["aurora-g", "aurora-g-light", "aurora-p", "aurora-p-light"],
+  neutrals: [
+    "background",
+    "foreground",
+    "text",
+    "card",
+    "panel",
+    "border",
+    "line",
+    "input",
+    "ring",
+    "muted",
+    "muted-foreground",
+    "surface",
+    "surface-2",
+    "surface-vhs",
+    "surface-streak",
+  ],
+  accents: [
+    "accent",
+    "accent-2",
+    "accent-foreground",
+    "danger",
+    "success",
+    "glow-strong",
+    "glow-soft",
+    "icon-fg",
+  ],
+};
+
+export const COLOR_PALETTE_TABS: { id: ColorPalette; label: string }[] = [
+  { id: "aurora", label: "Aurora" },
+  { id: "neutrals", label: "Neutrals" },
+  { id: "accents", label: "Accents" },
+];
+
 export const VARIANTS: { id: Variant; label: string }[] = [
   { id: "lg", label: "Glitch" },
   { id: "aurora", label: "Aurora" },


### PR DESCRIPTION
## Summary
- group color tokens into aurora, neutral, and accent palettes
- add TabBar in `ColorGallery` to filter palettes
- document palette tabs on prompts page

## Testing
- `node -e "const cliProgress=require('cli-progress'); const { execSync } = require('child_process'); const tasks=['npm run regen-ui','npm test -- --run','npm run lint','npm run typecheck']; const bars=new cliProgress.MultiBar({ clearOnComplete:false, hideCursor:true }, cliProgress.Presets.shades_grey); const bar=bars.create(tasks.length,0); tasks.forEach((cmd,i)=>{execSync(cmd,{stdio:'inherit'}); bar.update(i+1);}); bars.stop();"`

------
https://chatgpt.com/codex/tasks/task_e_68bf9edf7cb0832caef56aea5b46dec6