### PR TITLE
refactor: replace custom hsl colors with tokens

### DIFF
--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -243,7 +243,7 @@ export default function TimerTab() {
 
           {/* GLITCH loader */}
           <div className="mt-6">
-            <div className="lg-loader">
+            <div className="lg-loader bg-gradient-to-r from-muted/25 to-muted/15">
               {/* track texture */}
               <div className="lg-noise" aria-hidden />
               {/* progress core */}
@@ -304,8 +304,8 @@ export default function TimerTab() {
         {/* Complete state */}
         {finished && (
           <div className="mt-6 grid place-items-center">
-            <div className="complete text-sm px-3 py-1 rounded-full">Complete</div>
-            <div className="complete-text mt-2 text-xs">Good. Now do the review, not Twitter.</div>
+            <div className="complete text-sm px-3 py-1 rounded-full bg-gradient-to-r from-primary to-accent text-primary-foreground">Complete</div>
+            <div className="mt-2 text-xs text-muted-foreground complete-text">Good. Now do the review, not Twitter.</div>
           </div>
         )}
       </SectionCard.Body>
@@ -330,7 +330,6 @@ export default function TimerTab() {
           height: 12px;
           border-radius: 9999px;
           overflow: hidden;
-          background: linear-gradient(90deg, hsl(var(--muted) / .25), hsl(var(--muted) / .15));
           box-shadow: inset 0 0 0 1px hsl(var(--card-hairline));
           isolation: isolate;
         }
@@ -408,13 +407,10 @@ export default function TimerTab() {
         }
 
         .complete {
-          background: linear-gradient(90deg,hsl(var(--primary)) 0%, hsl(var(--accent)) 100%);
-          color: hsl(var(--primary-foreground));
           box-shadow: 0 0 12px hsl(var(--ring)/.25);
           animation: softPulse 2.4s ease-in-out infinite;
         }
         .complete-text {
-          color: hsl(var(--muted-foreground));
           text-shadow: 0 0 8px hsl(var(--ring)/.25);
           animation: flicker .2s steps(2) 12, glow 2.4s ease-in-out infinite 2.4s;
         }

--- a/src/components/ui/layout/TitleBar.tsx
+++ b/src/components/ui/layout/TitleBar.tsx
@@ -12,7 +12,7 @@ export default function TitleBar({ label, idText = "ID:0x13LG" }: Props) {
   return (
     <>
       <div className="term-mini flex items-center gap-2 px-2 py-2 rounded-full">
-        <span className="term-mini__text">{label}</span>
+        <span className="term-mini__text text-muted-foreground">{label}</span>
         <span className="pill pill--pulse ml-auto">{idText}</span>
       </div>
 
@@ -37,7 +37,6 @@ export default function TitleBar({ label, idText = "ID:0x13LG" }: Props) {
             "Liberation Mono", "Courier New", monospace;
           font-size: 0.95rem;
           letter-spacing: 0.3px;
-          color: hsl(var(--muted-foreground));
         }
       `}</style>
     </>

--- a/src/components/ui/primitives/Badge.tsx
+++ b/src/components/ui/primitives/Badge.tsx
@@ -60,15 +60,15 @@ export default function Badge<T extends React.ElementType = "span">({
       data-selected={selected ? "true" : undefined}
       className={cn(
         "inline-flex max-w-full items-center gap-1.5 whitespace-nowrap rounded-full font-medium tracking-[-0.01em]",
-        "border bg-[color-mix(in_oklab,hsl(var(--muted))_18%,transparent)]",
+        "border bg-muted/18",
         "shadow-[inset_0_1px_0_hsl(var(--foreground)/.06),0_0_0_.5px_hsl(var(--card-hairline)/.35),0_10px_20px_hsl(var(--shadow-color)/.18)]",
         "transition-[background,box-shadow,transform] duration-140 ease-out",
         sizeMap[size],
         toneBorder[tone],
         interactive && "cursor-pointer",
-        interactive && "hover:bg-[color-mix(in_oklab,hsl(var(--muted))_28%,transparent)]",
+        interactive && "hover:bg-muted/28",
         selected &&
-          "bg-[color-mix(in_oklab,hsl(var(--primary-soft))_36%,transparent)] border-[var(--ring-contrast)] shadow-[0_0_0_1px_var(--ring-contrast)_inset,0_8px_22px_var(--glow-active)] text-[var(--text-on-accent)]",
+          "bg-primary-soft/36 border-[var(--ring-contrast)] shadow-[0_0_0_1px_var(--ring-contrast)_inset,0_8px_22px_var(--glow-active)] text-[var(--text-on-accent)]",
         glitch &&
           "shadow-[0_0_0_1px_hsl(var(--card-hairline))_inset,0_0_16px_var(--glow-active)] hover:shadow-[0_0_0_1px_var(--ring-contrast)_inset,0_0_20px_var(--glow-active)]",
         className


### PR DESCRIPTION
## Summary
- replace ad-hoc HSL color classes with Tailwind tokens
- align TimerTab and TitleBar styles with tokenized colors

## Testing
- `npx ts-node --esm run-checks.ts` *(tests, lint, typecheck with progress bar)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c757b60c832c9872f97cf4b4e2fb