### PR TITLE
feat(prompts): organize color tokens by palette

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -113,6 +113,10 @@ export default function Page() {
         <li className="text-sm text-muted-foreground">
           DurationSelector active state uses accent color tokens.
         </li>
+        <li className="text-sm text-muted-foreground">
+          Color gallery groups tokens into Aurora, Neutrals, and Accents
+          palettes with tabs.
+        </li>
       </ul>
       <div className="mb-8 flex flex-wrap gap-2">
         <Button tone="primary">Primary tone</Button>

--- a/src/components/prompts/ColorGallery.tsx
+++ b/src/components/prompts/ColorGallery.tsx
@@ -1,33 +1,51 @@
 "use client";
 
 import * as React from "react";
-import { COLOR_TOKENS } from "@/lib/theme";
+import { TabBar, type TabItem } from "@/components/ui";
+import { COLOR_PALETTES, type ColorPalette } from "@/lib/theme";
 
 export default function ColorGallery() {
+  const paletteTabs: TabItem<ColorPalette>[] = [
+    { key: "aurora", label: "Aurora" },
+    { key: "neutrals", label: "Neutrals" },
+    { key: "accents", label: "Accents" },
+  ];
+  const [palette, setPalette] = React.useState<ColorPalette>("aurora");
+
   return (
-    <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
-      <div className="flex flex-col items-center gap-2 sm:col-span-2 md:col-span-3">
-        <span className="text-sm font-medium">Aurora Palette</span>
-        <div className="flex gap-2">
-          <div className="w-10 h-10 rounded bg-auroraG" />
-          <div className="w-10 h-10 rounded bg-auroraGLight" />
-          <div className="w-10 h-10 rounded bg-auroraP" />
-          <div className="w-10 h-10 rounded bg-auroraPLight" />
-        </div>
-        <p className="text-xs text-muted-foreground mt-2 text-center">
-          Use <code>auroraG</code>, <code>auroraGLight</code>, <code>auroraP</code>,
-          and<code>auroraPLight</code> Tailwind classes for aurora effects.
-        </p>
+    <div className="flex flex-col gap-8">
+      <TabBar
+        items={paletteTabs}
+        value={palette}
+        onValueChange={setPalette}
+        ariaLabel="Color palettes"
+      />
+      <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
+        {palette === "aurora" && (
+          <div className="flex flex-col items-center gap-2 sm:col-span-2 md:col-span-3">
+            <span className="text-sm font-medium">Aurora Palette</span>
+            <div className="flex gap-2">
+              <div className="w-10 h-10 rounded bg-auroraG" />
+              <div className="w-10 h-10 rounded bg-auroraGLight" />
+              <div className="w-10 h-10 rounded bg-auroraP" />
+              <div className="w-10 h-10 rounded bg-auroraPLight" />
+            </div>
+            <p className="mt-2 text-center text-xs text-muted-foreground">
+              Use <code>auroraG</code>, <code>auroraGLight</code>, <code>auroraP</code>,
+              and<code>auroraPLight</code> Tailwind classes for aurora effects.
+            </p>
+          </div>
+        )}
+        {COLOR_PALETTES[palette].map((c) => (
+          <div key={c} className="flex flex-col items-center gap-2">
+            <span className="text-xs uppercase tracking-wide text-accent">{c}</span>
+            <div
+              className="h-16 w-24 rounded-md border"
+              style={{ backgroundColor: `hsl(var(--${c}))` }}
+            />
+          </div>
+        ))}
       </div>
-      {COLOR_TOKENS.map((c) => (
-        <div key={c} className="flex flex-col items-center gap-2">
-          <span className="text-xs uppercase tracking-wide text-accent">{c}</span>
-          <div
-            className="w-24 h-16 rounded-md border"
-            style={{ backgroundColor: `hsl(var(--${c}))` }}
-          />
-        </div>
-      ))}
     </div>
   );
 }

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -32,34 +32,43 @@ export const BG_CLASSES = [
   "bg-streak",
 ] as const;
 
+export const COLOR_PALETTES = {
+  aurora: ["aurora-g", "aurora-g-light", "aurora-p", "aurora-p-light"],
+  neutrals: [
+    "background",
+    "foreground",
+    "text",
+    "card",
+    "panel",
+    "border",
+    "line",
+    "input",
+    "ring",
+    "muted",
+    "muted-foreground",
+    "surface",
+    "surface-2",
+    "surface-vhs",
+    "surface-streak",
+    "icon-fg",
+  ],
+  accents: [
+    "accent",
+    "accent-2",
+    "accent-foreground",
+    "danger",
+    "success",
+    "glow-strong",
+    "glow-soft",
+  ],
+} as const;
+
+export type ColorPalette = keyof typeof COLOR_PALETTES;
+
 export const COLOR_TOKENS = [
-  "background",
-  "foreground",
-  "text",
-  "card",
-  "panel",
-  "border",
-  "line",
-  "input",
-  "ring",
-  "accent",
-  "accent-2",
-  "accent-foreground",
-  "muted",
-  "muted-foreground",
-  "surface",
-  "surface-2",
-  "surface-vhs",
-  "surface-streak",
-  "danger",
-  "success",
-  "glow-strong",
-  "glow-soft",
-  "aurora-g",
-  "aurora-g-light",
-  "aurora-p",
-  "aurora-p-light",
-  "icon-fg",
+  ...COLOR_PALETTES.neutrals,
+  ...COLOR_PALETTES.accents,
+  ...COLOR_PALETTES.aurora,
 ] as const;
 
 export const VARIANTS: { id: Variant; label: string }[] = [


### PR DESCRIPTION
## Summary
- group color tokens into aurora, neutral, and accent palettes
- add palette tabs to color gallery
- document color gallery palettes on prompts page

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bfa435b160832ca0f880d9e3434faa