### PR TITLE
fix timer reset effect

### DIFF
--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -70,12 +70,17 @@ export default function TimerTab() {
     false,
   );
 
+  const prevProfile = React.useRef<ProfileKey>(profile);
   // Reset timer when switching profiles (studying, cleaning, coding)
   React.useEffect(() => {
-    setRunning(false);
-    setRemaining((profile === "personal" ? personalMinutes : profileDef.defaultMin) * 60_000);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [profile]);
+    if (prevProfile.current !== profile) {
+      setRunning(false);
+      setRemaining(
+        (profile === "personal" ? personalMinutes : profileDef.defaultMin) * 60_000,
+      );
+      prevProfile.current = profile;
+    }
+  }, [profile, personalMinutes, profileDef.defaultMin, setRunning, setRemaining]);
 
   // edit mode for mm:ss
   const [timeEdit, setTimeEdit] = React.useState(fmt(remaining));

--- a/tests/goals/timer-tab.test.tsx
+++ b/tests/goals/timer-tab.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import TimerTab from "@/components/goals/TimerTab";
+
+afterEach(cleanup);
+
+describe("TimerTab", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("resets remaining time and stops when switching profiles", () => {
+    render(<TimerTab />);
+    fireEvent.click(screen.getByRole("button", { name: "Start" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Cleaning" }));
+    expect(screen.getByText("30:00")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- clean up TimerTab profile reset effect and remove lint disable
- add test verifying timer resets when switching profiles

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bfa10f0f2c832ca31fa03b887c5c48