### PR TITLE
fix: track scroll target change

### DIFF
--- a/src/components/planner/ScrollTopFloatingButton.tsx
+++ b/src/components/planner/ScrollTopFloatingButton.tsx
@@ -20,8 +20,11 @@ export default function ScrollTopFloatingButton({
       entries.forEach(e => setVisible(!e.isIntersecting));
     });
     obs.observe(target);
-    return () => obs.disconnect();
-  }, [watchRef]);
+    return () => {
+      obs.unobserve(target);
+      obs.disconnect();
+    };
+  }, [watchRef.current, watchRef]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const scrollTop = () => {
     if (typeof window !== "undefined") {

--- a/tests/planner/ScrollTopFloatingButton.test.tsx
+++ b/tests/planner/ScrollTopFloatingButton.test.tsx
@@ -1,14 +1,23 @@
 import * as React from "react";
-import { render, fireEvent } from "@testing-library/react";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, fireEvent, cleanup, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import ScrollTopFloatingButton from "@/components/planner/ScrollTopFloatingButton";
 
 describe("ScrollTopFloatingButton", () => {
+  let observerCallback: (entries: any[]) => void;
   beforeEach(() => {
     (window as any).IntersectionObserver = class {
+      constructor(cb: any) {
+        observerCallback = cb;
+      }
       observe() {}
+      unobserve() {}
       disconnect() {}
     };
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it("scrolls to top when clicked", () => {
@@ -20,5 +29,29 @@ describe("ScrollTopFloatingButton", () => {
     );
     fireEvent.click(getByRole("button", { name: "Scroll to top" }));
     expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "smooth" });
+  });
+
+  it("updates visibility when watchRef.current changes", () => {
+    const ref = React.createRef<HTMLElement>() as React.MutableRefObject<HTMLElement | null>;
+    const first = document.createElement("div");
+    const second = document.createElement("div");
+    ref.current = first;
+    const { rerender, queryByRole } = render(
+      <ScrollTopFloatingButton watchRef={ref} />,
+    );
+    act(() => {
+      observerCallback([{ target: first, isIntersecting: false }]);
+    });
+    expect(queryByRole("button")).not.toBeNull();
+    ref.current = second;
+    rerender(<ScrollTopFloatingButton watchRef={ref} />);
+    act(() => {
+      observerCallback([{ target: second, isIntersecting: true }]);
+    });
+    expect(queryByRole("button")).toBeNull();
+    act(() => {
+      observerCallback([{ target: second, isIntersecting: false }]);
+    });
+    expect(queryByRole("button")).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- observe/unobserve scroll target when ref changes
- test ScrollTopFloatingButton reactivity to watchRef

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c18518de64832cba3207b506c5a665