### PR TITLE
fix: configure webpack path alias

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,15 @@
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 /** @type {import('next').NextConfig} */
-const nextConfig = { reactStrictMode: true };
+const nextConfig = {
+  reactStrictMode: true,
+  webpack: (config) => {
+    config.resolve.alias["@"] = path.resolve(__dirname, "src");
+    return config;
+  },
+};
+
 export default nextConfig;


### PR DESCRIPTION
## Summary
- ensure `@` imports resolve to `src` via webpack alias

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c02beb6e54832cbf484d21377e0c32