### PR TITLE
feat: add segmented button component

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -6,6 +6,7 @@ import {
   IconButton,
   Input,
   SearchBar,
+  SegmentedButton,
   TabBar,
   ThemeToggle,
   type TabItem,
@@ -118,6 +119,18 @@ const SPEC_DATA: Record<Section, Spec[]> = {
       ),
       tags: ["button", "action"],
       props: [{ label: "sizes", value: "sm md lg" }],
+    },
+    {
+      id: "segmented-button",
+      name: "SegmentedButton",
+      description: "Segmented control button",
+      element: (
+        <div className="flex gap-4">
+          <SegmentedButton>Default</SegmentedButton>
+          <SegmentedButton isActive>Active</SegmentedButton>
+        </div>
+      ),
+      tags: ["button", "segmented"],
     },
   ],
   iconButton: [

--- a/src/components/chrome/PageTabs.tsx
+++ b/src/components/chrome/PageTabs.tsx
@@ -4,6 +4,7 @@
 import * as React from "react";
 import Link from "next/link";
 import { motion } from "framer-motion";
+import SegmentedButton from "@/components/ui/primitives/SegmentedButton";
 
 type TabItem = { id: string; label: React.ReactNode; href?: string };
 
@@ -18,7 +19,7 @@ export interface PageTabsProps {
 
 /**
  * PageTabs — secondary tab row for a page section.
- * - Uses .btn-like-segmented tokened style.
+ * - Uses SegmentedButton tokened style.
  * - No hover translate.
  */
 export default function PageTabs({
@@ -51,47 +52,53 @@ export default function PageTabs({
     >
       <div className="mx-auto max-w-6xl px-4">
         <div className="flex gap-2 py-2">
-          {tabs.map((t) => {
-            const active = t.id === value;
-            const classNames = [
-              "btn-like-segmented rounded-xl px-4 py-2 font-mono text-sm border relative",
-              active ? "is-active btn-glitch" : "",
-            ]
-              .filter(Boolean)
-              .join(" ");
+            {tabs.map((t) => {
+              const active = t.id === value;
+              const className = [
+                "rounded-xl px-4 py-2 font-mono text-sm border relative",
+                active ? "btn-glitch" : "",
+              ]
+                .filter(Boolean)
+                .join(" ");
 
-            const inner = (
-              <>
-                {t.label}
-                {active && (
-                  <motion.span
-                    layoutId="glitch-tabs-underline"
-                    className="absolute left-2 right-2 -bottom-1 h-px"
-                    style={{
-                      background:
-                        "linear-gradient(90deg, hsl(var(--primary)), hsl(var(--accent)), hsl(var(--primary)))",
-                    }}
-                    transition={{ type: "tween", duration: 0.25, ease: "easeOut" }}
-                  />
-                )}
-              </>
-            );
+              const inner = (
+                <>
+                  {t.label}
+                  {active && (
+                    <motion.span
+                      layoutId="glitch-tabs-underline"
+                      className="absolute left-2 right-2 -bottom-1 h-px"
+                      style={{
+                        background:
+                          "linear-gradient(90deg, hsl(var(--primary)), hsl(var(--accent)), hsl(var(--primary)))",
+                      }}
+                      transition={{ type: "tween", duration: 0.25, ease: "easeOut" }}
+                    />
+                  )}
+                </>
+              );
 
-            return t.href ? (
-              <Link key={t.id} href={t.href} className={classNames}>
-                {inner}
-              </Link>
-            ) : (
-              <button
-                key={t.id}
-                type="button"
-                onClick={() => onChange?.(t.id)}
-                className={classNames}
-              >
-                {inner}
-              </button>
-            );
-          })}
+              return t.href ? (
+                <SegmentedButton
+                  as={Link}
+                  key={t.id}
+                  href={t.href}
+                  className={className}
+                  isActive={active}
+                >
+                  {inner}
+                </SegmentedButton>
+              ) : (
+                <SegmentedButton
+                  key={t.id}
+                  onClick={() => onChange?.(t.id)}
+                  className={className}
+                  isActive={active}
+                >
+                  {inner}
+                </SegmentedButton>
+              );
+            })}
         </div>
       </div>
     </div>

--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -19,6 +19,7 @@ import Textarea from "@/components/ui/primitives/Textarea";
 import Badge from "@/components/ui/primitives/Badge";
 import IconButton from "@/components/ui/primitives/IconButton";
 import TabBar from "@/components/ui/layout/TabBar";
+import SegmentedButton from "@/components/ui/primitives/SegmentedButton";
 import { uid, usePersistentState } from "@/lib/db";
 import {
   Search,
@@ -192,21 +193,21 @@ export default function Reminders() {
             />
 
             {/* pinned */}
-            <button
-              className={["btn-like-segmented h-10", onlyPinned && "is-active"].filter(Boolean).join(" ")}
-              onClick={() => setOnlyPinned(v => !v)}
-              aria-pressed={onlyPinned}
-              type="button"
-              title="Pinned only"
-            >
-              {onlyPinned ? <PinOff className="mr-1" /> : <Pin className="mr-1" />}
-              {onlyPinned ? "Pinned only" : "Any pin"}
-            </button>
+              <SegmentedButton
+                className="h-10"
+                onClick={() => setOnlyPinned(v => !v)}
+                aria-pressed={onlyPinned}
+                title="Pinned only"
+                isActive={onlyPinned}
+              >
+                {onlyPinned ? <PinOff className="mr-1" /> : <Pin className="mr-1" />}
+                {onlyPinned ? "Pinned only" : "Any pin"}
+              </SegmentedButton>
 
             {/* actions */}
-            <button className="btn-like-segmented h-10" onClick={resetSeeds} type="button" title="Replace with curated seeds">
-              Reset
-            </button>
+              <SegmentedButton className="h-10" onClick={resetSeeds} title="Replace with curated seeds">
+                Reset
+              </SegmentedButton>
           </div>
         </SectionCard.Header>
 

--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -23,6 +23,7 @@ import Button from "@/components/ui/primitives/Button";
 import IconButton from "@/components/ui/primitives/IconButton";
 import Hero, { HeroSearchBar } from "@/components/ui/layout/Hero";
 import TabBar from "@/components/ui/layout/TabBar";
+import SegmentedButton from "@/components/ui/primitives/SegmentedButton";
 import { uid, usePersistentState } from "@/lib/db";
 import {
   Search,
@@ -301,18 +302,16 @@ export default function RemindersTab() {
                 size="md"
                 align="between"
                 right={
-                  <button
-                    className={["btn-like-segmented inline-flex items-center gap-1", showFilters && "is-active"]
-                      .filter(Boolean)
-                      .join(" ")}
-                  onClick={() => setShowFilters((v) => !v)}
-                  aria-expanded={showFilters}
-                  title="Filters"
-                  type="button"
-                >
+                  <SegmentedButton
+                    className="inline-flex items-center gap-1"
+                    onClick={() => setShowFilters((v) => !v)}
+                    aria-expanded={showFilters}
+                    title="Filters"
+                    isActive={showFilters}
+                  >
                     <SlidersHorizontal size={16} aria-hidden />
-                  Filters
-                </button>
+                    Filters
+                  </SegmentedButton>
               }
             />
           )}
@@ -327,16 +326,15 @@ export default function RemindersTab() {
                   ariaLabel="Reminder source filter"
                   size="sm"
                 />
-                <button
-                  type="button"
-                  onClick={() => setOnlyPinned((v) => !v)}
-                  aria-pressed={onlyPinned}
-                  className={["btn-like-segmented", onlyPinned && "is-active"].filter(Boolean).join(" ")}
-                  title="Pinned only"
-                >
-                  {onlyPinned ? <PinOff className="mr-1" /> : <Pin className="mr-1" />}
-                  {onlyPinned ? "Pinned only" : "Any pin"}
-                </button>
+                  <SegmentedButton
+                    onClick={() => setOnlyPinned((v) => !v)}
+                    aria-pressed={onlyPinned}
+                    title="Pinned only"
+                    isActive={onlyPinned}
+                  >
+                    {onlyPinned ? <PinOff className="mr-1" /> : <Pin className="mr-1" />}
+                    {onlyPinned ? "Pinned only" : "Any pin"}
+                  </SegmentedButton>
               </div>
             )}
 
@@ -526,42 +524,39 @@ function RemTile({
             />
 
             <div className="segmented inline-flex">
-              {(["pregame", "laning", "trading", "tempo", "review", "quick"] as Group[]).map((g) => (
-                <button
-                  key={g}
-                  className={["btn-like-segmented", value.group === g && "is-active"].filter(Boolean).join(" ")}
-                  onClick={() => onChange({ group: g })}
-                  type="button"
-                >
-                  {g === "pregame" ? "Pre-Game" : cap(g)}
-                </button>
-              ))}
+                {(["pregame", "laning", "trading", "tempo", "review", "quick"] as Group[]).map((g) => (
+                  <SegmentedButton
+                    key={g}
+                    onClick={() => onChange({ group: g })}
+                    isActive={value.group === g}
+                  >
+                    {g === "pregame" ? "Pre-Game" : cap(g)}
+                  </SegmentedButton>
+                ))}
             </div>
 
             <div className="segmented inline-flex">
-              {(["MLA", "BLA", "BrokenByConcept", "Custom"] as Source[]).map((s) => (
-                <button
-                  key={s}
-                  className={["btn-like-segmented", value.source === s && "is-active"].filter(Boolean).join(" ")}
-                  onClick={() => onChange({ source: s })}
-                  type="button"
-                >
-                  {s}
-                </button>
-              ))}
+                {(["MLA", "BLA", "BrokenByConcept", "Custom"] as Source[]).map((s) => (
+                  <SegmentedButton
+                    key={s}
+                    onClick={() => onChange({ source: s })}
+                    isActive={value.source === s}
+                  >
+                    {s}
+                  </SegmentedButton>
+                ))}
             </div>
 
             <div className="segmented inline-flex">
-              {(["Life", "League", "Learn"] as Domain[]).map((d) => (
-                <button
-                  key={d}
-                  className={["btn-like-segmented", (value.domain ?? "League") === d && "is-active"].filter(Boolean).join(" ")}
-                  onClick={() => onChange({ domain: d })}
-                  type="button"
-                >
-                  {d}
-                </button>
-              ))}
+                {(["Life", "League", "Learn"] as Domain[]).map((d) => (
+                  <SegmentedButton
+                    key={d}
+                    onClick={() => onChange({ domain: d })}
+                    isActive={(value.domain ?? "League") === d}
+                  >
+                    {d}
+                  </SegmentedButton>
+                ))}
             </div>
 
             <div className="flex gap-2">

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -14,6 +14,7 @@ import SectionCard from "@/components/ui/layout/SectionCard";
 import IconButton from "@/components/ui/primitives/IconButton";
 import TabBar from "@/components/ui/layout/TabBar";
 import Hero from "@/components/ui/layout/Hero";
+import SegmentedButton from "@/components/ui/primitives/SegmentedButton";
 import {
   Play, Pause, RotateCcw, Plus, Minus,
   BookOpen, Brush, Code2, User,
@@ -270,37 +271,35 @@ export default function TimerTab() {
 
         {/* Controls row */}
         <div className="mt-4 flex items-center justify-center gap-2">
-          {!running ? (
-            <button
-              className="btn-like-segmented inline-flex items-center gap-2 px-4 py-2"
-              onClick={start}
-              type="button"
-              title="Start"
+            {!running ? (
+              <SegmentedButton
+                className="inline-flex items-center gap-2 px-4 py-2"
+                onClick={start}
+                title="Start"
+              >
+                <Play />
+                Start
+              </SegmentedButton>
+            ) : (
+              <SegmentedButton
+                className="inline-flex items-center gap-2 px-4 py-2"
+                onClick={pause}
+                title="Pause"
+                isActive
+              >
+                <Pause />
+                Pause
+              </SegmentedButton>
+            )}
+            <SegmentedButton
+              className="inline-flex items-center gap-2 px-4 py-2"
+              onClick={reset}
+              title="Reset"
             >
-              <Play />
-              Start
-            </button>
-          ) : (
-            <button
-              className="btn-like-segmented inline-flex items-center gap-2 px-4 py-2 is-active"
-              onClick={pause}
-              type="button"
-              title="Pause"
-            >
-              <Pause />
-              Pause
-            </button>
-          )}
-          <button
-            className="btn-like-segmented inline-flex items-center gap-2 px-4 py-2"
-            onClick={reset}
-            type="button"
-            title="Reset"
-          >
-            <RotateCcw />
-            Reset
-          </button>
-        </div>
+              <RotateCcw />
+              Reset
+            </SegmentedButton>
+          </div>
 
         {/* Complete state */}
         {finished && (

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -38,6 +38,8 @@ export * from "./primitives/Input";
 export * from "./primitives/Neu";
 export { default as SearchBar } from "./primitives/SearchBar";
 export * from "./primitives/SearchBar";
+export { default as SegmentedButton } from "./primitives/SegmentedButton";
+export * from "./primitives/SegmentedButton";
 export { default as Textarea } from "./primitives/Textarea";
 export * from "./primitives/Textarea";
 export { default as AnimatedSelect } from "./selects/AnimatedSelect";

--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -9,6 +9,7 @@
  */
 
 import * as React from "react";
+import SegmentedButton from "@/components/ui/primitives/SegmentedButton";
 
 function cx(...parts: Array<string | false | null | undefined>) {
   return parts.filter(Boolean).join(" ");
@@ -177,26 +178,23 @@ export function HeaderTabs<Key extends string = string>({
     >
       {tabs.map((t, i) => {
         const active = activeKey === t.key;
-        return (
-          <button
-            key={t.key}
-            ref={setBtnRef(i)}
-            role="tab"
-            aria-selected={active}
-            aria-controls={`${t.key}-panel`}
-            id={`${t.key}-tab`}
-            title={t.hint}
-            onClick={() => onChange(t.key)}
-            className={[
-              "btn-like-segmented",
-              active ? "is-active" : "",
-              " h-8 sm:h-9 text-xs sm:text-sm px-3 focus-visible:ghost-2 focus-visible:ghost-[hsl(var(--ghost))]",
-            ].join(" ")}
-          >
-            {t.icon}
-            {t.label}
-          </button>
-        );
+          return (
+            <SegmentedButton
+              key={t.key}
+              ref={setBtnRef(i) as (el: HTMLButtonElement | null) => void}
+              role="tab"
+              aria-selected={active}
+              aria-controls={`${t.key}-panel`}
+              id={`${t.key}-tab`}
+              title={t.hint}
+              onClick={() => onChange(t.key)}
+              className="h-8 sm:h-9 text-xs sm:text-sm px-3 focus-visible:ghost-2 focus-visible:ghost-[hsl(var(--ghost))]"
+              isActive={active}
+            >
+              {t.icon}
+              {t.label}
+            </SegmentedButton>
+          );
       })}
     </nav>
   );

--- a/src/components/ui/primitives/SegmentedButton.tsx
+++ b/src/components/ui/primitives/SegmentedButton.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type SegmentedButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  as?: React.ElementType;
+  isActive?: boolean;
+  href?: string;
+};
+
+const SegmentedButton = React.forwardRef<
+  HTMLElement,
+  SegmentedButtonProps
+>(({ as: Comp = "button", isActive, className, type, ...props }, ref) => {
+  const cls = cn("btn-like-segmented", isActive && "is-active", className);
+  const typeProp =
+    Comp === "button" && (props as React.ButtonHTMLAttributes<HTMLButtonElement>).type === undefined
+      ? { type: type ?? "button" }
+      : {};
+  return <Comp ref={ref as React.Ref<HTMLElement>} className={cls} {...typeProp} {...props} />;
+});
+
+SegmentedButton.displayName = "SegmentedButton";
+export default SegmentedButton;


### PR DESCRIPTION
## Summary
- add SegmentedButton primitive for btn-like-segmented styling
- refactor Reminders, TimerTab, PageTabs, and header to use SegmentedButton
- showcase SegmentedButton on prompts playground

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c080136658832ca0e958ca008fb2cd