### PR TITLE
fix: guard overlay portals against SSR document access

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -11,7 +11,13 @@ export interface ModalProps extends React.ComponentProps<typeof PrimitiveCard> {
 }
 
 export default function Modal({ open, onClose, className, children, ...props }: ModalProps) {
-  if (!open) return null;
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!open || !mounted) return null;
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="absolute inset-0 bg-background/80" onClick={onClose} />

--- a/src/components/ui/Sheet.tsx
+++ b/src/components/ui/Sheet.tsx
@@ -19,7 +19,13 @@ export default function Sheet({
   children,
   ...props
 }: SheetProps) {
-  if (!open) return null;
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!open || !mounted) return null;
   return createPortal(
     <div className="fixed inset-0 z-50">
       <div className="absolute inset-0 bg-background/80" onClick={onClose} />

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -19,13 +19,19 @@ export default function Toast({
   children,
   ...props
 }: ToastProps) {
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
   React.useEffect(() => {
     if (!open) return;
     const timer = setTimeout(() => onOpenChange(false), duration);
     return () => clearTimeout(timer);
   }, [open, duration, onOpenChange]);
 
-  if (!open) return null;
+  if (!open || !mounted) return null;
   return createPortal(
     <div className="fixed bottom-4 right-4 z-50">
       <PrimitiveCard className={cn(className)} {...props}>


### PR DESCRIPTION
## Summary
- guard Toast portal against SSR
- guard Sheet and Modal portals before accessing `document`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c1a1e697e4832cad5eb508020f68a5