### PR TITLE
Ensure accent foreground contrast

### DIFF
--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -161,6 +161,7 @@ html.theme-aurora {
   --primary-soft: 150 100% 20%;
   --accent: 272 80% 60%;
   --accent-2: 150 100% 60%;
+  --accent-foreground: 0 0% 100%;
   --accent-soft: 272 80% 20%;
   --muted: 279 100% 15%;
   --muted-foreground: 279 20% 75%;
@@ -203,6 +204,7 @@ html.theme-citrus {
   --primary-soft: 24 95% 22%;
   --accent: 24 96% 35%;
   --accent-2: 170 80% 25%;
+  --accent-foreground: 0 0% 100%;
   --accent-soft: 24 96% 15%;
   --muted: 214 18% 24%;
   --muted-foreground: 214 20% 72%;
@@ -229,6 +231,7 @@ html.theme-noir {
   --primary-soft: 0 90% 24%;
   --accent: 178 91% 25%;
   --accent-2: 40 96% 25%;
+  --accent-foreground: 0 0% 100%;
   --accent-soft: 178 91% 10%;
   --muted: 350 35% 18%;
   --muted-foreground: 350 25% 65%;
@@ -255,6 +258,7 @@ html.theme-ocean {
   --primary-soft: 195 85% 16%;
   --accent: 199 100% 27%;
   --accent-2: 225 85% 30%;
+  --accent-foreground: 0 0% 100%;
   --accent-soft: 199 100% 12%;
   --muted: 220 24% 16%;
   --muted-foreground: 220 14% 72%;
@@ -281,6 +285,7 @@ html.theme-kitten {
   --primary-soft: 330 100% 24%;
   --accent: 336 100% 27%;
   --accent-2: 330 100% 40%;
+  --accent-foreground: 0 0% 100%;
   --accent-soft: 336 100% 12%;
   --muted: 330 100% 20%;
   --muted-foreground: 330 20% 70%;


### PR DESCRIPTION
## Summary
- define `--accent-foreground` for aurora, citrus, noir, ocean, and kitten themes to guarantee readable text on accent surfaces
- verify foreground contrast against accents using `--text-on-accent`

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bfa3ff2bd0832cabb5a6f39dc7d96a