### PR TITLE
fix: guard overlay portals for SSR

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -11,7 +11,10 @@ export interface ModalProps extends React.ComponentProps<typeof PrimitiveCard> {
 }
 
 export default function Modal({ open, onClose, className, children, ...props }: ModalProps) {
-  if (!open) return null;
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => setMounted(true), []);
+
+  if (!open || !mounted || typeof document === "undefined") return null;
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="absolute inset-0 bg-background/80" onClick={onClose} />

--- a/src/components/ui/Sheet.tsx
+++ b/src/components/ui/Sheet.tsx
@@ -19,13 +19,16 @@ export default function Sheet({
   children,
   ...props
 }: SheetProps) {
-  if (!open) return null;
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => setMounted(true), []);
+
+  if (!open || !mounted || typeof document === "undefined") return null;
   return createPortal(
     <div className="fixed inset-0 z-50">
       <div className="absolute inset-0 bg-background/80" onClick={onClose} />
       <PrimitiveCard
         className={cn(
-          "fixed top-0 h-full w-80 overflow-y-auto", 
+          "fixed top-0 h-full w-80 overflow-y-auto",
           side === "right" ? "right-0" : "left-0",
           className,
         )}

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -25,7 +25,10 @@ export default function Toast({
     return () => clearTimeout(timer);
   }, [open, duration, onOpenChange]);
 
-  if (!open) return null;
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => setMounted(true), []);
+
+  if (!open || !mounted || typeof document === "undefined") return null;
   return createPortal(
     <div className="fixed bottom-4 right-4 z-50">
       <PrimitiveCard className={cn(className)} {...props}>


### PR DESCRIPTION
## Summary
- guard Modal, Sheet, and Toast portals against server-side `document` access

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c1a1e52e94832ca21f1284861e07ec