### PR TITLE
feat: add home landing page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
-// Root: "/" → Reviews
-import { ReviewPage } from "@/components/reviews";
+// Root: "/" → Home
+import { HomePage } from "@/components/home";
 
 export default function Page() {
-  return <ReviewPage />;
+  return <HomePage />;
 }

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -20,6 +20,7 @@ import {
   ReviewSummaryScore,
 } from "@/components/reviews";
 import { ComponentGallery, ColorGallery } from "@/components/prompts";
+import { HomePage } from "@/components/home";
 import { ROLE_OPTIONS, SCORE_POOLS, scoreIcon } from "@/components/reviews/reviewData";
 import type { Role } from "@/lib/types";
 import { Plus } from "lucide-react";
@@ -179,6 +180,7 @@ export default function Page() {
       <UpdatesList />
       <ButtonShowcase />
       <IconButtonShowcase />
+      <HomePage />
       <p className="mb-4 text-xs text-danger">Example error message</p>
       <div className="mb-8">
         <TabBar

--- a/src/components/home/HomePage.tsx
+++ b/src/components/home/HomePage.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+
+/**
+ * HomePage — landing view with quick nav links.
+ */
+export default function HomePage() {
+  return (
+    <main className="page-shell py-6 space-y-6 text-center">
+      <header>
+        <h1 className="text-2xl font-semibold">Welcome to Planner</h1>
+        <p className="mt-2 text-muted-foreground">
+          Streamline your planning and reviews.
+        </p>
+      </header>
+      <nav className="flex justify-center gap-4">
+        <Link className="text-accent underline" href="/planner">
+          Planner
+        </Link>
+        <Link className="text-accent underline" href="/reviews">
+          Reviews
+        </Link>
+        <Link className="text-accent underline" href="/prompts">
+          Prompts
+        </Link>
+      </nav>
+    </main>
+  );
+}

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -1,0 +1,2 @@
+// src/components/home/index.ts
+export { default as HomePage } from "./HomePage";

--- a/tests/home/HomePage.test.tsx
+++ b/tests/home/HomePage.test.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import HomePage from "@/components/home/HomePage";
+
+describe("HomePage", () => {
+  it("renders navigation links", () => {
+    render(<HomePage />);
+    const planner = screen.getByRole("link", { name: "Planner" });
+    const reviews = screen.getByRole("link", { name: "Reviews" });
+    const prompts = screen.getByRole("link", { name: "Prompts" });
+    expect(planner).toHaveAttribute("href", "/planner");
+    expect(reviews).toHaveAttribute("href", "/reviews");
+    expect(prompts).toHaveAttribute("href", "/prompts");
+  });
+});


### PR DESCRIPTION
## Summary
- add HomePage component with planner, reviews, and prompts links
- render HomePage at root route and document it in prompts gallery
- test HomePage navigation links

## Testing
- `npm run regen-ui`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bfa952489c832cadece77b0e3b74dc