### PR TITLE
feat: extract prompt list component

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -10,6 +10,8 @@ import {
   ButtonShowcase,
   IconButtonShowcase,
   GoalListDemo,
+  PromptList,
+  type PromptWithTitle,
 } from "@/components/prompts";
 import { FRUIT_ITEMS } from "@/components/prompts/demoData";
 import { HomePage } from "@/components/home";
@@ -27,6 +29,7 @@ export default function Page() {
   const [view, setView] = React.useState<View>("components");
   const [role, setRole] = React.useState<Role>(ROLE_OPTIONS[0].value);
   const [fruit, setFruit] = React.useState(FRUIT_ITEMS[0].value);
+  const demoPrompts: PromptWithTitle[] = [];
 
   return (
     <main className="page-shell py-6">
@@ -40,6 +43,7 @@ export default function Page() {
       <ButtonShowcase />
       <IconButtonShowcase />
       <GoalListDemo />
+      <PromptList prompts={demoPrompts} />
       <HomePage />
       <p className="mb-4 text-xs text-danger">Example error message</p>
       <div className="mb-8">

--- a/src/components/prompts/PromptList.tsx
+++ b/src/components/prompts/PromptList.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { Card } from "@/components/ui";
+import { LOCALE } from "@/lib/utils";
+import type { PromptWithTitle } from "./usePrompts";
+
+export type PromptListProps = {
+  prompts: PromptWithTitle[];
+};
+
+export default function PromptList({ prompts }: PromptListProps) {
+  return (
+    <ul className="mt-4 space-y-3">
+      {prompts.map((p) => (
+        <li key={p.id}>
+          <Card className="p-3">
+            <header className="flex items-center justify-between">
+              <h3 className="font-semibold">{p.title}</h3>
+              <time
+                dateTime={new Date(p.createdAt).toISOString()}
+                className="text-xs text-muted-foreground"
+              >
+                {new Date(p.createdAt).toLocaleString(LOCALE)}
+              </time>
+            </header>
+            {p.text ? (
+              <p className="mt-1 whitespace-pre-wrap text-sm">{p.text}</p>
+            ) : null}
+          </Card>
+        </li>
+      ))}
+      {prompts.length === 0 ? (
+        <li className="text-muted-foreground">
+          Nothing matches your search. Typical.
+        </li>
+      ) : null}
+    </ul>
+  );
+}
+

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -7,11 +7,11 @@
  */
 
 import * as React from "react";
-import { SectionCard, Card } from "@/components/ui";
-import { LOCALE } from "@/lib/utils";
+import { SectionCard } from "@/components/ui";
 import PromptsHeader from "./PromptsHeader";
 import PromptsComposePanel from "./PromptsComposePanel";
 import PromptsDemos from "./PromptsDemos";
+import PromptList from "./PromptList";
 import { usePrompts } from "./usePrompts";
 
 export default function PromptsPage() {
@@ -47,32 +47,7 @@ export default function PromptsPage() {
           onTextChange={setTextDraft}
         />
 
-        {/* List */}
-        <ul className="mt-4 space-y-3">
-          {filtered.map((p) => (
-            <li key={p.id}>
-              <Card className="p-3">
-                <header className="flex items-center justify-between">
-                  <h3 className="font-semibold">{p.title}</h3>
-                  <time
-                    dateTime={new Date(p.createdAt).toISOString()}
-                    className="text-xs text-muted-foreground"
-                  >
-                    {new Date(p.createdAt).toLocaleString(LOCALE)}
-                  </time>
-                </header>
-                {p.text ? (
-                  <p className="mt-1 whitespace-pre-wrap text-sm">{p.text}</p>
-                ) : null}
-              </Card>
-            </li>
-          ))}
-          {filtered.length === 0 && (
-            <li className="text-muted-foreground">
-              Nothing matches your search. Typical.
-            </li>
-          )}
-        </ul>
+        <PromptList prompts={filtered} />
 
         <PromptsDemos />
       </SectionCard.Body>

--- a/src/components/prompts/index.ts
+++ b/src/components/prompts/index.ts
@@ -8,6 +8,8 @@ export { default as GalleryItem } from "./GalleryItem";
 export { default as GoalListDemo } from "./GoalListDemo";
 export { default as IconButtonShowcase } from "./IconButtonShowcase";
 export { default as OutlineGlowDemo } from "./OutlineGlowDemo";
+export { default as PromptList } from "./PromptList";
+export * from "./PromptList";
 export { default as PromptsComposePanel } from "./PromptsComposePanel";
 export { default as PromptsDemos } from "./PromptsDemos";
 export { default as PromptsHeader } from "./PromptsHeader";


### PR DESCRIPTION
## Summary
- add PromptList component encapsulating prompt list and empty state
- use PromptList in PromptsPage
- showcase PromptList on prompts page

## Testing
- `npm run regen-ui`
- `npm run regen-feature`
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c029649f68832c85c0ae1e2379a73c