### PR TITLE
chore: align reviews page grid

### DIFF
--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -146,7 +146,7 @@ export default function ReviewsPage({
       />
 
       <div className={cn("grid items-start gap-6 md:grid-cols-12")}>
-        <nav aria-label="Review list" className="md:col-span-5 md:w-72 lg:col-span-4 lg:w-80">
+        <nav aria-label="Review list" className="md:col-span-4 lg:col-span-3">
           <div className="card-neo-soft overflow-hidden bg-card/50 shadow-neo-strong">
             <div className="section-b">
               <div className="mb-2 text-sm text-muted-foreground">
@@ -166,7 +166,7 @@ export default function ReviewsPage({
           </div>
         </nav>
 
-          <div className="md:col-span-7 lg:col-span-8 flex justify-center">
+          <div className="md:col-span-8 lg:col-span-9 flex justify-center">
             {!active ? (
               <ReviewPanel className="flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
                 <Ghost className="h-6 w-6 opacity-60" />

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -747,7 +747,7 @@ exports[`ReviewsPage > renders default state 1`] = `
     >
       <nav
         aria-label="Review list"
-        class="md:col-span-5 md:w-72 lg:col-span-4 lg:w-80"
+        class="md:col-span-4 lg:col-span-3"
       >
         <div
           class="card-neo-soft overflow-hidden bg-card/50 shadow-neo-strong"
@@ -884,7 +884,7 @@ exports[`ReviewsPage > renders default state 1`] = `
         </div>
       </nav>
       <div
-        class="md:col-span-7 lg:col-span-8 flex justify-center"
+        class="md:col-span-8 lg:col-span-9 flex justify-center"
       >
         <div
           class="max-w-[880px] w-full rounded-xl p-5 bg-card/60 ring-1 ring-ring/5 shadow-[0_0_40px_-12px_hsl(var(--glow-soft))] flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground"


### PR DESCRIPTION
## Summary
- remove fixed sidebar widths on ReviewsPage to let 12-column grid control layout
- update snapshot for new grid-based column spans

## Testing
- `npm run regen-ui`
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bfa0c82e68832c990dc5448e75ce1c