### PR TITLE
refactor: align Split layout gap with spacing token

### DIFF
--- a/src/components/ui/layout/Split.tsx
+++ b/src/components/ui/layout/Split.tsx
@@ -18,7 +18,7 @@ export default function Split({
   className?: string;
 }) {
   return (
-    <div className={["grid gap-6 md:grid-cols-2", className].join(" ")}>
+    <div className={["grid gap-5 md:grid-cols-2", className].join(" ")}>
       <div className="min-w-0">{left}</div>
       <div className="min-w-0">{right}</div>
     </div>


### PR DESCRIPTION
## Summary
- use `gap-5` in `Split` layout for 24px spacing

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c05bdf37e4832c8ac14a6beda35d4e