### PR TITLE
fix: align list spacing to 4px grid

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1379,7 +1379,7 @@ textarea:-webkit-autofill {
   }
 }
 .ds-list {
-  @apply list-disc pl-5 space-y-1.5;
+  @apply list-disc pl-5 space-y-2;
 }
 
 /* === Champ badges ===================================== */


### PR DESCRIPTION
## Summary
- replace fractional ds-list spacing with whole-token value to match 4px grid

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c05900cdac832c9d0e2f76c7b9c34e