### PR TITLE
refactor: streamline reviews markup

### DIFF
--- a/src/components/reviews/ReviewListItem.tsx
+++ b/src/components/reviews/ReviewListItem.tsx
@@ -52,55 +52,54 @@ export default function ReviewListItem({
     : "";
 
   return (
-    <div data-scope="reviews">
-      <button
-        type="button"
-        disabled={disabled}
-        onClick={onClick}
-        aria-label={`Open review: ${title}`}
-        data-selected={selected ? "true" : undefined}
-        className={cn(itemBase, selected && itemSelected)}
-      >
-        <div className="grid grid-cols-[20px_1fr_auto] gap-3">
-          <span
-            aria-hidden
+    <button
+      data-scope="reviews"
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      aria-label={`Open review: ${title}`}
+      data-selected={selected ? "true" : undefined}
+      className={cn(itemBase, selected && itemSelected)}
+    >
+      <div className="grid grid-cols-[20px_1fr_auto] gap-3">
+        <span
+          aria-hidden
+          className={cn(
+            statusDotBase,
+            statusDotBlink,
+            review?.result === "Win"
+              ? statusDotWin
+              : review?.result === "Loss"
+              ? statusDotLoss
+              : statusDotDefault,
+            review?.status === "new" && statusDotPulse
+          )}
+        />
+        <div className="min-w-0 flex flex-col gap-1">
+          <div
             className={cn(
-              statusDotBase,
-              statusDotBlink,
-              review?.result === "Win"
-                ? statusDotWin
-                : review?.result === "Loss"
-                ? statusDotLoss
-                : statusDotDefault,
-              review?.status === "new" && statusDotPulse
+              "truncate font-medium text-base",
+              untitled && "text-muted-foreground/70"
             )}
-          />
-          <div className="min-w-0 flex flex-col gap-1">
-            <div
-              className={cn(
-                "truncate font-medium text-base",
-                untitled && "text-muted-foreground/70"
-              )}
-              aria-label={untitled ? "Untitled Review" : undefined}
-            >
-              {title}
-            </div>
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              {typeof score === "number" ? (
-                <Badge variant="accent" aria-label={`Rating ${score} out of 10`}>
-                  {score}/10
-                </Badge>
-              ) : null}
-              {subline ? (
-                <span className="line-clamp-1 truncate">{subline}</span>
-              ) : null}
-            </div>
+            aria-label={untitled ? "Untitled Review" : undefined}
+          >
+            {title}
           </div>
-          <span className="self-start text-xs text-muted-foreground whitespace-nowrap">
-            {dateStr}
-          </span>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            {typeof score === "number" ? (
+              <Badge variant="accent" aria-label={`Rating ${score} out of 10`}>
+                {score}/10
+              </Badge>
+            ) : null}
+            {subline ? (
+              <span className="line-clamp-1 truncate">{subline}</span>
+            ) : null}
+          </div>
         </div>
-      </button>
-    </div>
+        <span className="self-start text-xs text-muted-foreground whitespace-nowrap">
+          {dateStr}
+        </span>
+      </div>
+    </button>
   );
 }

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -91,6 +91,7 @@ export default function ReviewsPage({
   }, [base, q, sort]);
 
   const active = base.find((r) => r.id === selectedId) || null;
+  const panelClass = "md:col-span-8 lg:col-span-9 mx-auto";
 
   return (
     <main className="page-shell py-6 space-y-6">
@@ -165,38 +166,40 @@ export default function ReviewsPage({
             </div>
           </div>
         </nav>
-
-          <div className="md:col-span-8 lg:col-span-9 flex justify-center">
-            {!active ? (
-              <ReviewPanel className="flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
-                <Ghost className="h-6 w-6 opacity-60" />
-                <p>Select a review from the list or create a new one.</p>
-              </ReviewPanel>
-            ) : panelMode === "summary" ? (
-              <ReviewPanel>
-                <ReviewSummary
-                  key={`summary-${active.id}`}
-                  review={active}
-                  onEdit={() => setPanelMode("edit")}
-                />
-              </ReviewPanel>
-            ) : (
-              <ReviewPanel>
-                <ReviewEditor
-                  key={`editor-${active.id}`}
-                  review={active}
-                  onChangeNotes={(value: string) => onChangeNotes?.(active.id, value)}
-                  onChangeTags={(values: string[]) => onChangeTags?.(active.id, values)}
-                  onRename={(title: string) => onRename(active.id, title)}
-                  onChangeMeta={(partial: Partial<Review>) =>
-                    onChangeMeta?.(active.id, partial)
-                  }
-                  onDone={() => setPanelMode("summary")}
-                  onDelete={onDelete ? () => onDelete(active.id) : undefined}
-                />
-              </ReviewPanel>
+        {!active ? (
+          <ReviewPanel
+            className={cn(
+              panelClass,
+              "flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground"
             )}
-          </div>
+          >
+            <Ghost className="h-6 w-6 opacity-60" />
+            <p>Select a review from the list or create a new one.</p>
+          </ReviewPanel>
+        ) : panelMode === "summary" ? (
+          <ReviewPanel className={panelClass}>
+            <ReviewSummary
+              key={`summary-${active.id}`}
+              review={active}
+              onEdit={() => setPanelMode("edit")}
+            />
+          </ReviewPanel>
+        ) : (
+          <ReviewPanel className={panelClass}>
+            <ReviewEditor
+              key={`editor-${active.id}`}
+              review={active}
+              onChangeNotes={(value: string) => onChangeNotes?.(active.id, value)}
+              onChangeTags={(values: string[]) => onChangeTags?.(active.id, values)}
+              onRename={(title: string) => onRename(active.id, title)}
+              onChangeMeta={(partial: Partial<Review>) =>
+                onChangeMeta?.(active.id, partial)
+              }
+              onDone={() => setPanelMode("summary")}
+              onDelete={onDelete ? () => onDelete(active.id) : undefined}
+            />
+          </ReviewPanel>
+        )}
       </div>
     </main>
   );

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -2,54 +2,51 @@
 
 exports[`ReviewListItem > renders default state 1`] = `
 <div>
-  <div
+  <button
+    aria-label="Open review: Sample Review"
+    class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
     data-scope="reviews"
+    type="button"
   >
-    <button
-      aria-label="Open review: Sample Review"
-      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
-      type="button"
+    <div
+      class="grid grid-cols-[20px_1fr_auto] gap-3"
     >
+      <span
+        aria-hidden="true"
+        class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-success"
+      />
       <div
-        class="grid grid-cols-[20px_1fr_auto] gap-3"
+        class="min-w-0 flex flex-col gap-1"
       >
-        <span
-          aria-hidden="true"
-          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-success"
-        />
         <div
-          class="min-w-0 flex flex-col gap-1"
+          class="truncate font-medium text-base"
         >
-          <div
-            class="truncate font-medium text-base"
-          >
-            Sample Review
-          </div>
-          <div
-            class="flex items-center gap-2 text-sm text-muted-foreground"
-          >
-            <span
-              aria-label="Rating 9 out of 10"
-              class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--accent)/0.15)] border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))] shadow-[0_0_8px_hsl(var(--accent)/0.3)]"
-            >
-              9
-              /10
-            </span>
-            <span
-              class="line-clamp-1 truncate"
-            >
-              Quick note
-            </span>
-          </div>
+          Sample Review
         </div>
-        <span
-          class="self-start text-xs text-muted-foreground whitespace-nowrap"
+        <div
+          class="flex items-center gap-2 text-sm text-muted-foreground"
         >
-          11/14/2023
-        </span>
+          <span
+            aria-label="Rating 9 out of 10"
+            class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--accent)/0.15)] border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))] shadow-[0_0_8px_hsl(var(--accent)/0.3)]"
+          >
+            9
+            /10
+          </span>
+          <span
+            class="line-clamp-1 truncate"
+          >
+            Quick note
+          </span>
+        </div>
       </div>
-    </button>
-  </div>
+      <span
+        class="self-start text-xs text-muted-foreground whitespace-nowrap"
+      >
+        11/14/2023
+      </span>
+    </div>
+  </button>
 </div>
 `;
 
@@ -71,108 +68,102 @@ exports[`ReviewListItem > renders loading state 1`] = `
 
 exports[`ReviewListItem > renders selected state 1`] = `
 <div>
-  <div
+  <button
+    aria-label="Open review: Sample Review"
+    class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none review-tile--active"
     data-scope="reviews"
+    data-selected="true"
+    type="button"
   >
-    <button
-      aria-label="Open review: Sample Review"
-      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none review-tile--active"
-      data-selected="true"
-      type="button"
+    <div
+      class="grid grid-cols-[20px_1fr_auto] gap-3"
     >
+      <span
+        aria-hidden="true"
+        class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-success"
+      />
       <div
-        class="grid grid-cols-[20px_1fr_auto] gap-3"
+        class="min-w-0 flex flex-col gap-1"
       >
-        <span
-          aria-hidden="true"
-          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-success"
-        />
         <div
-          class="min-w-0 flex flex-col gap-1"
+          class="truncate font-medium text-base"
         >
-          <div
-            class="truncate font-medium text-base"
-          >
-            Sample Review
-          </div>
-          <div
-            class="flex items-center gap-2 text-sm text-muted-foreground"
-          >
-            <span
-              aria-label="Rating 9 out of 10"
-              class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--accent)/0.15)] border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))] shadow-[0_0_8px_hsl(var(--accent)/0.3)]"
-            >
-              9
-              /10
-            </span>
-            <span
-              class="line-clamp-1 truncate"
-            >
-              Quick note
-            </span>
-          </div>
+          Sample Review
         </div>
