### PR TITLE
fix: use whole-token size for planner icons

### DIFF
--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -28,7 +28,7 @@
   @apply size-8 rounded-full opacity-0 transition-opacity duration-140 ease-out;
 }
 .daycard :where(.iconbtn > svg) {
-  @apply size-3.5;
+  @apply size-4;
 }
 
 /* Reveal actions on hover or focus-within for a11y */


### PR DESCRIPTION
## Summary
- replace fractional `size-3.5` icon class with whole-token `size-4`
- keep icon buttons at `size-8` to maintain tap-target spacing

## Testing
- `npm run regen-ui`
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c082e8916c832cb26e1cc4175efab4