### PR TITLE
refactor: simplify icon button showcase

### DIFF
--- a/src/components/prompts/IconButtonShowcase.tsx
+++ b/src/components/prompts/IconButtonShowcase.tsx
@@ -1,19 +1,38 @@
 import * as React from "react";
-import { IconButton } from "@/components/ui";
+import { IconButton, type IconButtonProps } from "@/components/ui";
 import { Plus } from "lucide-react";
+
+const ICON_BUTTONS = [
+  {
+    size: "xs",
+    variant: "ring",
+    "aria-label": "Add item xs",
+    title: "Add item xs",
+  },
+  {
+    size: "md",
+    variant: "ring",
+    "aria-label": "Add item",
+    title: "Add item",
+  },
+  {
+    size: "md",
+    variant: "glow",
+    "aria-label": "Add item glow",
+    title: "Add item glow",
+  },
+] satisfies Array<
+  Pick<IconButtonProps, "size" | "variant"> & { "aria-label": string; title: string }
+>;
 
 export default function IconButtonShowcase() {
   return (
     <div className="mb-8 flex gap-2">
-      <IconButton size="xs" aria-label="Add item xs" title="Add item xs">
-        <Plus size={16} aria-hidden />
-      </IconButton>
-      <IconButton aria-label="Add item" title="Add item">
-        <Plus size={16} aria-hidden />
-      </IconButton>
-      <IconButton variant="glow" aria-label="Add item glow" title="Add item glow">
-        <Plus size={16} aria-hidden />
-      </IconButton>
+      {ICON_BUTTONS.map((props) => (
+        <IconButton key={props.title} {...props}>
+          <Plus size={16} aria-hidden />
+        </IconButton>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- refactor IconButtonShowcase to map over variant definitions

## Testing
- `npm run regen-ui`
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c01e1fa054832c95a0d04af7399ac2