### PR TITLE
Use tokenized hover shadow in GoalList

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -153,7 +153,7 @@ const SPEC_DATA: Record<Section, Spec[]> = {
     {
       id: "goal-list",
       name: "GoalList",
-      description: "Demo goal list",
+      description: "Demo goal list with tokenized hover shadow",
       element: <GoalListDemo />,
       tags: ["planner"],
     },

--- a/src/components/goals/GoalList.tsx
+++ b/src/components/goals/GoalList.tsx
@@ -27,7 +27,7 @@ export default function GoalList({ goals, onToggleDone, onRemove }: GoalListProp
             className={[
               "relative rounded-2xl p-6",
               "card-neo transition",
-              "hover:shadow-[0_0_0_1px_hsl(var(--primary)/.25),0_12px_40px_hsl(var(--shadow-color)/0.35)]",
+              "hover:shadow-neoSoft",
               "min-h-8 flex flex-col",
             ].join(" ")}
           >


### PR DESCRIPTION
## Summary
- replace custom GoalList hover shadow with tokenized `shadow-neoSoft`
- document hover shadow on prompts playground

## Testing
- `npm run regen-ui`
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0c3a66fc8832ca417d175ac9252f8