### PR TITLE
chore: reconcile theme styles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -449,125 +449,29 @@ html.bg-intense body::after {
     }
   }
 
-  @keyframes btnShift {
-    0% {
-      background-position: 0% 50%;
-    }
-    100% {
-      background-position: 200% 50%;
-    }
-  }
-  @keyframes btnFlicker {
-    0%,
-    2%,
-    35%,
-    37%,
-    100% {
-      opacity: 1;
-    }
-    1% {
-      opacity: 0.86;
-    }
-    36% {
-      opacity: 0.92;
-    }
-    60% {
-      opacity: 0.88;
-    }
-    61% {
-      opacity: 1;
-    }
-  }
-  @keyframes btnScan {
-    0% {
-      transform: translateY(-28%);
-    }
-    100% {
-      transform: translateY(28%);
-    }
-  }
-  @keyframes igniteFlicker {
-    0% {
-      opacity: 0.1;
-      filter: blur(0.6px);
-    }
-    8% {
-      opacity: 1;
-    }
-    12% {
-      opacity: 0.25;
-    }
-    20% {
-      opacity: 1;
-    }
-    28% {
-      opacity: 0.35;
-    }
-    40% {
-      opacity: 1;
-    }
-    55% {
-      opacity: 0.45;
-      filter: blur(0.2px);
-    }
-    70% {
-      opacity: 1;
-    }
-    100% {
-      opacity: 0;
-    }
-  }
-  @keyframes powerDown {
-    0% {
-      opacity: 0.8;
-      transform: scale(1);
-    }
-    30% {
-      opacity: 0.35;
-      transform: scale(0.992) translateY(0.2px);
-    }
-    60% {
-      opacity: 0.12;
-      transform: scale(0.985) translateY(-0.2px);
-    }
-    100% {
-      opacity: 0;
-      transform: scale(0.985);
-    }
-  }
-
   .btn-like-segmented {
     @apply inline-flex items-center justify-center px-4 py-2 text-sm rounded-full;
     position: relative;
     overflow: hidden;
-<<<<<<< HEAD
-    border-color: hsl(var(--card-hairline));
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    text-align: center;
+    border: 1px solid hsl(var(--card-hairline));
     background:
       linear-gradient(90deg, hsl(var(--primary-soft)) 0%, transparent 100%),
       hsl(var(--card));
     color: hsl(var(--muted-foreground));
+    box-shadow: 0 0 4px hsl(var(--ring) / 0.4);
     transition:
       transform var(--dur-quick) var(--ease-out),
       background var(--dur-quick),
-      color var(--dur-quick);
+      color var(--dur-quick),
+      box-shadow var(--dur-quick);
   }
   .btn-like-segmented:hover {
     background:
       linear-gradient(90deg, hsl(var(--primary) / 0.12) 0%, transparent 100%),
       hsl(var(--card));
-=======
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    text-align: center;
-    border: 1px solid hsl(var(--ring) / 0.6);
-    background: hsl(var(--surface-2) / 0.1);
-    color: hsl(var(--muted-foreground));
-    box-shadow: 0 0 4px hsl(var(--ring) / 0.4);
-    transition: color 180ms ease-in-out, background 180ms ease-in-out,
-      box-shadow 180ms ease-in-out;
-  }
-  .btn-like-segmented:hover {
->>>>>>> origin/final
     color: hsl(var(--foreground));
     box-shadow: 0 0 6px hsl(var(--ring) / 0.7);
   }
@@ -594,19 +498,13 @@ html.bg-intense body::after {
     color: hsl(var(--foreground));
     background: hsl(var(--accent) / 0.15);
     border-color: hsl(var(--ring));
-<<<<<<< HEAD
     box-shadow:
       0 0 0 2px hsl(var(--ring) / 0.35),
       0 12px 28px hsl(var(--ring) / 0.25);
-=======
-    box-shadow: inset 0 0 8px hsl(var(--accent) / 0.6),
-      0 0 8px hsl(var(--ring) / 0.8),
-      0 0 12px hsl(var(--accent) / 0.5);
   }
   .btn-like-segmented.is-active::before,
   .btn-like-segmented[aria-current="page"]::before {
     opacity: 1;
->>>>>>> origin/final
   }
 
   .btn-glitch {

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -84,12 +84,9 @@ const UPDATES: React.ReactNode[] = [
   <>
     Color gallery groups tokens into Aurora, Neutrals, and Accents palettes with tabs.
   </>,
-<<<<<<< HEAD
   <>Icons now use the <code>size-4</code> token instead of hardcoded 18px dimensions.</>,
   <>Accent secondary and success colors updated for improved contrast.</>,
-=======
->>>>>>> main
-];
+  ];
 
 const DEMO_SCORE = 7;
 const { Icon: DemoScoreIcon, cls: demoScoreCls } = scoreIcon(DEMO_SCORE);

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -11,7 +11,6 @@
   --panel: var(--card);
   --border: #312d43;
   --line: var(--border);
