### PR TITLE
refactor: use min-h-44 textarea height

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -68,6 +68,9 @@ const UPDATES: React.ReactNode[] = [
   <>
     Color gallery groups tokens into Aurora, Neutrals, and Accents palettes with tabs.
   </>,
+  <>
+    Textareas use <code>min-h-44</code> to align with spacing tokens instead of hardcoded heights.
+  </>,
 ];
 
 const DEMO_SCORE = 7;

--- a/src/components/planner/WeekNotes.tsx
+++ b/src/components/planner/WeekNotes.tsx
@@ -53,7 +53,7 @@ export default function WeekNotes({ iso }: Props) {
           onChange={(e) => setValue(e.target.value)}
           name={`notes-${iso}`}
           resize="resize-y"
-          textareaClassName="min-h-[180px] leading-relaxed"
+          textareaClassName="min-h-44 leading-relaxed"
           onBlur={commit}
         />
         <div className="mt-2 text-xs text-[hsl(var(--muted-foreground))]" aria-live="polite">

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -889,7 +889,7 @@ export default function ReviewEditor({
             placeholder="Key moments, mistakes to fix, drills to run…"
             className="rounded-2xl"
             resize="resize-y"
-            textareaClassName="min-h-[180px] leading-relaxed"
+            textareaClassName="min-h-44 leading-relaxed"
           />
         </div>
       </div>

--- a/src/components/team/Builder.tsx
+++ b/src/components/team/Builder.tsx
@@ -280,7 +280,7 @@ function SideEditor(props: {
             value={value.notes ?? ""}
             onChange={(e) => onNotes(e.currentTarget.value)}
             resize="resize-y"
-            textareaClassName="min-h-[180px] leading-relaxed"
+            textareaClassName="min-h-44 leading-relaxed"
             rows={4}
           />
         </div>

--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -236,7 +236,7 @@ function ParagraphEdit({
       rows={2}
       className="mt-1"
       resize="resize-y"
-      textareaClassName="min-h-[180px] text-sm text-[hsl(var(--muted-foreground))] leading-relaxed"
+      textareaClassName="min-h-44 text-sm text-[hsl(var(--muted-foreground))] leading-relaxed"
       aria-label="Description"
     />
   );

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -397,7 +397,7 @@ export default function MyComps({ query = "" }: MyCompsProps) {
                           aria-label="Notes"
                           rows={4}
                           resize="resize-y"
-                          textareaClassName="min-h-[180px] leading-relaxed"
+                          textareaClassName="min-h-44 leading-relaxed"
                           value={c.notes ?? ""}
                           onChange={e => patch(c.id, { notes: e.target.value })}
                         />


### PR DESCRIPTION
## Summary
- replace hardcoded `min-h-[180px]` with `min-h-44` across textareas
- document textarea height token in prompts page

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bface2ba44832c8dd5c33f54e18e73