### PR TITLE
chore: add branch cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -1,0 +1,41 @@
+name: Cleanup branches
+
+on:
+  workflow_dispatch:
+    inputs:
+      prefix:
+        description: "Branch name prefix to target"
+        required: true
+      dry_run:
+        description: "Skip deletions when true"
+        required: false
+        default: "true"
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup branches
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const prefix = core.getInput("prefix");
+            const dryRun = core.getInput("dry_run");
+            const branches = await github.paginate(github.rest.repos.listBranches, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+            for (const branch of branches) {
+              if (branch.name.startsWith(prefix)) {
+                core.info(`Candidate: ${branch.name}`);
+                if (dryRun === "false") {
+                  core.info(`Deleting ${branch.name}`);
+                  await github.rest.git.deleteRef({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    ref: `heads/${branch.name}`,
+                  });
+                }
+              }
+            }


### PR DESCRIPTION
## Summary
- automate branch cleanup with manual workflow

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c058281228832c8bd9f5917421008c