### PR TITLE
Fix Tailwind card hairline class build error

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1060,17 +1060,19 @@ textarea:-webkit-autofill {
 .pill-compact {
   @apply inline-flex items-center rounded-full
         border border-card-hairline
-        bg-muted/18
         px-2 py-1 text-xs leading-tight tracking-[-0.01em];
+  background-color: hsl(var(--muted) / 0.18);
 }
 .pill-compact:hover {
-  @apply bg-muted/28;
+  background-color: hsl(var(--muted) / 0.28);
 }
 .pill-compact--primary {
-  @apply border-ring bg-primary-soft/25;
+  @apply border-ring;
+  background-color: hsl(var(--primary-soft) / 0.25);
 }
 .pill-compact--accent {
-  @apply border-ring bg-accent-soft/25;
+  @apply border-ring;
+  background-color: hsl(var(--accent-soft) / 0.25);
 }
 
 /* Card padding rhythm */

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -6,6 +6,7 @@ export const colorTokens = [
   "bg-foreground",
   "bg-card",
   "bg-panel",
+  "bg-card-hairline",
   "bg-primary",
   "bg-accent",
   "bg-accent-2",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,6 +17,7 @@ const config: Config = {
         foreground: "hsl(var(--foreground))",
         card: { DEFAULT: "hsl(var(--card))" },
         panel: { DEFAULT: "hsl(var(--panel))" },
+        "card-hairline": "hsl(var(--card-hairline))",
         primary: {
           DEFAULT: "hsl(var(--primary))",
           foreground: "hsl(var(--primary-foreground))",


### PR DESCRIPTION
## Summary
- add `card-hairline` color token to Tailwind config
- replace unsupported bg opacity utilities in compact pill styles
- include `bg-card-hairline` in demo color tokens

## Testing
- `npm run build`
- `npm test -- --run --reporter basic`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0c0badfcc832c93bc1d38e7893d64