### PR TITLE
chore: remove redundant main role

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -171,7 +171,7 @@ export default function GoalsPage() {
         : "Pick a duration and focus.";
 
   return (
-    <main id="goals-main" role="main" className="page-shell py-6 space-y-6">
+    <main id="goals-main" className="page-shell py-6 space-y-6">
       {/* ======= HEADER ======= */}
       <Header
         eyebrow="Goals"


### PR DESCRIPTION
## Summary
- remove unnecessary `role="main"` from GoalsPage main element

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0ce184d70832c9beee8338dd2b772