### PR TITLE
feat: add accessible inline goal editing

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -3,11 +3,11 @@
 import * as React from "react";
 import { TabBar, Header, Hero, Button, IconButton, type TabItem, Input } from "@/components/ui";
 import Banner from "@/components/chrome/Banner";
-import { GoalsProgress } from "@/components/goals";
+import { GoalsProgress, GoalSlot } from "@/components/goals";
 import { RoleSelector, NeonIcon, ReviewSummaryHeader, ReviewSummaryScore } from "@/components/reviews";
 import { ComponentGallery, ColorGallery } from "@/components/prompts";
 import { ROLE_OPTIONS, SCORE_POOLS, scoreIcon } from "@/components/reviews/reviewData";
-import type { Role } from "@/lib/types";
+import type { Role, Goal } from "@/lib/types";
 import { Plus } from "lucide-react";
 
 type View = "components" | "colors";
@@ -20,6 +20,12 @@ export default function Page() {
 
   const [view, setView] = React.useState<View>("components");
   const [role, setRole] = React.useState<Role>(ROLE_OPTIONS[0].value);
+  const [demoGoal, setDemoGoal] = React.useState<Goal>({
+    id: "demo-goal",
+    title: "Demo goal",
+    done: false,
+    createdAt: Date.now(),
+  });
 
   const demoScore = 7;
   const { Icon: DemoScoreIcon, cls: demoScoreCls } = scoreIcon(demoScore);
@@ -33,6 +39,12 @@ export default function Page() {
         <Banner title="Banner" actions={<Button size="sm">Action</Button>} />
         <div className="flex justify-center">
           <GoalsProgress total={5} pct={60} />
+        </div>
+        <div className="flex justify-center">
+          <GoalSlot
+            goal={demoGoal}
+            onEdit={(_, t) => setDemoGoal((g) => ({ ...g, title: t }))}
+          />
         </div>
         <div className="flex justify-center">
           <RoleSelector value={role} onChange={setRole} />

--- a/src/components/goals/GoalSlot.tsx
+++ b/src/components/goals/GoalSlot.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { Check, Pencil, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { Goal } from "@/lib/types";
-import { PillarBadge } from "@/components/ui";
+import { PillarBadge, Input, Button } from "@/components/ui";
 
 interface GoalSlotProps {
   goal?: Goal | null;
@@ -14,12 +14,43 @@ interface GoalSlotProps {
 }
 
 export default function GoalSlot({ goal, onToggleDone, onEdit, onDelete }: GoalSlotProps) {
-  function handleEdit() {
+  const [editing, setEditing] = React.useState(false);
+  const [title, setTitle] = React.useState("");
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const editBtnRef = React.useRef<HTMLButtonElement>(null);
+  const inputId = React.useId();
+
+  React.useEffect(() => {
+    if (editing) {
+      setTitle(goal?.title || "");
+      const t = setTimeout(() => inputRef.current?.focus(), 0);
+      return () => clearTimeout(t);
+    }
+    editBtnRef.current?.focus();
+    return undefined;
+  }, [editing, goal?.title]);
+
+  function startEditing() {
     if (!goal || !onEdit) return;
-    const t = window.prompt("Edit goal title", goal.title);
-    if (t !== null) {
-      const clean = t.trim();
-      if (clean) onEdit(goal.id, clean);
+    setEditing(true);
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!goal || !onEdit) return;
+    const clean = title.trim();
+    if (clean) onEdit(goal.id, clean);
+    setEditing(false);
+  }
+
+  function handleCancel() {
+    setEditing(false);
+  }
+
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      handleCancel();
     }
   }
 
@@ -32,42 +63,68 @@ export default function GoalSlot({ goal, onToggleDone, onEdit, onDelete }: GoalS
         )}
       >
         {goal ? (
-          <>
-            <div className="flex flex-col items-center">
-              <span className={cn("block", goal?.done && "line-through")}>{goal.title}</span>
-              {goal.pillar && (
-                <PillarBadge pillar={goal.pillar} size="sm" className="mt-1" as="span" />
-              )}
-            </div>
-            <button
-              type="button"
-              className={cn(
-                "absolute bottom-1 right-1 flex rounded bg-[hsl(var(--surface))] p-[0.15rem] text-[hsl(var(--foreground))]",
-                goal?.done && "text-[hsl(var(--success))]",
-              )}
-              aria-label={goal.done ? "Mark goal undone" : "Mark goal done"}
-              aria-pressed={goal.done}
-              onClick={() => onToggleDone?.(goal.id)}
+          editing ? (
+            <form
+              onSubmit={handleSubmit}
+              onKeyDown={onKeyDown}
+              className="absolute inset-0 flex items-center justify-center gap-1 bg-[hsl(var(--surface-2))]"
             >
-              <Check className="h-4 w-4" />
-            </button>
-            <button
-              type="button"
-              className="absolute bottom-1 left-1 flex rounded bg-[hsl(var(--surface))] p-[0.15rem] text-[hsl(var(--foreground))] opacity-0 transition-opacity group-hover:opacity-100"
-              aria-label="Edit goal"
-              onClick={handleEdit}
-            >
-              <Pencil className="h-4 w-4" />
-            </button>
-            <button
-              type="button"
-              className="absolute bottom-1 left-7 flex rounded bg-[hsl(var(--surface))] p-[0.15rem] text-[hsl(var(--foreground))] opacity-0 transition-opacity group-hover:opacity-100"
-              aria-label="Delete goal"
-              onClick={() => onDelete?.(goal.id)}
-            >
-              <Trash2 className="h-4 w-4" />
-            </button>
-          </>
+              <label htmlFor={inputId} className="sr-only">
+                Goal title
+              </label>
+              <Input
+                ref={inputRef}
+                id={inputId}
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className="w-24"
+              />
+              <Button size="sm" type="submit">
+                Save
+              </Button>
+              <Button size="sm" variant="ghost" type="button" onClick={handleCancel}>
+                Cancel
+              </Button>
+            </form>
+          ) : (
+            <>
+              <div className="flex flex-col items-center">
+                <span className={cn("block", goal?.done && "line-through")}>{goal.title}</span>
+                {goal.pillar && (
+                  <PillarBadge pillar={goal.pillar} size="sm" className="mt-1" as="span" />
+                )}
+              </div>
+              <button
+                type="button"
+                className={cn(
+                  "absolute bottom-1 right-1 flex rounded bg-[hsl(var(--surface))] p-[0.15rem] text-[hsl(var(--foreground))]",
+                  goal?.done && "text-[hsl(var(--success))]",
+                )}
+                aria-label={goal.done ? "Mark goal undone" : "Mark goal done"}
+                aria-pressed={goal.done}
+                onClick={() => onToggleDone?.(goal.id)}
+              >
+                <Check className="h-4 w-4" />
+              </button>
+              <button
+                ref={editBtnRef}
+                type="button"
+                className="absolute bottom-1 left-1 flex rounded bg-[hsl(var(--surface))] p-[0.15rem] text-[hsl(var(--foreground))] opacity-0 transition-opacity group-hover:opacity-100"
+                aria-label="Edit goal"
+                onClick={startEditing}
+              >
+                <Pencil className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                className="absolute bottom-1 left-7 flex rounded bg-[hsl(var(--surface))] p-[0.15rem] text-[hsl(var(--foreground))] opacity-0 transition-opacity group-hover:opacity-100"
+                aria-label="Delete goal"
+                onClick={() => onDelete?.(goal.id)}
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </>
+          )
         ) : (
           <span className="text-[hsl(var(--muted-foreground))]">NO SIGNAL</span>
         )}

--- a/tests/goals/goal-slot.test.tsx
+++ b/tests/goals/goal-slot.test.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { GoalSlot } from "@/components/goals";
+
+afterEach(cleanup);
+
+describe("GoalSlot", () => {
+  const goal = {
+    id: "g1",
+    title: "Initial",
+    done: false,
+    createdAt: Date.now(),
+  };
+
+  it("edits title and calls onEdit", async () => {
+    const onEdit = vi.fn();
+    render(<GoalSlot goal={goal} onEdit={onEdit} />);
+    const editBtn = screen.getByLabelText("Edit goal");
+    fireEvent.click(editBtn);
+    const input = screen.getByRole("textbox", { name: "Goal title" });
+    await waitFor(() => expect(input).toHaveFocus());
+    fireEvent.change(input, { target: { value: "Updated" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(onEdit).toHaveBeenCalledWith("g1", "Updated");
+    expect(screen.queryByRole("textbox", { name: "Goal title" })).toBeNull();
+  });
+
+  it("cancels edit without calling onEdit", async () => {
+    const onEdit = vi.fn();
+    render(<GoalSlot goal={goal} onEdit={onEdit} />);
+    const editBtn = screen.getByLabelText("Edit goal");
+    fireEvent.click(editBtn);
+    const input = screen.getByRole("textbox", { name: "Goal title" });
+    fireEvent.change(input, { target: { value: "Updated" } });
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(screen.queryByRole("textbox", { name: "Goal title" })).toBeNull();
+    const editBtnAfter = screen.getByLabelText("Edit goal");
+    await waitFor(() => expect(document.activeElement).toBe(editBtnAfter));
+  });
+
+  it("does not use window.prompt", () => {
+    const promptSpy = vi.spyOn(window, "prompt");
+    const onEdit = vi.fn();
+    render(<GoalSlot goal={goal} onEdit={onEdit} />);
+    fireEvent.click(screen.getByLabelText("Edit goal"));
+    expect(promptSpy).not.toHaveBeenCalled();
+    promptSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- replace prompt with inline goal editing using Input and Button
- add demo slot in prompts gallery
- test goal editing success and cancel flows

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68bfa0f08f3c832c8dab7489df07e6e2