### PR TITLE
chore: use size-4 for icons

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -68,6 +68,7 @@ const UPDATES: React.ReactNode[] = [
   <>
     Color gallery groups tokens into Aurora, Neutrals, and Accents palettes with tabs.
   </>,
+  <>Icons now use the <code>size-4</code> token instead of hardcoded 18px dimensions.</>,
 ];
 
 const DEMO_SCORE = 7;

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -400,7 +400,7 @@ export default function ReviewEditor({
 
             <div className="mb-2">
               <div className="relative">
-                <Target className="pointer-events-none absolute left-4 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-muted-foreground" />
+                <Target className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
                 <Input
                   ref={laneRef}
                   value={lane}
@@ -423,7 +423,7 @@ export default function ReviewEditor({
             <div>
               <SectionLabel>Opponent</SectionLabel>
               <div className="relative">
-                <Shield className="pointer-events-none absolute left-4 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-muted-foreground" />
+                <Shield className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
                 <Input
                   ref={opponentRef}
                   value={opponent}
@@ -828,7 +828,7 @@ export default function ReviewEditor({
           <SectionLabel>Tags</SectionLabel>
           <div className="mt-1 flex items-center gap-2">
             <div className="relative flex-1">
-              <Tag className="pointer-events-none absolute left-4 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-muted-foreground" />
+              <Tag className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
               <Input
                 value={draftTag}
                 onChange={(e) => setDraftTag(e.target.value)}

--- a/src/components/ui/primitives/SearchBar.tsx
+++ b/src/components/ui/primitives/SearchBar.tsx
@@ -120,7 +120,7 @@ export default function SearchBar({
               inputRef.current?.focus();
             }}
           >
-            <X className="h-[18px] w-[18px]" />
+            <X className="size-4" />
           </button>
         )}
       </div>


### PR DESCRIPTION
## Summary
- replace hardcoded 18px icon sizing with `size-4`
- note icon token in prompts update log

## Testing
- `node -e "require('ts-node/register'); const { createTaskBar, stopBars } = require('./src/utils/progress'); const { spawnSync } = require('child_process'); const steps = ['npm run regen-ui','npm test','npm run lint','npm run typecheck']; const bar = createTaskBar(steps.length); for (let i=0;i<steps.length;i++){ const cmd = steps[i]; const r = spawnSync(cmd,{shell:true,stdio:'inherit'}); if (r.status !== 0){ stopBars(); process.exit(r.status);} bar.update(i+1);} stopBars();"`

------
https://chatgpt.com/codex/tasks/task_e_68bfaccb9a74832c9f6d3d0d7e5d9147