-<<<<<<< HEAD
   --input: 250 22% 12%;
   --ring: 262 83% 58%;
   --theme-ring: hsl(var(--ring));
@@ -44,40 +43,6 @@
   --ring-contrast: hsl(var(--ring));
   --glow-active: hsl(var(--glow));
   --text-on-accent: hsl(var(--foreground));
-=======
-  --input: #1a1825;
-  --ring: #7c3bed;
-  --theme-ring: var(--ring);
-  --primary: #7c3bed;
-  --primary-foreground: #ffffff;
-  --primary-soft: #240854;
-  --accent: #9409aa;
-  --accent-2: #006680;
-  --accent-foreground: #ffffff;
-  --accent-soft: #3f0449;
-  --glow: #9409aa;
-  --ring-muted: #302d43;
-  --danger: #ef4343;
-  --muted: #1d1a2d;
-  --muted-foreground: #aba7be;
-  --surface: #191726;
-  --surface-2: #221f33;
-  --surface-vhs: #0b0f13;
-  --surface-streak: #1a1a23;
-  --shadow-color: #7c3bed;
-  --lav-deep: #f042b6;
-  --success: #f96cd3;
-  --success-glow: #f514b999;
-  --aurora-g: #33ff99;
-  --aurora-g-light: #b3ffd9;
-  --aurora-p: #9e47eb;
-  --aurora-p-light: #dbbaf7;
-  --icon-fg: #978aff;
-  --accent-overlay: var(--accent);
-  --ring-contrast: var(--ring);
-  --glow-active: var(--glow);
-  --text-on-accent: var(--foreground);
->>>>>>> main
 
   /* Default button tones */
   --neon: var(--glow);
