### PR TITLE
feat: add timer hero and unify goals tab layout

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -196,15 +196,6 @@ export default function GoalsPage() {
         }
       />
 
-      {tab === "goals" && (
-        <Hero
-          eyebrow="Guide"
-          heading="Overview"
-          subtitle={`Cap ${ACTIVE_CAP}, ${remaining} remaining (${activeCount} active, ${doneCount} done)`}
-          sticky={false}
-        />
-      )}
-
       <section className="grid gap-6">
         <div
           role="tabpanel"
@@ -213,7 +204,14 @@ export default function GoalsPage() {
           hidden={tab !== "goals"}
         >
           {tab === "goals" && (
-            <>
+            <div className="grid gap-4">
+              <Hero
+                eyebrow="Guide"
+                heading="Overview"
+                subtitle={`Cap ${ACTIVE_CAP}, ${remaining} remaining (${activeCount} active, ${doneCount} done)`}
+                sticky={false}
+              />
+
               {totalCount === 0 ? (
                 <GoalsProgress
                   total={totalCount}
@@ -354,7 +352,7 @@ export default function GoalsPage() {
                   }}
                 />
               )}
-            </>
+            </div>
           )}
         </div>
 

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -13,6 +13,7 @@ import * as React from "react";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import IconButton from "@/components/ui/primitives/IconButton";
 import TabBar from "@/components/ui/layout/TabBar";
+import Hero from "@/components/ui/layout/Hero";
 import {
   Play, Pause, RotateCcw, Plus, Minus,
   BookOpen, Brush, Code2, User,
@@ -171,23 +172,29 @@ export default function TimerTab() {
   ) : null;
 
   return (
-    <SectionCard className="goal-card no-hover">
-      <SectionCard.Header sticky topClassName="top-0">
-        <TabBar
-          items={tabItems}
-          value={profile}
-          onValueChange={(k) => setProfile(k as ProfileKey)}
-          size="md"
-          align="between"
-          ariaLabel="Timer profiles"
-          right={rightSlot}
-          showBaseline
-        />
-      </SectionCard.Header>
+    <div className="grid gap-4">
+      <Hero
+        eyebrow="Focus"
+        heading="Timer"
+        subtitle="Pick a duration and focus."
+        right={
+          <TabBar
+            items={tabItems}
+            value={profile}
+            onValueChange={(k) => setProfile(k as ProfileKey)}
+            size="md"
+            align="between"
+            ariaLabel="Timer profiles"
+            right={rightSlot}
+            showBaseline
+          />
+        }
+      />
 
-      <SectionCard.Body>
-        {/* Stage row with side buttons and centered digits */}
-        <div className="goal-card p-5 sm:p-6 overflow-hidden">
+      <SectionCard className="goal-card no-hover">
+        <SectionCard.Body>
+          {/* Stage row with side buttons and centered digits */}
+          <div className="goal-card p-5 sm:p-6 overflow-hidden">
           <div className="relative grid grid-cols-[auto_1fr_auto] items-center gap-3 sm:gap-4">
             {/* minus */}
             <IconButton
@@ -420,5 +427,6 @@ export default function TimerTab() {
         }
       `}</style>
     </SectionCard>
+  </div>
   );
 }

--- a/tests/goals/goals-page.test.tsx
+++ b/tests/goals/goals-page.test.tsx
@@ -57,6 +57,18 @@ describe("GoalsPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows timer hero with profile tabs", () => {
+    render(<GoalsPage />);
+    const timerTab = screen.getByRole("tab", { name: "Timer" });
+    fireEvent.click(timerTab);
+    expect(
+      screen.getByRole("heading", { name: "Timer" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("tablist", { name: "Timer profiles" }),
+    ).toBeInTheDocument();
+  });
+
   it("handles adding goals, cap enforcement, completion toggles, and undo", async () => {
     render(<GoalsPage />);
 


### PR DESCRIPTION
## Summary
- Move Goals tab hero inside its panel for consistent layout
- Add Timer tab hero with profile tabs and controls
- Test Timer hero rendering

## Testing
- `npm run regen-ui`
- `node <<'NODE' ...` (npm test, npm run lint, npm run typecheck)
- `npm test -- --run` (via commit hook)


------
https://chatgpt.com/codex/tasks/task_e_68bfac8e121c832c856f79f82b420447