-        <span
-          class="self-start text-xs text-muted-foreground whitespace-nowrap"
+        <div
+          class="flex items-center gap-2 text-sm text-muted-foreground"
         >
-          11/14/2023
-        </span>
+          <span
+            aria-label="Rating 9 out of 10"
+            class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--accent)/0.15)] border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))] shadow-[0_0_8px_hsl(var(--accent)/0.3)]"
+          >
+            9
+            /10
+          </span>
+          <span
+            class="line-clamp-1 truncate"
+          >
+            Quick note
+          </span>
+        </div>
       </div>
-    </button>
-  </div>
+      <span
+        class="self-start text-xs text-muted-foreground whitespace-nowrap"
+      >
+        11/14/2023
+      </span>
+    </div>
+  </button>
 </div>
 `;
 
 exports[`ReviewListItem > renders untitled state 1`] = `
 <div>
-  <div
+  <button
+    aria-label="Open review: Untitled Review"
+    class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
     data-scope="reviews"
+    type="button"
   >
-    <button
-      aria-label="Open review: Untitled Review"
-      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
-      type="button"
+    <div
+      class="grid grid-cols-[20px_1fr_auto] gap-3"
     >
+      <span
+        aria-hidden="true"
+        class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-success"
+      />
       <div
-        class="grid grid-cols-[20px_1fr_auto] gap-3"
+        class="min-w-0 flex flex-col gap-1"
       >
