### PR TITLE
Refactor review editor into modular subcomponents

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -13,10 +13,10 @@ import {
 } from "@/components/ui";
 import Banner from "@/components/chrome/Banner";
 import { GoalsProgress } from "@/components/goals";
-import { RoleSelector, NeonIcon, ReviewSummaryHeader, ReviewSummaryScore } from "@/components/reviews";
+import { RoleSelector, NeonIcon, ReviewSummaryHeader, ReviewSummaryScore, ReviewMetadata, ReviewNotesTags, ReviewMarkerEditor, type Result } from "@/components/reviews";
 import { ComponentGallery, ColorGallery } from "@/components/prompts";
-import { ROLE_OPTIONS, SCORE_POOLS, scoreIcon } from "@/components/reviews/reviewData";
-import type { Role } from "@/lib/types";
+import { ROLE_OPTIONS, SCORE_POOLS, FOCUS_POOLS, scoreIcon } from "@/components/reviews/reviewData";
+import type { Role, Pillar, ReviewMarker } from "@/lib/types";
 import { Plus } from "lucide-react";
 
 type View = "components" | "colors";
@@ -34,6 +34,24 @@ export default function Page() {
     { value: "orange", label: "Orange" },
   ];
   const [fruit, setFruit] = React.useState(fruitItems[0].value);
+
+  const [metaResult, setMetaResult] = React.useState<Result>("Win");
+  const [metaScore, setMetaScore] = React.useState(5);
+  const [metaFocusOn, setMetaFocusOn] = React.useState(false);
+  const [metaFocus, setMetaFocus] = React.useState(5);
+  const [metaPillars, setMetaPillars] = React.useState<Pillar[]>([]);
+  const metaScoreInfo = scoreIcon(metaScore);
+  const metaScoreMsg = SCORE_POOLS[metaScore][0];
+  const metaFocusMsg = (FOCUS_POOLS[metaFocus] ?? FOCUS_POOLS[5])[0];
+  const metaResultRef = React.useRef<HTMLButtonElement>(null);
+
+  const [demoMarkers, setDemoMarkers] = React.useState<ReviewMarker[]>([]);
+  const markerTimeRef = React.useRef<HTMLInputElement>(null);
+  const [demoMarkerMode, setDemoMarkerMode] = React.useState(true);
+  const [demoMarkerTime, setDemoMarkerTime] = React.useState("");
+
+  const [demoNotes, setDemoNotes] = React.useState("");
+  const [demoTags, setDemoTags] = React.useState<string[]>([]);
 
   const demoScore = 7;
   const { Icon: DemoScoreIcon, cls: demoScoreCls } = scoreIcon(demoScore);
