### PR TITLE
feat(team): add builder hero

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -68,6 +68,9 @@ const UPDATES: React.ReactNode[] = [
   <>
     Color gallery groups tokens into Aurora, Neutrals, and Accents palettes with tabs.
   </>,
+  <>
+    Team Builder now features a Hero header with swap and copy actions.
+  </>,
 ];
 
 const DEMO_SCORE = 7;

--- a/src/components/team/Builder.tsx
+++ b/src/components/team/Builder.tsx
@@ -10,7 +10,8 @@ import "./style.css";
  * - Center spine shows on md+ only
  */
 
-import { useMemo, useState } from "react";
+import * as React from "react";
+import Hero from "@/components/ui/layout/Hero";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import Input from "@/components/ui/primitives/Input";
 import Textarea from "@/components/ui/primitives/Textarea";
@@ -23,7 +24,6 @@ import {
   ClipboardCheck,
   Eraser,
   NotebookPen,
-  Info,
   Copy,
 } from "lucide-react";
 import { usePersistentState } from "@/lib/db";
@@ -94,9 +94,9 @@ export default function Builder() {
     allies: { ...EMPTY_TEAM },
     enemies: { ...EMPTY_TEAM },
   });
-  const [copied, setCopied] = useState<"all" | "allies" | "enemies" | null>(null);
+  const [copied, setCopied] = React.useState<"all" | "allies" | "enemies" | null>(null);
 
-  const filledCount = useMemo(() => {
+  const filledCount = React.useMemo(() => {
     const countTeam = (t: Team) =>
       [t.top, t.jungle, t.mid, t.adc, t.support].filter(Boolean).length;
     return { allies: countTeam(state.allies), enemies: countTeam(state.enemies) };
@@ -144,42 +144,38 @@ export default function Builder() {
   /* ─────────────── UI ─────────────── */
 
   return (
-    <div data-scope="team" className="grid gap-4">
-      <SectionCard className="card-neo-soft glitch-card">
-        <SectionCard.Header
-          sticky
-          title={
-            <div className="flex items-center gap-2">
-              <span className="pill">
-                <Info className="mr-1" /> Fill allies vs enemies. Swap in one click.
-              </span>
-            </div>
-          }
-          actions={
-            <div className="flex items-center gap-2">
-              <IconButton
-                title="Swap Allies ↔ Enemies"
-                aria-label="Swap Allies and Enemies"
-                onClick={swapSides}
-                size="sm"
-                iconSize="sm"
-              >
-                <Shuffle />
-              </IconButton>
-              <IconButton
-                title="Copy both sides"
-                aria-label="Copy both sides"
-                onClick={() => copy("all")}
-                size="sm"
-                iconSize="sm"
-              >
-                {copied === "all" ? <ClipboardCheck /> : <Clipboard />}
-              </IconButton>
-            </div>
-          }
-        />
-        <SectionCard.Body>
-          <div className="grid grid-cols-1 md:grid-cols-[1fr_12px_1fr] gap-6">
+    <div data-scope="team" className="w-full">
+      <Hero
+        eyebrow="Comps"
+        heading="Builder"
+        subtitle="Fill allies vs enemies. Swap in one click."
+        right={
+          <div className="flex items-center gap-2">
+            <IconButton
+              title="Swap Allies ↔ Enemies"
+              aria-label="Swap Allies and Enemies"
+              onClick={swapSides}
+              size="sm"
+              iconSize="sm"
+            >
+              <Shuffle />
+            </IconButton>
+            <IconButton
+              title="Copy both sides"
+              aria-label="Copy both sides"
+              onClick={() => copy("all")}
+              size="sm"
+              iconSize="sm"
+            >
+              {copied === "all" ? <ClipboardCheck /> : <Clipboard />}
+            </IconButton>
+          </div>
+        }
+      />
+      <div className="mt-6">
+        <SectionCard className="card-neo-soft glitch-card">
+          <SectionCard.Body>
+            <div className="grid grid-cols-1 md:grid-cols-[1fr_12px_1fr] gap-6">
             {/* Allies */}
             <SideEditor
               title="Allies"
@@ -213,7 +209,8 @@ export default function Builder() {
             />
           </div>
         </SectionCard.Body>
-      </SectionCard>
+        </SectionCard>
+      </div>
     </div>
   );
 }

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -12,7 +12,7 @@
  */
 import "./style.css";
 
-import * as React from "react";
+import React, { useState } from "react";
 import { Users2, BookOpenText, Hammer, Timer } from "lucide-react";
 import Header, { HeaderTabs, type HeaderTab } from "@/components/ui/layout/Header";
 import Builder from "./Builder";
@@ -43,7 +43,7 @@ const TABS: HeaderTab<Tab>[] = [
 ];
 
 export default function TeamCompPage() {
-  const [tab, setTab] = React.useState<Tab>("cheat");
+  const [tab, setTab] = useState<Tab>("cheat");
 
   return (
     <main className="page-shell py-6 space-y-6">

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -12,7 +12,7 @@
  */
 import "./style.css";
 
-import { useState } from "react";
+import * as React from "react";
 import { Users2, BookOpenText, Hammer, Timer } from "lucide-react";
 import Header, { HeaderTabs, type HeaderTab } from "@/components/ui/layout/Header";
 import Builder from "./Builder";
@@ -43,7 +43,7 @@ const TABS: HeaderTab<Tab>[] = [
 ];
 
 export default function TeamCompPage() {
-  const [tab, setTab] = useState<Tab>("cheat");
+  const [tab, setTab] = React.useState<Tab>("cheat");
 
   return (
     <main className="page-shell py-6 space-y-6">

--- a/tests/team/TeamCompPage.test.tsx
+++ b/tests/team/TeamCompPage.test.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import TeamCompPage from "@/components/team/TeamCompPage";
+
+describe("TeamCompPage builder tab", () => {
+  it("shows builder hero with spacing", () => {
+    render(<TeamCompPage />);
+    const builderTab = screen.getByRole("tab", { name: "Builder" });
+    fireEvent.click(builderTab);
+    const heroHeading = screen.getByRole("heading", { name: "Builder" });
+    expect(heroHeading).toBeInTheDocument();
+    const cardParent = screen.getByText("Allies").closest("section")?.parentElement;
+    expect(cardParent).toHaveClass("mt-6");
+  });
+});


### PR DESCRIPTION
## Summary
- add Hero to Team Builder with swap and copy actions
- note Builder hero in prompts page
- cover builder tab hero in tests

## Testing
- `npm run regen-ui`
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bfac8f3674832cb7fc779d76d68d9f