### PR TITLE
refactor: centralize planner focus management

### DIFF
--- a/src/components/planner/FocusPanel.tsx
+++ b/src/components/planner/FocusPanel.tsx
@@ -20,15 +20,10 @@ import type { ISODate } from "./plannerStore";
 type Props = { iso: ISODate };
 
 export default function FocusPanel({ iso }: Props) {
-  const { focus, setFocus, day, setNotes } = usePlannerStore();
+  const { day, setNotes } = usePlannerStore();
 
   // Initialize from current day.notes; safe because usePersistentState returns initial on first render.
   const [value, setValue] = React.useState<string>(day.notes ?? "");
-
-  // Keep global focus aligned with the visible iso without causing loops.
-  React.useEffect(() => {
-    if (focus !== iso) setFocus(iso);
-  }, [focus, iso, setFocus]);
 
   // When the underlying day notes change (due to iso switch or cross-tab sync), refresh local state.
   React.useEffect(() => {

--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -28,6 +28,9 @@ import { addDays, toISODate } from "@/lib/date";
 
 function Inner() {
   const { iso, today, setIso } = useFocusDate();
+  React.useEffect(() => {
+    setIso(iso);
+  }, [iso, setIso]);
   const { start, days } = useWeek(iso);
 
   // Derive once per week change; keeps list stable during edits elsewhere

--- a/src/components/planner/WeekNotes.tsx
+++ b/src/components/planner/WeekNotes.tsx
@@ -16,7 +16,7 @@ import type { ISODate } from "./plannerStore";
 type Props = { iso: ISODate };
 
 export default function WeekNotes({ iso }: Props) {
-  const { focus, setFocus, day, setNotes } = usePlannerStore();
+  const { day, setNotes } = usePlannerStore();
   const [value, setValue] = React.useState(day.notes ?? "");
   const trimmed = value.trim();
   const original = (day.notes ?? "").trim();
@@ -34,10 +34,6 @@ export default function WeekNotes({ iso }: Props) {
       setSaving(false);
     }
   }, [isDirty, setNotes, trimmed]);
-
-  React.useEffect(() => {
-    if (focus !== iso) setFocus(iso);
-  }, [focus, iso, setFocus]);
 
   React.useEffect(() => {
     setValue(day.notes ?? "");


### PR DESCRIPTION
## Summary
- remove per-component focus sync effects from FocusPanel and WeekNotes
- set planner focus at top level to avoid redundant updates

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c181ecee28832cbb25d50e953f8555