@@ -188,42 +153,23 @@ html.theme-aurora {
   --panel: var(--card);
   --border: #32004d;
   --line: var(--border);
-<<<<<<< HEAD
-  --input: #32004d;
-  --ring: #33ff99;
-  --theme-ring: var(--ring);
-  --primary: #33ff99;
-  --primary-foreground: #ffffff;
-  --primary-soft: #006633;
-  --accent: #9e47eb;
-  --accent-2: #33ff99;
-  --accent-foreground: #ffffff;
-  --accent-soft: #360a5c;
-  --muted: #32004d;
-  --muted-foreground: #c3b3cc;
-  --shadow-color: #33ff99;
-  --lav-deep: #9e47eb;
-  --success: #f96cd3;
-  --success-glow: #f514b999;
-=======
-  --input: 279 100% 15%;
-  --ring: 150 100% 60%;
-  --theme-ring: hsl(var(--ring));
-  --primary: 150 100% 60%;
-  --primary-foreground: 0 0% 100%;
-  --primary-soft: 150 100% 20%;
-  --accent: 272 80% 60%;
-  --accent-2: 150 100% 60%;
-  --accent-foreground: 0 0% 100%;
-  --accent-soft: 272 80% 20%;
-  --glow: 272 80% 60%;
-  --muted: 279 100% 15%;
-  --muted-foreground: 279 20% 75%;
-  --shadow-color: 150 100% 60%;
-  --lav-deep: 272 80% 60%;
-  --success: 316 92% 70%;
-  --success-glow: 316 92% 52% / 0.6;
->>>>>>> codex/add-glow-overrides-to-themes
+    --input: 279 100% 15%;
+    --ring: 150 100% 60%;
+    --theme-ring: hsl(var(--ring));
+    --primary: 150 100% 60%;
+    --primary-foreground: 0 0% 100%;
+    --primary-soft: 150 100% 20%;
+    --accent: 272 80% 60%;
+    --accent-2: 150 100% 60%;
+    --accent-foreground: 0 0% 100%;
+    --accent-soft: 272 80% 20%;
+    --glow: 272 80% 60%;
+    --muted: 279 100% 15%;
+    --muted-foreground: 279 20% 75%;
+    --shadow-color: 150 100% 60%;
+    --lav-deep: 272 80% 60%;
+    --success: 316 92% 70%;
+    --success-glow: 316 92% 52% / 0.6;
   --edge-iris: conic-gradient(
     from 180deg,
     #33ff9900,
@@ -251,42 +197,23 @@ html.theme-citrus {
   --panel: var(--card);
   --border: #3b4654;
   --line: var(--border);
-<<<<<<< HEAD
-  --input: #202832;
-  --ring: #f96d10;
-  --theme-ring: var(--ring);
-  --primary: #f96d10;
-  --primary-foreground: #ffffff;
-  --primary-soft: #6d2d03;
-  --accent: #af4804;
-  --accent-2: #0d7362;
-  --accent-foreground: #ffffff;
-  --accent-soft: #4b1f02;
-  --muted: #323c48;
-  --muted-foreground: #a9b6c6;
-  --shadow-color: #c75305;
-  --lav-deep: #f96d10;
-  --success: #22c373;
-  --success-glow: #1b985999;
-=======
-  --input: 214 22% 16%;
-  --ring: 24 95% 52%;
-  --theme-ring: hsl(var(--ring));
-  --primary: 24 95% 52%;
-  --primary-foreground: 0 0% 100%;
-  --primary-soft: 24 95% 22%;
-  --accent: 24 96% 35%;
-  --accent-2: 170 80% 25%;
-  --accent-foreground: 0 0% 100%;
-  --accent-soft: 24 96% 15%;
-  --glow: 24 96% 35%;
-  --muted: 214 18% 24%;
-  --muted-foreground: 214 20% 72%;
-  --shadow-color: 24 95% 40%;
-  --lav-deep: 24 95% 52%;
-  --success: 150 70% 45%;
-  --success-glow: 150 70% 35% / 0.6;
->>>>>>> codex/add-glow-overrides-to-themes
+    --input: 214 22% 16%;
+    --ring: 24 95% 52%;
+    --theme-ring: hsl(var(--ring));
+    --primary: 24 95% 52%;
+    --primary-foreground: 0 0% 100%;
+    --primary-soft: 24 95% 22%;
+    --accent: 24 96% 35%;
+    --accent-2: 170 80% 25%;
+    --accent-foreground: 0 0% 100%;
+    --accent-soft: 24 96% 15%;
+    --glow: 24 96% 35%;
+    --muted: 214 18% 24%;
+    --muted-foreground: 214 20% 72%;
+    --shadow-color: 24 95% 40%;
+    --lav-deep: 24 95% 52%;
+    --success: 150 70% 45%;
+    --success-glow: 150 70% 35% / 0.6;
 }
 
 /* ---------- Noir ---------- */
@@ -298,42 +225,23 @@ html.theme-noir {
   --panel: var(--card);
   --border: #4f2229;
   --line: var(--border);
-<<<<<<< HEAD
-  --input: #2c1115;
-  --ring: #f53d3d;
-  --theme-ring: var(--ring);
-  --primary: #f53d3d;
-  --primary-foreground: #ffffff;
-  --primary-soft: #740606;
-  --accent: #067a76;
-  --accent-2: #7d5403;
-  --accent-foreground: #ffffff;
-  --accent-soft: #02312f;
-  --muted: #3e1e23;
-  --muted-foreground: #bc8f97;
-  --shadow-color: #f20d0d;
-  --lav-deep: #f65555;
-  --success: #33cc66;
-  --success-glow: #29a35299;
-=======
-  --input: 350 45% 12%;
-  --ring: 0 90% 60%;
-  --theme-ring: hsl(var(--ring));
-  --primary: 0 90% 60%;
-  --primary-foreground: 0 0% 100%;
-  --primary-soft: 0 90% 24%;
-  --accent: 178 91% 25%;
-  --accent-2: 40 96% 25%;
-  --accent-foreground: 0 0% 100%;
-  --accent-soft: 178 91% 10%;
-  --glow: 178 91% 25%;
-  --muted: 350 35% 18%;
-  --muted-foreground: 350 25% 65%;
-  --shadow-color: 0 90% 50%;
-  --lav-deep: 0 90% 65%;
-  --success: 140 60% 50%;
-  --success-glow: 140 60% 40% / 0.6;
->>>>>>> codex/add-glow-overrides-to-themes
+    --input: 350 45% 12%;
+    --ring: 0 90% 60%;
+    --theme-ring: hsl(var(--ring));
+    --primary: 0 90% 60%;
+    --primary-foreground: 0 0% 100%;
+    --primary-soft: 0 90% 24%;
+    --accent: 178 91% 25%;
+    --accent-2: 40 96% 25%;
+    --accent-foreground: 0 0% 100%;
+    --accent-soft: 178 91% 10%;
+    --glow: 178 91% 25%;
+    --muted: 350 35% 18%;
+    --muted-foreground: 350 25% 65%;
+    --shadow-color: 0 90% 50%;
+    --lav-deep: 0 90% 65%;
+    --success: 140 60% 50%;
+    --success-glow: 140 60% 40% / 0.6;
 }
 
 /* ---------- Oceanic ---------- */
@@ -345,46 +253,24 @@ html.theme-ocean {
   --panel: var(--card);
   --border: #313949;
   --line: var(--border);
-<<<<<<< HEAD
-  --input: #1b212c;
-  --ring: #2bbdee;
-  --theme-ring: var(--ring);
-  --primary: #2bbdee;
-  --primary-foreground: #ffffff;
-  --primary-soft: #063a4b;
-  --accent: #005e8a;
-  --accent-2: #0b2c8e;
-  --accent-foreground: #ffffff;
-  --accent-soft: #002a3d;
-  --muted: #1f2633;
-  --muted-foreground: #aeb4c2;
-  --shadow-color: #25aff4;
-  --lav-deep: #765eed;
-  --success: #22c38e;
-  --success-glow: #1b986e99;
-}
-
-=======
-  --input: 220 24% 14%;
-  --ring: 195 85% 55%;
-  --theme-ring: hsl(var(--ring));
-  --primary: 195 85% 55%;
-  --primary-foreground: 0 0% 100%;
-  --primary-soft: 195 85% 16%;
-  --accent: 199 100% 27%;
-  --accent-2: 225 85% 30%;
-  --accent-foreground: 0 0% 100%;
-  --accent-soft: 199 100% 12%;
-  --glow: 199 100% 27%;
-  --muted: 220 24% 16%;
-  --muted-foreground: 220 14% 72%;
-  --shadow-color: 200 90% 55%;
-  --lav-deep: 250 80% 65%;
-  --success: 160 70% 45%;
-  --success-glow: 160 70% 35% / 0.6;
-}
-
->>>>>>> codex/add-glow-overrides-to-themes
+    --input: 220 24% 14%;
+    --ring: 195 85% 55%;
+    --theme-ring: hsl(var(--ring));
+    --primary: 195 85% 55%;
+    --primary-foreground: 0 0% 100%;
+    --primary-soft: 195 85% 16%;
+    --accent: 199 100% 27%;
+    --accent-2: 225 85% 30%;
+    --accent-foreground: 0 0% 100%;
+    --accent-soft: 199 100% 12%;
+    --glow: 199 100% 27%;
+    --muted: 220 24% 16%;
+    --muted-foreground: 220 14% 72%;
+    --shadow-color: 200 90% 55%;
+    --lav-deep: 250 80% 65%;
+    --success: 160 70% 45%;
+    --success-glow: 160 70% 35% / 0.6;
+  }
 /* ---------- Kitten ---------- */
 html.theme-kitten {
   --background: #0a0005;


### PR DESCRIPTION
## Summary
- resolve merge markers and standardize color tokens in themes
- clean up segmented button styles
- document new token updates in prompts

## Testing
- `npm test -- --run` *(fails: sizeMap is not defined, merge conflict markers)*
- `npm run lint -- src/app/themes.css src/app/globals.css src/app/prompts/page.tsx` *(fails: Couldn't find any `pages` or `app` directory)*
- `npm run typecheck` *(fails: merge conflict markers and missing identifiers)*

------
https://chatgpt.com/codex/tasks/task_e_68bfca2cb248832cb6c9fff03e0e3514