-        <span
-          aria-hidden="true"
-          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-success"
-        />
         <div
-          class="min-w-0 flex flex-col gap-1"
+          aria-label="Untitled Review"
+          class="truncate font-medium text-base text-muted-foreground/70"
         >
-          <div
-            aria-label="Untitled Review"
-            class="truncate font-medium text-base text-muted-foreground/70"
-          >
-            Untitled Review
-          </div>
-          <div
-            class="flex items-center gap-2 text-sm text-muted-foreground"
-          >
-            <span
-              aria-label="Rating 9 out of 10"
-              class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--accent)/0.15)] border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))] shadow-[0_0_8px_hsl(var(--accent)/0.3)]"
-            >
-              9
-              /10
-            </span>
-            <span
-              class="line-clamp-1 truncate"
-            >
-              Quick note
-            </span>
-          </div>
+          Untitled Review
         </div>
-        <span
-          class="self-start text-xs text-muted-foreground whitespace-nowrap"
+        <div
+          class="flex items-center gap-2 text-sm text-muted-foreground"
         >
-          11/14/2023
-        </span>
+          <span
+            aria-label="Rating 9 out of 10"
+            class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--accent)/0.15)] border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))] shadow-[0_0_8px_hsl(var(--accent)/0.3)]"
+          >
+            9
+            /10
+          </span>
+          <span
+            class="line-clamp-1 truncate"
+          >
+            Quick note
+          </span>
+        </div>
       </div>
