### PR TITLE
refactor: use semantic tailwind tokens in goals

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -222,6 +222,15 @@ function Swatch({ token }: SwatchProps) {
   );
 }
 
+function GradientSwatch() {
+  return (
+    <li className="col-span-12 md:col-span-6 flex flex-col items-center gap-3">
+      <div className="h-16 w-full rounded-xl bg-gradient-to-r from-primary via-accent to-transparent" />
+      <span className="text-xs font-medium">from-primary via-accent to-transparent</span>
+    </li>
+  );
+}
+
 type SectionCardProps = {
   title: string;
   children: React.ReactNode;
@@ -283,6 +292,11 @@ function ColorsView() {
           </ul>
         </SectionCard>
       ))}
+      <SectionCard title="Gradients">
+        <ul className="grid grid-cols-12 gap-6">
+          <GradientSwatch />
+        </ul>
+      </SectionCard>
     </div>
   );
 }

--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -62,7 +62,7 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
         />
         <SectionCard.Body className="grid gap-6">
           <label className="grid gap-2">
-            <span className="text-xs text-[hsl(var(--muted-foreground))]">Title</span>
+            <span className="text-xs text-muted-foreground">Title</span>
             <Input
               ref={titleRef}
               tone="default"
@@ -75,7 +75,7 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
           </label>
 
           <label className="grid gap-2">
-            <span className="text-xs text-[hsl(var(--muted-foreground))]">Metric (optional)</span>
+            <span className="text-xs text-muted-foreground">Metric (optional)</span>
             <Input
               tone="default"
               className="h-10 text-sm tabular-nums"
@@ -86,7 +86,7 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
           </label>
 
           <label className="grid gap-2">
-            <span className="text-xs text-[hsl(var(--muted-foreground))]">Notes (optional)</span>
+            <span className="text-xs text-muted-foreground">Notes (optional)</span>
             <Textarea
               tone="default"
               textareaClassName="min-h-24 text-sm"
@@ -96,9 +96,9 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
             />
           </label>
 
-          <div className="text-xs text-[hsl(var(--muted-foreground))]">
+          <div className="text-xs text-muted-foreground">
             {activeCount >= activeCap ? (
-              <span className="text-[hsl(var(--accent))]">
+              <span className="text-accent">
                 Cap reached. Finish one to add more.
               </span>
             ) : (
@@ -110,7 +110,7 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
           </div>
 
           {err ? (
-            <p role="status" aria-live="polite" className="text-xs text-[hsl(var(--accent))]">
+            <p role="status" aria-live="polite" className="text-xs text-accent">
               {err}
             </p>
           ) : null}

--- a/src/components/goals/GoalList.tsx
+++ b/src/components/goals/GoalList.tsx
@@ -17,7 +17,7 @@ export default function GoalList({ goals, onToggleDone, onRemove }: GoalListProp
   return (
     <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 [grid-auto-rows:minmax(0,1fr)]">
       {goals.length === 0 ? (
-        <p className="text-sm text-[hsl(var(--muted-foreground))]">
+        <p className="text-sm text-muted-foreground">
           No goals here. Add one simple, finishable thing.
         </p>
       ) : (
@@ -33,7 +33,7 @@ export default function GoalList({ goals, onToggleDone, onRemove }: GoalListProp
           >
             <span
               aria-hidden
-              className="absolute inset-y-4 left-0 w-1 rounded-full bg-gradient-to-b from-[hsl(var(--primary))] via-[hsl(var(--accent))] to-transparent opacity-60"
+              className="absolute inset-y-4 left-0 w-1 rounded-full bg-gradient-to-b from-primary via-accent to-transparent opacity-60"
             />
             <header className="flex items-start justify-between gap-2">
               <h3 className="font-semibold leading-tight pr-6 line-clamp-2">
@@ -56,7 +56,7 @@ export default function GoalList({ goals, onToggleDone, onRemove }: GoalListProp
                 </IconButton>
               </div>
             </header>
-            <div className="mt-4 text-sm text-[hsl(var(--muted-foreground))] space-y-2">
+            <div className="mt-4 text-sm text-muted-foreground space-y-2">
               {g.metric ? (
                 <div className="tabular-nums">
                   <span className="opacity-70">Metric:</span>{" "}
@@ -65,18 +65,18 @@ export default function GoalList({ goals, onToggleDone, onRemove }: GoalListProp
               ) : null}
               {g.notes ? <p className="leading-relaxed">{g.notes}</p> : null}
             </div>
-            <footer className="mt-auto pt-3 flex items-center justify-between text-xs text-[hsl(var(--muted-foreground))]">
+            <footer className="mt-auto pt-3 flex items-center justify-between text-xs text-muted-foreground">
               <span className="inline-flex items-center gap-2">
                 <span
                   aria-hidden
-                  className={["h-2 w-2 rounded-full", g.done ? "" : "bg-[hsl(var(--primary))]"].join(" ")}
+                  className={["h-2 w-2 rounded-full", g.done ? "" : "bg-primary"].join(" ")}
                   style={g.done ? { background: "var(--accent-overlay)" } : undefined}
                 />
                 <time className="tabular-nums" dateTime={new Date(g.createdAt).toISOString()}>
                   {shortDate.format(new Date(g.createdAt))}
                 </time>
               </span>
-              <span className={g.done ? "text-[hsl(var(--accent))]" : ""}>
+              <span className={g.done ? "text-accent" : ""}>
                 {g.done ? "Done" : "Active"}
               </span>
             </footer>


### PR DESCRIPTION
## Summary
- replace hard-coded hsl utilities with semantic classes in GoalForm
- update GoalList to use semantic text, gradient, and background utilities
- document primary→accent gradient in prompts page

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0780d7500832ca43cb7fdcd23b303