### PR TITLE
refactor: replace pixel spacing with tailwind utilities

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1061,7 +1061,7 @@ textarea:-webkit-autofill {
   @apply inline-flex items-center rounded-full
          border border-[hsl(var(--card-hairline))]
          bg-[hsl(var(--muted))/0.18]
-         px-2 py-[3px] text-[12px] leading-tight tracking-[-0.01em];
+        px-2 py-1 text-xs leading-tight tracking-[-0.01em];
 }
 .pill-compact:hover {
   @apply bg-[hsl(var(--muted))/0.28];

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -8,6 +8,7 @@ import {
   SearchBar,
   SegmentedButton,
   TabBar,
+  Badge,
   ThemeToggle,
   type TabItem,
 } from "@/components/ui";
@@ -182,6 +183,12 @@ const SPEC_DATA: Record<Section, Spec[]> = {
         </div>
       ),
       tags: ["status"],
+    },
+    {
+      id: "badge",
+      name: "Badge",
+      element: <Badge>Badge</Badge>,
+      tags: ["badge"],
     },
     {
       id: "role-selector",

--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -288,7 +288,7 @@ function ReminderCard({
   return (
     <article className="card-neo rounded-card p-4 sm:p-5 relative">
       {value.pinned && (
-        <span aria-hidden className="absolute inset-y-3 left-0 w-[2px] rounded-full bg-[hsl(var(--primary)/.55)]" />
+        <span aria-hidden className="absolute inset-y-3 left-0 w-0.5 rounded-full bg-[hsl(var(--primary)/.55)]" />
       )}
 
       <div className="flex items-center justify-between gap-2 mb-2">

--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -318,7 +318,7 @@ export default function RemindersTab() {
 
             {/* Filters panel (collapsible) */}
             {showFilters && (
-              <div className="flex flex-wrap items-center gap-4 pl-[2px]">
+              <div className="flex flex-wrap items-center gap-4 pl-0.5">
                 <TabBar
                   items={SOURCE_TABS}
                   value={source}
@@ -512,7 +512,7 @@ function RemTile({
               }
               className="rounded-2xl"
               resize="resize-y"
-              textareaClassName="min-h-[160px] leading-relaxed"
+              textareaClassName="min-h-40 leading-relaxed"
             />
 
             <label className="text-xs opacity-70">Tags</label>

--- a/src/components/planner/TaskList.tsx
+++ b/src/components/planner/TaskList.tsx
@@ -52,7 +52,7 @@ export default function TaskList({
           aria-label="Add task"
         />
       )}
-      <div className="min-h-[120px] max-h-[320px] overflow-y-auto px-2 py-2">
+      <div className="min-h-32 max-h-80 overflow-y-auto px-2 py-2">
         {!selectedProjectId ? (
           <EmptyRow text="No task selected." />
         ) : tasksForSelected.length === 0 ? (

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -567,7 +567,7 @@ export default function ComponentGallery() {
         label: "Review Layout",
         element: (
           <div className="grid w-full gap-4 md:grid-cols-12">
-            <div className="md:col-span-4 md:w-[240px] bg-panel h-10 rounded" />
+            <div className="md:col-span-4 md:w-60 bg-panel h-10 rounded" />
             <div className="md:col-span-8 bg-muted h-10 rounded" />
           </div>
         ),

--- a/src/components/reviews/ReviewSummaryTimestamps.tsx
+++ b/src/components/reviews/ReviewSummaryTimestamps.tsx
@@ -31,7 +31,7 @@ export default function ReviewSummaryTimestamps({ markers }: ReviewSummaryTimest
                 className="grid grid-cols-[auto_1fr] items-center gap-2 rounded-2xl border border-border bg-card px-3 py-2"
               >
                 {m.noteOnly ? (
-                  <span className="pill flex h-7 w-[56px] items-center justify-center px-0" title="Note" aria-label="Note">
+                  <span className="pill flex h-7 w-14 items-center justify-center px-0" title="Note" aria-label="Note">
                     <FileText size={14} className="opacity-80" />
                   </span>
                 ) : (

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -211,7 +211,7 @@ export default function TabBar<K extends string = string>({
             ref={indicatorRef}
             aria-hidden
             className={cn(
-              "pointer-events-none absolute -bottom-1 h-[2px] rounded-full opacity-0",
+              "pointer-events-none absolute -bottom-1 h-0.5 rounded-full opacity-0",
               "[background:var(--seg-active-grad,linear-gradient(90deg,hsl(var(--primary))_0%,hsl(var(--accent))_100%))]",
               "transition-[transform,width,opacity] duration-200 ease-out",
               "shadow-ring",
@@ -229,7 +229,7 @@ export default function TabBar<K extends string = string>({
       {showBaseline && (
         <div
           aria-hidden
-          className="absolute -bottom-[9px] left-0 right-0 h-px opacity-70 [background:linear-gradient(90deg,transparent,hsla(var(--ring),0.5),transparent)]"
+          className="absolute -bottom-2.5 left-0 right-0 h-px opacity-70 [background:linear-gradient(90deg,transparent,hsla(var(--ring),0.5),transparent)]"
         />
       )}
     </div>

--- a/src/components/ui/primitives/Badge.tsx
+++ b/src/components/ui/primitives/Badge.tsx
@@ -59,7 +59,7 @@ export default function Badge<T extends React.ElementType = "span">({
     <Comp
       data-selected={selected ? "true" : undefined}
       className={cn(
-        "inline-flex max-w-full items-center gap-[6px] whitespace-nowrap rounded-full font-medium tracking-[-0.01em]",
+        "inline-flex max-w-full items-center gap-1.5 whitespace-nowrap rounded-full font-medium tracking-[-0.01em]",
         "border bg-[color-mix(in_oklab,hsl(var(--muted))_18%,transparent)]",
         "shadow-[inset_0_1px_0_hsl(var(--foreground)/.06),0_0_0_.5px_hsl(var(--card-hairline)/.35),0_10px_20px_hsl(var(--shadow-color)/.18)]",
         "transition-[background,box-shadow,transform] duration-140 ease-out",

--- a/src/components/ui/toggles/CheckCircle.tsx
+++ b/src/components/ui/toggles/CheckCircle.tsx
@@ -193,7 +193,7 @@ export default function CheckCircle({
           <span
             aria-hidden
             className={cn(
-              "absolute inset-0 rounded-full p-[2px] pointer-events-none transition-opacity",
+              "absolute inset-0 rounded-full p-0.5 pointer-events-none transition-opacity",
               lit ? "opacity-100" : "opacity-0"
             )}
             style={{
@@ -214,7 +214,7 @@ export default function CheckCircle({
           <span
             aria-hidden
             className={cn(
-              "absolute inset-[2px] rounded-full pointer-events-none transition-opacity",
+              "absolute inset-0.5 rounded-full pointer-events-none transition-opacity",
               lit ? "opacity-100" : "opacity-0"
             )}
             style={{


### PR DESCRIPTION
## Summary
- replace hard-coded pixel spacing with Tailwind utilities
- add Badge to prompts gallery
- tidy TaskList and related component spacing

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0a735b5f8832c9b4b8cbc9f8740e4