### PR TITLE
refactor: use semantic colors in review UI

### DIFF
--- a/src/components/reviews/ReviewCard.tsx
+++ b/src/components/reviews/ReviewCard.tsx
@@ -19,7 +19,7 @@ export default function ReviewCard({
   const created = review.createdAt ? new Date(review.createdAt) : null;
 
   return (
-    <div className={cn("p-3 rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))]/85", active && "shadow-lg")}>
+    <div className={cn("p-3 rounded-2xl border border-border bg-card/85", active && "shadow-lg")}> 
       <div className="flex items-start gap-2">
         <div className="min-w-0 flex-1">
           <div className="flex items-center justify-between gap-2">

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -495,8 +495,8 @@ export default function ReviewEditor({
             }}
             className={cn(
               "relative inline-flex h-10 w-48 select-none items-center overflow-hidden rounded-2xl",
-              "border border-[hsl(var(--border))] bg-[hsl(var(--card))]",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
+              "border border-border bg-card",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             )}
             title="Toggle Win/Loss"
           >
@@ -509,8 +509,8 @@ export default function ReviewEditor({
                 transitionTimingFunction: "cubic-bezier(.22,1,.36,1)",
                 background:
                   result === "Win"
-                    ? "linear-gradient(90deg, hsla(160,90%,45%,.32), hsla(190,90%,60%,.28))"
-                    : "linear-gradient(90deg, hsla(0,90%,55%,.30), hsla(320,90%,65%,.26))",
+                    ? "linear-gradient(90deg, hsl(var(--success)/0.32), hsl(var(--accent)/0.28))"
+                    : "linear-gradient(90deg, hsl(var(--danger)/0.30), hsl(var(--primary)/0.26))",
                 boxShadow: "0 10px 30px hsl(var(--shadow-color) / .25)",
               }}
             />
@@ -518,7 +518,7 @@ export default function ReviewEditor({
               <div
                 className={cn(
                   "py-2 text-center",
-                  result === "Win" ? "text-[hsl(var(--foreground)/0.7)]" : "text-[hsl(var(--muted-foreground))]"
+                  result === "Win" ? "text-foreground/70" : "text-muted-foreground"
                 )}
               >
                 Win
@@ -526,7 +526,7 @@ export default function ReviewEditor({
               <div
                 className={cn(
                   "py-2 text-center",
-                  result === "Loss" ? "text-[hsl(var(--foreground)/0.7)]" : "text-[hsl(var(--muted-foreground))]"
+                  result === "Loss" ? "text-foreground/70" : "text-muted-foreground"
                 )}
               >
                 Loss
@@ -538,7 +538,7 @@ export default function ReviewEditor({
         {/* Score */}
         <div>
           <SectionLabel>Score</SectionLabel>
-          <div className="relative h-12 rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-4">
+          <div className="relative h-12 rounded-2xl border border-border bg-card px-4">
             <input
               ref={scoreRangeRef}
               type="range"
@@ -561,16 +561,13 @@ export default function ReviewEditor({
               aria-label="Score from 0 to 10"
             />
             <div className="absolute left-4 right-4 top-1/2 -translate-y-1/2">
-              <div className="relative h-2 w-full rounded-full bg-[hsl(var(--muted))] shadow-[inset_2px_2px_4px_hsl(var(--shadow-color)/0.45),inset_-2px_-2px_4px_hsl(var(--foreground)/0.06)]">
+              <div className="relative h-2 w-full rounded-full bg-muted shadow-[inset_2px_2px_4px_hsl(var(--shadow-color)/0.45),inset_-2px_-2px_4px_hsl(var(--foreground)/0.06)]">
                 <div
-                  className="absolute left-0 top-0 h-2 rounded-full shadow-[0_0_8px_hsl(var(--primary)/0.5)]"
-                  style={{
-                    width: `calc(${(score / 10) * 100}% + 10px)`,
-                    background: "linear-gradient(90deg, hsl(var(--primary)), hsl(var(--accent)))",
-                  }}
+                  className="absolute left-0 top-0 h-2 rounded-full bg-gradient-to-r from-primary to-accent shadow-[0_0_8px_hsl(var(--primary)/0.5)]"
+                  style={{ width: `calc(${(score / 10) * 100}% + 10px)` }}
                 />
                 <div
-                  className="absolute top-1/2 h-5 w-5 -translate-y-1/2 rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--card))] shadow-[0_10px_25px_hsl(var(--shadow-color)/.25)]"
+                  className="absolute top-1/2 h-5 w-5 -translate-y-1/2 rounded-full border border-border bg-card shadow-[0_10px_25px_hsl(var(--shadow-color)/.25)]"
                   style={{ left: `calc(${(score / 10) * 100}% - 10px)` }}
                 />
               </div>
@@ -590,7 +587,7 @@ export default function ReviewEditor({
               type="button"
               aria-label={focusOn ? "Brain light on" : "Brain light off"}
               aria-pressed={focusOn}
-              className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
+              className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               onClick={() => {
                 const v = !focusOn;
                 setFocusOn(v);
@@ -612,7 +609,7 @@ export default function ReviewEditor({
 
           {focusOn && (
             <>
-              <div className="mt-3 relative h-12 rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-4">
+          <div className="mt-3 relative h-12 rounded-2xl border border-border bg-card px-4">
                 <input
                   ref={focusRangeRef}
                   type="range"
@@ -629,17 +626,13 @@ export default function ReviewEditor({
                   aria-label="Focus from 0 to 10"
                 />
                 <div className="absolute left-4 right-4 top-1/2 -translate-y-1/2">
-                  <div className="relative h-2 w-full rounded-full bg-[hsl(var(--muted))] shadow-[inset_2px_2px_4px_hsl(var(--shadow-color)/0.45),inset_-2px_-2px_4px_hsl(var(--foreground)/0.06)]">
+                  <div className="relative h-2 w-full rounded-full bg-muted shadow-[inset_2px_2px_4px_hsl(var(--shadow-color)/0.45),inset_-2px_-2px_4px_hsl(var(--foreground)/0.06)]">
                     <div
-                      className="absolute left-0 top-0 h-2 rounded-full shadow-[0_0_8px_hsl(var(--accent)/0.5)]"
-                      style={{
-                        width: `calc(${(focus / 10) * 100}% + 10px)`,
-                        background:
-                          "linear-gradient(90deg, hsl(var(--accent)), hsl(var(--primary)))",
-                      }}
+                      className="absolute left-0 top-0 h-2 rounded-full bg-gradient-to-r from-accent to-primary shadow-[0_0_8px_hsl(var(--accent)/0.5)]"
+                      style={{ width: `calc(${(focus / 10) * 100}% + 10px)` }}
                     />
                     <div
-                      className="absolute top-1/2 h-5 w-5 -translate-y-1/2 rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--card))] shadow-[0_10px_25px_hsl(var(--shadow-color)/.25)]"
+                      className="absolute top-1/2 h-5 w-5 -translate-y-1/2 rounded-full border border-border bg-card shadow-[0_10px_25px_hsl(var(--shadow-color)/.25)]"
                       style={{ left: `calc(${(focus / 10) * 100}% - 10px)` }}
                     />
                   </div>
@@ -666,7 +659,7 @@ export default function ReviewEditor({
                   onClick={() => togglePillar(p)}
                   onKeyDown={(e) => onIconKey(e, () => togglePillar(p))}
                   aria-pressed={active}
-                  className="rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
+                  className="rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   title={active ? `${p} selected` : `Select ${p}`}
                 >
                   <NeonPillarChip active={active}>
@@ -685,7 +678,7 @@ export default function ReviewEditor({
               type="button"
               aria-label="Use timestamp"
               aria-pressed={useTimestamp}
-              className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
+              className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               onClick={() => {
                 setUseTimestamp(true);
                 setLastMarkerMode(true);
@@ -707,7 +700,7 @@ export default function ReviewEditor({
               type="button"
               aria-label="Use note only"
               aria-pressed={!useTimestamp}
-              className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
+              className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               onClick={() => {
                 setUseTimestamp(false);
                 setLastMarkerMode(false);
@@ -753,7 +746,7 @@ export default function ReviewEditor({
               />
             ) : (
               <span
-                className="inline-flex h-10 items-center justify-center gap-2 rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 text-sm text-[hsl(var(--foreground)/0.7)]"
+                className="inline-flex h-10 items-center justify-center gap-2 rounded-2xl border border-border bg-card px-3 text-sm text-foreground/70"
                 style={{ width: "calc(5ch + 1.5rem)" }}
                 title="Timestamp disabled"
               >
@@ -801,7 +794,7 @@ export default function ReviewEditor({
               {sortedMarkers.map((m) => (
                 <li
                   key={m.id}
-                  className="grid grid-cols-[auto_1fr_auto] items-center gap-2 rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2"
+                  className="grid grid-cols-[auto_1fr_auto] items-center gap-2 rounded-2xl border border-border bg-card px-3 py-2"
                 >
                   {m.noteOnly ? (
                     <span className="pill h-7 min-w-[60px] px-0 flex items-center justify-center">

--- a/src/components/reviews/ReviewListItem.tsx
+++ b/src/components/reviews/ReviewListItem.tsx
@@ -8,16 +8,16 @@ import { Badge } from "@/components/ui";
 import { shortDate } from "@/lib/date";
 
 const itemBase =
-  "review-tile relative w-full text-left h-auto min-h-[76px] p-4 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none";
+  "review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none";
 const itemSelected = "review-tile--active";
 const statusDotBase = "self-center justify-self-center h-2 w-2 rounded-full";
-const statusDotWin = "bg-[hsl(var(--success))]";
-const statusDotLoss = "bg-[hsl(var(--danger))]";
-const statusDotDefault = "bg-[hsl(var(--muted-foreground))]";
+const statusDotWin = "bg-success";
+const statusDotLoss = "bg-danger";
+const statusDotDefault = "bg-muted-foreground";
 const statusDotPulse = "animate-[pulse_2s_ease-in-out_infinite]";
 const statusDotBlink = "animate-[blink_1s_steps(2)_infinite]";
 const itemLoading = cn(itemBase, "animate-pulse");
-const loadingLine = "h-3 rounded bg-[hsl(var(--muted))]";
+const loadingLine = "h-3 rounded bg-muted";
 
 export type ReviewListItemProps = {
   review?: Review;

--- a/src/components/reviews/ReviewPanel.tsx
+++ b/src/components/reviews/ReviewPanel.tsx
@@ -5,7 +5,7 @@ export default function ReviewPanel({ className, ...props }: HTMLAttributes<HTML
   return (
     <div
       className={cn(
-        "max-w-[880px] w-full rounded-xl p-5 bg-[hsl(var(--card)/0.6)] ring-1 ring-[hsl(var(--ring)/0.05)] shadow-[0_0_40px_-12px_hsl(var(--glow-soft))]",
+        "max-w-[880px] w-full rounded-xl p-5 bg-card/60 ring-1 ring-ring/5 shadow-[0_0_40px_-12px_hsl(var(--glow-soft))]",
         className
       )}
       {...props}

--- a/src/components/reviews/ReviewSummaryHeader.tsx
+++ b/src/components/reviews/ReviewSummaryHeader.tsx
@@ -28,10 +28,10 @@ export default function ReviewSummaryHeader({
       <span
         className={cn(
           "inline-flex h-10 items-center rounded-2xl border px-3 text-sm font-semibold",
-          "border-[hsl(var(--border))] bg-[hsl(var(--card))]",
+          "border-border bg-card",
           result === "Win"
-            ? "shadow-[0_0_0_1px_hsl(var(--ring)/.35)_inset] bg-[linear-gradient(90deg,hsla(160,90%,45%,.20),hsla(190,90%,60%,.16))]"
-            : "bg-[linear-gradient(90deg,hsla(0,90%,55%,.18),hsla(320,90%,65%,.16))]",
+            ? "shadow-[0_0_0_1px_hsl(var(--ring)/.35)_inset] bg-gradient-to-r from-success/20 to-accent/16"
+            : "bg-gradient-to-r from-danger/18 to-primary/16",
         )}
         aria-label={`Result: ${result}`}
         title={`Result: ${result}`}
@@ -44,8 +44,8 @@ export default function ReviewSummaryHeader({
     <div className="section-h sticky">
       <div className="grid w-full grid-cols-[1fr_auto] items-center gap-4">
         <div className="min-w-0">
-          <div className="mb-1 text-xs text-[hsl(var(--foreground)/0.25)]">Title</div>
-          <div className="truncate text-lg font-medium leading-7 text-[hsl(var(--foreground)/0.7)]">
+          <div className="mb-1 text-xs text-foreground/25">Title</div>
+          <div className="truncate text-lg font-medium leading-7 text-foreground/70">
             {title || "Untitled review"}
           </div>
         </div>
@@ -53,8 +53,8 @@ export default function ReviewSummaryHeader({
           {role ? (
             <span
               className={cn(
-                "inline-flex h-10 items-center gap-2 rounded-2xl border border-[hsl(var(--border))]",
-                "bg-[hsl(var(--card))] px-3 text-sm font-semibold",
+                "inline-flex h-10 items-center gap-2 rounded-2xl border border-border",
+                "bg-card px-3 text-sm font-semibold",
               )}
               title={roleLabel}
             >

--- a/src/components/reviews/ReviewSummaryNotes.tsx
+++ b/src/components/reviews/ReviewSummaryNotes.tsx
@@ -9,7 +9,7 @@ export default function ReviewSummaryNotes({ notes }: ReviewSummaryNotesProps) {
   return (
     <div>
       <SectionLabel>Notes</SectionLabel>
-      <div className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-3 text-sm leading-6 text-[hsl(var(--foreground)/0.7)]">
+      <div className="rounded-2xl border border-border bg-card p-3 text-sm leading-6 text-foreground/70">
         {notes}
       </div>
     </div>

--- a/src/components/reviews/ReviewSummaryPillars.tsx
+++ b/src/components/reviews/ReviewSummaryPillars.tsx
@@ -8,11 +8,11 @@ function StaticNeonWrap({ children }: { children: React.ReactNode }) {
     <span className="relative inline-flex">
       <span
         aria-hidden
-        className="pointer-events-none absolute inset-0 rounded-2xl bg-[linear-gradient(90deg,hsl(var(--accent)),hsl(var(--primary)))] opacity-40 blur-[6px]"
+        className="pointer-events-none absolute inset-0 rounded-2xl bg-gradient-to-r from-accent to-primary opacity-40 blur-[6px]"
       />
       <span
         aria-hidden
-        className="pointer-events-none absolute inset-0 rounded-2xl ring-1 ring-[hsl(var(--ring)/.35)]"
+        className="pointer-events-none absolute inset-0 rounded-2xl ring-1 ring-ring/35"
       />
       <span className="relative z-10">{children}</span>
     </span>

--- a/src/components/reviews/ReviewSummaryScore.tsx
+++ b/src/components/reviews/ReviewSummaryScore.tsx
@@ -25,18 +25,15 @@ export default function ReviewSummaryScore({
   return (
     <div>
       <SectionLabel>Score</SectionLabel>
-      <div className="relative h-12 rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-4">
+      <div className="relative h-12 rounded-2xl border border-border bg-card px-4">
         <div className="absolute left-4 right-4 top-1/2 -translate-y-1/2">
-          <div className="relative h-2 w-full rounded-full bg-[hsl(var(--muted))] shadow-[inset_2px_2px_4px_hsl(var(--shadow-color)/0.45),inset_-2px_-2px_4px_hsl(var(--foreground)/0.06)]">
+          <div className="relative h-2 w-full rounded-full bg-muted shadow-[inset_2px_2px_4px_hsl(var(--shadow-color)/0.45),inset_-2px_-2px_4px_hsl(var(--foreground)/0.06)]">
             <div
-              className="absolute left-0 top-0 h-2 rounded-full shadow-[0_0_8px_hsl(var(--primary)/0.5)]"
-              style={{
-                width: `calc(${score * 10}% + 10px)`,
-                background: "linear-gradient(90deg, hsl(var(--primary)), hsl(var(--accent)))",
-              }}
+              className="absolute left-0 top-0 h-2 rounded-full bg-gradient-to-r from-primary to-accent shadow-[0_0_8px_hsl(var(--primary)/0.5)]"
+              style={{ width: `calc(${score * 10}% + 10px)` }}
             />
             <div
-              className="absolute top-1/2 h-5 w-5 -translate-y-1/2 rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--card))] shadow-[0_10px_25px_hsl(var(--shadow-color)/.25)]"
+              className="absolute top-1/2 h-5 w-5 -translate-y-1/2 rounded-full border border-border bg-card shadow-[0_10px_25px_hsl(var(--shadow-color)/.25)]"
               style={{ left: `calc(${score * 10}% - 10px)` }}
             />
           </div>
@@ -51,20 +48,17 @@ export default function ReviewSummaryScore({
         <div className="mt-4 space-y-2">
           <div className="mb-2 flex items-center gap-2" aria-label="Focus">
             <NeonIcon kind="brain" on={true} size={32} staticGlow />
-            <div className="h-px flex-1 bg-gradient-to-r from-[hsl(var(--foreground)/0.20)] via-[hsl(var(--foreground)/0.05)] to-transparent" />
+            <div className="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
           </div>
-          <div className="relative h-12 rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-4">
+          <div className="relative h-12 rounded-2xl border border-border bg-card px-4">
             <div className="absolute left-4 right-4 top-1/2 -translate-y-1/2">
-              <div className="relative h-2 w-full rounded-full bg-[hsl(var(--muted))] shadow-[inset_2px_2px_4px_hsl(var(--shadow-color)/0.45),inset_-2px_-2px_4px_hsl(var(--foreground)/0.06)]">
+              <div className="relative h-2 w-full rounded-full bg-muted shadow-[inset_2px_2px_4px_hsl(var(--shadow-color)/0.45),inset_-2px_-2px_4px_hsl(var(--foreground)/0.06)]">
                 <div
-                  className="absolute left-0 top-0 h-2 rounded-full shadow-[0_0_8px_hsl(var(--accent)/0.5)]"
-                  style={{
-                    width: `calc(${(focus / 10) * 100}% + 10px)`,
-                    background: "linear-gradient(90deg, hsl(var(--accent)), hsl(var(--primary)))",
-                  }}
+                  className="absolute left-0 top-0 h-2 rounded-full bg-gradient-to-r from-accent to-primary shadow-[0_0_8px_hsl(var(--accent)/0.5)]"
+                  style={{ width: `calc(${(focus / 10) * 100}% + 10px)` }}
                 />
                 <div
-                  className="absolute top-1/2 h-5 w-5 -translate-y-1/2 rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--card))] shadow-[0_10px_25px_hsl(var(--shadow-color)/.25)]"
+                  className="absolute top-1/2 h-5 w-5 -translate-y-1/2 rounded-full border border-border bg-card shadow-[0_10px_25px_hsl(var(--shadow-color)/.25)]"
                   style={{ left: `calc(${(focus / 10) * 100}% - 10px)` }}
                 />
               </div>

--- a/src/components/reviews/ReviewSummaryTimestamps.tsx
+++ b/src/components/reviews/ReviewSummaryTimestamps.tsx
@@ -17,7 +17,7 @@ export default function ReviewSummaryTimestamps({ markers }: ReviewSummaryTimest
       <div className="mb-2 flex items-center gap-2" aria-label="Timestamps">
         <NeonIcon kind="clock" on={!!hasTimed} size={32} staticGlow />
         <NeonIcon kind="file" on={!!hasNoteOnly} size={32} staticGlow />
-        <div className="h-px flex-1 bg-gradient-to-r from-[hsl(var(--foreground)/0.20)] via-[hsl(var(--foreground)/0.05)] to-transparent" />
+        <div className="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
       </div>
       {!markers.length ? (
         <div className="text-sm text-muted-foreground">No timestamps yet.</div>
@@ -28,7 +28,7 @@ export default function ReviewSummaryTimestamps({ markers }: ReviewSummaryTimest
             .map((m) => (
               <li
                 key={m.id}
-                className="grid grid-cols-[auto_1fr] items-center gap-2 rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-3 py-2"
+                className="grid grid-cols-[auto_1fr] items-center gap-2 rounded-2xl border border-border bg-card px-3 py-2"
               >
                 {m.noteOnly ? (
                   <span className="pill flex h-7 w-[56px] items-center justify-center px-0" title="Note" aria-label="Note">

--- a/src/components/reviews/SectionLabel.tsx
+++ b/src/components/reviews/SectionLabel.tsx
@@ -4,8 +4,8 @@ import * as React from "react";
 export default function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
     <div className="mb-2 flex items-center gap-2">
-      <div className="text-xs tracking-wide text-[hsl(var(--foreground)/0.2)]">{children}</div>
-      <div className="h-px flex-1 bg-gradient-to-r from-[hsl(var(--foreground)/0.20)] via-[hsl(var(--foreground)/0.05)] to-transparent" />
+      <div className="text-xs tracking-wide text-foreground/20">{children}</div>
+      <div className="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
     </div>
   );
 }

--- a/src/components/reviews/style.css
+++ b/src/components/reviews/style.css
@@ -1,10 +1,5 @@
 /* src/components/reviews/style.css */
 :where(.reviews-scope, [data-scope="reviews"]) .review-tile{
-  position: relative;
-  border-radius: var(--radius-lg);
-  background: hsl(var(--card)/.6);
-  border: 1px solid hsl(var(--border)/.5);
-  padding: .5rem;
   background-clip: padding-box;
   isolation: isolate;
   contain: paint;

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`ReviewListItem > renders default state 1`] = `
   >
     <button
       aria-label="Open review: Sample Review"
-      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
+      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
       type="button"
     >
       <div
@@ -15,7 +15,7 @@ exports[`ReviewListItem > renders default state 1`] = `
       >
         <span
           aria-hidden="true"
-          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-[hsl(var(--success))]"
+          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-success"
         />
         <div
           class="min-w-0 flex flex-col gap-1"
@@ -56,14 +56,14 @@ exports[`ReviewListItem > renders default state 1`] = `
 exports[`ReviewListItem > renders loading state 1`] = `
 <div>
   <div
-    class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none animate-pulse"
+    class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none animate-pulse"
     data-scope="reviews"
   >
     <div
-      class="h-3 rounded bg-[hsl(var(--muted))] w-3/5 mb-3"
+      class="h-3 rounded bg-muted w-3/5 mb-3"
     />
     <div
-      class="h-3 rounded bg-[hsl(var(--muted))] w-2/5"
+      class="h-3 rounded bg-muted w-2/5"
     />
   </div>
 </div>
@@ -76,7 +76,7 @@ exports[`ReviewListItem > renders selected state 1`] = `
   >
     <button
       aria-label="Open review: Sample Review"
-      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none review-tile--active"
+      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none review-tile--active"
       data-selected="true"
       type="button"
     >
@@ -85,7 +85,7 @@ exports[`ReviewListItem > renders selected state 1`] = `
       >
         <span
           aria-hidden="true"
-          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-[hsl(var(--success))]"
+          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-success"
         />
         <div
           class="min-w-0 flex flex-col gap-1"
@@ -130,7 +130,7 @@ exports[`ReviewListItem > renders untitled state 1`] = `
   >
     <button
       aria-label="Open review: Untitled Review"
-      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
+      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
       type="button"
     >
       <div
@@ -138,7 +138,7 @@ exports[`ReviewListItem > renders untitled state 1`] = `
       >
         <span
           aria-hidden="true"
-          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-[hsl(var(--success))]"
+          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-success"
         />
         <div
           class="min-w-0 flex flex-col gap-1"

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -773,7 +773,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                   >
                     <button
                       aria-label="Open review: Alpha"
-                      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
+                      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
                       type="button"
                     >
                       <div
@@ -781,7 +781,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                       >
                         <span
                           aria-hidden="true"
-                          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-[hsl(var(--muted-foreground))]"
+                          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-muted-foreground"
                         />
                         <div
                           class="min-w-0 flex flex-col gap-1"
@@ -810,7 +810,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                   >
                     <button
                       aria-label="Open review: Gamma"
-                      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
+                      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
                       type="button"
                     >
                       <div
@@ -818,7 +818,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                       >
                         <span
                           aria-hidden="true"
-                          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-[hsl(var(--muted-foreground))]"
+                          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-muted-foreground"
                         />
                         <div
                           class="min-w-0 flex flex-col gap-1"
@@ -847,7 +847,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                   >
                     <button
                       aria-label="Open review: Beta"
-                      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
+                      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
                       type="button"
                     >
                       <div
@@ -855,7 +855,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                       >
                         <span
                           aria-hidden="true"
-                          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-[hsl(var(--muted-foreground))]"
+                          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-muted-foreground"
                         />
                         <div
                           class="min-w-0 flex flex-col gap-1"
@@ -887,7 +887,7 @@ exports[`ReviewsPage > renders default state 1`] = `
         class="md:col-span-7 lg:col-span-8 flex justify-center"
       >
         <div
-          class="max-w-[880px] w-full rounded-xl p-5 bg-[hsl(var(--card)/0.6)] ring-1 ring-[hsl(var(--ring)/0.05)] shadow-[0_0_40px_-12px_hsl(var(--glow-soft))] flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground"
+          class="max-w-[880px] w-full rounded-xl p-5 bg-card/60 ring-1 ring-ring/5 shadow-[0_0_40px_-12px_hsl(var(--glow-soft))] flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground"
         >
           <svg
             class="lucide lucide-ghost h-6 w-6 opacity-60"


### PR DESCRIPTION
## Summary
- replace hard-coded HSL utilities with semantic Tailwind tokens across review components
- clean up duplicated color styles in reviews stylesheet

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf9ebaecdc832cb02a4f017f544c90