### PR TITLE
refactor: use Card primitive in review panel

### DIFF
--- a/src/components/reviews/ReviewPanel.tsx
+++ b/src/components/reviews/ReviewPanel.tsx
@@ -1,13 +1,11 @@
 import React, { type HTMLAttributes } from "react";
 import { cn } from "@/lib/utils";
+import Card from "@/components/ui/primitives/Card";
 
 export default function ReviewPanel({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   return (
-    <div
-      className={cn(
-        "max-w-[880px] w-full rounded-xl p-5 bg-card/60 ring-1 ring-ring/5 shadow-[0_0_40px_-12px_hsl(var(--glow-soft))]",
-        className
-      )}
+    <Card
+      className={cn("w-full max-w-[880px] p-5", className)}
       {...props}
     />
   );

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -875,7 +875,7 @@ exports[`ReviewsPage > renders default state 1`] = `
         </div>
       </nav>
       <div
-        class="max-w-[880px] w-full rounded-xl p-5 bg-card/60 ring-1 ring-ring/5 shadow-[0_0_40px_-12px_hsl(var(--glow-soft))] md:col-span-8 lg:col-span-9 mx-auto flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground"
+        class="rounded-xl border border-[hsl(var(--border)/0.25)] bg-[hsl(var(--card)/0.6)] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] w-full max-w-[880px] p-5 md:col-span-8 lg:col-span-9 mx-auto flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground"
       >
         <svg
           class="lucide lucide-ghost h-6 w-6 opacity-60"


### PR DESCRIPTION
## Summary
- refactor review panel to use Card primitive with width and padding overrides
- update ReviewsPage snapshot for new Card markup

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c06d0ccafc832c8f6b80c08017ce4c