### PR TITLE
refactor: replace custom text sizes with tokens

### DIFF
--- a/src/components/planner/TodayHero.tsx
+++ b/src/components/planner/TodayHero.tsx
@@ -195,7 +195,7 @@ export default function TodayHero({ iso }: Props) {
 
       {/* Tasks (only when a project is selected) */}
       {!selProjectId ? (
-        <div className="mt-4 text-[13px] text-[hsl(var(--muted-foreground))]">Select a project to add and view tasks.</div>
+        <div className="mt-4 text-sm text-[hsl(var(--muted-foreground))]">Select a project to add and view tasks.</div>
       ) : (
         <div className="mt-4 space-y-4">
           <form

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -576,7 +576,7 @@ export default function ReviewEditor({
               </div>
             </div>
           </div>
-          <div className="mt-1 flex items-center gap-2 text-[13px] text-muted-foreground">
+          <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
             <span className="pill h-6 px-2 text-xs">{score}/10</span>
             <ScoreIcon className={cn("h-4 w-4", scoreIconCls)} />
             <span>{msg}</span>
@@ -641,7 +641,7 @@ export default function ReviewEditor({
                   </div>
                 </div>
               </div>
-              <div className="mt-1 flex items-center gap-2 text-[13px] text-muted-foreground">
+              <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
                 <span className="pill h-6 px-2 text-xs">{focus}/10</span>
                 <span>{focusMsg}</span>
               </div>
@@ -804,7 +804,7 @@ export default function ReviewEditor({
                       <FileText size={14} className="opacity-80" />
                     </span>
                   ) : (
-                    <span className="pill h-7 min-w-[60px] px-3 text-[11px] font-mono tabular-nums text-center">
+                    <span className="pill h-7 min-w-[60px] px-3 text-xs font-mono tabular-nums text-center">
                       {m.time}
                     </span>
                   )}

--- a/src/components/reviews/ReviewSummaryScore.tsx
+++ b/src/components/reviews/ReviewSummaryScore.tsx
@@ -39,7 +39,7 @@ export default function ReviewSummaryScore({
           </div>
         </div>
       </div>
-      <div className="mt-1 flex items-center gap-2 text-[13px] text-muted-foreground">
+      <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
         <span className="pill h-6 px-2 text-xs">{score}/10</span>
         <ScoreIcon className={cn("h-4 w-4", scoreIconCls)} />
         <span>{msg}</span>
@@ -64,7 +64,7 @@ export default function ReviewSummaryScore({
               </div>
             </div>
           </div>
-          <div className="mt-1 flex items-center gap-2 text-[13px] text-muted-foreground">
+          <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
             <span className="pill h-6 px-2 text-xs">{focus}/10</span>
             <span>{focusMsg}</span>
           </div>

--- a/src/components/reviews/ReviewSummaryTimestamps.tsx
+++ b/src/components/reviews/ReviewSummaryTimestamps.tsx
@@ -35,7 +35,7 @@ export default function ReviewSummaryTimestamps({ markers }: ReviewSummaryTimest
                     <FileText size={14} className="opacity-80" />
                   </span>
                 ) : (
-                  <span className="pill h-7 px-3 text-[11px] font-mono tabular-nums leading-none">{m.time ?? "00:00"}</span>
+                  <span className="pill h-7 px-3 text-xs font-mono tabular-nums leading-none">{m.time ?? "00:00"}</span>
                 )}
                 <span className="truncate text-sm">{m.note || "—"}</span>
               </li>

--- a/src/components/team/Builder.tsx
+++ b/src/components/team/Builder.tsx
@@ -244,7 +244,7 @@ function SideEditor(props: {
           <strong className="text-base sm:text-lg">{title}</strong>
         </span>
 
-        <span className="ml-auto pill pill-compact text-[10px] tracking-wide uppercase">
+        <span className="ml-auto pill pill-compact text-xs tracking-wide uppercase">
           {count}/5 filled
         </span>
       </header>

--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -169,7 +169,7 @@ function Label({ children }: { children: React.ReactNode }) {
   const text = typeof children === "string" ? children : String(children ?? "");
   return (
     <div
-      className="glitch-anim glitch-label text-[10px] font-semibold tracking-wide uppercase text-[hsl(var(--muted-foreground))]"
+      className="glitch-anim glitch-label text-xs font-semibold tracking-wide uppercase text-[hsl(var(--muted-foreground))]"
       data-text={text}
     >
       {text}

--- a/src/components/team/JungleClears.tsx
+++ b/src/components/team/JungleClears.tsx
@@ -183,7 +183,7 @@ export default function JungleClears() {
               />
               <SectionCard.Body>
                 <div className="mb-2 flex flex-wrap items-center gap-2">
-                  <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-2 py-1 text-[10px] tracking-wide uppercase">
+                  <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-2 py-1 text-xs tracking-wide uppercase">
                     {SPEED_PERSONA[bucket].tag}
                   </span>
                   <span className="text-sm text-[hsl(var(--muted-foreground))]">

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -124,7 +124,7 @@ export default function Hero({
 
           <div className="min-w-0">
             {eyebrow ? (
-              <div className="text-[10px] font-semibold tracking-[0.14em] uppercase text-[hsl(var(--muted-foreground))]">
+              <div className="text-xs font-semibold tracking-[0.14em] uppercase text-[hsl(var(--muted-foreground))]">
                 {eyebrow}
               </div>
             ) : null}

--- a/src/components/ui/league/pillars/PillarBadge.tsx
+++ b/src/components/ui/league/pillars/PillarBadge.tsx
@@ -52,7 +52,7 @@ export default function PillarBadge({
     size === "lg"
       ? "h-10 px-4 text-base gap-2"
       : size === "sm"
-      ? "h-8 px-3 text-[13px] gap-2"
+      ? "h-8 px-3 text-xs gap-2"
       : "h-9 px-4 text-sm gap-2";
 
   // Default element: "button" if interactive, else "span".


### PR DESCRIPTION
## Summary
- replace bespoke text-[13px] styles with text-sm
- migrate text-[10px] and text-[11px] to text-xs across UI

## Testing
- `npm run regen-ui`
- `npm run lint`
- `npm test -- --run`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0b5acadcc832cbeb9c5fd4f5da0cb