### PR TITLE
Improve accent and success color contrast

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -69,6 +69,7 @@ const UPDATES: React.ReactNode[] = [
     Color gallery groups tokens into Aurora, Neutrals, and Accents palettes with tabs.
   </>,
   <>Icons now use the <code>size-4</code> token instead of hardcoded 18px dimensions.</>,
+  <>Accent secondary and success colors updated for improved contrast.</>,
 ];
 
 const DEMO_SCORE = 7;

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -18,7 +18,7 @@
   --primary-foreground: 0 0% 100%;
   --primary-soft: 262 83% 18%;
   --accent: 292 90% 35%;
-  --accent-2: 192 100% 25%;
+  --accent-2: 52 100% 25%;
   --accent-foreground: 0 0% 100%;
   --accent-soft: 292 90% 15%;
   --glow: 292 90% 35%;
@@ -32,8 +32,8 @@
   --surface-streak: 240 16% 12%;
   --shadow-color: 262 83% 58%;
   --lav-deep: 320 85% 60%;
-  --success: 316 92% 70%;
-  --success-glow: 316 92% 52% / 0.6;
+  --success: 142 72% 30%;
+  --success-glow: 142 72% 12% / 0.6;
   --aurora-g: 150 100% 60%;
   --aurora-g-light: 150 100% 85%;
   --aurora-p: 272 80% 60%;


### PR DESCRIPTION
## Summary
- switch accent-2 token to golden hue and keep readable foreground
- use green success tones distinct from accent
- note color token updates on prompts page

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bfae885c04832cb8fb2765d9a0f2ab