### PR TITLE
feat: update kitten theme accent

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -69,6 +69,7 @@ const UPDATES: React.ReactNode[] = [
     Color gallery groups tokens into Aurora, Neutrals, and Accents palettes with tabs.
   </>,
   <>Icons now use the <code>size-4</code> token instead of hardcoded 18px dimensions.</>,
+  <>Kitten theme adopts a cyan <code>accent-2</code> for secondary actions.</>,
 ];
 
 const DEMO_SCORE = 7;

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -284,7 +284,7 @@ html.theme-kitten {
   --primary-foreground: 0 0% 100%;
   --primary-soft: 330 100% 24%;
   --accent: 336 100% 27%;
-  --accent-2: 330 100% 40%;
+  --accent-2: 196 100% 30%;
   --accent-foreground: 0 0% 100%;
   --accent-soft: 336 100% 12%;
   --muted: 330 100% 20%;


### PR DESCRIPTION
## Summary
- tune kitten theme's secondary accent to a cyan hue
- document new accent in prompts page updates

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bfae8c627c832c8b6f8f5109f9a777