### PR TITLE
fix: clean prompts page merge conflict

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -27,26 +27,10 @@ import { Plus } from "lucide-react";
 
 type View = "components" | "colors";
 
-function ShowcaseSection({
-  title,
-  children,
-}: {
-  title: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <section className="mb-8">
-      <h2 className="mb-4 text-lg font-semibold tracking-tight">{title}</h2>
-      <div className="space-y-4">{children}</div>
-    </section>
-  );
-}
-
-export default function Page() {
-  const viewTabs: TabItem<View>[] = [
-    { key: "components", label: "Components" },
-    { key: "colors", label: "Colors" },
-  ];
+const viewTabs: TabItem<View>[] = [
+  { key: "components", label: "Components" },
+  { key: "colors", label: "Colors" },
+];
 
 const FRUIT_ITEMS = [
   { value: "apple", label: "Apple" },
@@ -84,11 +68,8 @@ const UPDATES: React.ReactNode[] = [
   <>
     Color gallery groups tokens into Aurora, Neutrals, and Accents palettes with tabs.
   </>,
-<<<<<<< HEAD
   <>Icons now use the <code>size-4</code> token instead of hardcoded 18px dimensions.</>,
   <>Accent secondary and success colors updated for improved contrast.</>,
-=======
->>>>>>> main
 ];
 
 const DEMO_SCORE = 7;


### PR DESCRIPTION
## Summary
- remove stray merge conflict in prompts page
- keep icon sizing and color update entries
- dedupe prompts page export

## Testing
- `npm run regen-ui`
- `npm test` *(fails: sizeMap is not defined, merge conflict markers)*
- `npm run lint` *(fails: merge conflict marker encountered in other files)*
- `npm run typecheck` *(fails: merge conflict markers and duplicate identifiers)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc7981fcc832c8af9142927b00023