### PR TITLE
feat(goals): add goal editing

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -179,7 +179,7 @@ const SPEC_DATA: Record<Section, Spec[]> = {
     {
       id: "goal-list",
       name: "GoalList",
-      description: "Demo goal list with tokenized hover shadow",
+      description: "Editable goal list with tokenized hover shadow",
       element: <GoalListDemo />,
       tags: ["planner"],
     },

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -163,6 +163,15 @@ export default function GoalsPage() {
     undoTimer.current = window.setTimeout(() => setLastDeleted(null), 5000);
   }
 
+  function updateGoal(
+    id: string,
+    updates: Pick<Goal, "title" | "metric" | "notes">,
+  ) {
+    setGoals((prev) =>
+      prev.map((g) => (g.id === id ? { ...g, ...updates } : g)),
+    );
+  }
+
   const summary =
     tab === "goals"
       ? `Cap: ${ACTIVE_CAP} active · Remaining: ${remaining} · ${pctDone}% done · ${totalCount} total`
@@ -236,6 +245,7 @@ export default function GoalsPage() {
                       goals={filtered}
                       onToggleDone={toggleDone}
                       onRemove={removeGoal}
+                      onUpdate={updateGoal}
                     />
                   </SectionCard.Body>
                 </SectionCard>

--- a/src/components/prompts/GoalListDemo.tsx
+++ b/src/components/prompts/GoalListDemo.tsx
@@ -15,6 +15,11 @@ export default function GoalListDemo() {
           )
         }
         onRemove={(id) => setItems((prev) => prev.filter((g) => g.id !== id))}
+        onUpdate={(id, updates) =>
+          setItems((prev) =>
+            prev.map((g) => (g.id === id ? { ...g, ...updates } : g)),
+          )
+        }
       />
     </div>
   );

--- a/tests/goals/goals-page.test.tsx
+++ b/tests/goals/goals-page.test.tsx
@@ -28,6 +28,36 @@ describe("GoalsPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("allows editing goal fields", async () => {
+    render(<GoalsPage />);
+
+    const titleInput = screen.getByRole("textbox", { name: "Title" });
+    const metricInput = screen.getByRole("textbox", { name: "Metric (optional)" });
+    const addButton = screen.getByRole("button", { name: /add goal/i });
+
+    fireEvent.change(titleInput, { target: { value: "Initial" } });
+    fireEvent.change(metricInput, { target: { value: "5" } });
+    fireEvent.click(addButton);
+
+    const goalTitle = await screen.findByText("Initial");
+    const article = goalTitle.closest("article") as HTMLElement;
+
+    const editButton = within(article).getByRole("button", { name: "Edit goal" });
+    fireEvent.click(editButton);
+
+    const editTitle = await within(article).findByPlaceholderText("Title");
+    fireEvent.change(editTitle, { target: { value: "Updated" } });
+    const editMetric = await within(article).findByPlaceholderText("Metric");
+    fireEvent.change(editMetric, { target: { value: "10" } });
+
+    const saveButton = within(article).getByRole("button", { name: "Save" });
+    fireEvent.click(saveButton);
+
+    expect(await screen.findByText("Updated")).toBeInTheDocument();
+    const metricLabel = within(article).getByText("Metric:");
+    expect(metricLabel.parentElement?.textContent).toBe("Metric: 10");
+  });
+
   it("renders dynamic subtitle with counts", () => {
     render(<GoalsPage />);
     expect(


### PR DESCRIPTION
## Summary
- add inline editing to GoalList with Input/Textarea fields and save/cancel controls
- persist goal updates in GoalsPage and demo
- document editable GoalList in prompts page

## Testing
- `npx vitest run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c18fe2e124832c8111f212c04daaa8