### PR TITLE
refactor: rely on segmented button icon sizing

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -45,19 +45,19 @@ const TABS: Array<{
   {
     key: "goals",
     label: "Goals",
-    icon: <Flag className="mr-1 h-4 w-4" />,
+    icon: <Flag />,
     hint: "Cap 3 active",
   },
   {
     key: "reminders",
     label: "Reminders",
-    icon: <ListChecks className="mr-1 h-4 w-4" />,
+    icon: <ListChecks />,
     hint: "Quick cues",
   },
   {
     key: "timer",
     label: "Timer",
-    icon: <TimerIcon className="mr-1 h-4 w-4" />,
+    icon: <TimerIcon />,
     hint: "Focus sprints",
   },
 ];


### PR DESCRIPTION
## Summary
- simplify goals page tab icons to use GlitchSegmentedButton's default gap and sizing

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c06d947aac832c93102a1dcc3c492f