### PR TITLE
feat: link site chrome brand to home

### DIFF
--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -6,6 +6,7 @@
  * - No hover translate (calm UI).
  * - Active when pathname matches or is nested under the href.
  */
+import * as React from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { motion } from "framer-motion";

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import * as React from "react";
 import NavBar from "@/components/chrome/NavBar";
 import ThemeToggle from "@/components/ui/theme/ThemeToggle";
 import AnimationToggle from "@/components/ui/AnimationToggle";
+import Link from "next/link";
 import "@/app/globals.css";
 
 /**
@@ -15,8 +17,8 @@ export default function SiteChrome() {
   return (
     <header role="banner" className="sticky-blur top-0 z-50">
       {/* Bar content */}
-        <div className="page-shell flex items-center justify-between py-2">
-        <div className="flex items-center gap-2">
+      <div className="page-shell flex items-center justify-between py-2">
+        <Link href="/" className="flex items-center gap-2">
           <span
             className="h-2 w-2 rounded-full animate-pulse"
             style={{
@@ -26,9 +28,9 @@ export default function SiteChrome() {
             aria-hidden
           />
           <span className="font-mono tracking-wide text-[hsl(var(--muted-foreground))]">
-            NOXIS PLANNER
+            noxi
           </span>
-        </div>
+        </Link>
 
         <div className="flex items-center gap-2">
           <NavBar />

--- a/tests/ui/site-chrome.test.tsx
+++ b/tests/ui/site-chrome.test.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import SiteChrome from "@/components/chrome/SiteChrome";
+
+describe("SiteChrome", () => {
+  it("links to the home page via the noxi brand", () => {
+    render(<SiteChrome />);
+    const homeLink = screen.getByRole("link", { name: /noxi/i });
+    expect(homeLink).toHaveAttribute("href", "/");
+  });
+});


### PR DESCRIPTION
## Summary
- link site chrome brand text to home page
- ensure React imports for client components
- test site chrome home link

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bfaf4d6070832cb7e9dcf1d76ad708