### PR TITLE
feat(ui): add disabled button styles

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -95,6 +95,7 @@ export default function Page() {
         <Button tone="danger" variant="primary">
           Danger primary
         </Button>
+        <Button disabled>Disabled</Button>
       </div>
       <div className="mb-8 flex gap-2">
         <IconButton aria-label="Add item" title="Add item">

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -53,12 +53,12 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ) => {
     const s = buttonSizes[size];
     const base = cn(
-      "relative inline-flex items-center justify-center rounded-2xl border border-[--theme-ring] font-medium transition-all duration-200 focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--theme-ring]",
+      "relative inline-flex items-center justify-center rounded-2xl border border-[--theme-ring] font-medium transition-all duration-200 focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--theme-ring] disabled:opacity-50 disabled:pointer-events-none",
       s.height,
       s.padding,
       s.text,
       s.gap,
-      className
+      className,
     );
 
     const colorVar: Record<Tone, string> = {

--- a/tests/primitives/button.test.tsx
+++ b/tests/primitives/button.test.tsx
@@ -1,29 +1,45 @@
-import React from 'react';
-import { render, cleanup } from '@testing-library/react';
-import { describe, it, expect, afterEach } from 'vitest';
-import { Button } from '../../src/components/ui/primitives/Button';
+import React from "react";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { Button } from "../../src/components/ui/primitives/Button";
 
 afterEach(cleanup);
 
-describe('Button', () => {
-  it('renders its children', () => {
+describe("Button", () => {
+  it("renders its children", () => {
     const { getByRole } = render(<Button>Click me</Button>);
-    expect(getByRole('button')).toHaveTextContent('Click me');
+    expect(getByRole("button")).toHaveTextContent("Click me");
   });
 
-  it('applies variant classes', () => {
+  it("applies variant classes", () => {
     const { getByRole } = render(
-      <Button className="btn-primary">Click me</Button>
+      <Button className="btn-primary">Click me</Button>,
     );
-    expect(getByRole('button')).toHaveClass('btn-primary');
+    expect(getByRole("button")).toHaveClass("btn-primary");
   });
 
-  it('has no outline when focused', () => {
+  it("has no outline when focused", () => {
     const { getByRole } = render(<Button>Focus</Button>);
-    const btn = getByRole('button');
+    const btn = getByRole("button");
     btn.focus();
     const style = getComputedStyle(btn);
-    expect(style.outlineStyle === 'none' || style.outlineStyle === '').toBe(true);
-    expect(style.outlineWidth === '0px' || style.outlineWidth === '').toBe(true);
+    expect(style.outlineStyle === "none" || style.outlineStyle === "").toBe(true);
+    expect(style.outlineWidth === "0px" || style.outlineWidth === "").toBe(true);
+  });
+
+  it("has reduced opacity and no pointer events when disabled", () => {
+    const onClick = vi.fn();
+    const { getByRole } = render(
+      <Button disabled onClick={onClick}>
+        Disabled
+      </Button>,
+    );
+    const btn = getByRole("button");
+    expect(btn).toHaveClass(
+      "disabled:opacity-50",
+      "disabled:pointer-events-none",
+    );
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
   });
 });

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -697,7 +697,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                   </div>
                 </div>
                 <button
-                  class="relative inline-flex items-center justify-center rounded-2xl border border-[--theme-ring] font-medium transition-all duration-200 focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--theme-ring] h-10 text-base gap-2 px-4 whitespace-nowrap bg-panel/85 overflow-hidden shadow-neo text-[hsl(var(--foreground))]"
+                  class="relative inline-flex items-center justify-center rounded-2xl border border-[--theme-ring] font-medium transition-all duration-200 focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--theme-ring] disabled:opacity-50 disabled:pointer-events-none h-10 text-base gap-2 px-4 whitespace-nowrap bg-panel/85 overflow-hidden shadow-neo text-[hsl(var(--foreground))]"
                   tabindex="0"
                   type="button"
                 >


### PR DESCRIPTION
## Summary
- add opacity and pointer-events styles for disabled buttons
- show disabled button example on prompts page
- test Button disabled state and update snapshots

## Testing
- `npm run regen-ui`
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf9ecffc04832c89345c99b8f21aa1