### PR TITLE
feat(ui): keep header body scrollable

### DIFF
--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -2,7 +2,7 @@
 
 /**
  * Header — sticky, glow, and unapologetically on top.
- * - Always sticky by default
+ * - Top bar sticks while the body scrolls
  * - High z-index (z-[999]) so it doesn't hide behind random divs
  * - No border; soft neon glow
  * - Keep topClassName if you need offset (e.g., under the global navbar)
@@ -49,8 +49,6 @@ export default function Header({
   return (
     <header
       className={cx(
-        // Sticky + very high z-index + stacking context
-        sticky && cx("sticky", topClassName),
         "z-[999] relative isolate",
 
         // Card look: no border, soft glow
@@ -67,6 +65,7 @@ export default function Header({
       {/* Top bar */}
       <div
         className={cx(
+          sticky && cx("sticky", topClassName),
           "relative flex items-center",
           "px-3 sm:px-4 py-3 sm:py-4 min-h-12",
           barClassName

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`ReviewsPage > renders default state 1`] = `
     class="page-shell py-6 space-y-6"
   >
     <header
-      class="sticky top-8 z-[999] relative isolate rounded-2xl bg-[hsl(var(--card))]/70 backdrop-blur-md shadow-[0_0_18px_hsl(var(--ring)/.35),0_0_32px_hsl(var(--accent)/.25)] overflow-hidden"
+      class="z-[999] relative isolate rounded-2xl bg-[hsl(var(--card))]/70 backdrop-blur-md shadow-[0_0_18px_hsl(var(--ring)/.35),0_0_32px_hsl(var(--accent)/.25)] overflow-hidden"
     >
       <div
-        class="relative flex items-center px-3 sm:px-4 py-3 sm:py-4 min-h-12"
+        class="sticky top-8 relative flex items-center px-3 sm:px-4 py-3 sm:py-4 min-h-12"
       >
         <div
           aria-hidden="true"


### PR DESCRIPTION
## Summary
- make only the header's top bar sticky so body content scrolls away
- update review snapshot for new header structure

## Testing
- `npm test -- -u --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c090b0d47c832ca802abd52a080afc