### PR TITLE
feat: add onboarding onboarding tabs for prompts

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -18,6 +18,7 @@ import {
 import UpdatesList from "@/components/prompts/UpdatesList";
 import GoalListDemo from "@/components/prompts/GoalListDemo";
 import PromptList from "@/components/prompts/PromptList";
+import OnboardingTabs from "@/components/prompts/OnboardingTabs";
 import type { PromptWithTitle } from "@/components/prompts/usePrompts";
 import { Plus } from "lucide-react";
 import { DashboardCard } from "@/components/home";
@@ -27,7 +28,7 @@ import type { Review } from "@/lib/types";
 import { COLOR_PALETTES, defaultTheme } from "@/lib/theme";
 import { GoalsProgress, RemindersTab, TimerRing, TimerTab } from "@/components/goals";
 
-type View = "components" | "colors";
+type View = "components" | "colors" | "onboarding";
 type Section =
   | "buttons"
   | "iconButton"
@@ -48,6 +49,7 @@ type Spec = {
 const VIEW_TABS: TabItem<View>[] = [
   { key: "components", label: "Components" },
   { key: "colors", label: "Colors" },
+  { key: "onboarding", label: "Onboarding" },
 ];
 
 const SECTION_TABS: TabItem<Section>[] = [
@@ -422,8 +424,10 @@ export default function Page() {
       <div className="col-span-12">
         {view === "components" ? (
           <ComponentsView query={query} />
-        ) : (
+        ) : view === "colors" ? (
           <ColorsView />
+        ) : (
+          <OnboardingTabs />
         )}
       </div>
     </main>

--- a/src/components/prompts/OnboardingTabs.tsx
+++ b/src/components/prompts/OnboardingTabs.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import * as React from "react";
+import { TabBar, type TabItem } from "@/components/ui";
+import { usePrompts } from "./usePrompts";
+
+type Role = "designer" | "developer";
+
+const ROLE_TABS: TabItem<Role>[] = [
+  { key: "designer", label: "Senior Lead Designer" },
+  { key: "developer", label: "Senior Lead Developer" },
+];
+
+export default function OnboardingTabs() {
+  const [role, setRole] = React.useState<Role>("designer");
+  const { prompts } = usePrompts();
+  const [updatedAt, setUpdatedAt] = React.useState(Date.now());
+
+  React.useEffect(() => {
+    setUpdatedAt(Date.now());
+  }, [prompts]);
+
+  return (
+    <div className="space-y-4">
+      <TabBar
+        items={ROLE_TABS}
+        value={role}
+        onValueChange={setRole}
+        ariaLabel="Onboarding roles"
+      />
+      <p className="text-sm text-muted-foreground">
+        Last updated {new Date(updatedAt).toLocaleTimeString()}
+      </p>
+      {role === "designer" ? (
+        <ul className="list-disc pl-6 space-y-1">
+          <li>Review design system guidelines</li>
+          <li>Audit existing components for consistency</li>
+          <li>Collaborate with developers on UI implementation</li>
+        </ul>
+      ) : (
+        <ul className="list-disc pl-6 space-y-1">
+          <li>Set up local development environment</li>
+          <li>Follow project coding standards and lint rules</li>
+          <li>Coordinate with designers on features</li>
+        </ul>
+      )}
+    </div>
+  );
+}
+

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -84,7 +84,7 @@ export const VARIANTS: { id: Variant; label: string }[] = [
 export function defaultTheme(): ThemeState {
   const prefersDark =
     typeof window !== "undefined" &&
-    window.matchMedia?.("(prefers-color-scheme: dark)").matches;
+    window.matchMedia?.("(prefers-color-scheme: dark)")?.matches;
   return { variant: "lg", mode: prefersDark ? "dark" : "light", bg: 0 };
 }
 


### PR DESCRIPTION
## Summary
- add Onboarding tab with designer/developer roles and auto-updating timestamp
- fix theme default to handle missing matchMedia

## Testing
- `npm run regen-ui`
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c19542bf70832c97e36081f14399dc