### PR TITLE
feat: holographic goals overview

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -23,6 +23,7 @@ import { RoleSelector } from "@/components/reviews";
 import ReviewListItem from "@/components/reviews/ReviewListItem";
 import type { Review } from "@/lib/types";
 import { COLOR_PALETTES } from "@/lib/theme";
+import { GoalsProgress } from "@/components/goals";
 
 type View = "components" | "colors";
 type Section =
@@ -166,6 +167,13 @@ const SPEC_DATA: Record<Section, Spec[]> = {
       description: "Neon gradient bar",
       element: <Progress value={50} />,
       tags: ["progress", "feedback"],
+    },
+    {
+      id: "goals-progress",
+      name: "GoalsProgress",
+      description: "Radial neon progress",
+      element: <GoalsProgress total={5} pct={60} />,
+      tags: ["progress", "goals"],
     },
     {
       id: "dashboard-card",

--- a/src/components/goals/GoalList.tsx
+++ b/src/components/goals/GoalList.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import IconButton from "@/components/ui/primitives/IconButton";
 import CheckCircle from "@/components/ui/toggles/CheckCircle";
-import { Trash2 } from "lucide-react";
+import { Trash2, Flag } from "lucide-react";
 import { shortDate } from "@/lib/date";
 import type { Goal } from "@/lib/types";
 
@@ -17,26 +17,27 @@ export default function GoalList({ goals, onToggleDone, onRemove }: GoalListProp
   return (
     <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 [grid-auto-rows:minmax(0,1fr)]">
       {goals.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          No goals here. Add one simple, finishable thing.
-        </p>
+        <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-accent/40 bg-card/20 p-6 text-center text-sm text-muted-foreground backdrop-blur-md shadow-[0_0_16px_hsl(var(--accent)/.2)]">
+          <Flag aria-hidden className="mb-2 h-6 w-6 text-accent drop-shadow-[0_0_8px_var(--neon)] animate-bounce" />
+          <p>No goals here. Add one simple, finishable thing.</p>
+        </div>
       ) : (
         goals.map((g) => (
           <article
             key={g.id}
             className={[
-              "relative rounded-2xl p-6",
-              "card-neo transition",
-              "hover:shadow-neoSoft",
-              "min-h-8 flex flex-col",
+              "relative overflow-hidden rounded-2xl p-6 min-h-8 flex flex-col",
+              "bg-card/30 backdrop-blur-md",
+              "shadow-[inset_0_0_8px_hsl(var(--accent)/.15),0_0_12px_hsl(var(--accent)/.25)]",
+              "transition-all duration-150 hover:-translate-y-1 hover:shadow-[inset_0_0_8px_hsl(var(--accent)/.25),0_0_24px_hsl(var(--accent)/.4)]",
             ].join(" ")}
           >
             <span
               aria-hidden
-              className="absolute inset-y-4 left-0 w-1 rounded-full bg-gradient-to-b from-primary via-accent to-transparent opacity-60"
+              className="pointer-events-none absolute inset-0 rounded-2xl p-px [background:linear-gradient(135deg,hsl(var(--primary)),hsl(var(--accent)),transparent)] [mask:linear-gradient(#000,#000)_content-box,linear-gradient(#000,#000)] [mask-composite:exclude]"
             />
-            <header className="flex items-start justify-between gap-2">
-              <h3 className="font-semibold leading-tight pr-6 line-clamp-2">
+            <header className="relative z-[1] flex items-start justify-between gap-2">
+              <h3 className="pr-6 font-semibold leading-tight line-clamp-2">
                 {g.title}
               </h3>
               <div className="flex items-center gap-2">
@@ -45,18 +46,22 @@ export default function GoalList({ goals, onToggleDone, onRemove }: GoalListProp
                   checked={g.done}
                   onChange={() => onToggleDone(g.id)}
                   size="lg"
+                  className="transition-transform shadow-[0_0_6px_var(--neon-soft)] hover:-translate-y-0.5 hover:shadow-[0_0_10px_var(--neon)]"
                 />
                 <IconButton
                   title="Delete"
                   aria-label="Delete goal"
                   onClick={() => onRemove(g.id)}
                   size="sm"
+                  variant="glow"
+                  tone="accent"
+                  className="transition-transform hover:-translate-y-0.5"
                 >
                   <Trash2 />
                 </IconButton>
               </div>
             </header>
-            <div className="mt-4 text-sm text-muted-foreground space-y-2">
+            <div className="relative z-[1] mt-4 space-y-2 text-sm text-muted-foreground">
               {g.metric ? (
                 <div className="tabular-nums">
                   <span className="opacity-70">Metric:</span>{" "}
@@ -65,18 +70,22 @@ export default function GoalList({ goals, onToggleDone, onRemove }: GoalListProp
               ) : null}
               {g.notes ? <p className="leading-relaxed">{g.notes}</p> : null}
             </div>
-            <footer className="mt-auto pt-3 flex items-center justify-between text-xs text-muted-foreground">
+            <footer className="relative z-[1] mt-auto pt-3 flex items-center justify-between text-xs text-muted-foreground">
               <span className="inline-flex items-center gap-2">
                 <span
                   aria-hidden
-                  className={["h-2 w-2 rounded-full", g.done ? "" : "bg-primary"].join(" ")}
-                  style={g.done ? { background: "var(--accent-overlay)" } : undefined}
+                  className={[
+                    "h-2 w-2 rounded-full transition-all",
+                    g.done
+                      ? "bg-muted-foreground/40"
+                      : "bg-accent shadow-[0_0_6px_hsl(var(--accent))] animate-pulse",
+                  ].join(" ")}
                 />
                 <time className="tabular-nums" dateTime={new Date(g.createdAt).toISOString()}>
                   {shortDate.format(new Date(g.createdAt))}
                 </time>
               </span>
-              <span className={g.done ? "text-accent" : ""}>
+              <span className={g.done ? "text-muted-foreground" : "text-accent"}>
                 {g.done ? "Done" : "Active"}
               </span>
             </footer>
@@ -86,4 +95,3 @@ export default function GoalList({ goals, onToggleDone, onRemove }: GoalListProp
     </div>
   );
 }
-

--- a/src/components/goals/GoalsProgress.tsx
+++ b/src/components/goals/GoalsProgress.tsx
@@ -25,25 +25,38 @@ export default function GoalsProgress({ total, pct, onAddFirst, maxWidth }: Goal
   }
 
   const v = Math.max(0, Math.min(100, Math.round(pct)));
-  const style = maxWidth
-    ? ({
-        "--progress-max":
-          typeof maxWidth === "number" ? `${maxWidth}px` : maxWidth,
-      } as React.CSSProperties)
-    : undefined;
+  const size = maxWidth ? (typeof maxWidth === "number" ? maxWidth : parseInt(maxWidth, 10)) : 64;
+  const radius = size / 2 - 6;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (v / 100) * circumference;
   return (
-    <div className="flex min-w-[120px] items-center gap-2" aria-label="Progress">
-      <div
-        className="h-2 w-full flex-1 max-w-[var(--progress-max,160px)] overflow-hidden rounded-full bg-fg/10"
-        style={style}
-      >
-        <div
-          className="h-2 rounded-full bg-accent transition-[width]"
-          style={{ width: `${v}%` }}
+    <div className="relative inline-flex items-center justify-center" style={{ width: size, height: size }} aria-label="Progress">
+      <svg className="h-full w-full rotate-[-90deg]" viewBox={`0 0 ${size} ${size}`}> 
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          stroke="currentColor"
+          strokeWidth={4}
+          className="text-fg/20"
+          fill="none"
         />
-      </div>
-      <span className="tabular-nums text-xs text-fg/60">{v}%</span>
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          stroke="currentColor"
+          strokeWidth={4}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          className="text-accent drop-shadow-[0_0_6px_var(--neon)] animate-pulse"
+          fill="none"
+        />
+      </svg>
+      <span className="absolute inset-0 flex items-center justify-center text-xs font-medium tabular-nums">
+        {v}%
+      </span>
     </div>
   );
 }
-

--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -58,6 +58,9 @@ export default function Header({
         // Safety: never let children bleed outside
         "overflow-hidden",
 
+        // Neon underline
+        "after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent",
+
         className
       )}
       {...rest}

--- a/src/components/ui/primitives/GlitchSegmented.tsx
+++ b/src/components/ui/primitives/GlitchSegmented.tsx
@@ -111,10 +111,10 @@ export const GlitchSegmentedButton = React.forwardRef<
         "flex-1 h-9 px-3 inline-flex items-center justify-center gap-2 text-sm font-medium select-none",
         "rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--theme-ring]",
         "bg-[var(--btn-bg)] text-[var(--btn-fg)]",
-        "hover:shadow-[0_0_8px_var(--neon),0_0_16px_var(--neon-soft)]",
+        "hover:-translate-y-px hover:shadow-[0_0_8px_var(--neon),0_0_16px_var(--neon-soft)]",
         "focus-visible:shadow-[0_0_8px_var(--neon),0_0_16px_var(--neon-soft)]",
         "active:shadow-[0_0_8px_var(--neon),0_0_16px_var(--neon-soft)] active:scale-95",
-        "data-[selected=true]:shadow-[0_0_8px_var(--neon),0_0_16px_var(--neon-soft)]",
+        "data-[selected=true]:shadow-[0_0_12px_var(--neon),0_0_24px_var(--neon-soft)] data-[selected=true]:ring-1 data-[selected=true]:ring-[--neon-soft]",
         "disabled:opacity-50 disabled:pointer-events-none",
         className,
       )}


### PR DESCRIPTION
## Summary
- add neon gradient underline to Header
- glow-up segmented tabs with outer pill radiance
- replace goal progress bar with pulsing radial meter and glass cards

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0d5e5ce58832cb3c11a7fc5f08bf8