### PR TITLE
fix(searchbar): sync outer and inner corner radii

### DIFF
--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -244,11 +244,8 @@ export function HeroSearchBar({
   return (
     <SearchBar
       {...props}
-      className={cx(
-        "w-full max-w-[640px]",
-        round && "rounded-full [&>input]:rounded-full",
-        className,
-      )}
+      className={cx("w-full max-w-[640px]", round && "rounded-full", className)}
+      fieldClassName={round ? "rounded-full [&>input]:rounded-full" : undefined}
     />
   );
 }

--- a/src/components/ui/primitives/SearchBar.tsx
+++ b/src/components/ui/primitives/SearchBar.tsx
@@ -18,6 +18,8 @@ export type SearchBarProps = Omit<
   debounceMs?: number;
   /** Visual height of the control */
   height?: InputSize | number;
+  /** Additional classes for the outer FieldShell */
+  fieldClassName?: string;
 };
 
 export default function SearchBar({
@@ -35,6 +37,7 @@ export default function SearchBar({
   spellCheck = false,
   autoCapitalize = "none",
   height,
+  fieldClassName,
   ...rest
 }: SearchBarProps) {
   // Hydration-safe: initial render = prop value
@@ -94,7 +97,7 @@ export default function SearchBar({
           placeholder={placeholder}
           indent
           height={height}
-          className={cn("w-full", showClear && "pr-7")}
+          className={cn("w-full", showClear && "pr-7", fieldClassName)}
           aria-label={rest["aria-label"] ?? "Search"}
           type="search"
           autoComplete={autoComplete}


### PR DESCRIPTION
## Summary
- allow SearchBar consumers to style outer FieldShell
- ensure HeroSearchBar's round variant rounds the inner field too

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0db53558c832c8f6ab8ac1cc59829