### PR TITLE
feat: centralize interaction state tokens

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -123,6 +123,22 @@ const SPEC_DATA: Record<Section, Spec[]> = {
       props: [{ label: "sizes", value: "sm md lg" }],
     },
     {
+      id: "button-states",
+      name: "Button States",
+      description: "State tokens",
+      element: (
+        <div className="flex flex-wrap gap-4">
+          <Button>Default</Button>
+          <Button className="bg-[--hover]">Hover</Button>
+          <Button className="ring-2 ring-[--focus]">Focus</Button>
+          <Button className="bg-[--active]">Active</Button>
+          <Button disabled>Disabled</Button>
+          <Button data-loading="true">Loading</Button>
+        </div>
+      ),
+      tags: ["button", "states"],
+    },
+    {
       id: "segmented-button",
       name: "SegmentedButton",
       description: "Segmented control button",
@@ -156,6 +172,34 @@ const SPEC_DATA: Record<Section, Spec[]> = {
       tags: ["icon", "button"],
       props: [{ label: "sizes", value: "xs sm md" }],
     },
+    {
+      id: "icon-button-states",
+      name: "IconButton States",
+      description: "State tokens",
+      element: (
+        <div className="flex items-center gap-4">
+          <IconButton aria-label="Default">
+            <Plus />
+          </IconButton>
+          <IconButton aria-label="Hover" className="bg-[--hover]">
+            <Plus />
+          </IconButton>
+          <IconButton aria-label="Focus" className="ring-2 ring-[--focus]">
+            <Plus />
+          </IconButton>
+          <IconButton aria-label="Active" className="bg-[--active]">
+            <Plus />
+          </IconButton>
+          <IconButton aria-label="Disabled" disabled>
+            <Plus />
+          </IconButton>
+          <IconButton aria-label="Loading" data-loading="true">
+            <Plus />
+          </IconButton>
+        </div>
+      ),
+      tags: ["icon", "button", "states"],
+    },
   ],
   inputs: [
     {
@@ -164,6 +208,22 @@ const SPEC_DATA: Record<Section, Spec[]> = {
       description: "Text input field",
       element: <Input placeholder="Type here" />,
       tags: ["input", "text"],
+    },
+    {
+      id: "input-states",
+      name: "Input States",
+      description: "State tokens",
+      element: (
+        <div className="flex flex-col gap-4">
+          <Input placeholder="Default" />
+          <Input placeholder="Hover" className="bg-[--hover]" />
+          <Input placeholder="Focus" className="ring-2 ring-[--focus]" />
+          <Input placeholder="Active" className="bg-[--active]" />
+          <Input placeholder="Disabled" disabled />
+          <Input placeholder="Loading" data-loading="true" />
+        </div>
+      ),
+      tags: ["input", "states"],
     },
   ],
   prompts: [

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -51,6 +51,13 @@
   --btn-bg: transparent;
   --btn-fg: hsl(var(--foreground));
 
+  /* Interaction states */
+  --hover: hsl(var(--foreground) / 0.08);
+  --focus: hsl(var(--ring));
+  --active: hsl(var(--foreground) / 0.12);
+  --disabled: 0.5;
+  --loading: 0.6;
+
   /* Hairlines, radii, motion, control geometry, gradients */
   /* Fallback (works everywhere) */
   --card-hairline: hsl(var(--border));

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -56,7 +56,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ) => {
     const s = buttonSizes[size];
     const base = cn(
-      "relative inline-flex items-center justify-center rounded-2xl border border-[--theme-ring] font-medium transition-all duration-200 focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--theme-ring] disabled:opacity-50 disabled:pointer-events-none",
+      "relative inline-flex items-center justify-center rounded-2xl border border-[--focus] font-medium transition-all duration-200 hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)]",
       s.height,
       s.padding,
       s.text,
@@ -85,21 +85,21 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       secondary: {
         primary: "text-foreground",
         accent:
-          "text-accent bg-accent/15 hover:bg-accent/25",
+          "text-accent bg-accent/15 [--hover:hsl(var(--accent)/0.25)] [--active:hsl(var(--accent)/0.35)]",
         info:
-          "text-accent-2 bg-accent-2/15 hover:bg-accent-2/25",
+          "text-accent-2 bg-accent-2/15 [--hover:hsl(var(--accent-2)/0.25)] [--active:hsl(var(--accent-2)/0.35)]",
         danger:
-          "text-danger bg-danger/15 hover:bg-danger/25",
+          "text-danger bg-danger/15 [--hover:hsl(var(--danger)/0.25)] [--active:hsl(var(--danger)/0.35)]",
       },
       ghost: {
         primary:
-          "text-foreground hover:bg-foreground/10",
+          "text-foreground [--hover:hsl(var(--foreground)/0.1)] [--active:hsl(var(--foreground)/0.2)]",
         accent:
-          "text-accent hover:bg-accent/10",
+          "text-accent [--hover:hsl(var(--accent)/0.1)] [--active:hsl(var(--accent)/0.2)]",
         info:
-          "text-accent-2 hover:bg-accent-2/10",
+          "text-accent-2 [--hover:hsl(var(--accent-2)/0.1)] [--active:hsl(var(--accent-2)/0.2)]",
         danger:
-          "text-danger hover:bg-danger/10",
+          "text-danger [--hover:hsl(var(--danger)/0.1)] [--active:hsl(var(--danger)/0.2)]",
       },
     };
 

--- a/src/components/ui/primitives/FieldShell.tsx
+++ b/src/components/ui/primitives/FieldShell.tsx
@@ -9,7 +9,7 @@ export interface FieldShellProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const FIELD_SHELL_BASE =
-  "relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]";
+  "relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]";
 
 const FieldShell = React.forwardRef<HTMLDivElement, FieldShellProps>(
   ({ error, disabled, className, style, ...props }, ref) => (
@@ -19,10 +19,10 @@ const FieldShell = React.forwardRef<HTMLDivElement, FieldShellProps>(
         FIELD_SHELL_BASE,
         error &&
           "border-danger/60 focus-within:ring-danger/35",
-        disabled && "opacity-60 pointer-events-none",
+        disabled && "opacity-[var(--disabled)] pointer-events-none",
         className,
       )}
-      style={{ "--theme-ring": "hsl(var(--ring))", ...style } as React.CSSProperties}
+      style={{ "--focus": "hsl(var(--ring))", ...style } as React.CSSProperties}
       {...props}
     />
   ),

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -36,9 +36,9 @@ const getSizeClass = (s: IconButtonSize) => {
 };
 
 const variantBase: Record<Variant, string> = {
-  ring: "border bg-card/35 hover:bg-panel/45",
+  ring: "border bg-card/35 hover:bg-[--hover] [--hover:hsl(var(--panel)/0.45)]",
   solid: "border",
-  glow: "border bg-card/35 hover:bg-panel/45 shadow-[0_0_8px_currentColor]",
+  glow: "border bg-card/35 hover:bg-[--hover] [--hover:hsl(var(--panel)/0.45)] shadow-[0_0_8px_currentColor]",
 };
 
 const toneClasses: Record<Variant, Record<Tone, string>> = {
@@ -54,13 +54,13 @@ const toneClasses: Record<Variant, Record<Tone, string>> = {
   },
   solid: {
     primary:
-      "border-transparent bg-foreground/15 hover:bg-foreground/25 text-foreground",
+      "border-transparent bg-foreground/15 text-foreground [--hover:hsl(var(--foreground)/0.25)] [--active:hsl(var(--foreground)/0.35)]",
     accent:
-      "border-transparent bg-accent/15 hover:bg-accent/25 text-accent",
+      "border-transparent bg-accent/15 text-accent [--hover:hsl(var(--accent)/0.25)] [--active:hsl(var(--accent)/0.35)]",
     info:
-      "border-transparent bg-accent-2/15 hover:bg-accent-2/25 text-accent-2",
+      "border-transparent bg-accent-2/15 text-accent-2 [--hover:hsl(var(--accent-2)/0.25)] [--active:hsl(var(--accent-2)/0.35)]",
     danger:
-      "border-transparent bg-danger/15 hover:bg-danger/25 text-danger",
+      "border-transparent bg-danger/15 text-danger [--hover:hsl(var(--danger)/0.25)] [--active:hsl(var(--danger)/0.35)]",
   },
   glow: {
     primary:
@@ -85,7 +85,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
         ref={ref}
         type="button"
         className={cn(
-          "inline-flex items-center justify-center select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--theme-ring] active:scale-95 disabled:opacity-50 disabled:pointer-events-none",
+          "inline-flex items-center justify-center select-none rounded-full transition hover:bg-[--hover] active:bg-[--active] active:scale-95 focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)]",
           variantBase[variant],
           toneClasses[variant][tone],
           sizeClass,

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -80,7 +80,7 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
         id={finalId}
         name={finalName}
         className={cn(
-          "w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]",
+          "w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed data-[loading=true]:opacity-[var(--loading)]",
           indent && "pl-7",
           showEndSlot && "pr-7",
           inputClassName

--- a/src/components/ui/primitives/SearchBar.tsx
+++ b/src/components/ui/primitives/SearchBar.tsx
@@ -112,7 +112,7 @@ export default function SearchBar({
             type="button"
             aria-label="Clear"
             title="Clear"
-            className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-foreground"
+            className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full p-1 text-muted-foreground transition hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)]"
             onClick={() => {
               setQuery("");
               onValueChange?.("");

--- a/tests/primitives/button.test.tsx
+++ b/tests/primitives/button.test.tsx
@@ -36,7 +36,7 @@ describe("Button", () => {
     );
     const btn = getByRole("button");
     expect(btn).toHaveClass(
-      "disabled:opacity-50",
+      "disabled:opacity-[var(--disabled)]",
       "disabled:pointer-events-none",
     );
     fireEvent.click(btn);

--- a/tests/primitives/icon-button.test.tsx
+++ b/tests/primitives/icon-button.test.tsx
@@ -67,7 +67,8 @@ describe("IconButton", () => {
       <IconButton variant="ring" tone="primary" aria-label="rp" />,
     );
     const classes = getByRole("button").className;
-    expect(classes).toContain("border bg-card/35 hover:bg-panel/45");
+    expect(classes).toContain("border bg-card/35 hover:bg-[--hover]");
+    expect(classes).toContain("[--hover:hsl(var(--panel)/0.45)]");
     expect(classes).toContain("border-line/35 text-foreground");
   });
 
@@ -78,8 +79,9 @@ describe("IconButton", () => {
     const classes = getByRole("button").className;
     expect(classes).toContain("border");
     expect(classes).toContain(
-      "border-transparent bg-accent/15 hover:bg-accent/25 text-accent",
+      "border-transparent bg-accent/15 text-accent",
     );
+    expect(classes).toContain("[--hover:hsl(var(--accent)/0.25)]");
   });
 
   it("applies glow variant with info tone", () => {
@@ -87,9 +89,10 @@ describe("IconButton", () => {
       <IconButton variant="glow" tone="info" aria-label="gi" />,
     );
     const classes = getByRole("button").className;
-    expect(classes).toContain(
-      "border bg-card/35 hover:bg-panel/45 shadow-[0_0_8px_currentColor]",
-    );
+    expect(classes).toContain("border bg-card/35");
+    expect(classes).toContain("hover:bg-[--hover]");
+    expect(classes).toContain("shadow-[0_0_8px_currentColor]");
+    expect(classes).toContain("[--hover:hsl(var(--panel)/0.45)]");
     expect(classes).toContain("border-accent-2/35 text-accent-2");
   });
 
@@ -98,7 +101,8 @@ describe("IconButton", () => {
       <IconButton variant="ring" tone="danger" aria-label="rd" />,
     );
     const classes = getByRole("button").className;
-    expect(classes).toContain("border bg-card/35 hover:bg-panel/45");
+    expect(classes).toContain("border bg-card/35 hover:bg-[--hover]");
+    expect(classes).toContain("[--hover:hsl(var(--panel)/0.45)]");
     expect(classes).toContain("border-danger/35 text-danger");
     expect(classes).not.toContain("shadow-[0_0_8px_currentColor]");
   });

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -365,14 +365,14 @@ exports[`ReviewsPage > renders default state 1`] = `
                     />
                   </svg>
                   <div
-                    class="relative inline-flex items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] w-full"
-                    style="--theme-ring: hsl(var(--ring)); --control-h: 2.5rem;"
+                    class="relative inline-flex items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] w-full"
+                    style="--focus: hsl(var(--ring)); --control-h: 2.5rem;"
                   >
                     <input
                       autocapitalize="none"
                       autocomplete="off"
                       autocorrect="off"
-                      class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] pl-7"
+                      class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed data-[loading=true]:opacity-[var(--loading)] pl-7"
                       id=":r0:"
                       name=":r0:"
                       placeholder="Search title, tags, opponent, patch…"
@@ -673,7 +673,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                   </div>
                 </div>
                 <button
-                  class="relative inline-flex items-center justify-center rounded-2xl border border-[--theme-ring] font-medium transition-all duration-200 focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--theme-ring] disabled:opacity-50 disabled:pointer-events-none h-10 text-base gap-2 [&>svg]:size-5 px-4 whitespace-nowrap bg-panel/85 overflow-hidden shadow-neo text-foreground"
+                  class="relative inline-flex items-center justify-center rounded-2xl border border-[--focus] font-medium transition-all duration-200 hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 text-base gap-2 [&>svg]:size-5 px-4 whitespace-nowrap bg-panel/85 overflow-hidden shadow-neo text-foreground"
                   tabindex="0"
                   type="button"
                 >

--- a/tests/ui/__snapshots__/input.test.tsx.snap
+++ b/tests/ui/__snapshots__/input.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`Input > renders default state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
-  style="--theme-ring: hsl(var(--ring)); --control-h: 2.5rem;"
+  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
+  style="--focus: hsl(var(--ring)); --control-h: 2.5rem;"
 >
   <input
-    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
+    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed data-[loading=true]:opacity-[var(--loading)]"
     id=":r0:"
     name=":r0:"
   />
@@ -15,11 +15,11 @@ exports[`Input > renders default state 1`] = `
 
 exports[`Input > renders disabled state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-60 pointer-events-none"
-  style="--theme-ring: hsl(var(--ring)); --control-h: 2.5rem;"
+  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-[var(--disabled)] pointer-events-none"
+  style="--focus: hsl(var(--ring)); --control-h: 2.5rem;"
 >
   <input
-    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
+    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed data-[loading=true]:opacity-[var(--loading)]"
     disabled=""
     id=":r4:"
     name=":r4:"
@@ -29,12 +29,12 @@ exports[`Input > renders disabled state 1`] = `
 
 exports[`Input > renders error state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-danger/60 focus-within:ring-danger/35"
-  style="--theme-ring: hsl(var(--ring)); --control-h: 2.5rem;"
+  class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-danger/60 focus-within:ring-danger/35"
+  style="--focus: hsl(var(--ring)); --control-h: 2.5rem;"
 >
   <input
     aria-invalid="true"
-    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
+    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed data-[loading=true]:opacity-[var(--loading)]"
     id=":r2:"
     name=":r2:"
   />
@@ -43,11 +43,11 @@ exports[`Input > renders error state 1`] = `
 
 exports[`Input > renders focus state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
-  style="--theme-ring: hsl(var(--ring)); --control-h: 2.5rem;"
+  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
+  style="--focus: hsl(var(--ring)); --control-h: 2.5rem;"
 >
   <input
-    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)]"
+    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed data-[loading=true]:opacity-[var(--loading)]"
     id=":r1:"
     name=":r1:"
   />

--- a/tests/ui/__snapshots__/select.test.tsx.snap
+++ b/tests/ui/__snapshots__/select.test.tsx.snap
@@ -5,8 +5,8 @@ exports[`Select > renders default state 1`] = `
   class="space-y-1"
 >
   <div
-    class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
-    style="--theme-ring: hsl(var(--ring));"
+    class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
+    style="--focus: hsl(var(--ring));"
   >
     <select
       aria-label="test"
@@ -50,8 +50,8 @@ exports[`Select > renders disabled state 1`] = `
   class="space-y-1"
 >
   <div
-    class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-[--theme-ring] focus-within:ring-offset-0 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-60 pointer-events-none group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)] cursor-not-allowed focus-within:ring-0 focus-within:shadow-none"
-    style="--theme-ring: hsl(var(--ring));"
+    class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-[--focus] focus-within:ring-offset-0 data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-[var(--disabled)] pointer-events-none group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)] cursor-not-allowed focus-within:ring-0 focus-within:shadow-none"
+    style="--focus: hsl(var(--ring));"
   >
     <select
       aria-label="test"
@@ -91,8 +91,8 @@ exports[`Select > renders error state 1`] = `
   class="space-y-1"
 >
   <div
-    class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-danger/60 focus-within:ring-danger/35 group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
-    style="--theme-ring: hsl(var(--ring));"
+    class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-danger/60 focus-within:ring-danger/35 group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
+    style="--focus: hsl(var(--ring));"
   >
     <select
       aria-describedby=":r2:-error"
@@ -139,8 +139,8 @@ exports[`Select > renders focus state 1`] = `
   class="space-y-1"
 >
   <div
-    class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
-    style="--theme-ring: hsl(var(--ring));"
+    class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
+    style="--focus: hsl(var(--ring));"
   >
     <select
       aria-label="test"
@@ -184,8 +184,8 @@ exports[`Select > renders success state 1`] = `
   class="space-y-1"
 >
   <div
-    class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)] border-[--theme-ring] focus-within:ring-[--theme-ring]"
-    style="--theme-ring: hsl(var(--ring));"
+    class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)] border-[--theme-ring] focus-within:ring-[--theme-ring]"
+    style="--focus: hsl(var(--ring));"
   >
     <select
       aria-describedby=":r3:-success"

--- a/tests/ui/__snapshots__/textarea.test.tsx.snap
+++ b/tests/ui/__snapshots__/textarea.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`Textarea > renders default state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
-  style="--theme-ring: hsl(var(--ring));"
+  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
+  style="--focus: hsl(var(--ring));"
 >
   <textarea
     class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
@@ -15,8 +15,8 @@ exports[`Textarea > renders default state 1`] = `
 
 exports[`Textarea > renders disabled state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-60 pointer-events-none"
-  style="--theme-ring: hsl(var(--ring));"
+  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-[var(--disabled)] pointer-events-none"
+  style="--focus: hsl(var(--ring));"
 >
   <textarea
     class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
@@ -29,8 +29,8 @@ exports[`Textarea > renders disabled state 1`] = `
 
 exports[`Textarea > renders error state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-danger/60 focus-within:ring-danger/35"
-  style="--theme-ring: hsl(var(--ring));"
+  class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-danger/60 focus-within:ring-danger/35"
+  style="--focus: hsl(var(--ring));"
 >
   <textarea
     aria-invalid="true"
@@ -43,8 +43,8 @@ exports[`Textarea > renders error state 1`] = `
 
 exports[`Textarea > renders focus state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-border/38 hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
-  style="--theme-ring: hsl(var(--ring));"
+  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
+  style="--focus: hsl(var(--ring));"
 >
   <textarea
     class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"


### PR DESCRIPTION
## Summary
- define global CSS vars for hover, focus, active, disabled, and loading
- refactor Button, IconButton, Input, FieldShell, and SearchBar to use the new state tokens
- demo state styles on the prompts page

## Testing
- `npm run regen-ui`
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c1994c6b90832ca2d6c664f9146aa2