### PR TITLE
refactor: tokenized review color utilities

### DIFF
--- a/COLOR_MAPPINGS.md
+++ b/COLOR_MAPPINGS.md
@@ -45,3 +45,7 @@
 | `rgba(255, 77, 210, 0.85)` | `hsl(var(--lav-deep) / 0.85)` |
 | `rgba(192, 132, 252, 0.6)` | `hsl(var(--accent))` |
 | `rgba(168, 85, 247, 0.2)` | `hsl(var(--accent) / 0.2)` |
+| `#fb7185` (`rose-400`) | `hsl(var(--danger))` |
+| `#fbbf24` (`amber-400`) | `hsl(var(--warning))` |
+| `#34d399` (`emerald-400`) | `hsl(var(--success))` |
+| `#6ee7b7` (`emerald-300`) | `hsl(var(--success))` |

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -48,6 +48,8 @@ export default function Page() {
       <PromptList prompts={demoPrompts} />
       <HomePage />
       <p className="mb-4 text-xs text-danger">Example error message</p>
+      <p className="mb-4 text-xs text-warning">Example warning message</p>
+      <p className="mb-4 text-xs text-success">Example success message</p>
       <div className="mb-8">
         <TabBar
           items={VIEW_TABS}

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -24,6 +24,7 @@
   --glow: 292 90% 35%;
   --ring-muted: 248 20% 22%;
   --danger: 0 84% 60%;
+  --warning: 43 96% 56%;
   --muted: 248 26% 14%;
   --muted-foreground: 250 15% 70%;
   --surface: 248 24% 12%;
@@ -132,6 +133,7 @@ html.light {
   --glow: 292 80% 45%;
   --ring-muted: 240 9% 90%;
   --danger: 0 84% 55%;
+  --warning: 43 96% 50%;
   --muted: 240 6% 96%;
   --muted-foreground: 240 4% 35%;
   --surface: 240 7% 98%;
@@ -318,6 +320,7 @@ html.theme-hardstuck {
   --glow: 120 100% 60%;
   --ring-muted: 120 30% 20%;
   --danger: 0 84% 60%;
+  --warning: 43 96% 56%;
   --muted: 120 35% 10%;
   --muted-foreground: 120 15% 70%;
   --surface: 120 32% 8%;

--- a/src/components/reviews/reviewData.ts
+++ b/src/components/reviews/reviewData.ts
@@ -57,10 +57,10 @@ export function scoreIcon(score: number): {
   Icon: ComponentType<{ className?: string }>;
   cls: string;
 } {
-  if (score <= 3) return { Icon: Skull, cls: "text-rose-400" };
-  if (score <= 6) return { Icon: Meh, cls: "text-amber-400" };
-  if (score >= 9) return { Icon: Trophy, cls: "text-emerald-400" };
-  return { Icon: Smile, cls: "text-emerald-300" };
+  if (score <= 3) return { Icon: Skull, cls: "text-danger" };
+  if (score <= 6) return { Icon: Meh, cls: "text-warning" };
+  if (score >= 9) return { Icon: Trophy, cls: "text-success" };
+  return { Icon: Smile, cls: "text-success/80" };
 }
 
 /** Short quips for performance score 0..10 (5 per tier) */

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -12,6 +12,7 @@ export const colorTokens = [
   "bg-glow",
   "bg-ringMuted",
   "bg-danger",
+  "bg-warning",
   "bg-success",
   "bg-auroraG",
   "bg-auroraGLight",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -30,6 +30,7 @@ const config: Config = {
         glow: "hsl(var(--glow))",
         ringMuted: "hsl(var(--ring-muted))",
         danger: "hsl(var(--danger))",
+        warning: "hsl(var(--warning))",
         success: {
           DEFAULT: "hsl(var(--success))",
           glow: "hsl(var(--success-glow))",


### PR DESCRIPTION
## Summary
- replace hardcoded review colors with tokens like `text-danger`, `text-warning`, `text-success`
- document new color token mappings and expose `bg-warning`
- showcase warning and success tokens on prompts page

## Testing
- `npm run regen-ui`
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0564b98cc832c87d714556ec15ebe