-    </button>
-  </div>
+      <span
+        class="self-start text-xs text-muted-foreground whitespace-nowrap"
+      >
+        11/14/2023
+      </span>
+    </div>
+  </button>
 </div>
 `;

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -768,115 +768,106 @@ exports[`ReviewsPage > renders default state 1`] = `
                 class="flex flex-col gap-3"
               >
                 <li>
-                  <div
+                  <button
+                    aria-label="Open review: Alpha"
+                    class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
                     data-scope="reviews"
+                    type="button"
                   >
-                    <button
-                      aria-label="Open review: Alpha"
-                      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
-                      type="button"
+                    <div
+                      class="grid grid-cols-[20px_1fr_auto] gap-3"
                     >
+                      <span
+                        aria-hidden="true"
+                        class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-muted-foreground"
+                      />
                       <div
-                        class="grid grid-cols-[20px_1fr_auto] gap-3"
+                        class="min-w-0 flex flex-col gap-1"
                       >
-                        <span
-                          aria-hidden="true"
-                          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-muted-foreground"
-                        />
                         <div
-                          class="min-w-0 flex flex-col gap-1"
+                          class="truncate font-medium text-base"
                         >
-                          <div
-                            class="truncate font-medium text-base"
-                          >
-                            Alpha
-                          </div>
-                          <div
-                            class="flex items-center gap-2 text-sm text-muted-foreground"
-                          />
+                          Alpha
                         </div>
-                        <span
-                          class="self-start text-xs text-muted-foreground whitespace-nowrap"
-                        >
-                          1/1/1970
-                        </span>
+                        <div
+                          class="flex items-center gap-2 text-sm text-muted-foreground"
+                        />
                       </div>
-                    </button>
-                  </div>
+                      <span
+                        class="self-start text-xs text-muted-foreground whitespace-nowrap"
+                      >
+                        1/1/1970
+                      </span>
+                    </div>
+                  </button>
                 </li>
                 <li>
-                  <div
+                  <button
+                    aria-label="Open review: Gamma"
+                    class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
                     data-scope="reviews"
+                    type="button"
                   >
-                    <button
-                      aria-label="Open review: Gamma"
-                      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
-                      type="button"
+                    <div
+                      class="grid grid-cols-[20px_1fr_auto] gap-3"
                     >
+                      <span
+                        aria-hidden="true"
+                        class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-muted-foreground"
+                      />
                       <div
-                        class="grid grid-cols-[20px_1fr_auto] gap-3"
+                        class="min-w-0 flex flex-col gap-1"
                       >
-                        <span
-                          aria-hidden="true"
-                          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-muted-foreground"
-                        />
                         <div
-                          class="min-w-0 flex flex-col gap-1"
+                          class="truncate font-medium text-base"
                         >
-                          <div
-                            class="truncate font-medium text-base"
-                          >
-                            Gamma
-                          </div>
-                          <div
-                            class="flex items-center gap-2 text-sm text-muted-foreground"
-                          />
+                          Gamma
                         </div>
