### PR TITLE
refactor: use tokenized Tailwind colors

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1053,24 +1053,24 @@ textarea:-webkit-autofill {
 
 /* Hairline border that respects theme tokens */
 .card-hairline {
-  @apply border border-[hsl(var(--card-hairline))];
+  @apply border border-card-hairline;
 }
 
 /* Compact pill */
 .pill-compact {
   @apply inline-flex items-center rounded-full
-         border border-[hsl(var(--card-hairline))]
-         bg-[hsl(var(--muted))/0.18]
+        border border-card-hairline
+        bg-muted/18
         px-2 py-1 text-xs leading-tight tracking-[-0.01em];
 }
 .pill-compact:hover {
-  @apply bg-[hsl(var(--muted))/0.28];
+  @apply bg-muted/28;
 }
 .pill-compact--primary {
-  @apply border-[hsl(var(--ring))]   bg-[hsl(var(--primary-soft))/0.25];
+  @apply border-ring bg-primary-soft/25;
 }
 .pill-compact--accent {
-  @apply border-[hsl(var(--ring))]   bg-[hsl(var(--accent-soft))/0.25];
+  @apply border-ring bg-accent-soft/25;
 }
 
 /* Card padding rhythm */
@@ -1910,7 +1910,7 @@ a:active .lucide {
 
 @layer components {
   .goal-card {
-    @apply relative overflow-hidden rounded-xl border border-[hsl(var(--border))];
+    @apply relative overflow-hidden rounded-xl border border-border;
     background: linear-gradient(
       135deg,
       hsl(var(--surface-2)),

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           dangerouslySetInnerHTML={{ __html: noFlash }}
         />
       </head>
-      <body className="min-h-screen bg-[hsl(var(--background))] text-[hsl(var(--foreground))] glitch-root">
+      <body className="min-h-screen bg-background text-foreground glitch-root">
         <SiteChrome />
         <div className="relative z-10">
           {children}

--- a/src/components/chrome/Banner.tsx
+++ b/src/components/chrome/Banner.tsx
@@ -35,7 +35,7 @@ export default function Banner({
       <div className="mx-auto max-w-6xl px-2 md:px-4 py-2">
         {title || actions ? (
           <div className="flex items-center justify-between gap-4">
-            <div className="font-mono text-sm text-[hsl(var(--muted-foreground))]">
+            <div className="font-mono text-sm text-muted-foreground">
               {title}
             </div>
             <div className="flex items-center gap-2">{actions}</div>

--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -39,8 +39,8 @@ export default function NavBar() {
                   "relative inline-flex items-center rounded-xl border px-4 py-2 font-mono text-sm transition",
                   "bg-[color:color-mix(in_oklab,hsl(var(--card))_85%,transparent)]",
                   active
-                    ? "text-foreground border-[hsl(var(--ring))] shadow-[0_0_0_1px_hsl(var(--ring)/.35),0_8px_24px_hsl(var(--ring)/.2)]"
-                    : "text-muted-foreground border-transparent hover:border-[hsl(var(--border))]"
+                    ? "text-foreground border-ring shadow-[0_0_0_1px_hsl(var(--ring)/.35),0_8px_24px_hsl(var(--ring)/.2)]"
+                    : "text-muted-foreground border-transparent hover:border-border"
                 )}
               >
                 <span className="relative z-10">{it.label}</span>

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -27,7 +27,7 @@ export default function SiteChrome() {
             }}
             aria-hidden
           />
-          <span className="font-mono tracking-wide text-[hsl(var(--muted-foreground))]">
+          <span className="font-mono tracking-wide text-muted-foreground">
             noxi
           </span>
         </Link>

--- a/src/components/goals/DurationSelector.tsx
+++ b/src/components/goals/DurationSelector.tsx
@@ -34,11 +34,11 @@ export default function DurationSelector({
             className={cn(
               "inline-flex items-center justify-center h-9 px-3 rounded-full text-center text-sm",
               "border transition-colors",
-              "border-[hsl(var(--border)/0.1)] bg-[hsl(var(--foreground)/0.05)] text-[hsl(var(--foreground)/0.7)]",
-              "hover:bg-[hsl(var(--foreground)/0.10)] hover:text-[hsl(var(--foreground)/0.70)]",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+              "border-border/10 bg-foreground/5 text-foreground/70",
+              "hover:bg-foreground/10 hover:text-foreground/70",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
               active &&
-                "border-[hsl(var(--accent))] bg-[hsl(var(--accent)/0.2)] text-[hsl(var(--foreground)/0.70)] font-semibold"
+                "border-accent bg-accent/20 text-foreground/70 font-semibold"
             )}
           >
             {m}m

--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -30,16 +30,16 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
     <SectionCard className="card-neo-soft">
       <SectionCard.Header title={<h2 className="text-lg font-semibold">Goal Queue</h2>} />
       <SectionCard.Body className="grid gap-6">
-          <ul className="divide-y divide-[hsl(var(--border)/0.1)]">
+          <ul className="divide-y divide-border/10">
             {items.length === 0 ? (
-              <li className="py-3 text-sm text-[hsl(var(--muted-foreground))]">No queued goals</li>
+              <li className="py-3 text-sm text-muted-foreground">No queued goals</li>
             ) : (
               items.map((it) => (
                 <li key={it.id} className="group flex items-center gap-2 py-3">
-                  <span className="h-2 w-2 rounded-full bg-[hsl(var(--foreground)/0.4)]" aria-hidden />
+                  <span className="h-2 w-2 rounded-full bg-foreground/40" aria-hidden />
                   <p className="flex-1 truncate text-sm">{it.text}</p>
                   <time
-                    className="text-xs text-[hsl(var(--muted-foreground))] opacity-0 group-hover:opacity-100"
+                    className="text-xs text-muted-foreground opacity-0 group-hover:opacity-100"
                     dateTime={new Date(it.createdAt).toISOString()}
                   >
                     {shortDate.format(new Date(it.createdAt))}
@@ -63,7 +63,7 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
           </ul>
 
           <form onSubmit={submit} className="flex items-center gap-2 pt-3">
-            <span className="h-2 w-2 rounded-full bg-[hsl(var(--foreground)/0.4)]" aria-hidden />
+            <span className="h-2 w-2 rounded-full bg-foreground/40" aria-hidden />
             <Input
               tone="default"
               className="flex-1 h-9 text-sm"

--- a/src/components/goals/GoalSlot.tsx
+++ b/src/components/goals/GoalSlot.tsx
@@ -24,11 +24,11 @@ export default function GoalSlot({ goal, onToggleDone, onEdit, onDelete }: GoalS
   }
 
   return (
-    <div className="group relative rounded-lg border-4 border-[hsl(var(--border))] bg-[hsl(var(--surface))] p-1 shadow-neoSoft">
+    <div className="group relative rounded-lg border-4 border-border bg-surface p-1 shadow-neoSoft">
       <div
         className={cn(
-          "relative flex aspect-[4/3] w-full items-center justify-center rounded-sm bg-[hsl(var(--surface-2))] font-mono text-center text-sm text-[hsl(var(--foreground))]",
-          goal?.done && "bg-[hsl(var(--muted))] text-[hsl(var(--muted-foreground))]",
+          "relative flex aspect-[4/3] w-full items-center justify-center rounded-sm bg-surface-2 font-mono text-center text-sm text-foreground",
+          goal?.done && "bg-muted text-muted-foreground",
         )}
       >
         {goal ? (
@@ -42,8 +42,8 @@ export default function GoalSlot({ goal, onToggleDone, onEdit, onDelete }: GoalS
             <button
               type="button"
               className={cn(
-                "absolute bottom-1 right-1 flex rounded bg-[hsl(var(--surface))] p-[0.15rem] text-[hsl(var(--foreground))]",
-                goal?.done && "text-[hsl(var(--success))]",
+                "absolute bottom-1 right-1 flex rounded bg-surface p-[0.15rem] text-foreground",
+                goal?.done && "text-success",
               )}
               aria-label={goal.done ? "Mark goal undone" : "Mark goal done"}
               aria-pressed={goal.done}
@@ -53,7 +53,7 @@ export default function GoalSlot({ goal, onToggleDone, onEdit, onDelete }: GoalS
             </button>
             <button
               type="button"
-              className="absolute bottom-1 left-1 flex rounded bg-[hsl(var(--surface))] p-[0.15rem] text-[hsl(var(--foreground))] opacity-0 transition-opacity group-hover:opacity-100"
+              className="absolute bottom-1 left-1 flex rounded bg-surface p-[0.15rem] text-foreground opacity-0 transition-opacity group-hover:opacity-100"
               aria-label="Edit goal"
               onClick={handleEdit}
             >
@@ -61,7 +61,7 @@ export default function GoalSlot({ goal, onToggleDone, onEdit, onDelete }: GoalS
             </button>
             <button
               type="button"
-              className="absolute bottom-1 left-7 flex rounded bg-[hsl(var(--surface))] p-[0.15rem] text-[hsl(var(--foreground))] opacity-0 transition-opacity group-hover:opacity-100"
+              className="absolute bottom-1 left-7 flex rounded bg-surface p-[0.15rem] text-foreground opacity-0 transition-opacity group-hover:opacity-100"
               aria-label="Delete goal"
               onClick={() => onDelete?.(goal.id)}
             >
@@ -69,7 +69,7 @@ export default function GoalSlot({ goal, onToggleDone, onEdit, onDelete }: GoalS
             </button>
           </>
         ) : (
-          <span className="text-[hsl(var(--muted-foreground))]">NO SIGNAL</span>
+          <span className="text-muted-foreground">NO SIGNAL</span>
         )}
       </div>
     </div>

--- a/src/components/goals/GoalsProgress.tsx
+++ b/src/components/goals/GoalsProgress.tsx
@@ -13,8 +13,8 @@ interface GoalsProgressProps {
 export default function GoalsProgress({ total, pct, onAddFirst, maxWidth }: GoalsProgressProps) {
   if (total === 0) {
     return (
-      <div className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] p-6 text-center">
-        <p className="mb-4 text-sm text-[hsl(var(--fg-muted))]">No goals yet.</p>
+      <div className="rounded-xl border border-border bg-surface-2 p-6 text-center">
+        <p className="mb-4 text-sm text-fg-muted">No goals yet.</p>
         {onAddFirst && (
           <Button onClick={onAddFirst} size="sm" className="mx-auto rounded-xl">
             Add a first goal
@@ -34,15 +34,15 @@ export default function GoalsProgress({ total, pct, onAddFirst, maxWidth }: Goal
   return (
     <div className="flex min-w-[120px] items-center gap-2" aria-label="Progress">
       <div
-        className="h-2 w-full flex-1 max-w-[var(--progress-max,160px)] overflow-hidden rounded-full bg-[hsl(var(--fg)/0.1)]"
+        className="h-2 w-full flex-1 max-w-[var(--progress-max,160px)] overflow-hidden rounded-full bg-fg/10"
         style={style}
       >
         <div
-          className="h-2 rounded-full bg-[hsl(var(--accent))] transition-[width]"
+          className="h-2 rounded-full bg-accent transition-[width]"
           style={{ width: `${v}%` }}
         />
       </div>
-      <span className="tabular-nums text-xs text-[hsl(var(--fg)/0.6)]">{v}%</span>
+      <span className="tabular-nums text-xs text-fg/60">{v}%</span>
     </div>
   );
 }

--- a/src/components/goals/GoalsTabs.tsx
+++ b/src/components/goals/GoalsTabs.tsx
@@ -39,7 +39,7 @@ export default function GoalsTabs({ value, onChange }: GoalsTabsProps) {
                 "hover:-translate-y-px",
                 "border-none outline-none focus:outline-none focus-visible:outline-none",
                 active
-                  ? "font-semibold text-[hsl(var(--accent))] bg-[hsl(var(--accent)/0.1)]"
+                  ? "font-semibold text-accent bg-accent/10"
                   : undefined,
               )}
             >

--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -178,7 +178,7 @@ export default function Reminders() {
                 value={query}
                 onChange={(e) => setQuery(e.currentTarget.value)}
               />
-              <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-[hsl(var(--muted-foreground))]">
+              <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">
                 {filtered.length}
               </span>
             </div>
@@ -226,7 +226,7 @@ export default function Reminders() {
             <IconButton title="Add quick" aria-label="Add quick" onClick={addQuick} size="md" variant="solid">
               <Plus />
             </IconButton>
-            <p className="text-xs sm:text-sm italic text-[hsl(var(--muted-foreground))]">
+            <p className="text-xs sm:text-sm italic text-muted-foreground">
               Stop procrastinating, do it now if you have time
             </p>
           </div>
@@ -244,7 +244,7 @@ export default function Reminders() {
             ))}
 
             {filtered.length === 0 && (
-              <p className="text-sm text-[hsl(var(--muted-foreground))]">
+              <p className="text-sm text-muted-foreground">
                 Nothing here. Add one or relax your filters.
               </p>
             )}
@@ -288,7 +288,7 @@ function ReminderCard({
   return (
     <article className="card-neo rounded-card p-4 sm:p-5 relative">
       {value.pinned && (
-        <span aria-hidden className="absolute inset-y-3 left-0 w-0.5 rounded-full bg-[hsl(var(--primary)/.55)]" />
+        <span aria-hidden className="absolute inset-y-3 left-0 w-0.5 rounded-full bg-primary/55" />
       )}
 
       <div className="flex items-center justify-between gap-2 mb-2">
@@ -417,9 +417,9 @@ function ReminderCard({
         ) : (
           <>
             {value.body ? (
-              <p className="text-sm leading-6 text-[hsl(var(--muted-foreground))]">{value.body}</p>
+              <p className="text-sm leading-6 text-muted-foreground">{value.body}</p>
             ) : (
-              <p className="text-sm text-[hsl(var(--muted-foreground))]/80">No text. Click to edit.</p>
+              <p className="text-sm text-muted-foreground/80">No text. Click to edit.</p>
             )}
             <div className="flex flex-wrap items-center gap-2 pt-1">
               {value.tags.map((t) => <span key={t} className="pill">{t}</span>)}

--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -594,7 +594,7 @@ function RemTile({
               </div>
 
               <button
-                className="text-xs underline underline-offset-2 text-[hsl(var(--primary))] hover:brightness-75"
+                className="text-xs underline underline-offset-2 text-primary hover:brightness-75"
                 onClick={() => onChange({ pinned: !pinned })}
                 title={pinned ? "Unpin" : "Pin"}
                 type="button"

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -222,7 +222,7 @@ export default function TimerTab() {
                       onChange={(e) => setTimeEdit(e.currentTarget.value)}
                       onBlur={commitEdit}
                       onKeyDown={(e) => e.key === "Enter" && commitEdit()}
-                      className="bg-transparent text-center opacity-0 focus:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] text-6xl sm:text-7xl font-bold tabular-nums"
+                      className="bg-transparent text-center opacity-0 focus:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring text-6xl sm:text-7xl font-bold tabular-nums"
                     />
                   </div>
                 )}

--- a/src/components/home/DashboardCard.tsx
+++ b/src/components/home/DashboardCard.tsx
@@ -12,7 +12,7 @@ interface DashboardCardProps {
 
 export default function DashboardCard({ title, children, cta, actions }: DashboardCardProps) {
   return (
-    <div className="rounded-xl border border-[hsl(var(--card-hairline))] bg-[hsl(var(--surface-2))] p-4 space-y-4">
+    <div className="rounded-xl border border-card-hairline bg-surface-2 p-4 space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold tracking-[-0.01em]">{title}</h2>
         {actions}

--- a/src/components/home/HomePage.tsx
+++ b/src/components/home/HomePage.tsx
@@ -71,7 +71,7 @@ export default function HomePage() {
             {activeGoals.map(g => (
               <li key={g.id}>
                 <p className="text-sm">{g.title}</p>
-                <div className="mt-1 h-2 w-full rounded-full bg-[hsl(var(--card-hairline))]">
+                <div className="mt-1 h-2 w-full rounded-full bg-card-hairline">
                   <div className="h-2 rounded-full" style={{ background: "var(--neon)", width: "0%" }} />
                 </div>
               </li>
@@ -112,13 +112,13 @@ export default function HomePage() {
 
         <DashboardCard title="Team quick actions">
           <div className="grid grid-cols-3 gap-2 text-sm">
-            <Link href="/team" className="rounded-md border border-[hsl(var(--card-hairline))] p-2 text-center hover:text-accent">
+            <Link href="/team" className="rounded-md border border-card-hairline p-2 text-center hover:text-accent">
               Archetypes
             </Link>
-            <Link href="/team" className="rounded-md border border-[hsl(var(--card-hairline))] p-2 text-center hover:text-accent">
+            <Link href="/team" className="rounded-md border border-card-hairline p-2 text-center hover:text-accent">
               Team Builder
             </Link>
-            <Link href="/team" className="rounded-md border border-[hsl(var(--card-hairline))] p-2 text-center hover:text-accent">
+            <Link href="/team" className="rounded-md border border-card-hairline p-2 text-center hover:text-accent">
               Jungle Clears
             </Link>
           </div>

--- a/src/components/planner/DayCard.tsx
+++ b/src/components/planner/DayCard.tsx
@@ -64,9 +64,9 @@ export default function DayCard({ iso, isToday }: Props) {
         "daycard relative overflow-hidden card-neo-soft rounded-2xl border card-pad",
         "grid gap-4 lg:gap-6",
         "grid-cols-1 lg:grid-cols-[minmax(260px,320px)_1px_1fr]",
-        isToday && "ring-1 ring-[hsl(var(--ring)/0.65)] title-glow",
+        isToday && "ring-1 ring-ring/65 title-glow",
         "before:pointer-events-none before:absolute before:inset-x-4 before:top-0 before:h-px before:bg-gradient-to-r",
-        "before:from-transparent before:via-[hsl(var(--ring)/.45)] before:to-transparent",
+        "before:from-transparent before:via-ring/45 before:to-transparent",
         "after:pointer-events-none after:absolute after:-inset-px after:rounded-2xl after:bg-[radial-gradient(60%_40%_at_100%_0%,hsl(var(--ring)/.12),transparent_60%)]",
       )}
       aria-label={`Planner for ${iso}`}
@@ -105,7 +105,7 @@ export default function DayCard({ iso, isToday }: Props) {
       />
 
       <div
-        className="hidden lg:block w-px bg-[hsl(var(--card-hairline)/0.9)]/90 rounded-full self-stretch"
+        className="hidden lg:block w-px bg-card-hairline/90 rounded-full self-stretch"
         aria-hidden
       />
 

--- a/src/components/planner/DayCardHeader.tsx
+++ b/src/components/planner/DayCardHeader.tsx
@@ -71,8 +71,8 @@ export default function DayCardHeader({
         </div>
       </div>
 
-      <div className="shrink-0 flex items-baseline gap-3 text-xs text-[hsl(var(--muted-foreground))]">
-        <span className="tabular-nums font-medium text-[hsl(var(--foreground))]">
+      <div className="shrink-0 flex items-baseline gap-3 text-xs text-muted-foreground">
+        <span className="tabular-nums font-medium text-foreground">
           {pctNum}%
         </span>
         <span className="hidden sm:inline">·</span>

--- a/src/components/planner/FocusPanel.tsx
+++ b/src/components/planner/FocusPanel.tsx
@@ -86,7 +86,7 @@ export default function FocusPanel({ iso }: Props) {
         </form>
 
         {/* Subtle status text without yelling at the user */}
-        <div className="mt-2 text-xs text-[hsl(var(--muted-foreground))]" aria-live="polite">
+        <div className="mt-2 text-xs text-muted-foreground" aria-live="polite">
           {saving
             ? "Saving changes…"
             : isDirty

--- a/src/components/planner/ProjectList.tsx
+++ b/src/components/planner/ProjectList.tsx
@@ -93,11 +93,11 @@ export default function ProjectList({
                     }}
                     className={cn(
                       "proj-card group relative [overflow:visible] w-full text-left rounded-2xl border pl-4 pr-2 py-2",
-                      "bg-[hsl(var(--card)/0.55)] hover:bg-[hsl(var(--card)/0.7)] transition",
+                      "bg-card/55 hover:bg-card/70 transition",
                       "grid min-h-12 grid-cols-[auto,1fr,auto] items-center gap-4",
-                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                       active &&
-                        "proj-card--active ring-1 ring-[hsl(var(--ring))]",
+                        "proj-card--active ring-1 ring-ring",
                     )}
                   >
                     <span

--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -50,8 +50,8 @@ export default function TaskRow({
       <div
         className={cn(
           "relative [overflow:visible] grid min-h-12 min-w-0 grid-cols-[auto,1fr,auto] items-center gap-4 rounded-2xl border pl-4 pr-2 py-2",
-          "bg-[hsl(var(--card)/0.55)] hover:bg-[hsl(var(--card)/0.7)]",
-          "focus-within:ring-2 focus-within:ring-[hsl(var(--ring))]",
+          "bg-card/55 hover:bg-card/70",
+          "focus-within:ring-2 focus-within:ring-ring",
         )}
         onClick={onSelect}
       >
@@ -67,7 +67,7 @@ export default function TaskRow({
         <div className="flex-1 min-w-0 px-1">
           {!editing ? (
             <button
-              className="task-tile__text block w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] rounded-md"
+              className="task-tile__text block w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md"
               onClick={onToggle}
               onDoubleClick={start}
               aria-pressed={task.done}

--- a/src/components/planner/TodayHero.tsx
+++ b/src/components/planner/TodayHero.tsx
@@ -150,8 +150,8 @@ export default function TodayHero({ iso }: Props) {
                   key={p.id}
                   className={cn(
                     "group flex select-none items-center justify-between rounded-2xl border px-3 py-2 text-sm transition",
-                    "border-[hsl(var(--border))] bg-[hsl(var(--card)/0.55)] hover:bg-[hsl(var(--card)/0.7)]",
-                    isSelected && "ring-1 ring-[hsl(var(--ring))]"
+                    "border-border bg-card/55 hover:bg-card/70",
+                    isSelected && "ring-1 ring-ring"
                   )}
                   onClick={() => !isEditing && setSelProjectId(p.id)}
                   title={isEditing ? "Editing…" : isSelected ? "Selected" : "Click to select"}
@@ -195,7 +195,7 @@ export default function TodayHero({ iso }: Props) {
 
       {/* Tasks (only when a project is selected) */}
       {!selProjectId ? (
-        <div className="mt-4 text-sm text-[hsl(var(--muted-foreground))]">Select a project to add and view tasks.</div>
+        <div className="mt-4 text-sm text-muted-foreground">Select a project to add and view tasks.</div>
       ) : (
         <div className="mt-4 space-y-4">
           <form
@@ -227,7 +227,7 @@ export default function TodayHero({ iso }: Props) {
                     key={t.id}
                     className={cn(
                       "task-tile flex items-center justify-between rounded-2xl border px-3 py-2",
-                      "border-[hsl(var(--border))] bg-[hsl(var(--card)/0.55)] hover:bg-[hsl(var(--card)/0.7)]"
+                      "border-border bg-card/55 hover:bg-card/70"
                     )}
                     role="listitem"
                     onClick={() => setSelTaskId(t.id)}

--- a/src/components/planner/WeekNotes.tsx
+++ b/src/components/planner/WeekNotes.tsx
@@ -56,7 +56,7 @@ export default function WeekNotes({ iso }: Props) {
           textareaClassName="min-h-[180px] leading-relaxed"
           onBlur={commit}
         />
-        <div className="mt-2 text-xs text-[hsl(var(--muted-foreground))]" aria-live="polite">
+        <div className="mt-2 text-xs text-muted-foreground" aria-live="polite">
           {saving
             ? "Saving changes…"
             : isDirty

--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -80,12 +80,12 @@ function DayChip({
       className={cn(
         "chip relative flex-none min-w-[min(160px,40%)] rounded-2xl border text-left px-3 py-2 transition snap-start",
         // default border is NOT white; use card hairline tint
-        "border-[hsl(var(--card-hairline))] bg-[hsl(var(--card)/0.75)]",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+        "border-card-hairline bg-card/75",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         today && "chip--today",
         selected
-          ? "border-dashed border-[hsl(var(--primary)/.75)]"
-          : "hover:border-[hsl(var(--primary)/.4)]"
+          ? "border-dashed border-primary/75"
+          : "hover:border-primary/40"
       )}
       data-today={today || undefined}
       data-active={selected || undefined}
@@ -93,15 +93,15 @@ function DayChip({
       <div
         className={cn(
           "chip__date",
-          today ? "text-[hsl(var(--accent))]" : "text-[hsl(var(--muted-foreground))]"
+          today ? "text-accent" : "text-muted-foreground"
         )}
         data-text={iso}
       >
         {iso}
       </div>
       <div className="chip__counts">
-        <span className="tabular-nums text-[hsl(var(--foreground))]">{done}</span>
-        <span className="text-[hsl(var(--muted-foreground))]"> / {total}</span>
+        <span className="tabular-nums text-foreground">{done}</span>
+        <span className="text-muted-foreground"> / {total}</span>
       </div>
       {/* decorative layers */}
       <span aria-hidden className="chip__scan" />
@@ -196,7 +196,7 @@ export default function WeekPicker() {
             <span
               className={cn(
                 "inline-flex items-center gap-2 rounded-2xl px-3 py-2 text-sm",
-                "bg-[hsl(var(--card)/0.72)] ring-1 ring-[hsl(var(--border)/0.55)] backdrop-blur"
+                "bg-card/72 ring-1 ring-border/55 backdrop-blur"
               )}
               aria-label={`Week range ${rangeLabel}`}
             >
@@ -204,9 +204,9 @@ export default function WeekPicker() {
               <span className="opacity-90">{rangeLabel}</span>
             </span>
 
-            <span className="text-sm text-[hsl(var(--muted-foreground))]">
+            <span className="text-sm text-muted-foreground">
               <span className="opacity-70">Total tasks: </span>
-              <span className="font-medium tabular-nums text-[hsl(var(--foreground))]">
+              <span className="font-medium tabular-nums text-foreground">
                 {weekDone} / {weekTotal}
               </span>
             </span>

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -459,7 +459,7 @@ export default function ComponentGallery() {
       {
         label: "Accent Overlay Box",
         element: (
-          <div className="w-56 h-6 flex items-center justify-center rounded bg-[var(--accent-overlay)] text-[hsl(var(--accent-foreground))]">
+          <div className="w-56 h-6 flex items-center justify-center rounded bg-[var(--accent-overlay)] text-accent-foreground">
             Overlay
           </div>
         ),
@@ -467,7 +467,7 @@ export default function ComponentGallery() {
       {
         label: "Foreground Overlay Box",
         element: (
-          <div className="w-56 h-6 flex items-center justify-center rounded border border-[hsl(var(--border)/0.1)] bg-[hsl(var(--foreground)/0.05)] text-[hsl(var(--foreground)/0.7)]">
+          <div className="w-56 h-6 flex items-center justify-center rounded border border-border/10 bg-foreground/5 text-foreground/70">
             FG Overlay
           </div>
         ),
@@ -475,7 +475,7 @@ export default function ComponentGallery() {
       {
         label: "Surface",
         element: (
-          <div className="w-56 h-6 flex items-center justify-center rounded bg-[hsl(var(--surface))]">
+          <div className="w-56 h-6 flex items-center justify-center rounded bg-surface">
             Surface
           </div>
         ),
@@ -483,7 +483,7 @@ export default function ComponentGallery() {
       {
         label: "Surface 2",
         element: (
-          <div className="w-56 h-6 flex items-center justify-center rounded bg-[hsl(var(--surface-2))]">
+          <div className="w-56 h-6 flex items-center justify-center rounded bg-surface-2">
             Surface 2
           </div>
         ),
@@ -491,7 +491,7 @@ export default function ComponentGallery() {
       {
         label: "Ring Subtle",
         element: (
-          <div className="w-56 h-6 flex items-center justify-center rounded ring-1 ring-[hsl(var(--ring)/0.05)]">
+          <div className="w-56 h-6 flex items-center justify-center rounded ring-1 ring-ring/5">
             Ring 5%
           </div>
         ),

--- a/src/components/prompts/PromptsComposePanel.tsx
+++ b/src/components/prompts/PromptsComposePanel.tsx
@@ -30,7 +30,7 @@ export default function PromptsComposePanel({
         <button
           type="button"
           aria-label="Confirm"
-          className="absolute right-2 top-1/2 -translate-y-1/2 size-7 rounded-full grid place-items-center border border-[hsl(var(--accent)/0.45)] bg-[hsl(var(--accent)/0.12)] text-[hsl(var(--accent))] shadow-[0_0_0_1px_hsl(var(--accent)/0.25)] hover:shadow-[0_0_16px_hsl(var(--accent)/0.22)]"
+          className="absolute right-2 top-1/2 -translate-y-1/2 size-7 rounded-full grid place-items-center border border-accent/45 bg-accent/12 text-accent shadow-[0_0_0_1px_hsl(var(--accent)/0.25)] hover:shadow-[0_0_16px_hsl(var(--accent)/0.22)]"
         >
           <CheckIcon className="size-4" />
         </button>

--- a/src/components/prompts/PromptsDemos.tsx
+++ b/src/components/prompts/PromptsDemos.tsx
@@ -66,7 +66,7 @@ export default function PromptsDemos() {
             <button
               type="button"
               aria-label="Confirm"
-              className="absolute right-2 top-1/2 -translate-y-1/2 size-7 rounded-full grid place-items-center border border-[hsl(var(--accent)/0.45)] bg-[hsl(var(--accent)/0.12)] text-[hsl(var(--accent))] shadow-[0_0_0_1px_hsl(var(--accent)/0.25)] hover:shadow-[0_0_16px_hsl(var(--accent)/0.22)]"
+              className="absolute right-2 top-1/2 -translate-y-1/2 size-7 rounded-full grid place-items-center border border-accent/45 bg-accent/12 text-accent shadow-[0_0_0_1px_hsl(var(--accent)/0.25)] hover:shadow-[0_0_16px_hsl(var(--accent)/0.22)]"
             >
               <CheckIcon className="size-4" />
             </button>
@@ -256,7 +256,7 @@ export default function PromptsDemos() {
         <div className="flex gap-2">
           <button
             type="button"
-            className="px-3 py-1 rounded bg-[hsl(var(--accent)/0.2)] transition-opacity duration-420 hover:opacity-60"
+            className="px-3 py-1 rounded bg-accent/20 transition-opacity duration-420 hover:opacity-60"
           >
             Slow fade
           </button>

--- a/src/components/team/Builder.tsx
+++ b/src/components/team/Builder.tsx
@@ -192,7 +192,7 @@ export default function Builder() {
             <div className="hidden md:block relative">
               <span
                 aria-hidden
-                className="absolute left-1/2 top-0 -translate-x-1/2 h-full w-px bg-[hsl(var(--border))]"
+                className="absolute left-1/2 top-0 -translate-x-1/2 h-full w-px bg-border"
               />
             </div>
 
@@ -253,7 +253,7 @@ function SideEditor(props: {
         {LANES.map(({ key, label }) => (
           <div key={key} className="grid grid-cols-[88px_1fr] items-center gap-3">
             <label
-              className="glitch-title glitch-flicker text-xs font-medium text-[hsl(var(--muted-foreground))]"
+              className="glitch-title glitch-flicker text-xs font-medium text-muted-foreground"
               data-text={label}
             >
               {label}
@@ -268,7 +268,7 @@ function SideEditor(props: {
         ))}
 
         <div className="grid gap-3">
-          <label className="text-xs text-[hsl(var(--muted-foreground))] inline-flex items-center gap-2">
+          <label className="text-xs text-muted-foreground inline-flex items-center gap-2">
             <NotebookPen className="opacity-80" /> Notes
           </label>
           <Textarea

--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -169,7 +169,7 @@ function Label({ children }: { children: React.ReactNode }) {
   const text = typeof children === "string" ? children : String(children ?? "");
   return (
     <div
-      className="glitch-anim glitch-label text-xs font-semibold tracking-wide uppercase text-[hsl(var(--muted-foreground))]"
+      className="glitch-anim glitch-label text-xs font-semibold tracking-wide uppercase text-muted-foreground"
       data-text={text}
     >
       {text}
@@ -212,7 +212,7 @@ function TitleEdit({
       dir="ltr"
       value={value}
       onChange={(e) => onChange(sanitizeText(e.currentTarget.value))}
-      className="w-full bg-transparent border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] text-lg sm:text-xl font-semibold glitch-title title-glow"
+      className="w-full bg-transparent border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring text-lg sm:text-xl font-semibold glitch-title title-glow"
       aria-label="Archetype title"
       autoFocus
     />
@@ -226,7 +226,7 @@ function ParagraphEdit({
 }: { value: string; onChange: (v: string) => void; editing: boolean }) {
   if (!editing)
     return (
-      <p className="mt-1 text-sm text-[hsl(var(--muted-foreground))]">{value}</p>
+      <p className="mt-1 text-sm text-muted-foreground">{value}</p>
     );
   return (
     <Textarea
@@ -236,7 +236,7 @@ function ParagraphEdit({
       rows={2}
       className="mt-1"
       resize="resize-y"
-      textareaClassName="min-h-[180px] text-sm text-[hsl(var(--muted-foreground))] leading-relaxed"
+      textareaClassName="min-h-[180px] text-sm text-muted-foreground leading-relaxed"
       aria-label="Description"
     />
   );
@@ -382,7 +382,7 @@ function ChampPillsEdit({
             }}
             aria-label="Champion name"
             autoComplete="off"
-            className="bg-transparent border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] w-24"
+            className="bg-transparent border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring w-24"
           />
         </span>
       ))}
@@ -532,7 +532,7 @@ export default function CheatSheet({
                     return (
                       <div key={role} className="grid grid-cols-[88px_1fr] items-start gap-x-3">
                         <div
-                          className="glitch-title glitch-flicker text-xs font-medium text-[hsl(var(--muted-foreground))] pt-1"
+                          className="glitch-title glitch-flicker text-xs font-medium text-muted-foreground pt-1"
                           data-text={role}
                         >
                           {role}

--- a/src/components/team/JungleClears.tsx
+++ b/src/components/team/JungleClears.tsx
@@ -141,7 +141,7 @@ export default function JungleClears() {
           right: <span className="text-xs opacity-80">{filtered.length} shown</span>,
         }}
       >
-        <p className="text-sm text-[hsl(var(--muted-foreground))]">
+        <p className="text-sm text-muted-foreground">
           If you’re on a <em>Medium</em> champ, don’t race farm vs <em>Very Fast</em>. Path for fights,
           ganks, or cross-map trades.
         </p>
@@ -183,19 +183,19 @@ export default function JungleClears() {
               />
               <SectionCard.Body>
                 <div className="mb-2 flex flex-wrap items-center gap-2">
-                  <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--card))] px-2 py-1 text-xs tracking-wide uppercase">
+                  <span className="rounded-full border border-border bg-card px-2 py-1 text-xs tracking-wide uppercase">
                     {SPEED_PERSONA[bucket].tag}
                   </span>
-                  <span className="text-sm text-[hsl(var(--muted-foreground))]">
+                  <span className="text-sm text-muted-foreground">
                     {SPEED_HINT[bucket]}
                   </span>
                 </div>
 
                 {/* Example row (canonical pills) */}
                 <div className="mb-3 flex flex-wrap items-center gap-2">
-                  <span className="text-[hsl(var(--muted-foreground))] text-sm">Example:</span>
+                  <span className="text-muted-foreground text-sm">Example:</span>
                   <span className="pill pill-compact text-xs">{exampleByBucket[bucket]}</span>
-                  <span className="text-xs text-[hsl(var(--muted-foreground))]">
+                  <span className="text-xs text-muted-foreground">
                     ({rowsAll.length} total)
                   </span>
                 </div>
@@ -209,7 +209,7 @@ export default function JungleClears() {
                 <div className="overflow-x-auto">
                   <table className="w-full text-sm">
                     <caption className="sr-only">{bucket} junglers with types and notes</caption>
-                    <thead className="text-left text-[hsl(var(--muted-foreground))]">
+                    <thead className="text-left text-muted-foreground">
                       <tr className="h-9">
                         <th scope="col" className="pr-3">Champion</th>
                         <th scope="col" className="pr-3">Type</th>
@@ -224,7 +224,7 @@ export default function JungleClears() {
                         editing?.id === r.id ? (
                           <tr
                             key={r.id}
-                            className="h-10 border-t border-[hsl(var(--border))]/40 hover:bg-[hsl(var(--card))/0.45]"
+                            className="h-10 border-t border-border/40 hover:bg-card/45"
                           >
                             <td className="py-2 pr-3 font-medium">
                               <Input
@@ -268,7 +268,7 @@ export default function JungleClears() {
                         ) : (
                           <tr
                             key={r.id}
-                            className="h-10 border-t border-[hsl(var(--border))]/40 hover:bg-[hsl(var(--card))/0.45]"
+                            className="h-10 border-t border-border/40 hover:bg-card/45"
                           >
                             <td className="py-2 pr-3 font-medium">{r.champ}</td>
                             <td className="py-2 pr-3">

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -195,7 +195,7 @@ function ChampChips({
             }}
             aria-label="Champion name"
             autoComplete="off"
-            className="bg-transparent border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] w-24"
+            className="bg-transparent border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring w-24"
           />
         </span>
       ))}
@@ -301,11 +301,11 @@ export default function MyComps({ query = "" }: MyCompsProps) {
 
           {/* Empty states */}
           {items.length === 0 ? (
-            <div className="rounded-2xl p-6 text-sm text-[hsl(var(--muted-foreground))] border border-[hsl(var(--border))]">
+            <div className="rounded-2xl p-6 text-sm text-muted-foreground border border-border">
               No comps yet. Type a title above and press Enter.
             </div>
           ) : filtered.length === 0 ? (
-            <div className="rounded-2xl p-6 text-sm text-[hsl(var(--muted-foreground))] border border-[hsl(var(--border))]">
+            <div className="rounded-2xl p-6 text-sm text-muted-foreground border border-border">
               Nothing matches your search.
             </div>
           ) : null}
@@ -370,7 +370,7 @@ export default function MyComps({ query = "" }: MyCompsProps) {
                       return (
                         <div key={r} className="grid grid-cols-[88px_1fr] items-start gap-3">
                           <div
-                            className="glitch-title glitch-flicker text-xs font-medium text-[hsl(var(--muted-foreground))] pt-1"
+                            className="glitch-title glitch-flicker text-xs font-medium text-muted-foreground pt-1"
                             data-text={r}
                           >
                             {r}
@@ -384,11 +384,11 @@ export default function MyComps({ query = "" }: MyCompsProps) {
 
                     {/* notes */}
                     <div className="grid gap-3">
-                      <label className="text-xs text-[hsl(var(--muted-foreground))] inline-flex items-center gap-2">
+                      <label className="text-xs text-muted-foreground inline-flex items-center gap-2">
                         <NotebookPen className="opacity-80" /> Notes
                       </label>
                       {!editing ? (
-                        <p className="text-sm text-[hsl(var(--muted-foreground))]">
+                        <p className="text-sm text-muted-foreground">
                           {c.notes?.trim() || <span className="opacity-60">—</span>}
                         </p>
                       ) : (

--- a/src/components/ui/AnimationToggle.tsx
+++ b/src/components/ui/AnimationToggle.tsx
@@ -44,15 +44,15 @@ export default function AnimationToggle() {
         onClick={toggle}
         className={cn(
           "inline-flex h-9 w-9 items-center justify-center rounded-full shrink-0",
-          "border border-[hsl(var(--border))] bg-[hsl(var(--card))]",
+          "border border-border bg-card",
           "hover:shadow-[0_0_12px_hsl(var(--ring)/.35)]",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         )}
       >
         {enabled ? <Zap className="h-4 w-4" /> : <ZapOff className="h-4 w-4" />}
       </button>
       {showNotice && (
-        <span className="text-xs text-[hsl(var(--muted-foreground))]">
+        <span className="text-xs text-muted-foreground">
           Animations disabled per OS preference
         </span>
       )}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -13,11 +13,11 @@ export default function Badge({ variant = "neutral", className, children, ...pro
   const base = "inline-flex items-center text-xs font-medium border";
   const variants: Record<BadgeVariant, string> = {
     neutral:
-      "rounded-md px-2 py-1 bg-[hsl(var(--muted)/0.25)] border-[hsl(var(--border)/0.2)] text-[hsl(var(--muted-foreground))]",
+      "rounded-md px-2 py-1 bg-muted/25 border-border/20 text-muted-foreground",
     accent:
-      "rounded-md px-2 py-1 bg-[hsl(var(--accent)/0.15)] border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))] shadow-[0_0_8px_hsl(var(--accent)/0.3)]",
+      "rounded-md px-2 py-1 bg-accent/15 border-accent/35 text-accent shadow-[0_0_8px_hsl(var(--accent)/0.3)]",
     pill:
-      "rounded-full px-2 py-1 bg-[hsl(var(--accent)/0.15)] border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))]",
+      "rounded-full px-2 py-1 bg-accent/15 border-accent/35 text-accent",
   };
 
   return (

--- a/src/components/ui/Label.tsx
+++ b/src/components/ui/Label.tsx
@@ -14,7 +14,7 @@ const Label = React.forwardRef<HTMLLabelElement, LabelProps>(function Label(
     <label
       ref={ref}
       className={cn(
-        "text-xs font-medium text-[hsl(var(--muted-foreground))] mb-2",
+        "text-xs font-medium text-muted-foreground mb-2",
         className
       )}
       {...props}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -64,14 +64,14 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(function Select(
           aria-invalid={errorText ? "true" : props["aria-invalid"]}
           aria-describedby={describedBy}
           className={cn(
-            "flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none",
+            "flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-foreground placeholder:text-muted-foreground/80 caret-accent appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none",
             selectClassName
           )}
           {...props}
         >
           {children}
         </select>
-          <ChevronDown className="pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]" />
+          <ChevronDown className="pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-muted-foreground group-focus-within:text-accent" />
       </FieldShell>
       {success && (
         <p

--- a/src/components/ui/feedback/Progress.tsx
+++ b/src/components/ui/feedback/Progress.tsx
@@ -6,7 +6,7 @@ export default function Progress({ value, label }: { value: number; label?: stri
   const v = Math.max(0, Math.min(100, Math.round(value)));
   return (
     <div
-      className="h-2 w-full rounded-full bg-[hsl(var(--muted))] shadow-[inset_2px_2px_4px_hsl(var(--shadow-color)/0.45),inset_-2px_-2px_4px_hsl(var(--foreground)/0.06)]"
+      className="h-2 w-full rounded-full bg-muted shadow-[inset_2px_2px_4px_hsl(var(--shadow-color)/0.45),inset_-2px_-2px_4px_hsl(var(--foreground)/0.06)]"
       aria-label={label}
     >
       <div

--- a/src/components/ui/feedback/Snackbar.tsx
+++ b/src/components/ui/feedback/Snackbar.tsx
@@ -21,7 +21,7 @@ export default function Snackbar({
       role="status"
       aria-live="polite"
       className={cn(
-        "mx-auto w-fit rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] px-4 py-2 text-sm shadow-sm",
+        "mx-auto w-fit rounded-2xl border border-border bg-surface-2 px-4 py-2 text-sm shadow-sm",
         className,
       )}
       {...props}

--- a/src/components/ui/feedback/Spinner.tsx
+++ b/src/components/ui/feedback/Spinner.tsx
@@ -15,7 +15,7 @@ export default function Spinner({
       role="status"
       aria-label="Loading"
       className={cn(
-        "inline-block animate-spin rounded-full border-2 border-[hsl(var(--accent))] border-t-transparent",
+        "inline-block animate-spin rounded-full border-2 border-accent border-t-transparent",
         className
       )}
       style={{ width: size, height: size }}

--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -52,7 +52,7 @@ export default function Header({
         "z-[999] relative isolate",
 
         // Card look: no border, soft glow
-        "rounded-2xl bg-[hsl(var(--card))]/70 backdrop-blur-md",
+        "rounded-2xl bg-card/70 backdrop-blur-md",
         "shadow-[0_0_18px_hsl(var(--ring)/.35),0_0_32px_hsl(var(--accent)/.25)]",
 
         // Safety: never let children bleed outside
@@ -83,16 +83,16 @@ export default function Header({
           {icon ? <span className="shrink-0 opacity-90">{icon}</span> : null}
           <div className="min-w-0">
             {eyebrow ? (
-              <div className="mb-1 truncate text-[0.6875rem] uppercase tracking-wide text-[hsl(var(--muted-foreground))]">
+              <div className="mb-1 truncate text-[0.6875rem] uppercase tracking-wide text-muted-foreground">
                 {eyebrow}
               </div>
             ) : null}
             <div className="flex min-w-0 items-baseline gap-2">
-              <h1 className="truncate text-base leading-tight text-[hsl(var(--foreground))] sm:text-lg title-glow">
+              <h1 className="truncate text-base leading-tight text-foreground sm:text-lg title-glow">
                 {heading}
               </h1>
               {subtitle ? (
-                <span className="hidden truncate text-xs text-[hsl(var(--muted-foreground))] sm:inline">
+                <span className="hidden truncate text-xs text-muted-foreground sm:inline">
                   {subtitle}
                 </span>
               ) : null}
@@ -187,7 +187,7 @@ export function HeaderTabs<Key extends string = string>({
               id={`${t.key}-tab`}
               title={t.hint}
               onClick={() => onChange(t.key)}
-              className="h-8 sm:h-9 text-xs sm:text-sm px-3 focus-visible:ghost-2 focus-visible:ghost-[hsl(var(--ghost))]"
+              className="h-8 sm:h-9 text-xs sm:text-sm px-3 focus-visible:ghost-2 focus-visible:ghost-ghost"
               isActive={active}
             >
               {t.icon}

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -124,7 +124,7 @@ export default function Hero({
 
           <div className="min-w-0">
             {eyebrow ? (
-              <div className="text-xs font-semibold tracking-[0.14em] uppercase text-[hsl(var(--muted-foreground))]">
+              <div className="text-xs font-semibold tracking-[0.14em] uppercase text-muted-foreground">
                 {eyebrow}
               </div>
             ) : null}
@@ -137,7 +137,7 @@ export default function Hero({
                 {heading}
               </h2>
               {subtitle ? (
-                <span className="text-xs sm:text-sm tracking-wide text-[hsl(var(--muted-foreground))] truncate">
+                <span className="text-xs sm:text-sm tracking-wide text-muted-foreground truncate">
                   {subtitle}
                 </span>
               ) : null}
@@ -169,7 +169,7 @@ export default function Hero({
         {/* subtle rim */}
         <div
           aria-hidden
-          className="absolute inset-0 rounded-2xl ring-1 ring-inset ring-[hsl(var(--border)/0.55)]"
+          className="absolute inset-0 rounded-2xl ring-1 ring-inset ring-border/55"
         />
       </div>
     </section>

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -173,7 +173,7 @@ export default function TabBar<K extends string = string>({
                   s.text,
                   size === "lg" ? "font-medium" : "font-normal",
                   "text-foreground hover:text-foreground data-[active=true]:text-foreground",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] focus-visible:ring-offset-0",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
                   item.disabled && "opacity-40 pointer-events-none",
                   item.className,
                 )}
@@ -198,7 +198,7 @@ export default function TabBar<K extends string = string>({
                 )}
                 <span className="truncate">{item.label}</span>
                 {item.badge != null && (
-                  <span className="ml-2 inline-flex items-center justify-center rounded-full text-xs leading-none px-2 py-1 bg-[hsl(var(--primary-soft))] text-foreground">
+                  <span className="ml-2 inline-flex items-center justify-center rounded-full text-xs leading-none px-2 py-1 bg-primary-soft text-foreground">
                     {item.badge}
                   </span>
                 )}

--- a/src/components/ui/league/SideSelector.tsx
+++ b/src/components/ui/league/SideSelector.tsx
@@ -54,8 +54,8 @@ export default function SideSelector({
       onKeyDown={onKey}
       className={cn(
         "relative inline-flex select-none items-center overflow-hidden rounded-full",
-        "border border-[hsl(var(--border))] bg-[hsl(var(--card))]",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+        "border border-border bg-card",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         "min-w-[14rem] sm:min-w-[16rem] w-full max-w-xs h-10", // responsive default
         className
       )}
@@ -92,7 +92,7 @@ export default function SideSelector({
         <div
           className={cn(
             "py-2 text-center transition-colors",
-            !isRight ? "text-[hsl(var(--foreground)/0.7)]" : "text-[hsl(var(--muted-foreground))]"
+            !isRight ? "text-foreground/70" : "text-muted-foreground"
           )}
           style={{ textShadow: !isRight ? "0 0 10px hsl(200 100% 60% / .35)" : undefined }}
         >
@@ -101,7 +101,7 @@ export default function SideSelector({
         <div
           className={cn(
             "py-2 text-center transition-colors",
-            isRight ? "text-[hsl(var(--foreground)/0.7)]" : "text-[hsl(var(--muted-foreground))]"
+            isRight ? "text-foreground/70" : "text-muted-foreground"
           )}
           style={{ textShadow: isRight ? "0 0 10px hsl(0 85% 60% / .35)" : undefined }}
         >

--- a/src/components/ui/league/pillars/PillarSelector.tsx
+++ b/src/components/ui/league/pillars/PillarSelector.tsx
@@ -54,7 +54,7 @@ export default function PillarSelector({
                 aria-hidden
                 className={cn(
                   "h-2 w-2 rounded-full",
-                  active ? "" : "bg-[hsl(var(--muted-foreground))]"
+                  active ? "" : "bg-muted-foreground"
                 )}
                 style={active ? { background: "var(--accent-overlay)" } : undefined}
               />

--- a/src/components/ui/primitives/Badge.tsx
+++ b/src/components/ui/primitives/Badge.tsx
@@ -32,14 +32,14 @@ const sizeMap: Record<Size, string> = {
 };
 
 const toneBorder: Record<Tone, string> = {
-  neutral: "border-[hsl(var(--card-hairline))]",
-  primary: "border-[hsl(var(--ring))]",
+  neutral: "border-card-hairline",
+  primary: "border-ring",
   accent: "border-[var(--accent-overlay)]",
-  top: "border-[hsl(var(--tone-top))]",
-  jungle: "border-[hsl(var(--tone-jg))]",
-  mid: "border-[hsl(var(--tone-mid))]",
-  adc: "border-[hsl(var(--tone-adc))]",
-  support: "border-[hsl(var(--tone-sup))]",
+  top: "border-tone-top",
+  jungle: "border-tone-jg",
+  mid: "border-tone-mid",
+  adc: "border-tone-adc",
+  support: "border-tone-sup",
 };
 
 export default function Badge<T extends React.ElementType = "span">({

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -77,29 +77,29 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       Record<Tone, string>
     > = {
       primary: {
-        primary: "text-[hsl(var(--foreground))]",
-        accent: "text-[hsl(var(--accent))]",
-        info: "text-[hsl(var(--accent-2))]",
-        danger: "text-[hsl(var(--danger))]",
+        primary: "text-foreground",
+        accent: "text-accent",
+        info: "text-accent-2",
+        danger: "text-danger",
       },
       secondary: {
-        primary: "text-[hsl(var(--foreground))]",
+        primary: "text-foreground",
         accent:
-          "text-[hsl(var(--accent))] bg-[hsl(var(--accent)/0.15)] hover:bg-[hsl(var(--accent)/0.25)]",
+          "text-accent bg-accent/15 hover:bg-accent/25",
         info:
-          "text-[hsl(var(--accent-2))] bg-[hsl(var(--accent-2)/0.15)] hover:bg-[hsl(var(--accent-2)/0.25)]",
+          "text-accent-2 bg-accent-2/15 hover:bg-accent-2/25",
         danger:
-          "text-[hsl(var(--danger))] bg-[hsl(var(--danger)/0.15)] hover:bg-[hsl(var(--danger)/0.25)]",
+          "text-danger bg-danger/15 hover:bg-danger/25",
       },
       ghost: {
         primary:
-          "text-[hsl(var(--foreground))] hover:bg-[hsl(var(--foreground)/0.1)]",
+          "text-foreground hover:bg-foreground/10",
         accent:
-          "text-[hsl(var(--accent))] hover:bg-[hsl(var(--accent)/0.1)]",
+          "text-accent hover:bg-accent/10",
         info:
-          "text-[hsl(var(--accent-2))] hover:bg-[hsl(var(--accent-2)/0.1)]",
+          "text-accent-2 hover:bg-accent-2/10",
         danger:
-          "text-[hsl(var(--danger))] hover:bg-[hsl(var(--danger)/0.1)]",
+          "text-danger hover:bg-danger/10",
       },
     };
 

--- a/src/components/ui/primitives/Card.tsx
+++ b/src/components/ui/primitives/Card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
       <div
         ref={ref}
         className={cn(
-          "rounded-xl p-4 border border-[hsl(var(--border)/0.25)] bg-[hsl(var(--card)/0.6)] shadow-[0_0_0_1px_hsl(var(--border)/0.12)]",
+          "rounded-xl p-4 border border-border/25 bg-card/60 shadow-[0_0_0_1px_hsl(var(--border)/0.12)]",
           className
         )}
         {...props}

--- a/src/components/ui/primitives/FieldShell.tsx
+++ b/src/components/ui/primitives/FieldShell.tsx
@@ -10,7 +10,7 @@ export interface FieldShellProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const FIELD_SHELL_BASE =
-  "relative inline-flex w-full items-center rounded-xl border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]";
+  "relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]";
 
 const FieldShell = React.forwardRef<HTMLDivElement, FieldShellProps>(
   ({ tone = "default", error, disabled, className, style, ...props }, ref) => (
@@ -20,7 +20,7 @@ const FieldShell = React.forwardRef<HTMLDivElement, FieldShellProps>(
         FIELD_SHELL_BASE,
         tone === "pill" && "rounded-full",
         error &&
-          "border-[hsl(var(--danger)/0.6)] focus-within:ring-[hsl(var(--danger)/0.35)]",
+          "border-danger/60 focus-within:ring-danger/35",
         disabled && "opacity-60 pointer-events-none",
         className
       )}

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -44,33 +44,33 @@ const variantBase: Record<Variant, string> = {
 const toneClasses: Record<Variant, Record<Tone, string>> = {
   ring: {
     primary:
-      "border-[hsl(var(--line)/0.35)] text-[hsl(var(--foreground))]",
+      "border-line/35 text-foreground",
     accent:
-      "border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))]",
+      "border-accent/35 text-accent",
     info:
-      "border-[hsl(var(--accent-2)/0.35)] text-[hsl(var(--accent-2))]",
+      "border-accent-2/35 text-accent-2",
     danger:
-      "border-[hsl(var(--danger)/0.35)] text-[hsl(var(--danger))]",
+      "border-danger/35 text-danger",
   },
   solid: {
     primary:
-      "border-transparent bg-[hsl(var(--foreground)/0.15)] hover:bg-[hsl(var(--foreground)/0.25)] text-[hsl(var(--foreground))]",
+      "border-transparent bg-foreground/15 hover:bg-foreground/25 text-foreground",
     accent:
-      "border-transparent bg-[hsl(var(--accent)/0.15)] hover:bg-[hsl(var(--accent)/0.25)] text-[hsl(var(--accent))]",
+      "border-transparent bg-accent/15 hover:bg-accent/25 text-accent",
     info:
-      "border-transparent bg-[hsl(var(--accent-2)/0.15)] hover:bg-[hsl(var(--accent-2)/0.25)] text-[hsl(var(--accent-2))]",
+      "border-transparent bg-accent-2/15 hover:bg-accent-2/25 text-accent-2",
     danger:
-      "border-transparent bg-[hsl(var(--danger)/0.15)] hover:bg-[hsl(var(--danger)/0.25)] text-[hsl(var(--danger))]",
+      "border-transparent bg-danger/15 hover:bg-danger/25 text-danger",
   },
   glow: {
     primary:
-      "border-[hsl(var(--foreground)/0.35)] text-[hsl(var(--foreground))]",
+      "border-foreground/35 text-foreground",
     accent:
-      "border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))]",
+      "border-accent/35 text-accent",
     info:
-      "border-[hsl(var(--accent-2)/0.35)] text-[hsl(var(--accent-2))]",
+      "border-accent-2/35 text-accent-2",
     danger:
-      "border-[hsl(var(--danger)/0.35)] text-[hsl(var(--danger))]",
+      "border-danger/35 text-danger",
   },
 };
 

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -85,7 +85,7 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
         id={finalId}
         name={finalName}
         className={cn(
-          "w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]",
+          "w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]",
           indent && "pl-7",
           showEndSlot && "pr-7",
           inputClassName

--- a/src/components/ui/primitives/SearchBar.tsx
+++ b/src/components/ui/primitives/SearchBar.tsx
@@ -97,7 +97,7 @@ export default function SearchBar({
           className={cn(
             "w-full",
             showClear && "pr-7",
-            "border-[hsl(var(--border))] bg-[hsl(var(--input))]"
+            "border-border bg-input"
           )}
           aria-label={rest["aria-label"] ?? "Search"}
           type="search"

--- a/src/components/ui/primitives/Textarea.tsx
+++ b/src/components/ui/primitives/Textarea.tsx
@@ -22,7 +22,7 @@ export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & 
 
 const INNER =
   "block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent " +
-  "text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] " +
+  "text-foreground placeholder:text-muted-foreground " +
   "focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed";
 
 export default React.forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(

--- a/src/components/ui/selects/AnimatedSelect.tsx
+++ b/src/components/ui/selects/AnimatedSelect.tsx
@@ -253,7 +253,7 @@ export default function AnimatedSelect({
   // ── Trigger (glitch chrome + stays lit on selection) ──
   const triggerCls = [
     "glitch-trigger relative flex items-center rounded-full px-3 overflow-hidden",
-    "bg-[hsl(var(--muted)/.12)] hover:bg-[hsl(var(--muted)/.18)]",
+    "bg-muted/12 hover:bg-muted/18",
     "focus:[outline:none] focus-visible:[outline:none]",
     "transition",
     buttonClassName,
@@ -269,7 +269,7 @@ export default function AnimatedSelect({
           className={
             hideLabel
               ? "sr-only"
-              : "mb-1 text-xs text-[hsl(var(--muted-foreground))]"
+              : "mb-1 text-xs text-muted-foreground"
           }
         >
           {label}
@@ -301,9 +301,9 @@ export default function AnimatedSelect({
             className={[
               "font-medium glitch-text",
               lit
-                ? "text-[hsl(var(--foreground))]"
-                : "text-[hsl(var(--muted-foreground))]",
-              "group-hover:text-[hsl(var(--foreground))]",
+                ? "text-foreground"
+                : "text-muted-foreground",
+              "group-hover:text-foreground",
             ].join(" ")}
           >
             {current ? (
@@ -361,11 +361,11 @@ export default function AnimatedSelect({
                 onKeyDown={onListKeyDown}
                 className={[
                   "relative pointer-events-auto rounded-2xl overflow-hidden",
-                  "bg-[hsl(var(--card))]/92 backdrop-blur-xl",
-                  "shadow-[0_12px_40px_hsl(var(--shadow-color)/0.55)] ring-1 ring-[hsl(var(--ring)/.18)]",
+                  "bg-card/92 backdrop-blur-xl",
+                  "shadow-[0_12px_40px_hsl(var(--shadow-color)/0.55)] ring-1 ring-ring/18",
                   "p-2",
                   "max-h-[60vh] min-w-[220px] overflow-y-auto scrollbar-thin",
-                  "scrollbar-thumb-[hsl(var(--foreground)/.12)] scrollbar-track-transparent",
+                  "scrollbar-thumb-foreground/12 scrollbar-track-transparent",
                   dropdownClassName,
                 ].join(" ")}
                 data-open="true"
@@ -395,8 +395,8 @@ export default function AnimatedSelect({
                             ? "opacity-50 cursor-not-allowed"
                             : "cursor-pointer",
                           active
-                            ? "bg-[hsl(var(--primary)/.14)] text-[hsl(var(--primary-foreground))]"
-                            : "hover:bg-[hsl(var(--foreground)/0.05)]",
+                            ? "bg-primary/14 text-primary-foreground"
+                            : "hover:bg-foreground/5",
                           "focus:[outline:none] focus-visible:[outline:none] focus:ring-2 focus:ring-[--theme-ring] focus:ring-offset-0",
                           it.className ?? "",
                         ].join(" ")}
@@ -421,7 +421,7 @@ export default function AnimatedSelect({
                           aria-hidden
                           className={[
                             "pointer-events-none absolute left-0 top-1/2 h-[70%] w-[2px] -translate-y-1/2 rounded",
-                            active ? "bg-[hsl(var(--ring))]" : "bg-transparent",
+                            active ? "bg-ring" : "bg-transparent",
                           ].join(" ")}
                         />
                       </button>

--- a/src/components/ui/theme/ThemeToggle.tsx
+++ b/src/components/ui/theme/ThemeToggle.tsx
@@ -64,7 +64,7 @@ export default function ThemeToggle({
     return (
       <span
         aria-hidden
-        className={`inline-block h-9 w-9 rounded-full bg-[hsl(var(--input))] ${className}`}
+        className={`inline-block h-9 w-9 rounded-full bg-input ${className}`}
       />
     );
   }
@@ -84,9 +84,9 @@ export default function ThemeToggle({
         title={modeDisabled ? "This palette uses dark tokens" : isDark ? "Dark → Light" : "Light → Dark"}
         className={[
           "inline-flex h-9 w-9 items-center justify-center rounded-full shrink-0",
-          "border border-[hsl(var(--border))] bg-[hsl(var(--card))]",
+          "border border-border bg-card",
           "hover:shadow-[0_0_12px_hsl(var(--ring)/.35)]",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           modeDisabled ? "opacity-60 cursor-not-allowed" : "",
         ].join(" ")}
       >
@@ -99,7 +99,7 @@ export default function ThemeToggle({
         aria-label={`${aria}: cycle background`}
         onClick={cycleBg}
         title="Change background"
-        className="inline-flex h-9 w-9 items-center justify-center rounded-full shrink-0 border border-[hsl(var(--border))] bg-[hsl(var(--card))] hover:shadow-[0_0_12px_hsl(var(--ring)/.35)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
+        className="inline-flex h-9 w-9 items-center justify-center rounded-full shrink-0 border border-border bg-card hover:shadow-[0_0_12px_hsl(var(--ring)/.35)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         <ImageIcon className="h-4 w-4" />
       </button>

--- a/src/components/ui/toggles/CheckCircle.tsx
+++ b/src/components/ui/toggles/CheckCircle.tsx
@@ -178,7 +178,7 @@ export default function CheckCircle({
           onPointerDown={retriggerIgnite}
           className={cn(
             "relative inline-grid place-items-center rounded-full transition",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
             "disabled:opacity-50 disabled:pointer-events-none",
             "h-full w-full"
           )}
@@ -187,7 +187,7 @@ export default function CheckCircle({
           {/* Base */}
           <span
             aria-hidden
-            className="absolute inset-0 rounded-full ring-1 ring-[hsl(var(--border))] bg-[hsl(var(--card)/.35)]"
+            className="absolute inset-0 rounded-full ring-1 ring-border bg-card/35"
           />
 
           {/* Neon rim */}
@@ -300,9 +300,9 @@ export default function CheckCircle({
             }}
             className={cn(
               "absolute -right-2 -top-2 grid h-5 w-5 place-items-center rounded-full",
-              "border border-[hsl(var(--card-hairline))] bg-[hsl(var(--card))] text-[hsl(var(--foreground))]",
+              "border border-card-hairline bg-card text-foreground",
               "shadow-sm hover:shadow-[0_0_10px_hsl(var(--ring)/.45)]",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             )}
           >
             <X aria-hidden className="h-4 w-4" />

--- a/src/components/ui/toggles/NeonIcon.tsx
+++ b/src/components/ui/toggles/NeonIcon.tsx
@@ -68,7 +68,7 @@ export function NeonIcon({
     <span
       className={cn(
         "ni-root relative inline-grid place-items-center overflow-visible rounded-full border",
-        "border-[hsl(var(--border))] bg-[hsl(var(--card)/.35)]",
+        "border-border bg-card/35",
         className
       )}
       style={styleVars}

--- a/src/components/ui/toggles/toggle.tsx
+++ b/src/components/ui/toggles/toggle.tsx
@@ -43,8 +43,8 @@ export default function Toggle({
       onKeyDown={onKeyDown}
       className={cn(
         "relative inline-flex w-[16rem] h-10 items-center rounded-full border",
-        "border-[hsl(var(--border))] bg-[hsl(var(--card))] overflow-hidden",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+        "border-border bg-card overflow-hidden",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         className
       )}
       data-side={value}
@@ -65,7 +65,7 @@ export default function Toggle({
       <span
         className={cn(
           "relative z-10 flex-1 text-center font-mono text-sm transition-colors",
-          !isRight ? "text-[hsl(var(--foreground)/0.7)]" : "text-[hsl(var(--muted-foreground))]"
+          !isRight ? "text-foreground/70" : "text-muted-foreground"
         )}
         style={{ textShadow: !isRight ? "0 0 10px hsl(200 100% 60% / .35)" : undefined }}
       >
@@ -74,7 +74,7 @@ export default function Toggle({
       <span
         className={cn(
           "relative z-10 flex-1 text-center font-mono text-sm transition-colors",
-          isRight ? "text-[hsl(var(--foreground)/0.7)]" : "text-[hsl(var(--muted-foreground))]"
+          isRight ? "text-foreground/70" : "text-muted-foreground"
         )}
         style={{ textShadow: isRight ? "0 0 10px hsl(0 85% 60% / .35)" : undefined }}
       >

--- a/tests/primitives/icon-button.test.tsx
+++ b/tests/primitives/icon-button.test.tsx
@@ -68,9 +68,7 @@ describe("IconButton", () => {
     );
     const classes = getByRole("button").className;
     expect(classes).toContain("border bg-transparent hover:bg-panel/45");
-    expect(classes).toContain(
-      "border-[hsl(var(--line)/0.35)] text-[hsl(var(--foreground))]",
-    );
+    expect(classes).toContain("border-line/35 text-foreground");
   });
 
   it("applies solid variant with accent tone", () => {
@@ -80,7 +78,7 @@ describe("IconButton", () => {
     const classes = getByRole("button").className;
     expect(classes).toContain("border");
     expect(classes).toContain(
-      "border-transparent bg-[hsl(var(--accent)/0.15)] hover:bg-[hsl(var(--accent)/0.25)] text-[hsl(var(--accent))]",
+      "border-transparent bg-accent/15 hover:bg-accent/25 text-accent",
     );
   });
 
@@ -92,9 +90,7 @@ describe("IconButton", () => {
     expect(classes).toContain(
       "border bg-transparent hover:bg-panel/45 shadow-[0_0_8px_currentColor]",
     );
-    expect(classes).toContain(
-      "border-[hsl(var(--accent-2)/0.35)] text-[hsl(var(--accent-2))]",
-    );
+    expect(classes).toContain("border-accent-2/35 text-accent-2");
   });
 
   it("applies ring variant with danger tone", () => {
@@ -103,9 +99,7 @@ describe("IconButton", () => {
     );
     const classes = getByRole("button").className;
     expect(classes).toContain("border bg-transparent hover:bg-panel/45");
-    expect(classes).toContain(
-      "border-[hsl(var(--danger)/0.35)] text-[hsl(var(--danger))]",
-    );
+    expect(classes).toContain("border-danger/35 text-danger");
     expect(classes).not.toContain("shadow-[0_0_8px_currentColor]");
   });
 });

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`ReviewListItem > renders default state 1`] = `
         >
           <span
             aria-label="Rating 9 out of 10"
-            class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--accent)/0.15)] border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))] shadow-[0_0_8px_hsl(var(--accent)/0.3)]"
+            class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-accent/15 border-accent/35 text-accent shadow-[0_0_8px_hsl(var(--accent)/0.3)]"
           >
             9
             /10
@@ -95,7 +95,7 @@ exports[`ReviewListItem > renders selected state 1`] = `
         >
           <span
             aria-label="Rating 9 out of 10"
-            class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--accent)/0.15)] border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))] shadow-[0_0_8px_hsl(var(--accent)/0.3)]"
+            class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-accent/15 border-accent/35 text-accent shadow-[0_0_8px_hsl(var(--accent)/0.3)]"
           >
             9
             /10
@@ -146,7 +146,7 @@ exports[`ReviewListItem > renders untitled state 1`] = `
         >
           <span
             aria-label="Rating 9 out of 10"
-            class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-[hsl(var(--accent)/0.15)] border-[hsl(var(--accent)/0.35)] text-[hsl(var(--accent))] shadow-[0_0_8px_hsl(var(--accent)/0.3)]"
+            class="inline-flex items-center text-xs font-medium border rounded-md px-2 py-1 bg-accent/15 border-accent/35 text-accent shadow-[0_0_8px_hsl(var(--accent)/0.3)]"
           >
             9
             /10

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`ReviewsPage > renders default state 1`] = `
     class="page-shell py-6 space-y-6"
   >
     <header
-      class="z-[999] relative isolate rounded-2xl bg-[hsl(var(--card))]/70 backdrop-blur-md shadow-[0_0_18px_hsl(var(--ring)/.35),0_0_32px_hsl(var(--accent)/.25)] overflow-hidden"
+      class="z-[999] relative isolate rounded-2xl bg-card/70 backdrop-blur-md shadow-[0_0_18px_hsl(var(--ring)/.35),0_0_32px_hsl(var(--accent)/.25)] overflow-hidden"
     >
       <div
         class="sticky top-8 relative flex items-center px-3 sm:px-4 py-3 sm:py-4 min-h-12"
@@ -25,7 +25,7 @@ exports[`ReviewsPage > renders default state 1`] = `
               class="flex min-w-0 items-baseline gap-2"
             >
               <h1
-                class="truncate text-base leading-tight text-[hsl(var(--foreground))] sm:text-lg title-glow"
+                class="truncate text-base leading-tight text-foreground sm:text-lg title-glow"
               >
                 Reviews
               </h1>
@@ -394,14 +394,14 @@ exports[`ReviewsPage > renders default state 1`] = `
                     />
                   </svg>
                   <div
-                    class="relative inline-flex items-center rounded-xl border backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] w-full border-[hsl(var(--border))] bg-[hsl(var(--input))]"
+                    class="relative inline-flex items-center rounded-xl border backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] w-full border-border bg-input"
                     style="--theme-ring: hsl(var(--ring)); --control-h: 2.5rem;"
                   >
                     <input
                       autocapitalize="none"
                       autocomplete="off"
                       autocorrect="off"
-                      class="w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] pl-7"
+                      class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] pl-7"
                       id=":r0:"
                       name=":r0:"
                       placeholder="Search title, tags, opponent, patch…"
@@ -432,13 +432,13 @@ exports[`ReviewsPage > renders default state 1`] = `
                         aria-expanded="false"
                         aria-haspopup="listbox"
                         aria-label="Select option"
-                        class="glitch-trigger relative flex items-center rounded-full px-3 overflow-hidden bg-[hsl(var(--muted)/.12)] hover:bg-[hsl(var(--muted)/.18)] focus:[outline:none] focus-visible:[outline:none] transition h-10 px-4"
+                        class="glitch-trigger relative flex items-center rounded-full px-3 overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition h-10 px-4"
                         data-lit="true"
                         data-open="false"
                         type="button"
                       >
                         <span
-                          class="font-medium glitch-text text-[hsl(var(--foreground))] group-hover:text-[hsl(var(--foreground))]"
+                          class="font-medium glitch-text text-foreground group-hover:text-foreground"
                         >
                           Newest
                         </span>
@@ -702,7 +702,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                   </div>
                 </div>
                 <button
-                  class="relative inline-flex items-center justify-center rounded-2xl border border-[--theme-ring] font-medium transition-all duration-200 focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--theme-ring] disabled:opacity-50 disabled:pointer-events-none h-10 text-base gap-2 [&>svg]:size-5 px-4 whitespace-nowrap bg-panel/85 overflow-hidden shadow-neo text-[hsl(var(--foreground))]"
+                  class="relative inline-flex items-center justify-center rounded-2xl border border-[--theme-ring] font-medium transition-all duration-200 focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--theme-ring] disabled:opacity-50 disabled:pointer-events-none h-10 text-base gap-2 [&>svg]:size-5 px-4 whitespace-nowrap bg-panel/85 overflow-hidden shadow-neo text-foreground"
                   tabindex="0"
                   type="button"
                 >
@@ -743,7 +743,7 @@ exports[`ReviewsPage > renders default state 1`] = `
         </div>
         <div
           aria-hidden="true"
-          class="absolute inset-0 rounded-2xl ring-1 ring-inset ring-[hsl(var(--border)/0.55)]"
+          class="absolute inset-0 rounded-2xl ring-1 ring-inset ring-border/55"
         />
       </div>
     </section>
@@ -767,7 +767,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                shown
             </div>
             <div
-              class="rounded-xl border border-[hsl(var(--border)/0.25)] bg-[hsl(var(--card)/0.6)] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] w-full mx-auto backdrop-blur-sm max-h-screen overflow-auto p-2"
+              class="rounded-xl border border-border/25 bg-card/60 shadow-[0_0_0_1px_hsl(var(--border)/0.12)] w-full mx-auto backdrop-blur-sm max-h-screen overflow-auto p-2"
             >
               <ul
                 class="flex flex-col gap-3"
@@ -880,7 +880,7 @@ exports[`ReviewsPage > renders default state 1`] = `
         </div>
       </nav>
       <div
-        class="rounded-xl border border-[hsl(var(--border)/0.25)] bg-[hsl(var(--card)/0.6)] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] w-full max-w-[880px] p-5 md:col-span-8 lg:col-span-9 mx-auto flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground"
+        class="rounded-xl border border-border/25 bg-card/60 shadow-[0_0_0_1px_hsl(var(--border)/0.12)] w-full max-w-[880px] p-5 md:col-span-8 lg:col-span-9 mx-auto flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground"
       >
         <svg
           class="lucide lucide-ghost h-6 w-6 opacity-60"

--- a/tests/ui/__snapshots__/input.test.tsx.snap
+++ b/tests/ui/__snapshots__/input.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`Input > renders default state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
+  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
   style="--theme-ring: hsl(var(--ring)); --control-h: 2.5rem;"
 >
   <input
-    class="w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
+    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
     id=":r0:"
     name=":r0:"
   />
@@ -15,11 +15,11 @@ exports[`Input > renders default state 1`] = `
 
 exports[`Input > renders disabled state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-60 pointer-events-none"
+  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-60 pointer-events-none"
   style="--theme-ring: hsl(var(--ring)); --control-h: 2.5rem;"
 >
   <input
-    class="w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
+    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
     disabled=""
     id=":r4:"
     name=":r4:"
@@ -29,12 +29,12 @@ exports[`Input > renders disabled state 1`] = `
 
 exports[`Input > renders error state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-[hsl(var(--danger)/0.6)] focus-within:ring-[hsl(var(--danger)/0.35)]"
+  class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-danger/60 focus-within:ring-danger/35"
   style="--theme-ring: hsl(var(--ring)); --control-h: 2.5rem;"
 >
   <input
     aria-invalid="true"
-    class="w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
+    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
     id=":r2:"
     name=":r2:"
   />
@@ -43,11 +43,11 @@ exports[`Input > renders error state 1`] = `
 
 exports[`Input > renders focus state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
+  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
   style="--theme-ring: hsl(var(--ring)); --control-h: 2.5rem;"
 >
   <input
-    class="w-full bg-transparent px-4 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
+    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
     id=":r1:"
     name=":r1:"
   />

--- a/tests/ui/__snapshots__/select.test.tsx.snap
+++ b/tests/ui/__snapshots__/select.test.tsx.snap
@@ -5,12 +5,12 @@ exports[`Select > renders default state 1`] = `
   class="space-y-1"
 >
   <div
-    class="relative inline-flex w-full items-center rounded-xl border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
+    class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
     style="--theme-ring: hsl(var(--ring));"
   >
     <select
       aria-label="test"
-      class="flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
+      class="flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-foreground placeholder:text-muted-foreground/80 caret-accent appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
       id=":r0:"
       name="test"
     >
@@ -26,7 +26,7 @@ exports[`Select > renders default state 1`] = `
       </option>
     </select>
     <svg
-      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]"
+      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-muted-foreground group-focus-within:text-accent"
       fill="none"
       height="24"
       stroke="currentColor"
@@ -50,12 +50,12 @@ exports[`Select > renders disabled state 1`] = `
   class="space-y-1"
 >
   <div
-    class="relative inline-flex w-full items-center rounded-xl border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-[--theme-ring] focus-within:ring-offset-0 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-60 pointer-events-none group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)] cursor-not-allowed focus-within:ring-0 focus-within:shadow-none"
+    class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-[--theme-ring] focus-within:ring-offset-0 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-60 pointer-events-none group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)] cursor-not-allowed focus-within:ring-0 focus-within:shadow-none"
     style="--theme-ring: hsl(var(--ring));"
   >
     <select
       aria-label="test"
-      class="flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
+      class="flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-foreground placeholder:text-muted-foreground/80 caret-accent appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
       disabled=""
       id=":r4:"
       name="test"
@@ -67,7 +67,7 @@ exports[`Select > renders disabled state 1`] = `
       </option>
     </select>
     <svg
-      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]"
+      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-muted-foreground group-focus-within:text-accent"
       fill="none"
       height="24"
       stroke="currentColor"
@@ -91,14 +91,14 @@ exports[`Select > renders error state 1`] = `
   class="space-y-1"
 >
   <div
-    class="relative inline-flex w-full items-center rounded-xl border bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-[hsl(var(--danger)/0.6)] focus-within:ring-[hsl(var(--danger)/0.35)] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
+    class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-danger/60 focus-within:ring-danger/35 group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
     style="--theme-ring: hsl(var(--ring));"
   >
     <select
       aria-describedby=":r2:-error"
       aria-invalid="true"
       aria-label="test"
-      class="flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
+      class="flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-foreground placeholder:text-muted-foreground/80 caret-accent appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
       id=":r2:"
       name="test"
     >
@@ -109,7 +109,7 @@ exports[`Select > renders error state 1`] = `
       </option>
     </select>
     <svg
-      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]"
+      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-muted-foreground group-focus-within:text-accent"
       fill="none"
       height="24"
       stroke="currentColor"
@@ -139,12 +139,12 @@ exports[`Select > renders focus state 1`] = `
   class="space-y-1"
 >
   <div
-    class="relative inline-flex w-full items-center rounded-xl border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
+    class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
     style="--theme-ring: hsl(var(--ring));"
   >
     <select
       aria-label="test"
-      class="flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
+      class="flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-foreground placeholder:text-muted-foreground/80 caret-accent appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
       id=":r1:"
       name="test"
     >
@@ -160,7 +160,7 @@ exports[`Select > renders focus state 1`] = `
       </option>
     </select>
     <svg
-      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]"
+      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-muted-foreground group-focus-within:text-accent"
       fill="none"
       height="24"
       stroke="currentColor"
@@ -184,13 +184,13 @@ exports[`Select > renders success state 1`] = `
   class="space-y-1"
 >
   <div
-    class="relative inline-flex w-full items-center rounded-xl border bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)] border-[--theme-ring] focus-within:ring-[--theme-ring]"
+    class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)] border-[--theme-ring] focus-within:ring-[--theme-ring]"
     style="--theme-ring: hsl(var(--ring));"
   >
     <select
       aria-describedby=":r3:-success"
       aria-label="test"
-      class="flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))/0.8] caret-[hsl(var(--accent))] appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
+      class="flex-1 h-11 px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-foreground placeholder:text-muted-foreground/80 caret-accent appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
       id=":r3:"
       name="test"
     >
@@ -201,7 +201,7 @@ exports[`Select > renders success state 1`] = `
       </option>
     </select>
     <svg
-      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-[hsl(var(--muted-foreground))] group-focus-within:text-[hsl(var(--accent))]"
+      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-4 w-4 text-muted-foreground group-focus-within:text-accent"
       fill="none"
       height="24"
       stroke="currentColor"

--- a/tests/ui/__snapshots__/textarea.test.tsx.snap
+++ b/tests/ui/__snapshots__/textarea.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`Textarea > renders default state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
+  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
   style="--theme-ring: hsl(var(--ring));"
 >
   <textarea
-    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
+    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
     id=":r0:"
     name="test"
   />
@@ -15,11 +15,11 @@ exports[`Textarea > renders default state 1`] = `
 
 exports[`Textarea > renders disabled state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-60 pointer-events-none"
+  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-60 pointer-events-none"
   style="--theme-ring: hsl(var(--ring));"
 >
   <textarea
-    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
+    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
     disabled=""
     id=":r2:"
     name="test"
@@ -29,12 +29,12 @@ exports[`Textarea > renders disabled state 1`] = `
 
 exports[`Textarea > renders error state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-[hsl(var(--danger)/0.6)] focus-within:ring-[hsl(var(--danger)/0.35)]"
+  class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-danger/60 focus-within:ring-danger/35"
   style="--theme-ring: hsl(var(--ring));"
 >
   <textarea
     aria-invalid="true"
-    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
+    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
     id=":r5:"
     name="test"
   />
@@ -43,11 +43,11 @@ exports[`Textarea > renders error state 1`] = `
 
 exports[`Textarea > renders focus state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
+  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
   style="--theme-ring: hsl(var(--ring));"
 >
   <textarea
-    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
+    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
     id=":r1:"
     name="test"
   />
@@ -56,11 +56,11 @@ exports[`Textarea > renders focus state 1`] = `
 
 exports[`Textarea > renders pill tone 1`] = `
 <div
-  class="relative inline-flex w-full items-center border border-[hsl(var(--border)/0.28)] bg-[hsl(var(--card)/0.6)] backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] rounded-full"
+  class="relative inline-flex w-full items-center border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] rounded-full"
   style="--theme-ring: hsl(var(--ring));"
 >
   <textarea
-    class="block w-full max-w-full px-4 py-3 text-base bg-transparent text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed rounded-full min-h-6"
+    class="block w-full max-w-full px-4 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed rounded-full min-h-6"
     id=":r3:"
     name="test"
   />

--- a/tests/ui/badge.test.tsx
+++ b/tests/ui/badge.test.tsx
@@ -11,13 +11,13 @@ describe('Badge', () => {
   it('renders neutral variant by default', () => {
     const { getByText } = render(<Badge>Neutral</Badge>);
     const badge = getByText('Neutral');
-    expect(badge).toHaveClass('bg-[hsl(var(--muted)/0.25)]');
+    expect(badge).toHaveClass('bg-muted/25');
   });
 
   it('applies accent variant styles', () => {
     const { getByText } = render(<Badge variant="accent">Accent</Badge>);
     const badge = getByText('Accent');
-    expect(badge).toHaveClass('text-[hsl(var(--accent))]');
+    expect(badge).toHaveClass('text-accent');
   });
 
   it('applies pill variant styles', () => {


### PR DESCRIPTION
## Summary
- replace hardcoded HSL utility classes with tokenized Tailwind colors
- adjust tests to expect tokenized color classes

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0ba1ab3c8832c9746b7fd23082868