### PR TITLE
fix: align goals tab spacing

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -25,7 +25,7 @@ import { RoleSelector } from "@/components/reviews";
 import ReviewListItem from "@/components/reviews/ReviewListItem";
 import type { Review } from "@/lib/types";
 import { COLOR_PALETTES, defaultTheme } from "@/lib/theme";
-import { GoalsProgress, TimerRing } from "@/components/goals";
+import { GoalsProgress, RemindersTab, TimerRing, TimerTab } from "@/components/goals";
 
 type View = "components" | "colors";
 type Section =
@@ -196,6 +196,20 @@ const SPEC_DATA: Record<Section, Spec[]> = {
       description: "Radial neon progress",
       element: <GoalsProgress total={5} pct={60} />,
       tags: ["progress", "goals"],
+    },
+    {
+      id: "reminders-tab",
+      name: "RemindersTab",
+      description: "Reminders tab layout",
+      element: <RemindersTab />,
+      tags: ["reminders", "planner"],
+    },
+    {
+      id: "timer-tab",
+      name: "TimerTab",
+      description: "Timer tab layout",
+      element: <TimerTab />,
+      tags: ["timer", "planner"],
     },
     {
       id: "timer-ring",

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -277,6 +277,7 @@ export default function GoalsPage() {
           id="reminders-panel"
           aria-labelledby="reminders-tab"
           hidden={tab !== "reminders"}
+          className="grid gap-4"
         >
           {tab === "reminders" && <RemindersTab />}
         </div>
@@ -286,6 +287,7 @@ export default function GoalsPage() {
           id="timer-panel"
           aria-labelledby="timer-tab"
           hidden={tab !== "timer"}
+          className="grid gap-4"
         >
           {tab === "timer" && <TimerTab />}
         </div>


### PR DESCRIPTION
## Summary
- ensure reminders and timer panels use grid spacing
- document new goals tabs in prompts playground

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c18d0d318c832c90875a7a52255b77