-                        <span
-                          class="self-start text-xs text-muted-foreground whitespace-nowrap"
-                        >
-                          1/1/1970
-                        </span>
+                        <div
+                          class="flex items-center gap-2 text-sm text-muted-foreground"
+                        />
                       </div>
-                    </button>
-                  </div>
+                      <span
+                        class="self-start text-xs text-muted-foreground whitespace-nowrap"
+                      >
+                        1/1/1970
+                      </span>
+                    </div>
+                  </button>
                 </li>
                 <li>
-                  <div
+                  <button
+                    aria-label="Open review: Beta"
+                    class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
                     data-scope="reviews"
+                    type="button"
                   >
-                    <button
-                      aria-label="Open review: Beta"
-                      class="review-tile relative w-full text-left h-auto min-h-[76px] p-4 rounded-lg border border-border/50 bg-card/60 scanlines noise jitter transition-all duration-200 hover:-translate-y-[1px] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none"
-                      type="button"
+                    <div
+                      class="grid grid-cols-[20px_1fr_auto] gap-3"
                     >
+                      <span
+                        aria-hidden="true"
+                        class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-muted-foreground"
+                      />
                       <div
-                        class="grid grid-cols-[20px_1fr_auto] gap-3"
+                        class="min-w-0 flex flex-col gap-1"
                       >
-                        <span
-                          aria-hidden="true"
-                          class="self-center justify-self-center h-2 w-2 rounded-full animate-[blink_1s_steps(2)_infinite] bg-muted-foreground"
-                        />
                         <div
-                          class="min-w-0 flex flex-col gap-1"
+                          class="truncate font-medium text-base"
                         >
-                          <div
-                            class="truncate font-medium text-base"
-                          >
-                            Beta
-                          </div>
-                          <div
-                            class="flex items-center gap-2 text-sm text-muted-foreground"
-                          />
+                          Beta
                         </div>
-                        <span
-                          class="self-start text-xs text-muted-foreground whitespace-nowrap"
-                        >
-                          1/1/1970
-                        </span>
+                        <div
+                          class="flex items-center gap-2 text-sm text-muted-foreground"
+                        />
                       </div>
-                    </button>
-                  </div>
+                      <span
+                        class="self-start text-xs text-muted-foreground whitespace-nowrap"
+                      >
+                        1/1/1970
+                      </span>
+                    </div>
+                  </button>
                 </li>
               </ul>
             </div>
@@ -884,37 +875,33 @@ exports[`ReviewsPage > renders default state 1`] = `
         </div>
       </nav>
       <div
-        class="md:col-span-8 lg:col-span-9 flex justify-center"
+        class="max-w-[880px] w-full rounded-xl p-5 bg-card/60 ring-1 ring-ring/5 shadow-[0_0_40px_-12px_hsl(var(--glow-soft))] md:col-span-8 lg:col-span-9 mx-auto flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground"
       >
-        <div
-          class="max-w-[880px] w-full rounded-xl p-5 bg-card/60 ring-1 ring-ring/5 shadow-[0_0_40px_-12px_hsl(var(--glow-soft))] flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground"
+        <svg
+          class="lucide lucide-ghost h-6 w-6 opacity-60"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            class="lucide lucide-ghost h-6 w-6 opacity-60"
-            fill="none"
-            height="24"
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M9 10h.01"
-            />
-            <path
-              d="M15 10h.01"
-            />
-            <path
-              d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z"
-            />
-          </svg>
-          <p>
-            Select a review from the list or create a new one.
-          </p>
-        </div>
+          <path
+            d="M9 10h.01"
+          />
+          <path
+            d="M15 10h.01"
+          />
+          <path
+            d="M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z"
+          />
+        </svg>
+        <p>
+          Select a review from the list or create a new one.
+        </p>
       </div>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- remove redundant wrapper divs in review list items
- simplify ReviewsPage layout by eliminating extra grid wrapper

## Testing
- `npm run regen-ui`
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0148fc5d0832cac7690d3a6537fa5