### PR TITLE
fix: wrap home page in suspense

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,11 @@
 // Root: "/" → Home
+import { Suspense } from "react";
 import { HomePage } from "@/components/home";
 
 export default function Page() {
-  return <HomePage />;
+  return (
+    <Suspense fallback={null}>
+      <HomePage />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## Summary
- wrap home page in `<Suspense>` to handle `useSearchParams`

## Testing
- `npm test -- --run --reporter=basic`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0e0aaa870832c99dbee2714c3e9e7