### PR TITLE
Refactor goals list into reusable component

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -12,7 +12,7 @@ import {
   AnimatedSelect,
 } from "@/components/ui";
 import Banner from "@/components/chrome/Banner";
-import { GoalsProgress } from "@/components/goals";
+import { GoalsProgress, GoalList } from "@/components/goals";
 import {
   RoleSelector,
   NeonIcon,
@@ -22,7 +22,7 @@ import {
 import { ComponentGallery, ColorGallery } from "@/components/prompts";
 import { HomePage } from "@/components/home";
 import { ROLE_OPTIONS, SCORE_POOLS, scoreIcon } from "@/components/reviews/reviewData";
-import type { Role } from "@/lib/types";
+import type { Role, Goal } from "@/lib/types";
 import { Plus } from "lucide-react";
 
 type View = "components" | "colors";
@@ -164,6 +164,33 @@ const IconButtonShowcase = () => (
   </div>
 );
 
+const GOAL_DEMO_ITEMS: Goal[] = [
+  { id: "g1", title: "Demo active goal", done: false, createdAt: Date.now() },
+  {
+    id: "g2",
+    title: "Demo done goal",
+    done: true,
+    createdAt: Date.now() - 86_400_000,
+  },
+];
+
+const GoalListDemo = () => {
+  const [items, setItems] = React.useState<Goal[]>(GOAL_DEMO_ITEMS);
+  return (
+    <div className="mb-8">
+      <GoalList
+        goals={items}
+        onToggleDone={(id) =>
+          setItems((prev) =>
+            prev.map((g) => (g.id === id ? { ...g, done: !g.done } : g)),
+          )
+        }
+        onRemove={(id) => setItems((prev) => prev.filter((g) => g.id !== id))}
+      />
+    </div>
+  );
+};
+
 export default function Page() {
   const [view, setView] = React.useState<View>("components");
   const [role, setRole] = React.useState<Role>(ROLE_OPTIONS[0].value);
@@ -180,6 +207,7 @@ export default function Page() {
       <UpdatesList />
       <ButtonShowcase />
       <IconButtonShowcase />
+      <GoalListDemo />
       <HomePage />
       <p className="mb-4 text-xs text-danger">Example error message</p>
       <div className="mb-8">

--- a/src/components/goals/GoalList.tsx
+++ b/src/components/goals/GoalList.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import * as React from "react";
+import IconButton from "@/components/ui/primitives/IconButton";
+import CheckCircle from "@/components/ui/toggles/CheckCircle";
+import { Trash2 } from "lucide-react";
+import { shortDate } from "@/lib/date";
+import type { Goal } from "@/lib/types";
+
+interface GoalListProps {
+  goals: Goal[];
+  onToggleDone: (id: string) => void;
+  onRemove: (id: string) => void;
+}
+
+export default function GoalList({ goals, onToggleDone, onRemove }: GoalListProps) {
+  return (
+    <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 [grid-auto-rows:minmax(0,1fr)]">
+      {goals.length === 0 ? (
+        <p className="text-sm text-[hsl(var(--muted-foreground))]">
+          No goals here. Add one simple, finishable thing.
+        </p>
+      ) : (
+        goals.map((g) => (
+          <article
+            key={g.id}
+            className={[
+              "relative rounded-2xl p-6",
+              "card-neo transition",
+              "hover:shadow-[0_0_0_1px_hsl(var(--primary)/.25),0_12px_40px_hsl(var(--shadow-color)/0.35)]",
+              "min-h-8 flex flex-col",
+            ].join(" ")}
+          >
+            <span
+              aria-hidden
+              className="absolute inset-y-4 left-0 w-1 rounded-full bg-gradient-to-b from-[hsl(var(--primary))] via-[hsl(var(--accent))] to-transparent opacity-60"
+            />
+            <header className="flex items-start justify-between gap-2">
+              <h3 className="font-semibold leading-tight pr-6 line-clamp-2">
+                {g.title}
+              </h3>
+              <div className="flex items-center gap-2">
+                <CheckCircle
+                  aria-label={g.done ? "Mark active" : "Mark done"}
+                  checked={g.done}
+                  onChange={() => onToggleDone(g.id)}
+                  size="lg"
+                />
+                <IconButton
+                  title="Delete"
+                  aria-label="Delete goal"
+                  onClick={() => onRemove(g.id)}
+                  size="sm"
+                >
+                  <Trash2 />
+                </IconButton>
+              </div>
+            </header>
+            <div className="mt-4 text-sm text-[hsl(var(--muted-foreground))] space-y-2">
+              {g.metric ? (
+                <div className="tabular-nums">
+                  <span className="opacity-70">Metric:</span>{" "}
+                  {g.metric}
+                </div>
+              ) : null}
+              {g.notes ? <p className="leading-relaxed">{g.notes}</p> : null}
+            </div>
+            <footer className="mt-auto pt-3 flex items-center justify-between text-xs text-[hsl(var(--muted-foreground))]">
+              <span className="inline-flex items-center gap-2">
+                <span
+                  aria-hidden
+                  className={["h-2 w-2 rounded-full", g.done ? "" : "bg-[hsl(var(--primary))]"].join(" ")}
+                  style={g.done ? { background: "var(--accent-overlay)" } : undefined}
+                />
+                <time className="tabular-nums" dateTime={new Date(g.createdAt).toISOString()}>
+                  {shortDate.format(new Date(g.createdAt))}
+                </time>
+              </span>
+              <span className={g.done ? "text-[hsl(var(--accent))]" : ""}>
+                {g.done ? "Done" : "Active"}
+              </span>
+            </footer>
+          </article>
+        ))
+      )}
+    </div>
+  );
+}
+

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -11,14 +11,12 @@
  */
 
 import * as React from "react";
-import { Flag, ListChecks, Timer as TimerIcon, Trash2 } from "lucide-react";
+import { Flag, ListChecks, Timer as TimerIcon } from "lucide-react";
 
 import Header from "@/components/ui/layout/Header";
 import Hero from "@/components/ui/layout/Hero";
 import SectionCard from "@/components/ui/layout/SectionCard";
-import IconButton from "@/components/ui/primitives/IconButton";
-import CheckCircle from "@/components/ui/toggles/CheckCircle";
-import {
+import { 
   GlitchSegmentedGroup,
   GlitchSegmentedButton,
   Snackbar,
@@ -26,10 +24,10 @@ import {
 import GoalsTabs, { FilterKey } from "./GoalsTabs";
 import GoalForm, { GoalFormHandle } from "./GoalForm";
 import GoalsProgress from "./GoalsProgress";
+import GoalList from "./GoalList";
 
 import { usePersistentState } from "@/lib/db";
 import type { Goal, Pillar } from "@/lib/types";
-import { shortDate } from "@/lib/date";
 
 /* Tabs */
 import RemindersTab from "./RemindersTab";
@@ -236,93 +234,11 @@ export default function GoalsPage() {
                     <GoalsTabs value={filter} onChange={setFilter} />
                   </SectionCard.Header>
                   <SectionCard.Body>
-                    <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 [grid-auto-rows:minmax(0,1fr)]">
-                      {filtered.length === 0 ? (
-                        <p className="text-sm text-[hsl(var(--muted-foreground))]">
-                          No goals here. Add one simple, finishable thing.
-                        </p>
-                      ) : (
-                        filtered.map((g) => (
-                          <article
-                            key={g.id}
-                            className={[
-                              "relative rounded-2xl p-6",
-                              "card-neo transition",
-                              "hover:shadow-[0_0_0_1px_hsl(var(--primary)/.25),0_12px_40px_hsl(var(--shadow-color)/0.35)]",
-                              "min-h-8 flex flex-col",
-                            ].join(" ")}
-                          >
-                            <span
-                              aria-hidden
-                              className="absolute inset-y-4 left-0 w-1 rounded-full bg-gradient-to-b from-[hsl(var(--primary))] via-[hsl(var(--accent))] to-transparent opacity-60"
-                            />
-                            <header className="flex items-start justify-between gap-2">
-                              <h3 className="font-semibold leading-tight pr-6 line-clamp-2">
-                                {g.title}
-                              </h3>
-                              <div className="flex items-center gap-2">
-                                <CheckCircle
-                                  aria-label={
-                                    g.done ? "Mark active" : "Mark done"
-                                  }
-                                  checked={g.done}
-                                  onChange={() => toggleDone(g.id)}
-                                  size="lg"
-                                />
-                                <IconButton
-                                  title="Delete"
-                                  aria-label="Delete goal"
-                                  onClick={() => removeGoal(g.id)}
-                                  size="sm"
-                                >
-                                  <Trash2 />
-                                </IconButton>
-                              </div>
-                            </header>
-                            <div className="mt-4 text-sm text-[hsl(var(--muted-foreground))] space-y-2">
-                              {g.metric ? (
-                                <div className="tabular-nums">
-                                  <span className="opacity-70">Metric:</span>{" "}
-                                  {g.metric}
-                                </div>
-                              ) : null}
-                              {g.notes ? (
-                                <p className="leading-relaxed">{g.notes}</p>
-                              ) : null}
-                            </div>
-                            <footer className="mt-auto pt-3 flex items-center justify-between text-xs text-[hsl(var(--muted-foreground))]">
-                              <span className="inline-flex items-center gap-2">
-                                <span
-                                  aria-hidden
-                                  className={[
-                                    "h-2 w-2 rounded-full",
-                                    g.done ? "" : "bg-[hsl(var(--primary))]",
-                                  ].join(" ")}
-                                  style={
-                                    g.done
-                                      ? { background: "var(--accent-overlay)" }
-                                      : undefined
-                                  }
-                                />
-                                <time
-                                  className="tabular-nums"
-                                  dateTime={new Date(g.createdAt).toISOString()}
-                                >
-                                  {shortDate.format(new Date(g.createdAt))}
-                                </time>
-                              </span>
-                              <span
-                                className={
-                                  g.done ? "text-[hsl(var(--accent))]" : ""
-                                }
-                              >
-                                {g.done ? "Done" : "Active"}
-                              </span>
-                            </footer>
-                          </article>
-                        ))
-                      )}
-                    </div>
+                    <GoalList
+                      goals={filtered}
+                      onToggleDone={toggleDone}
+                      onRemove={removeGoal}
+                    />
                   </SectionCard.Body>
                 </SectionCard>
               )}

--- a/src/components/goals/index.ts
+++ b/src/components/goals/index.ts
@@ -7,6 +7,7 @@ export type { WaitItem } from "./GoalQueue";
 export { default as GoalSlot } from "./GoalSlot";
 export { default as GoalsPage } from "./GoalsPage";
 export { default as GoalsProgress } from "./GoalsProgress";
+export { default as GoalList } from "./GoalList";
 export { default as GoalsTabs } from "./GoalsTabs";
 export type { FilterKey } from "./GoalsTabs";
 export { default as Reminders } from "./Reminders";


### PR DESCRIPTION
## Summary
- extract goal list rendering into new `GoalList` component
- update `GoalsPage` to use `GoalList` and export through goals index
- showcase `GoalList` on prompts page

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bfac567794832ca7bdef8b5f5a2fb5