### PR TITLE
feat: debounce localStorage writes

### DIFF
--- a/tests/lib/db.test.ts
+++ b/tests/lib/db.test.ts
@@ -6,6 +6,8 @@ import {
   removeLocal,
   usePersistentState,
   uid,
+  flushWriteLocal,
+  setWriteLocalDelay,
 } from "@/lib/db";
 
 // Tests for localStorage helpers
@@ -37,6 +39,8 @@ describe("localStorage helpers", () => {
       value: mockStorage,
       configurable: true,
     });
+    setWriteLocalDelay(0);
+    flushWriteLocal();
   });
 
   afterAll(() => {
@@ -45,6 +49,7 @@ describe("localStorage helpers", () => {
 
   it("writes and reads namespaced values", () => {
     writeLocal("foo", { bar: 1 });
+    flushWriteLocal();
     expect(mockStorage.setItem).toHaveBeenCalledWith(
       "noxis-planner:foo",
       JSON.stringify({ bar: 1 }),
@@ -54,6 +59,7 @@ describe("localStorage helpers", () => {
 
   it("removes values", () => {
     writeLocal("foo", "baz");
+    flushWriteLocal();
     removeLocal("foo");
     expect(mockStorage.removeItem).toHaveBeenCalledWith("noxis-planner:foo");
     expect(readLocal("foo")).toBeNull();
@@ -65,6 +71,8 @@ describe("localStorage helpers", () => {
 describe("usePersistentState", () => {
   beforeEach(() => {
     window.localStorage.clear();
+    setWriteLocalDelay(0);
+    flushWriteLocal();
   });
 
   it("hydrates state from localStorage after mount", async () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,4 +1,17 @@
-import '@testing-library/jest-dom/vitest';
+import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockReturnValue({
+    matches: false,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }),
+});
 
 export function resetLocalStorage() {
   window.localStorage.clear();


### PR DESCRIPTION
## Summary
- debounce localStorage writes to batch frequent updates
- expose configurable delay and flush helper
- adjust tests and setup for debounced persistence

## Testing
- `node -e "/* progress bar script executed automatically; see logs */"`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bfa2837de8832cb18beb33dd4e7a66