### PR TITLE
feat: standardize button icon sizing

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -47,13 +47,18 @@ This project ships with a small design system based on Tailwind CSS and CSS vari
 - Control height is set via a `height` prop that accepts `"sm" | "md" | "lg"`
   or a numeric Tailwind token (e.g. `12` for `h-12`). The native `size`
   attribute remains available for setting character width.
+ - `Button` automatically sizes any `svg` icons based on the `size` option.
 
 ```tsx
 import { Button } from "@/components/ui/primitives/Button";
+import { Plus } from "lucide-react";
 
 export function Submit() {
   return (
-    <Button className="bg-primary text-primary-foreground">Save</Button>
+    <Button size="sm">
+      <Plus />
+      Save
+    </Button>
   );
 }
 ```

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -40,6 +40,7 @@ export default function Page() {
         onFruitChange={setFruit}
       />
       <UpdatesList />
+      {/* Buttons now auto-size svg icons */}
       <ButtonShowcase />
       {/* IconButton now maintains 4px padding around icons */}
       <IconButtonShowcase />

--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -50,7 +50,7 @@ function Inner() {
         aria-label="Previous week"
         onClick={prevWeek}
       >
-        <ChevronLeft className="size-4" />
+        <ChevronLeft />
         <span>Prev</span>
       </Button>
       <Button size="sm" aria-label="Jump to today" onClick={jumpToday}>
@@ -63,7 +63,7 @@ function Inner() {
         onClick={nextWeek}
       >
         <span>Next</span>
-        <ChevronRight className="size-4" />
+        <ChevronRight />
       </Button>
     </div>
   );

--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -172,7 +172,7 @@ export default function WeekPicker() {
         onClick={jumpToTop}
         title="Jump to top"
       >
-        <ArrowUpToLine className="size-4" />
+        <ArrowUpToLine />
         <span>Top</span>
       </Button>
     ) : undefined;

--- a/src/components/prompts/ButtonShowcase.tsx
+++ b/src/components/prompts/ButtonShowcase.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Button } from "@/components/ui";
+import { Plus } from "lucide-react";
 
 export default function ButtonShowcase() {
   return (
@@ -13,6 +14,10 @@ export default function ButtonShowcase() {
         Danger primary
       </Button>
       <Button disabled>Disabled</Button>
+      <Button size="sm">
+        <Plus />
+        Add item
+      </Button>
     </div>
   );
 }

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -138,7 +138,7 @@ export default function ReviewsPage({
                   onCreate();
                 }}
               >
-                <Plus className="size-4" />
+                <Plus />
                 <span>New Review</span>
               </Button>
             </div>

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -13,18 +13,21 @@ export const buttonSizes = {
     padding: "px-4",
     text: "text-sm",
     gap: "gap-2",
+    icon: "[&>svg]:size-4",
   },
   md: {
     height: "h-10",
     padding: "px-5",
     text: "text-base",
     gap: "gap-2",
+    icon: "[&>svg]:size-5",
   },
   lg: {
     height: "h-11",
     padding: "px-6",
     text: "text-lg",
     gap: "gap-2",
+    icon: "[&>svg]:size-6",
   },
 } as const;
 
@@ -58,6 +61,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       s.padding,
       s.text,
       s.gap,
+      s.icon,
       className,
     );
 

--- a/tests/primitives/button.test.tsx
+++ b/tests/primitives/button.test.tsx
@@ -42,4 +42,17 @@ describe("Button", () => {
     fireEvent.click(btn);
     expect(onClick).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ["sm", "[&>svg]:size-4"],
+    ["md", "[&>svg]:size-5"],
+    ["lg", "[&>svg]:size-6"],
+  ])("applies %s icon sizing", (size, cls) => {
+    const { getByRole } = render(
+      <Button size={size as any}>
+        <svg />
+      </Button>,
+    );
+    expect(getByRole("button")).toHaveClass(cls);
+  });
 });

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -697,7 +697,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                   </div>
                 </div>
                 <button
-                  class="relative inline-flex items-center justify-center rounded-2xl border border-[--theme-ring] font-medium transition-all duration-200 focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--theme-ring] disabled:opacity-50 disabled:pointer-events-none h-10 text-base gap-2 px-4 whitespace-nowrap bg-panel/85 overflow-hidden shadow-neo text-[hsl(var(--foreground))]"
+                  class="relative inline-flex items-center justify-center rounded-2xl border border-[--theme-ring] font-medium transition-all duration-200 focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--theme-ring] disabled:opacity-50 disabled:pointer-events-none h-10 text-base gap-2 [&>svg]:size-5 px-4 whitespace-nowrap bg-panel/85 overflow-hidden shadow-neo text-[hsl(var(--foreground))]"
                   tabindex="0"
                   type="button"
                 >
@@ -709,7 +709,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                     class="relative z-10 inline-flex items-center gap-2"
                   >
                     <svg
-                      class="lucide lucide-plus size-4"
+                      class="lucide lucide-plus"
                       fill="none"
                       height="24"
                       stroke="currentColor"


### PR DESCRIPTION
## Summary
- auto-size button icons via size-mapped `[&>svg]` utilities
- remove manual icon sizing from existing buttons and showcase new example
- document button icon sizing behavior

## Testing
- `npm run regen-ui`
- `npm test -- -u`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c03c755420832c8aae95fcac5ae813