@@ -80,6 +98,46 @@ export default function Page() {
             className="btn-like-segmented btn-glitch w-[5ch]"
             inputClassName="text-center"
             type="text"
+          />
+        </div>
+        <div className="space-y-4">
+          <ReviewMetadata
+            result={metaResult}
+            onChangeResult={setMetaResult}
+            score={metaScore}
+            onChangeScore={setMetaScore}
+            focusOn={metaFocusOn}
+            onToggleFocus={setMetaFocusOn}
+            focus={metaFocus}
+            onChangeFocus={setMetaFocus}
+            pillars={metaPillars}
+            togglePillar={(p) =>
+              setMetaPillars((prev) =>
+                prev.includes(p) ? prev.filter((x) => x !== p) : prev.concat(p),
+              )
+            }
+            scoreMsg={metaScoreMsg}
+            ScoreIcon={metaScoreInfo.Icon}
+            scoreIconCls={metaScoreInfo.cls}
+            focusMsg={metaFocusMsg}
+            onScoreNext={() => markerTimeRef.current?.focus()}
+            resultRef={metaResultRef}
+          />
+          <ReviewMarkerEditor
+            markers={demoMarkers}
+            onChange={setDemoMarkers}
+            timeRef={markerTimeRef}
+            lastMarkerMode={demoMarkerMode}
+            setLastMarkerMode={setDemoMarkerMode}
+            lastMarkerTime={demoMarkerTime}
+            setLastMarkerTime={setDemoMarkerTime}
+          />
+          <ReviewNotesTags
+            notes={demoNotes}
+            onNotesChange={setDemoNotes}
+            onNotesBlur={() => {}}
+            tags={demoTags}
+            onTagsChange={setDemoTags}
           />
         </div>
       </div>

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -4,28 +4,18 @@
 import "./style.css";
 import { RoleSelector } from "@/components/reviews";
 import SectionLabel from "@/components/reviews/SectionLabel";
-import NeonIcon from "@/components/reviews/NeonIcon";
+import ReviewMetadata from "@/components/reviews/ReviewMetadata";
+import ReviewNotesTags from "@/components/reviews/ReviewNotesTags";
+import ReviewMarkerEditor from "@/components/reviews/ReviewMarkerEditor";
 
 import * as React from "react";
-import type { Review, Pillar, Role } from "@/lib/types";
+import type { Review, Pillar, Role, ReviewMarker } from "@/lib/types";
 import Input from "@/components/ui/primitives/Input";
-import Textarea from "@/components/ui/primitives/Textarea";
 import IconButton from "@/components/ui/primitives/IconButton";
-import PillarBadge from "@/components/ui/league/pillars/PillarBadge";
-import {
-  Tag,
-  Trash2,
-  Check,
-  Target,
-  Shield,
-  Plus,
-  Clock,
-  FileText,
-} from "lucide-react";
+import { Trash2, Check, Target, Shield } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { uid, usePersistentState } from "@/lib/db";
 import {
-  ALL_PILLARS,
   LAST_ROLE_KEY,
   LAST_MARKER_MODE_KEY,
   LAST_MARKER_TIME_KEY,
@@ -34,130 +24,31 @@ import {
   pickIndex,
   scoreIcon,
 } from "@/components/reviews/reviewData";
+import { parseTime, formatSeconds, type Result } from "@/components/reviews/utils";
 
-
-/** Parse "m:ss" or "mm:ss" into seconds. Returns null for invalid input. */
-function parseTime(mmss: string): number | null {
-  const m = mmss.trim().match(/^(\d{1,2}):([0-5]\d)$/);
-  if (!m) return null;
-  return Number(m[1]) * 60 + Number(m[2]);
-}
-
-/** Convert seconds to "m:ss" with zero-padded seconds. */
-function formatSeconds(total: number): string {
-  const minutes = Math.max(0, Math.floor(total / 60));
-  const seconds = Math.max(0, total % 60);
-  return `${String(minutes)}:${String(seconds).padStart(2, "0")}`;
-}
-
-type Result = "Win" | "Loss";
-
-export type Marker = {
-  id: string;
-  time: string;
-  seconds: number;
-  note: string;
-  noteOnly?: boolean;
-};
 
 type ExtendedProps = {
   result?: Result;
   score?: number;
   role?: Role;
-  markers?: Marker[];
+  markers?: ReviewMarker[];
   focusOn?: boolean;
   focus?: number;
 };
 
 type MetaPatch = Omit<Partial<Review>, "role"> & Partial<ExtendedProps>;
 
-
-function NeonPillarChip({
-  active,
-  children,
-}: {
-  active: boolean;
-  children: React.ReactNode;
-}) {
-  const prev = React.useRef(active);
-  const [phase, setPhase] = React.useState<"steady-on" | "ignite" | "off" | "powerdown">(
-    active ? "steady-on" : "off"
-  );
-
-  React.useEffect(() => {
-    if (active !== prev.current) {
-      if (active) {
-        setPhase("ignite");
-        const t = setTimeout(() => setPhase("steady-on"), 620);
-        prev.current = active;
-        return () => clearTimeout(t);
-      } else {
-        setPhase("powerdown");
-        const t = setTimeout(() => setPhase("off"), 360);
-        prev.current = active;
-        return () => clearTimeout(t);
-      }
-    }
-    prev.current = active;
-  }, [active]);
-
-  const lit = phase === "ignite" || phase === "steady-on";
-
-  return (
-    <span className="relative inline-flex">
-      <span
-        className={cn(
-          "pointer-events-none absolute inset-0 rounded-2xl",
-          lit ? "opacity-60" : "opacity-0"
-        )}
-        style={{
-          filter: "blur(10px)",
-          background:
-            "radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%)",
-          transition: "opacity 220ms var(--ease-out)",
-        }}
-        aria-hidden
-      />
-      <span
-        className={cn(
-          "pointer-events-none absolute inset-0 rounded-2xl",
-          lit ? "opacity-40 animate-[neonAura_3.6s_ease-in-out_infinite]" : "opacity-0"
-        )}
-        style={{
-          filter: "blur(14px)",
-          background:
-            "radial-gradient(80% 80% at 50% 50%, hsl(var(--primary)/.35), transparent 75%)",
-          transition: "opacity 220ms var(--ease-out)",
-        }}
-        aria-hidden
-      />
-      <span
-        className={cn(
-          "pointer-events-none absolute inset-0 rounded-2xl",
-          lit ? "animate-[igniteFlicker_.62s_steps(18,end)_1]" : ""
-        )}
-        style={{
-          background:
-            "radial-gradient(80% 80% at 50% 50%, hsl(var(--foreground)/0.22), transparent 60%)",
-          mixBlendMode: "screen",
-          opacity: lit ? 0.8 : 0,
-        }}
-        aria-hidden
-      />
-      <span className="relative z-10">{children}</span>
-    </span>
-  );
-}
-
 function getExt(r: Review): Partial<ExtendedProps> {
   return r as unknown as Partial<ExtendedProps>;
 }
-function normalizeMarker(m: unknown): Marker {
+function normalizeMarker(m: unknown): ReviewMarker {
   const obj = (typeof m === "object" && m !== null ? m : {}) as Record<string, unknown>;
-  const asNum = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : undefined);
+  const asNum = (v: unknown) =>
+    typeof v === "number" && Number.isFinite(v) ? v : undefined;
   const asStr = (v: unknown) => (typeof v === "string" ? v : undefined);
 
-  const seconds = asNum(obj.seconds) ?? (asStr(obj.time) ? parseTime(asStr(obj.time)!) ?? 0 : 0);
+  const seconds =
+    asNum(obj.seconds) ?? (asStr(obj.time) ? parseTime(asStr(obj.time)!) ?? 0 : 0);
 
   const timeStr = asStr(obj.time) ?? formatSeconds(seconds);
   return {
@@ -189,15 +80,16 @@ export default function ReviewEditor({
   className?: string;
 }) {
   const [notes, setNotes] = React.useState(review.notes ?? "");
-  const [tags, setTags] = React.useState<string[]>(Array.isArray(review.tags) ? review.tags : []);
-  const [draftTag, setDraftTag] = React.useState("");
+  const [tags, setTags] = React.useState<string[]>(
+    Array.isArray(review.tags) ? review.tags : [],
+  );
 
   const rootRef = React.useRef<HTMLDivElement>(null);
 
   const [opponent, setOpponent] = React.useState(review.opponent ?? "");
   const [lane, setLane] = React.useState(review.lane ?? review.title ?? "");
   const [pillars, setPillars] = React.useState<Pillar[]>(
-    Array.isArray(review.pillars) ? review.pillars : []
+    Array.isArray(review.pillars) ? review.pillars : [],
   );
 
   const [lastRole, setLastRole] = usePersistentState<Role>(LAST_ROLE_KEY, "MID");
@@ -215,35 +107,27 @@ export default function ReviewEditor({
 
   const [result, setResult] = React.useState<Result>(ext0.result ?? "Win");
   const [score, setScore] = React.useState<number>(
-    Number.isFinite(ext0.score ?? NaN) ? Number(ext0.score) : 5
+    Number.isFinite(ext0.score ?? NaN) ? Number(ext0.score) : 5,
   );
 
   const [focusOn, setFocusOn] = React.useState<boolean>(Boolean(ext0.focusOn));
   const [focus, setFocus] = React.useState<number>(
-    Number.isFinite(ext0.focus ?? NaN) ? Number(ext0.focus) : 5
+    Number.isFinite(ext0.focus ?? NaN) ? Number(ext0.focus) : 5,
   );
 
-  const [markers, setMarkers] = React.useState<Marker[]>(
-    Array.isArray(ext0.markers) ? ext0.markers.map(normalizeMarker) : []
+  const [markers, setMarkers] = React.useState<ReviewMarker[]>(
+    Array.isArray(ext0.markers) ? ext0.markers.map(normalizeMarker) : [],
   );
-
-  const [useTimestamp, setUseTimestamp] = React.useState(lastMarkerMode);
-  const [tTime, setTTime] = React.useState(lastMarkerTime);
-  const [tNote, setTNote] = React.useState("");
 
   const laneRef = React.useRef<HTMLInputElement>(null);
   const opponentRef = React.useRef<HTMLInputElement>(null);
   const resultRef = React.useRef<HTMLButtonElement>(null);
-  const scoreRangeRef = React.useRef<HTMLInputElement>(null);
-  const focusRangeRef = React.useRef<HTMLInputElement>(null);
   const timeRef = React.useRef<HTMLInputElement>(null);
-  const noteRef = React.useRef<HTMLInputElement>(null);
 
   React.useEffect(() => {
     const ext = getExt(review);
     setNotes(review.notes ?? "");
     setTags(Array.isArray(review.tags) ? review.tags : []);
-    setDraftTag("");
 
     setOpponent(review.opponent ?? "");
     setLane(review.lane ?? review.title ?? "");
@@ -254,10 +138,6 @@ export default function ReviewEditor({
 
     const r = ext.role ?? lastRole ?? "MID";
     setRole(r);
-
-    // Default new reviews to the previously selected role without
-    // overwriting the remembered role when opening existing reviews.
-    // Persisting happens only when the user explicitly selects a role.
     if (ext.role == null) {
       onChangeMeta?.({ role: r });
     }
@@ -266,9 +146,6 @@ export default function ReviewEditor({
     setFocus(Number.isFinite(ext.focus ?? NaN) ? Number(ext.focus) : 5);
 
     setMarkers(Array.isArray(ext.markers) ? ext.markers.map(normalizeMarker) : []);
-    setUseTimestamp(lastMarkerMode);
-    setTTime(lastMarkerTime);
-    setTNote("");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [review.id]);
 
@@ -311,11 +188,6 @@ export default function ReviewEditor({
     return () => document.removeEventListener("pointerdown", handlePointerDown);
   }, [onDone]);
 
-  const sortedMarkers = React.useMemo(
-    () => [...markers].sort((a, b) => a.seconds - b.seconds),
-    [markers]
-  );
-
   function togglePillar(p: Pillar) {
     setPillars((prev) => {
       const has = prev.includes(p);
@@ -324,53 +196,16 @@ export default function ReviewEditor({
       return next;
     });
   }
-  function addTag(tagRaw: string) {
-    const t = tagRaw.trim().replace(/^#/, "");
-    if (!t || tags.includes(t)) return;
-    const next = [...tags, t];
-    setTags(next);
-    onChangeTags?.(next);
-  }
-  function removeTag(t: string) {
-    const next = tags.filter((x) => x !== t);
-    setTags(next);
-    onChangeTags?.(next);
-  }
-
-  const parsedTime = parseTime(tTime);
-  const timeError = useTimestamp && parsedTime === null;
-  const canAddMarker = (useTimestamp ? parsedTime !== null : true) &&
-    tNote.trim().length > 0;
-
-  function addMarker() {
-    const s = useTimestamp ? parsedTime : 0;
-    const safeS = s === null ? 0 : s;
-    const m: Marker = {
-      id: uid("mark"),
-      time: useTimestamp ? tTime.trim() || "00:00" : "00:00",
-      seconds: safeS,
-      note: tNote.trim(),
-      noteOnly: !useTimestamp,
-    };
-    const next = [...markers, m];
-    setMarkers(next);
-    commitMeta({ markers: next });
-    setTTime("");
-    setTNote("");
-    (useTimestamp ? timeRef : noteRef).current?.focus();
-  }
-  function removeMarker(id: string) {
-    const next = markers.filter((m) => m.id !== id);
-    setMarkers(next);
-    commitMeta({ markers: next });
-  }
 
   const msgIndex = pickIndex(String(review.id ?? "seed") + String(score), 5);
   const pool = SCORE_POOLS[score] ?? SCORE_POOLS[5];
   const msg = pool[msgIndex];
   const { Icon: ScoreIcon, cls: scoreIconCls } = scoreIcon(score);
 
-  const focusMsgIndex = pickIndex(String(review.id ?? "seed-focus") + String(focus), 10);
+  const focusMsgIndex = pickIndex(
+    String(review.id ?? "seed-focus") + String(focus),
+    10,
+  );
   const focusMsg = (FOCUS_POOLS[focus] ?? FOCUS_POOLS[5])[focusMsgIndex % 10];
 
   const go = (ref: React.RefObject<HTMLElement>) => ref.current?.focus();
@@ -381,15 +216,14 @@ export default function ReviewEditor({
     commitMeta({ role: v });
   }
 
-  function onIconKey(e: React.KeyboardEvent, handler: () => void) {
-    if (e.key === " " || e.key === "Enter") {
-      e.preventDefault();
-      handler();
-    }
-  }
-
   return (
-    <div ref={rootRef} className={cn("card-neo-soft r-card-lg overflow-hidden transition-none", className)}>
+    <div
+      ref={rootRef}
+      className={cn(
+        "card-neo-soft r-card-lg overflow-hidden transition-none",
+        className,
+      )}
+    >
       <div className="section-h sticky">
         <div className="grid w-full grid-cols-[1fr_auto] items-center gap-4">
           <div className="min-w-0">
@@ -477,421 +311,60 @@ export default function ReviewEditor({
       </div>
 
       <div className="section-b ds-card-pad space-y-6">
-        {/* Result */}
-        <div>
-          <SectionLabel>Result</SectionLabel>
-          <button
-            ref={resultRef}
-            type="button"
-            role="switch"
-            aria-checked={result === "Win"}
-            onClick={() => setResult((p) => (p === "Win" ? "Loss" : "Win"))}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                setResult((p) => (p === "Win" ? "Loss" : "Win"));
-                go(scoreRangeRef);
-              }
-            }}
-            className={cn(
-              "relative inline-flex h-10 w-48 select-none items-center overflow-hidden rounded-2xl",
-              "border border-border bg-card",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            )}
-            title="Toggle Win/Loss"
-          >
-            <span
-              aria-hidden
-              className="absolute top-1 bottom-1 left-1 rounded-xl transition-transform duration-300"
-              style={{
-                width: "calc(50% - 4px)",
-                transform: `translate3d(${result === "Win" ? "0" : "calc(100% + 2px)"},0,0)`,
-                transitionTimingFunction: "cubic-bezier(.22,1,.36,1)",
-                background:
-                  result === "Win"
-                    ? "linear-gradient(90deg, hsl(var(--success)/0.32), hsl(var(--accent)/0.28))"
-                    : "linear-gradient(90deg, hsl(var(--danger)/0.30), hsl(var(--primary)/0.26))",
-                boxShadow: "0 10px 30px hsl(var(--shadow-color) / .25)",
-              }}
-            />
-            <div className="relative z-10 grid w-full grid-cols-2 text-sm font-mono">
-              <div
-                className={cn(
-                  "py-2 text-center",
-                  result === "Win" ? "text-foreground/70" : "text-muted-foreground"
-                )}
-              >
-                Win
-              </div>
-              <div
-                className={cn(
-                  "py-2 text-center",
-                  result === "Loss" ? "text-foreground/70" : "text-muted-foreground"
-                )}
-              >
-                Loss
-              </div>
-            </div>
-          </button>
-        </div>
+        <ReviewMetadata
+          result={result}
+          onChangeResult={(r) => {
+            setResult(r);
+            commitMeta({ result: r });
+          }}
+          score={score}
+          onChangeScore={(v) => {
+            setScore(v);
+            commitMeta({ score: v });
+          }}
+          focusOn={focusOn}
+          onToggleFocus={(v) => {
+            setFocusOn(v);
+            commitMeta({ focusOn: v });
+          }}
+          focus={focus}
+          onChangeFocus={(v) => {
+            setFocus(v);
+            commitMeta({ focus: v });
+          }}
+          pillars={pillars}
+          togglePillar={togglePillar}
+          scoreMsg={msg}
+          ScoreIcon={ScoreIcon}
+          scoreIconCls={scoreIconCls}
+          focusMsg={focusMsg}
+          onScoreNext={() => timeRef.current?.focus()}
+          resultRef={resultRef}
+        />
 
-        {/* Score */}
-        <div>
-          <SectionLabel>Score</SectionLabel>
-          <div className="relative h-12 rounded-2xl border border-border bg-card px-4">
-            <input
-              ref={scoreRangeRef}
-              type="range"
-              min={0}
-              max={10}
-              step={1}
-              value={score}
-              onChange={(e) => {
-                const v = Number(e.target.value);
-                setScore(v);
-                commitMeta({ score: v });
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  go(timeRef);
-                }
-              }}
-              className="absolute inset-0 z-10 cursor-pointer opacity-0 [appearance:none]"
-              aria-label="Score from 0 to 10"
-            />
-            <div className="absolute left-4 right-4 top-1/2 -translate-y-1/2">
-              <div className="relative h-2 w-full rounded-full bg-muted shadow-[inset_2px_2px_4px_hsl(var(--shadow-color)/0.45),inset_-2px_-2px_4px_hsl(var(--foreground)/0.06)]">
-                <div
-                  className="absolute left-0 top-0 h-2 rounded-full bg-gradient-to-r from-primary to-accent shadow-[0_0_8px_hsl(var(--primary)/0.5)]"
-                  style={{ width: `calc(${(score / 10) * 100}% + 10px)` }}
-                />
-                <div
-                  className="absolute top-1/2 h-5 w-5 -translate-y-1/2 rounded-full border border-border bg-card shadow-[0_10px_25px_hsl(var(--shadow-color)/.25)]"
-                  style={{ left: `calc(${(score / 10) * 100}% - 10px)` }}
-                />
-              </div>
-            </div>
-          </div>
-          <div className="mt-1 flex items-center gap-2 text-[13px] text-muted-foreground">
-            <span className="pill h-6 px-2 text-xs">{score}/10</span>
-            <ScoreIcon className={cn("h-4 w-4", scoreIconCls)} />
-            <span>{msg}</span>
-          </div>
-        </div>
+        <ReviewMarkerEditor
+          markers={markers}
+          onChange={(next) => {
+            setMarkers(next);
+            commitMeta({ markers: next });
+          }}
+          timeRef={timeRef}
+          lastMarkerMode={lastMarkerMode}
+          setLastMarkerMode={setLastMarkerMode}
+          lastMarkerTime={lastMarkerTime}
+          setLastMarkerTime={setLastMarkerTime}
+        />
 
-        {/* Focus */}
-        <div>
-          <div className="flex items-center gap-3">
-            <button
-              type="button"
-              aria-label={focusOn ? "Brain light on" : "Brain light off"}
-              aria-pressed={focusOn}
-              className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              onClick={() => {
-                const v = !focusOn;
-                setFocusOn(v);
-                commitMeta({ focusOn: v });
-                if (v) focusRangeRef.current?.focus();
-              }}
-              onKeyDown={(e) =>
-                onIconKey(e, () => {
-                  const v = !focusOn;
-                  setFocusOn(v);
-                  commitMeta({ focusOn: v });
-                  if (v) focusRangeRef.current?.focus();
-                })
-              }
-            >
-              <NeonIcon kind="brain" on={focusOn} />
-            </button>
-          </div>
-
-          {focusOn && (
-            <>
-          <div className="mt-3 relative h-12 rounded-2xl border border-border bg-card px-4">
-                <input
-                  ref={focusRangeRef}
-                  type="range"
-                  min={0}
-                  max={10}
-                  step={1}
-                  value={focus}
-                  onChange={(e) => {
-                    const v = Number(e.target.value);
-                    setFocus(v);
-                    commitMeta({ focus: v });
-                  }}
-                  className="absolute inset-0 z-10 cursor-pointer opacity-0 [appearance:none]"
-                  aria-label="Focus from 0 to 10"
-                />
-                <div className="absolute left-4 right-4 top-1/2 -translate-y-1/2">
-                  <div className="relative h-2 w-full rounded-full bg-muted shadow-[inset_2px_2px_4px_hsl(var(--shadow-color)/0.45),inset_-2px_-2px_4px_hsl(var(--foreground)/0.06)]">
-                    <div
-                      className="absolute left-0 top-0 h-2 rounded-full bg-gradient-to-r from-accent to-primary shadow-[0_0_8px_hsl(var(--accent)/0.5)]"
-                      style={{ width: `calc(${(focus / 10) * 100}% + 10px)` }}
-                    />
-                    <div
-                      className="absolute top-1/2 h-5 w-5 -translate-y-1/2 rounded-full border border-border bg-card shadow-[0_10px_25px_hsl(var(--shadow-color)/.25)]"
-                      style={{ left: `calc(${(focus / 10) * 100}% - 10px)` }}
-                    />
-                  </div>
-                </div>
-              </div>
-              <div className="mt-1 flex items-center gap-2 text-[13px] text-muted-foreground">
-                <span className="pill h-6 px-2 text-xs">{focus}/10</span>
-                <span>{focusMsg}</span>
-              </div>
-            </>
-          )}
-        </div>
-
-        {/* Pillars */}
-        <div>
-          <SectionLabel>Pillars</SectionLabel>
-          <div className="flex flex-wrap gap-2">
-            {ALL_PILLARS.map((p) => {
-              const active = pillars.includes(p);
-              return (
-                <button
-                  key={p}
-                  type="button"
-                  onClick={() => togglePillar(p)}
-                  onKeyDown={(e) => onIconKey(e, () => togglePillar(p))}
-                  aria-pressed={active}
-                  className="rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  title={active ? `${p} selected` : `Select ${p}`}
-                >
-                  <NeonPillarChip active={active}>
-                    <PillarBadge pillar={p} size="md" interactive active={active} />
-                  </NeonPillarChip>
-                </button>
-              );
-            })}
-          </div>
-        </div>
-
-        {/* Timestamps */}
-        <div>
-          <div className="mb-3 flex items-center gap-3">
-            <button
-              type="button"
-              aria-label="Use timestamp"
-              aria-pressed={useTimestamp}
-              className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              onClick={() => {
-                setUseTimestamp(true);
-                setLastMarkerMode(true);
-                setTTime(lastMarkerTime);
-              }}
-              onKeyDown={(e) =>
-                onIconKey(e, () => {
-                  setUseTimestamp(true);
-                  setLastMarkerMode(true);
-                  setTTime(lastMarkerTime);
-                })
-              }
-              title="Timestamp mode"
-            >
-              <NeonIcon kind="clock" on={useTimestamp} />
-            </button>
-
-            <button
-              type="button"
-              aria-label="Use note only"
-              aria-pressed={!useTimestamp}
-              className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              onClick={() => {
-                setUseTimestamp(false);
-                setLastMarkerMode(false);
-              }}
-              onKeyDown={(e) =>
-                onIconKey(e, () => {
-                  setUseTimestamp(false);
-                  setLastMarkerMode(false);
-                })
-              }
-              title="Note-only mode"
-            >
-              <NeonIcon kind="file" on={!useTimestamp} />
-            </button>
-          </div>
-
-          <div className="grid grid-cols-[auto_1fr_auto] items-center gap-2">
-            {useTimestamp ? (
-              <Input
-                ref={timeRef}
-                value={tTime}
-                onChange={(e) => {
-                  setTTime(e.target.value);
-                  setLastMarkerTime(e.target.value);
-                }}
-                placeholder="00:00"
-                className="text-center font-mono tabular-nums"
-                aria-label="Timestamp time in mm:ss"
-                inputMode="numeric"
-                pattern="^[0-9]?\d:[0-5]\d$"
-                aria-invalid={timeError ? "true" : undefined}
-                aria-describedby={timeError ? "tTime-error" : undefined}
-                style={{ width: "calc(5ch + 1.7rem)" }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && canAddMarker) {
-                    e.preventDefault();
-                    addMarker();
-                  } else if (e.key === "Enter") {
-                    e.preventDefault();
-                    noteRef.current?.focus();
-                  }
-                }}
-              />
-            ) : (
-              <span
-                className="inline-flex h-10 items-center justify-center gap-2 rounded-2xl border border-border bg-card px-3 text-sm text-foreground/70"
-                style={{ width: "calc(5ch + 1.5rem)" }}
-                title="Timestamp disabled"
-              >
-                <Clock className="h-4 w-4" /> —
-              </span>
-            )}
-
-            <Input
-              ref={noteRef}
-              value={tNote}
-              onChange={(e) => setTNote(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && canAddMarker) {
-                  e.preventDefault();
-                  addMarker();
-                }
-              }}
-              placeholder="Note"
-              className="rounded-2xl"
-              aria-label="Timestamp note"
-            />
-
-            <IconButton
-              aria-label="Add timestamp"
-              title={canAddMarker ? "Add timestamp" : "Enter details"}
-              disabled={!canAddMarker}
-              size="md"
-              iconSize="sm"
-              variant="solid"
-              onClick={addMarker}
-            >
-              <Plus />
-            </IconButton>
-          </div>
-          {timeError && (
-            <p id="tTime-error" className="mt-1 text-xs text-danger">
-              Enter time as mm:ss
-            </p>
-          )}
-
-          {sortedMarkers.length === 0 ? (
-            <div className="mt-2 text-sm text-muted-foreground">No timestamps yet.</div>
-          ) : (
-            <ul className="mt-3 space-y-2">
-              {sortedMarkers.map((m) => (
-                <li
-                  key={m.id}
-                  className="grid grid-cols-[auto_1fr_auto] items-center gap-2 rounded-2xl border border-border bg-card px-3 py-2"
-                >
-                  {m.noteOnly ? (
-                    <span className="pill h-7 min-w-[60px] px-0 flex items-center justify-center">
-                      <FileText size={14} className="opacity-80" />
-                    </span>
-                  ) : (
-                    <span className="pill h-7 min-w-[60px] px-3 text-[11px] font-mono tabular-nums text-center">
-                      {m.time}
-                    </span>
-                  )}
-
-                  <span className="truncate text-sm">{m.note}</span>
-                  <IconButton
-                    aria-label="Delete timestamp"
-                    title="Delete timestamp"
-                    size="sm"
-                    iconSize="sm"
-                    variant="ring"
-                    onClick={() => removeMarker(m.id)}
-                  >
-                    <Trash2 />
-                  </IconButton>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-
-        {/* Tags */}
-        <div>
-          <SectionLabel>Tags</SectionLabel>
-          <div className="mt-1 flex items-center gap-2">
-            <div className="relative flex-1">
-              <Tag className="pointer-events-none absolute left-4 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-muted-foreground" />
-              <Input
-                value={draftTag}
-                onChange={(e) => setDraftTag(e.target.value)}
-                placeholder="Add tag and press Enter"
-                className="pl-6"
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    addTag(draftTag);
-                    setDraftTag("");
-                  }
-                }}
-              />
-            </div>
-
-            <IconButton
-              aria-label="Add tag"
-              title="Add tag"
-              size="md"
-              iconSize="sm"
-              variant="solid"
-              onClick={() => {
-                addTag(draftTag);
-                setDraftTag("");
-              }}
-            >
-              <Plus />
-            </IconButton>
-          </div>
-
-          {tags.length === 0 ? (
-            <div className="mt-2 text-sm text-muted-foreground/80">No tags yet.</div>
-          ) : (
-            <div className="mt-2 flex flex-wrap items-center gap-2">
-              {tags.map((t) => (
-                <button
-                  key={t}
-                  type="button"
-                  className="chip h-9 px-4 text-sm group inline-flex items-center gap-1"
-                  title="Remove tag"
-                  onClick={() => removeTag(t)}
-                >
-                  <span>#{t}</span>
-                  <span className="opacity-0 transition-opacity group-hover:opacity-100">✕</span>
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Notes */}
-        <div>
-          <SectionLabel>Notes</SectionLabel>
-          <Textarea
-            value={notes}
-            onChange={(e) => setNotes(e.target.value)}
-            onBlur={commitNotes}
-            placeholder="Key moments, mistakes to fix, drills to run…"
-            className="rounded-2xl"
-            resize="resize-y"
-            textareaClassName="min-h-[180px] leading-relaxed"
-          />
-        </div>
+        <ReviewNotesTags
+          notes={notes}
+          onNotesChange={setNotes}
+          onNotesBlur={commitNotes}
+          tags={tags}
+          onTagsChange={(next) => {
+            setTags(next);
+            onChangeTags?.(next);
+          }}
+        />
       </div>
     </div>
   );

--- a/src/components/reviews/ReviewMarkerEditor.tsx
+++ b/src/components/reviews/ReviewMarkerEditor.tsx
@@ -1,0 +1,221 @@
+import * as React from "react";
+import { uid } from "@/lib/db";
+import Input from "@/components/ui/primitives/Input";
+import IconButton from "@/components/ui/primitives/IconButton";
+import NeonIcon from "@/components/reviews/NeonIcon";
+import { onIconKey, parseTime } from "@/components/reviews/utils";
+import { Clock, FileText, Plus, Trash2 } from "lucide-react";
+import type { ReviewMarker } from "@/lib/types";
+
+export default function ReviewMarkerEditor({
+  markers,
+  onChange,
+  timeRef,
+  lastMarkerMode,
+  setLastMarkerMode,
+  lastMarkerTime,
+  setLastMarkerTime,
+}: {
+  markers: ReviewMarker[];
+  onChange: (next: ReviewMarker[]) => void;
+  timeRef: React.RefObject<HTMLInputElement>;
+  lastMarkerMode: boolean;
+  setLastMarkerMode: (v: boolean) => void;
+  lastMarkerTime: string;
+  setLastMarkerTime: (v: string) => void;
+}) {
+  const [useTimestamp, setUseTimestamp] = React.useState(lastMarkerMode);
+  const [tTime, setTTime] = React.useState(lastMarkerTime);
+  const [tNote, setTNote] = React.useState("");
+  const noteRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    setUseTimestamp(lastMarkerMode);
+    setTTime(lastMarkerTime);
+  }, [lastMarkerMode, lastMarkerTime]);
+
+  const sortedMarkers = React.useMemo(
+    () => [...markers].sort((a, b) => a.seconds - b.seconds),
+    [markers],
+  );
+
+  const parsedTime = parseTime(tTime);
+  const timeError = useTimestamp && parsedTime === null;
+  const canAddMarker =
+    (useTimestamp ? parsedTime !== null : true) && tNote.trim().length > 0;
+
+  function addMarker() {
+    const s = useTimestamp ? parsedTime : 0;
+    const safeS = s === null ? 0 : s;
+    const m: ReviewMarker = {
+      id: uid("mark"),
+      time: useTimestamp ? tTime.trim() || "00:00" : "00:00",
+      seconds: safeS,
+      note: tNote.trim(),
+      noteOnly: !useTimestamp,
+    };
+    const next = [...markers, m];
+    onChange(next);
+    setTTime("");
+    setTNote("");
+    (useTimestamp ? timeRef : noteRef).current?.focus();
+  }
+
+  function removeMarker(id: string) {
+    const next = markers.filter((m) => m.id !== id);
+    onChange(next);
+  }
+
+  return (
+    <div>
+      <div className="mb-3 flex items-center gap-3">
+        <button
+          type="button"
+          aria-label="Use timestamp"
+          aria-pressed={useTimestamp}
+          className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          onClick={() => {
+            setUseTimestamp(true);
+            setLastMarkerMode(true);
+            setTTime(lastMarkerTime);
+          }}
+          onKeyDown={(e) =>
+            onIconKey(e, () => {
+              setUseTimestamp(true);
+              setLastMarkerMode(true);
+              setTTime(lastMarkerTime);
+            })
+          }
+          title="Timestamp mode"
+        >
+          <NeonIcon kind="clock" on={useTimestamp} />
+        </button>
+
+        <button
+          type="button"
+          aria-label="Use note only"
+          aria-pressed={!useTimestamp}
+          className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          onClick={() => {
+            setUseTimestamp(false);
+            setLastMarkerMode(false);
+          }}
+          onKeyDown={(e) =>
+            onIconKey(e, () => {
+              setUseTimestamp(false);
+              setLastMarkerMode(false);
+            })
+          }
+          title="Note-only mode"
+        >
+          <NeonIcon kind="file" on={!useTimestamp} />
+        </button>
+      </div>
+
+      <div className="grid grid-cols-[auto_1fr_auto] items-center gap-2">
+        {useTimestamp ? (
+          <Input
+            ref={timeRef}
+            value={tTime}
+            onChange={(e) => {
+              setTTime(e.target.value);
+              setLastMarkerTime(e.target.value);
+            }}
+            placeholder="00:00"
+            className="text-center font-mono tabular-nums"
+            aria-label="Timestamp time in mm:ss"
+            inputMode="numeric"
+            pattern="^[0-9]?\d:[0-5]\d$"
+            aria-invalid={timeError ? "true" : undefined}
+            aria-describedby={timeError ? "tTime-error" : undefined}
+            style={{ width: "calc(5ch + 1.7rem)" }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && canAddMarker) {
+                e.preventDefault();
+                addMarker();
+              } else if (e.key === "Enter") {
+                e.preventDefault();
+                noteRef.current?.focus();
+              }
+            }}
+          />
+        ) : (
+          <span
+            className="inline-flex h-10 items-center justify-center gap-2 rounded-2xl border border-border bg-card px-3 text-sm text-foreground/70"
+            style={{ width: "calc(5ch + 1.5rem)" }}
+            title="Timestamp disabled"
+          >
+            <Clock className="h-4 w-4" /> —
+          </span>
+        )}
+
+        <Input
+          ref={noteRef}
+          value={tNote}
+          onChange={(e) => setTNote(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && canAddMarker) {
+              e.preventDefault();
+              addMarker();
+            }
+          }}
+          placeholder="Note"
+          className="rounded-2xl"
+          aria-label="Timestamp note"
+        />
+
+        <IconButton
+          aria-label="Add timestamp"
+          title={canAddMarker ? "Add timestamp" : "Enter details"}
+          disabled={!canAddMarker}
+          size="md"
+          iconSize="sm"
+          variant="solid"
+          onClick={addMarker}
+        >
+          <Plus />
+        </IconButton>
+      </div>
+      {timeError && (
+        <p id="tTime-error" className="mt-1 text-xs text-danger">
+          Enter time as mm:ss
+        </p>
+      )}
+
+      {sortedMarkers.length === 0 ? (
+        <div className="mt-2 text-sm text-muted-foreground">No timestamps yet.</div>
+      ) : (
+        <ul className="mt-3 space-y-2">
+          {sortedMarkers.map((m) => (
+            <li
+              key={m.id}
+              className="grid grid-cols-[auto_1fr_auto] items-center gap-2 rounded-2xl border border-border bg-card px-3 py-2"
+            >
+              {m.noteOnly ? (
+                <span className="pill h-7 min-w-[60px] px-0 flex items-center justify-center">
+                  <FileText size={14} className="opacity-80" />
+                </span>
+              ) : (
+                <span className="pill h-7 min-w-[60px] px-3 text-[11px] font-mono tabular-nums text-center">
+                  {m.time}
+                </span>
+              )}
+
+              <span className="truncate text-sm">{m.note}</span>
+              <IconButton
+                aria-label="Delete timestamp"
+                title="Delete timestamp"
+                size="sm"
+                iconSize="sm"
+                variant="ring"
+                onClick={() => removeMarker(m.id)}
+              >
+                <Trash2 />
+              </IconButton>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/reviews/ReviewMetadata.tsx
+++ b/src/components/reviews/ReviewMetadata.tsx
@@ -1,0 +1,323 @@
+import * as React from "react";
+import SectionLabel from "@/components/reviews/SectionLabel";
+import NeonIcon from "@/components/reviews/NeonIcon";
+import PillarBadge from "@/components/ui/league/pillars/PillarBadge";
+import { ALL_PILLARS } from "@/components/reviews/reviewData";
+import { cn } from "@/lib/utils";
+import type { Pillar } from "@/lib/types";
+import type { Result } from "@/components/reviews/utils";
+import { onIconKey } from "@/components/reviews/utils";
+
+function NeonPillarChip({
+  active,
+  children,
+}: {
+  active: boolean;
+  children: React.ReactNode;
+}) {
+  const prev = React.useRef(active);
+  const [phase, setPhase] = React.useState<
+    "steady-on" | "ignite" | "off" | "powerdown"
+  >(active ? "steady-on" : "off");
+
+  React.useEffect(() => {
+    if (active !== prev.current) {
+      if (active) {
+        setPhase("ignite");
+        const t = setTimeout(() => setPhase("steady-on"), 620);
+        prev.current = active;
+        return () => clearTimeout(t);
+      } else {
+        setPhase("powerdown");
+        const t = setTimeout(() => setPhase("off"), 360);
+        prev.current = active;
+        return () => clearTimeout(t);
+      }
+    }
+    prev.current = active;
+  }, [active]);
+
+  const lit = phase === "ignite" || phase === "steady-on";
+
+  return (
+    <span className="relative inline-flex">
+      <span
+        className={cn(
+          "pointer-events-none absolute inset-0 rounded-2xl",
+          lit ? "opacity-60" : "opacity-0",
+        )}
+        style={{
+          filter: "blur(10px)",
+          background:
+            "radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%)",
+          transition: "opacity 220ms var(--ease-out)",
+        }}
+        aria-hidden
+      />
+      <span
+        className={cn(
+          "pointer-events-none absolute inset-0 rounded-2xl",
+          lit
+            ? "opacity-40 animate-[neonAura_3.6s_ease-in-out_infinite]"
+            : "opacity-0",
+        )}
+        style={{
+          filter: "blur(14px)",
+          background:
+            "radial-gradient(80% 80% at 50% 50%, hsl(var(--primary)/.35), transparent 75%)",
+          transition: "opacity 220ms var(--ease-out)",
+        }}
+        aria-hidden
+      />
+      <span
+        className={cn(
+          "pointer-events-none absolute inset-0 rounded-2xl",
+          lit ? "animate-[igniteFlicker_.62s_steps(18,end)_1]" : "",
+        )}
+        style={{
+          background:
+            "radial-gradient(80% 80% at 50% 50%, hsl(var(--foreground)/0.22), transparent 60%)",
+          mixBlendMode: "screen",
+          opacity: lit ? 0.8 : 0,
+        }}
+        aria-hidden
+      />
+      <span className="relative z-10">{children}</span>
+    </span>
+  );
+}
+
+export default function ReviewMetadata({
+  result,
+  onChangeResult,
+  score,
+  onChangeScore,
+  focusOn,
+  onToggleFocus,
+  focus,
+  onChangeFocus,
+  pillars,
+  togglePillar,
+  scoreMsg,
+  ScoreIcon,
+  scoreIconCls,
+  focusMsg,
+  onScoreNext,
+  resultRef,
+}: {
+  result: Result;
+  onChangeResult: (r: Result) => void;
+  score: number;
+  onChangeScore: (v: number) => void;
+  focusOn: boolean;
+  onToggleFocus: (v: boolean) => void;
+  focus: number;
+  onChangeFocus: (v: number) => void;
+  pillars: Pillar[];
+  togglePillar: (p: Pillar) => void;
+  scoreMsg: string;
+  ScoreIcon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  scoreIconCls: string;
+  focusMsg: string;
+  onScoreNext?: () => void;
+  resultRef: React.RefObject<HTMLButtonElement>;
+}) {
+  const scoreRangeRef = React.useRef<HTMLInputElement>(null);
+  const focusRangeRef = React.useRef<HTMLInputElement>(null);
+
+  const go = (ref: React.RefObject<HTMLElement>) => ref.current?.focus();
+
+  return (
+    <>
+      {/* Result */}
+      <div>
+        <SectionLabel>Result</SectionLabel>
+        <button
+          ref={resultRef}
+          type="button"
+          role="switch"
+          aria-checked={result === "Win"}
+          onClick={() => onChangeResult(result === "Win" ? "Loss" : "Win")}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              onChangeResult(result === "Win" ? "Loss" : "Win");
+              go(scoreRangeRef);
+            }
+          }}
+          className={cn(
+            "relative inline-flex h-10 w-48 select-none items-center overflow-hidden rounded-2xl",
+            "border border-border bg-card",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          )}
+          title="Toggle Win/Loss"
+        >
+          <span
+            aria-hidden
+            className="absolute top-1 bottom-1 left-1 rounded-xl transition-transform duration-300"
+            style={{
+              width: "calc(50% - 4px)",
+              transform: `translate3d(${result === "Win" ? "0" : "calc(100% + 2px)"},0,0)`,
+              transitionTimingFunction: "cubic-bezier(.22,1,.36,1)",
+              background:
+                result === "Win"
+                  ? "linear-gradient(90deg, hsl(var(--success)/0.32), hsl(var(--accent)/0.28))"
+                  : "linear-gradient(90deg, hsl(var(--danger)/0.30), hsl(var(--primary)/0.26))",
+              boxShadow: "0 10px 30px hsl(var(--shadow-color) / .25)",
+            }}
+          />
+          <div className="relative z-10 grid w-full grid-cols-2 text-sm font-mono">
+            <div
+              className={cn(
+                "py-2 text-center",
+                result === "Win" ? "text-foreground/70" : "text-muted-foreground",
+              )}
+            >
+              Win
+            </div>
+            <div
+              className={cn(
+                "py-2 text-center",
+                result === "Loss" ? "text-foreground/70" : "text-muted-foreground",
+              )}
+            >
+              Loss
+            </div>
+          </div>
+        </button>
+      </div>
+
+      {/* Score */}
+      <div>
+        <SectionLabel>Score</SectionLabel>
+        <div className="relative h-12 rounded-2xl border border-border bg-card px-4">
+          <input
+            ref={scoreRangeRef}
+            type="range"
+            min={0}
+            max={10}
+            step={1}
+            value={score}
+            onChange={(e) => {
+              const v = Number(e.target.value);
+              onChangeScore(v);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                onScoreNext?.();
+              }
+            }}
+            className="absolute inset-0 z-10 cursor-pointer opacity-0 [appearance:none]"
+            aria-label="Score from 0 to 10"
+          />
+          <div className="absolute left-4 right-4 top-1/2 -translate-y-1/2">
+            <div className="relative h-2 w-full rounded-full bg-muted shadow-[inset_2px_2px_4px_hsl(var(--shadow-color)/0.45),inset_-2px_-2px_4px_hsl(var(--foreground)/0.06)]">
+              <div
+                className="absolute left-0 top-0 h-2 rounded-full bg-gradient-to-r from-primary to-accent shadow-[0_0_8px_hsl(var(--primary)/0.5)]"
+                style={{ width: `calc(${(score / 10) * 100}% + 10px)` }}
+              />
+              <div
+                className="absolute top-1/2 h-5 w-5 -translate-y-1/2 rounded-full border border-border bg-card shadow-[0_10px_25px_hsl(var(--shadow-color)/.25)]"
+                style={{ left: `calc(${(score / 10) * 100}% - 10px)` }}
+              />
+            </div>
+          </div>
+        </div>
+        <div className="mt-1 flex items-center gap-2 text-[13px] text-muted-foreground">
+          <span className="pill h-6 px-2 text-xs">{score}/10</span>
+          <ScoreIcon className={cn("h-4 w-4", scoreIconCls)} />
+          <span>{scoreMsg}</span>
+        </div>
+      </div>
+
+      {/* Focus */}
+      <div>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            aria-label={focusOn ? "Brain light on" : "Brain light off"}
+            aria-pressed={focusOn}
+            className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={() => {
+              const v = !focusOn;
+              onToggleFocus(v);
+              if (v) focusRangeRef.current?.focus();
+            }}
+            onKeyDown={(e) =>
+              onIconKey(e, () => {
+                const v = !focusOn;
+                onToggleFocus(v);
+                if (v) focusRangeRef.current?.focus();
+              })
+            }
+          >
+            <NeonIcon kind="brain" on={focusOn} />
+          </button>
+        </div>
+
+        {focusOn && (
+          <>
+            <div className="mt-3 relative h-12 rounded-2xl border border-border bg-card px-4">
+              <input
+                ref={focusRangeRef}
+                type="range"
+                min={0}
+                max={10}
+                step={1}
+                value={focus}
+                onChange={(e) => {
+                  const v = Number(e.target.value);
+                  onChangeFocus(v);
+                }}
+                className="absolute inset-0 z-10 cursor-pointer opacity-0 [appearance:none]"
+                aria-label="Focus from 0 to 10"
+              />
+              <div className="absolute left-4 right-4 top-1/2 -translate-y-1/2">
+                <div className="relative h-2 w-full rounded-full bg-muted shadow-[inset_2px_2px_4px_hsl(var(--shadow-color)/0.45),inset_-2px_-2px_4px_hsl(var(--foreground)/0.06)]">
+                  <div
+                    className="absolute left-0 top-0 h-2 rounded-full bg-gradient-to-r from-accent to-primary shadow-[0_0_8px_hsl(var(--accent)/0.5)]"
+                    style={{ width: `calc(${(focus / 10) * 100}% + 10px)` }}
+                  />
+                  <div
+                    className="absolute top-1/2 h-5 w-5 -translate-y-1/2 rounded-full border border-border bg-card shadow-[0_10px_25px_hsl(var(--shadow-color)/.25)]"
+                    style={{ left: `calc(${(focus / 10) * 100}% - 10px)` }}
+                  />
+                </div>
+              </div>
+            </div>
+            <div className="mt-1 flex items-center gap-2 text-[13px] text-muted-foreground">
+              <span className="pill h-6 px-2 text-xs">{focus}/10</span>
+              <span>{focusMsg}</span>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Pillars */}
+      <div>
+        <SectionLabel>Pillars</SectionLabel>
+        <div className="flex flex-wrap gap-2">
+          {ALL_PILLARS.map((p) => {
+            const active = pillars.includes(p);
+            return (
+              <button
+                key={p}
+                type="button"
+                onClick={() => togglePillar(p)}
+                onKeyDown={(e) => onIconKey(e, () => togglePillar(p))}
+                aria-pressed={active}
+                className="rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                title={active ? `${p} selected` : `Select ${p}`}
+              >
+                <NeonPillarChip active={active}>
+                  <PillarBadge pillar={p} size="md" interactive active={active} />
+                </NeonPillarChip>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/reviews/ReviewNotesTags.tsx
+++ b/src/components/reviews/ReviewNotesTags.tsx
@@ -1,0 +1,108 @@
+import * as React from "react";
+import SectionLabel from "@/components/reviews/SectionLabel";
+import Input from "@/components/ui/primitives/Input";
+import IconButton from "@/components/ui/primitives/IconButton";
+import Textarea from "@/components/ui/primitives/Textarea";
+import { Tag, Plus } from "lucide-react";
+
+export default function ReviewNotesTags({
+  notes,
+  onNotesChange,
+  onNotesBlur,
+  tags,
+  onTagsChange,
+}: {
+  notes: string;
+  onNotesChange: (v: string) => void;
+  onNotesBlur: () => void;
+  tags: string[];
+  onTagsChange: (next: string[]) => void;
+}) {
+  const [draftTag, setDraftTag] = React.useState("");
+
+  function addTag(tagRaw: string) {
+    const t = tagRaw.trim().replace(/^#/, "");
+    if (!t || tags.includes(t)) return;
+    const next = [...tags, t];
+    onTagsChange(next);
+  }
+
+  function removeTag(t: string) {
+    const next = tags.filter((x) => x !== t);
+    onTagsChange(next);
+  }
+
+  return (
+    <>
+      {/* Tags */}
+      <div>
+        <SectionLabel>Tags</SectionLabel>
+        <div className="mt-1 flex items-center gap-2">
+          <div className="relative flex-1">
+            <Tag className="pointer-events-none absolute left-4 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={draftTag}
+              onChange={(e) => setDraftTag(e.target.value)}
+              placeholder="Add tag and press Enter"
+              className="pl-6"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  addTag(draftTag);
+                  setDraftTag("");
+                }
+              }}
+            />
+          </div>
+
+          <IconButton
+            aria-label="Add tag"
+            title="Add tag"
+            size="md"
+            iconSize="sm"
+            variant="solid"
+            onClick={() => {
+              addTag(draftTag);
+              setDraftTag("");
+            }}
+          >
+            <Plus />
+          </IconButton>
+        </div>
+
+        {tags.length === 0 ? (
+          <div className="mt-2 text-sm text-muted-foreground/80">No tags yet.</div>
+        ) : (
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            {tags.map((t) => (
+              <button
+                key={t}
+                type="button"
+                className="chip h-9 px-4 text-sm group inline-flex items-center gap-1"
+                title="Remove tag"
+                onClick={() => removeTag(t)}
+              >
+                <span>#{t}</span>
+                <span className="opacity-0 transition-opacity group-hover:opacity-100">✕</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Notes */}
+      <div>
+        <SectionLabel>Notes</SectionLabel>
+        <Textarea
+          value={notes}
+          onChange={(e) => onNotesChange(e.target.value)}
+          onBlur={onNotesBlur}
+          placeholder="Key moments, mistakes to fix, drills to run…"
+          className="rounded-2xl"
+          resize="resize-y"
+          textareaClassName="min-h-[180px] leading-relaxed"
+        />
+      </div>
+    </>
+  );
+}

--- a/src/components/reviews/index.ts
+++ b/src/components/reviews/index.ts
@@ -12,3 +12,7 @@ export { default as ReviewSummaryNotes } from "./ReviewSummaryNotes";
 export { default as RoleSelector } from "./RoleSelector";
 export { default as ReviewPanel } from "./ReviewPanel";
 export { default as NeonIcon } from "./NeonIcon";
+export { default as ReviewMetadata } from "./ReviewMetadata";
+export { default as ReviewNotesTags } from "./ReviewNotesTags";
+export { default as ReviewMarkerEditor } from "./ReviewMarkerEditor";
+export * from "./utils";

--- a/src/components/reviews/utils.ts
+++ b/src/components/reviews/utils.ts
@@ -1,0 +1,27 @@
+import type * as React from "react";
+
+export type Result = "Win" | "Loss";
+
+/** Parse "m:ss" or "mm:ss" into seconds. Returns null for invalid input. */
+export function parseTime(mmss: string): number | null {
+  const m = mmss.trim().match(/^(\d{1,2}):([0-5]\d)$/);
+  if (!m) return null;
+  return Number(m[1]) * 60 + Number(m[2]);
+}
+
+/** Convert seconds to "m:ss" with zero-padded seconds. */
+export function formatSeconds(total: number): string {
+  const minutes = Math.max(0, Math.floor(total / 60));
+  const seconds = Math.max(0, total % 60);
+  return `${String(minutes)}:${String(seconds).padStart(2, "0")}`;
+}
+
+export function onIconKey(
+  e: React.KeyboardEvent,
+  handler: () => void,
+): void {
+  if (e.key === " " || e.key === "Enter") {
+    e.preventDefault();
+    handler();
+  }
+}


### PR DESCRIPTION
## Summary
- extract metadata, marker editor, and notes/tags into dedicated review components
- centralize time parsing utilities for reuse
- showcase new components on prompts demo page

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bfa606d6b8832caeaba314a5cc46cb