### PR TITLE
feat(button): adjust gaps by size

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -47,7 +47,8 @@ This project ships with a small design system based on Tailwind CSS and CSS vari
 - Control height is set via a `height` prop that accepts `"sm" | "md" | "lg"`
   or a numeric Tailwind token (e.g. `12` for `h-12`). The native `size`
   attribute remains available for setting character width.
- - `Button` automatically sizes any `svg` icons based on the `size` option.
+- `Button` automatically sizes any `svg` icons based on the `size` option
+  and sets icon gaps: `gap-1` for `sm`, `gap-2` for `md`, `gap-3` for `lg`.
 
 ```tsx
 import { Button } from "@/components/ui/primitives/Button";

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -40,7 +40,7 @@ export default function Page() {
         onFruitChange={setFruit}
       />
       <UpdatesList />
-      {/* Buttons now auto-size svg icons */}
+      {/* Buttons now auto-size svg icons and gaps per size */}
       <ButtonShowcase />
       {/* IconButton now maintains 4px padding around icons */}
       <IconButtonShowcase />

--- a/src/components/prompts/ButtonShowcase.tsx
+++ b/src/components/prompts/ButtonShowcase.tsx
@@ -4,20 +4,32 @@ import { Plus } from "lucide-react";
 
 export default function ButtonShowcase() {
   return (
-    <div className="mb-8 flex flex-wrap gap-2">
-      <Button tone="primary">Primary tone</Button>
-      <Button tone="accent">Accent tone</Button>
-      <Button tone="info" variant="ghost">
-        Info ghost
-      </Button>
-      <Button tone="danger" variant="primary">
-        Danger primary
-      </Button>
-      <Button disabled>Disabled</Button>
-      <Button size="sm">
-        <Plus />
-        Add item
-      </Button>
+    <div className="mb-8 space-y-4">
+      <div className="flex flex-wrap gap-2">
+        <Button tone="primary">Primary tone</Button>
+        <Button tone="accent">Accent tone</Button>
+        <Button tone="info" variant="ghost">
+          Info ghost
+        </Button>
+        <Button tone="danger" variant="primary">
+          Danger primary
+        </Button>
+        <Button disabled>Disabled</Button>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <Button size="sm">
+          <Plus />
+          Small
+        </Button>
+        <Button size="md">
+          <Plus />
+          Medium
+        </Button>
+        <Button size="lg">
+          <Plus />
+          Large
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -12,7 +12,7 @@ export const buttonSizes = {
     height: "h-9",
     padding: "px-4",
     text: "text-sm",
-    gap: "gap-2",
+    gap: "gap-1",
     icon: "[&>svg]:size-4",
   },
   md: {
@@ -26,7 +26,7 @@ export const buttonSizes = {
     height: "h-11",
     padding: "px-6",
     text: "text-lg",
-    gap: "gap-2",
+    gap: "gap-3",
     icon: "[&>svg]:size-6",
   },
 } as const;

--- a/tests/primitives/button.test.tsx
+++ b/tests/primitives/button.test.tsx
@@ -55,4 +55,18 @@ describe("Button", () => {
     );
     expect(getByRole("button")).toHaveClass(cls);
   });
+
+  it.each([
+    ["sm", "gap-1"],
+    ["md", "gap-2"],
+    ["lg", "gap-3"],
+  ])("applies %s gap spacing", (size, cls) => {
+    const { getByRole } = render(
+      <Button size={size as any}>
+        <svg />
+        Label
+      </Button>,
+    );
+    expect(getByRole("button")).toHaveClass(cls);
+  });
 });


### PR DESCRIPTION
## Summary
- scale button spacing with gap-1, gap-2, gap-3 for sm, md, lg
- demo sm/md/lg buttons with icons and document gap strategy
- add tests ensuring gap classes

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0441659b0832ca4d8c47c2a6aea8f