### PR TITLE
chore: adjust champ badge spacing

### DIFF
--- a/src/components/team/style.css
+++ b/src/components/team/style.css
@@ -3,7 +3,7 @@
 /* Champ badges */
 .champ-badges { @apply flex flex-wrap gap-2; }
 .champ-badge{
-  @apply inline-flex items-center h-7 px-2.5 rounded-full border text-xs leading-none whitespace-nowrap;
+  @apply inline-flex items-center h-8 px-3 rounded-full border text-xs leading-none whitespace-nowrap;
   border-color: hsl(var(--border));
   background: hsl(var(--card)); color: hsl(var(--foreground));
   transition: background .15s var(--ease-out), border-color .15s var(--ease-out), color .15s var(--ease-out);


### PR DESCRIPTION
## Summary
- tweak champ badge sizing to use standard h-8 and px-3 tokens

## Testing
- `npm run regen-ui` *(fails: Unknown file extension ".ts" for scripts/generate-ui-index.ts)*
- `npm run lint`
- `npm run typecheck` *(fails: Unknown file extension ".ts" for scripts/typecheck.ts)*
- `npm test` *(fails: Error [ERR_REQUIRE_ESM]: require() of ES Module vite)*

------
https://chatgpt.com/codex/tasks/task_e_68c05ef50ddc832c83c8172669293f36