### PR TITLE
refactor: centralize icon usage

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -37,6 +37,11 @@ This project ships with a small design system based on Tailwind CSS and CSS vari
 - `src/app/globals.css` resets layout, sets typography and applies focus and selection styles.
 - Respect the `no-animations` class for reduced motion users. Avoid forcing animations when it is present.
 
+## Icons
+- Prefer icons from `lucide-react`.
+- Define any custom icons in `src/icons` and import them where needed.
+- Avoid embedding raw `<svg>` tags in components. An inline SVG remains in `Hero` for a noise texture background.
+
 ## Primitive components
 - Reusable building blocks live under `src/components/ui/primitives` (e.g. `Button`, `Badge`, `Input`).
 - Prefer composing these primitives rather than creating bespoke styles.

--- a/src/components/ui/selects/AnimatedSelect.tsx
+++ b/src/components/ui/selects/AnimatedSelect.tsx
@@ -4,6 +4,7 @@
 import * as React from "react";
 import { createPortal } from "react-dom";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { Check, ChevronDown } from "lucide-react";
 
 /** Option item */
 export type DropItem = {
@@ -312,14 +313,10 @@ export default function AnimatedSelect({
             )}
           </span>
 
-          <svg viewBox="0 0 20 20" className={caretCls} aria-hidden="true">
-            <path
-              d="M5 7l5 6 5-6"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
+            <ChevronDown
+              className={caretCls}
+              aria-hidden="true"
             />
-          </svg>
 
           {/* ── glitch border stack (no whites) ── */}
           <span aria-hidden className="gb-iris" />
@@ -408,25 +405,15 @@ export default function AnimatedSelect({
                           <span className="text-sm leading-none glitch-text">
                             {it.label}
                           </span>
-                          <svg
-                            viewBox="0 0 20 20"
-                            className={[
-                              "size-4 shrink-0 transition-opacity",
-                              active
-                                ? "opacity-90"
-                                : "opacity-0 group-hover:opacity-30",
-                            ].join(" ")}
-                            aria-hidden="true"
-                          >
-                            <path
-                              d="M4 10.5l4 4 8-9"
-                              fill="none"
-                              stroke="currentColor"
-                              strokeWidth="2"
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
+                            <Check
+                              className={[
+                                "size-4 shrink-0 transition-opacity",
+                                active
+                                  ? "opacity-90"
+                                  : "opacity-0 group-hover:opacity-30",
+                              ].join(" ")}
+                              aria-hidden="true"
                             />
-                          </svg>
                         </div>
 
                         {/* Active left rail */}

--- a/src/components/ui/toggles/CheckCircle.tsx
+++ b/src/components/ui/toggles/CheckCircle.tsx
@@ -13,6 +13,7 @@
  */
 
 import { cn } from "@/lib/utils";
+import { Check, X } from "lucide-react";
 import * as React from "react";
 
 type CCVars = React.CSSProperties & {
@@ -272,27 +273,18 @@ export default function CheckCircle({
             }}
           />
 
-          {/* Tick glyph */}
-          <svg
-            viewBox="0 0 24 24"
-            aria-hidden
-            className={cn(
-              "relative z-[1] transition-all duration-200",
-              lit
-                ? "[color:var(--cc-color)] [filter:drop-shadow(0_0_8px_var(--cc-glow))] opacity-100"
-                : "text-muted-foreground/60 opacity-80"
-            )}
-            style={ccStyle}
-          >
-            <path
-              d="M20 7L10 17l-4-4"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
+            {/* Tick glyph */}
+            <Check
+              aria-hidden
+              className={cn(
+                "relative z-[1] transition-all duration-200",
+                lit
+                  ? "[color:var(--cc-color)] [filter:drop-shadow(0_0_8px_var(--cc-glow))] opacity-100"
+                  : "text-muted-foreground/60 opacity-80",
+              )}
+              style={ccStyle}
+              strokeWidth={2.5}
             />
-          </svg>
         </button>
 
         {/* Mini clear button */}
@@ -313,14 +305,7 @@ export default function CheckCircle({
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
             )}
           >
-            <svg viewBox="0 0 18 18" className="h-4 w-4" aria-hidden>
-              <path
-                d="M4 4l10 10M14 4L4 14"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-              />
-            </svg>
+            <X aria-hidden className="h-4 w-4" />
             <span aria-hidden className="ccx-glow" />
           </button>
         )}

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -444,14 +444,19 @@ exports[`ReviewsPage > renders default state 1`] = `
                         </span>
                         <svg
                           aria-hidden="true"
-                          class="caret ml-auto size-4 shrink-0 opacity-75 "
-                          viewBox="0 0 20 20"
+                          class="lucide lucide-chevron-down caret ml-auto size-4 shrink-0 opacity-75 "
+                          fill="none"
+                          height="24"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          viewBox="0 0 24 24"
+                          width="24"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
                           <path
-                            d="M5 7l5 6 5-6"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-width="2"
+                            d="m6 9 6 6 6-6"
                           />
                         </svg>
                         <span


### PR DESCRIPTION
## Summary
- replace inline SVGs with lucide-react icons in CheckCircle and AnimatedSelect
- document icon usage in design system

## Testing
- `npm run regen-ui`
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0ac46dc30832c81bd7e7c93877af1