### PR TITLE
feat: expand home dashboard

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -15,6 +15,7 @@ import GoalListDemo from "@/components/prompts/GoalListDemo";
 import PromptList from "@/components/prompts/PromptList";
 import type { PromptWithTitle } from "@/components/prompts/usePrompts";
 import { Plus } from "lucide-react";
+import { DashboardCard } from "@/components/home";
 
 type View = "components" | "colors";
 type Section =
@@ -152,6 +153,17 @@ const SPEC_DATA: Record<Section, Spec[]> = {
       description: "Demo goal list",
       element: <GoalListDemo />,
       tags: ["planner"],
+    },
+    {
+      id: "dashboard-card",
+      name: "DashboardCard",
+      description: "Home dashboard shell",
+      element: (
+        <DashboardCard title="Demo" cta={{ label: "Action", href: "#" }}>
+          <p className="text-sm">Content</p>
+        </DashboardCard>
+      ),
+      tags: ["home", "dashboard"],
     },
   ],
   misc: [

--- a/src/components/home/DashboardCard.tsx
+++ b/src/components/home/DashboardCard.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+
+interface DashboardCardProps {
+  title: string;
+  children?: React.ReactNode;
+  cta?: { label: string; href: string };
+  actions?: React.ReactNode;
+}
+
+export default function DashboardCard({ title, children, cta, actions }: DashboardCardProps) {
+  return (
+    <div className="rounded-xl border border-[hsl(var(--card-hairline))] bg-[hsl(var(--surface-2))] p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold tracking-[-0.01em]">{title}</h2>
+        {actions}
+      </div>
+      {children}
+      {cta && (
+        <Link href={cta.href} className="text-sm font-medium text-accent underline">
+          {cta.label}
+        </Link>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/home/HomePage.tsx
+++ b/src/components/home/HomePage.tsx
@@ -2,25 +2,151 @@
 
 import * as React from "react";
 import Link from "next/link";
+import Button from "@/components/ui/primitives/Button";
+import { SearchBar } from "@/components/ui";
+import { useRouter } from "next/navigation";
+import DashboardCard from "./DashboardCard";
+import { usePersistentState } from "@/lib/db";
+import { todayISO, type DayRecord, type ISODate } from "@/components/planner/plannerStore";
+import type { Goal, Review } from "@/lib/types";
+import { LOCALE } from "@/lib/utils";
 
-/**
- * HomePage — landing view with quick nav links.
- */
 export default function HomePage() {
+  const [query, setQuery] = React.useState("");
+  const router = useRouter();
+  const [days] = usePersistentState<Record<ISODate, DayRecord>>("planner:days", {});
+  const [goals] = usePersistentState<Goal[]>("goals.v2", []);
+  const [reviews] = usePersistentState<Review[]>("reviews.v1", []);
+
+  const iso = todayISO();
+  const tasks = React.useMemo(() => days[iso]?.tasks ?? [], [days, iso]);
+  const topTasks = tasks.slice(0, 3);
+
+  const activeGoals = React.useMemo(() => goals.filter(g => !g.done).slice(0, 3), [goals]);
+
+  const recentReviews = React.useMemo(
+    () => [...reviews].sort((a, b) => b.createdAt - a.createdAt).slice(0, 3),
+    [reviews],
+  );
+
   return (
-    <main className="page-shell py-6 space-y-6 text-center">
-      <header>
-        <h1 className="text-2xl font-semibold">Welcome to Planner</h1>
-        <p className="mt-2 text-muted-foreground">
-          Streamline your planning and reviews.
-        </p>
+    <main className="page-shell py-6 space-y-8">
+      {/* Header */}
+      <header className="text-center space-y-2">
+        <h1 className="text-2xl font-semibold tracking-[-0.01em]">Welcome to Planner</h1>
+        <p className="text-sm text-muted-foreground">Plan your day, track goals, and review games.</p>
       </header>
-      <nav className="flex justify-center gap-4">
+
+      {/* Hero */}
+      <section aria-label="Quick actions" className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        <div className="flex flex-wrap gap-4">
+          <Button onClick={() => router.push("/planner")}>Planner Today</Button>
+          <Button variant="ghost" onClick={() => router.push("/goals")}>New Goal</Button>
+          <Button variant="ghost" onClick={() => router.push("/reviews")}>New Review</Button>
+        </div>
+        <div className="md:justify-self-end">
+          <SearchBar role="search" value={query} onValueChange={setQuery} />
+        </div>
+      </section>
+      <div className="h-1 w-full rounded-full" style={{ background: "var(--edge-iris)" }} />
+
+      {/* Dashboard grid */}
+      <section aria-label="Dashboard" className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <DashboardCard title="Today" cta={{ label: "Open Planner", href: "/planner" }}>
+          <ul className="space-y-2">
+            {topTasks.map(t => (
+              <li key={t.id} className="flex justify-between text-sm">
+                <span>{t.title}</span>
+                <span className="text-muted-foreground">Today</span>
+              </li>
+            ))}
+            {topTasks.length === 0 && (
+              <li className="text-sm text-muted-foreground">No tasks</li>
+            )}
+          </ul>
+        </DashboardCard>
+
+        <DashboardCard title="Active goals" cta={{ label: "Manage Goals", href: "/goals" }}>
+          <ul className="space-y-2">
+            {activeGoals.map(g => (
+              <li key={g.id}>
+                <p className="text-sm">{g.title}</p>
+                <div className="mt-1 h-2 w-full rounded-full bg-[hsl(var(--card-hairline))]">
+                  <div className="h-2 rounded-full" style={{ background: "var(--neon)", width: "0%" }} />
+                </div>
+              </li>
+            ))}
+            {activeGoals.length === 0 && (
+              <li className="text-sm text-muted-foreground">No active goals</li>
+            )}
+          </ul>
+        </DashboardCard>
+
+        <DashboardCard
+          title="Recent reviews"
+          actions={
+            <div className="flex gap-2">
+              <Link href="/reviews" className="text-sm text-accent underline">
+                Open Reviews
+              </Link>
+              <Link href="/reviews" className="text-sm text-accent underline">
+                New
+              </Link>
+            </div>
+          }
+        >
+          <ul className="space-y-2">
+            {recentReviews.map(r => (
+              <li key={r.id} className="flex justify-between text-sm">
+                <span>{r.title || "Untitled"}</span>
+                <span className="text-muted-foreground">
+                  {new Date(r.createdAt).toLocaleDateString(LOCALE)}
+                </span>
+              </li>
+            ))}
+            {recentReviews.length === 0 && (
+              <li className="text-sm text-muted-foreground">No reviews yet</li>
+            )}
+          </ul>
+        </DashboardCard>
+
+        <DashboardCard title="Team quick actions">
+          <div className="grid grid-cols-3 gap-2 text-sm">
+            <Link href="/team" className="rounded-md border border-[hsl(var(--card-hairline))] p-2 text-center hover:text-accent">
+              Archetypes
+            </Link>
+            <Link href="/team" className="rounded-md border border-[hsl(var(--card-hairline))] p-2 text-center hover:text-accent">
+              Team Builder
+            </Link>
+            <Link href="/team" className="rounded-md border border-[hsl(var(--card-hairline))] p-2 text-center hover:text-accent">
+              Jungle Clears
+            </Link>
+          </div>
+        </DashboardCard>
+
+        <DashboardCard title="Prompts peek" cta={{ label: "Explore Prompts", href: "/prompts" }}>
+          <div
+            className="rounded-lg p-6 text-center text-sm"
+            style={{ background: "var(--seg-active-grad)", color: "var(--neon-soft)" }}
+          >
+            Get inspired with curated prompts
+          </div>
+        </DashboardCard>
+      </section>
+
+      {/* Bottom links */}
+      <nav className="flex justify-center gap-4 pt-4">
+        <Link className="text-accent underline" href="/goals">
+          Goals
+        </Link>
         <Link className="text-accent underline" href="/planner">
           Planner
         </Link>
         <Link className="text-accent underline" href="/reviews">
           Reviews
+        </Link>
+        <Link className="text-accent underline" href="/team">
+          Team
         </Link>
         <Link className="text-accent underline" href="/prompts">
           Prompts
@@ -29,3 +155,4 @@ export default function HomePage() {
     </main>
   );
 }
+

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -1,2 +1,3 @@
 // src/components/home/index.ts
 export { default as HomePage } from "./HomePage";
+export { default as DashboardCard } from "./DashboardCard";

--- a/tests/home/HomePage.test.tsx
+++ b/tests/home/HomePage.test.tsx
@@ -1,16 +1,23 @@
 import * as React from "react";
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import HomePage from "@/components/home/HomePage";
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
 
 describe("HomePage", () => {
   it("renders navigation links", () => {
     render(<HomePage />);
+    const goals = screen.getByRole("link", { name: "Goals" });
     const planner = screen.getByRole("link", { name: "Planner" });
     const reviews = screen.getByRole("link", { name: "Reviews" });
+    const team = screen.getByRole("link", { name: "Team" });
     const prompts = screen.getByRole("link", { name: "Prompts" });
+    expect(goals).toHaveAttribute("href", "/goals");
     expect(planner).toHaveAttribute("href", "/planner");
     expect(reviews).toHaveAttribute("href", "/reviews");
+    expect(team).toHaveAttribute("href", "/team");
     expect(prompts).toHaveAttribute("href", "/prompts");
   });
 });


### PR DESCRIPTION
## Summary
- add dashboard card shell and register with prompts page
- expand HomePage with hero actions, search, and dashboard sections
- cover HomePage navigation links

## Testing
- `node --input-type=module -e "import { MultiBar, Presets } from 'cli-progress'; import { execSync } from 'child_process'; const steps=['npm run regen-ui','npm test -- --run','npm run lint','npm run typecheck']; const bars=new MultiBar({ clearOnComplete:false, hideCursor:true }, Presets.shades_grey); const bar=bars.create(steps.length,0); for (let i=0;i<steps.length;i++){const cmd=steps[i]; console.log(cmd); execSync(cmd,{stdio:'inherit'}); bar.update(i+1);} bars.stop();"`
- `git commit -am "feat: expand home dashboard" && git status --short`
- `git commit -m "feat: add dashboard card component" && git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68c06adf5dac832cbd626de4ba8f5060