### PR TITLE
fix: restore theme ring customization

### DIFF
--- a/scripts/generate-tokens.ts
+++ b/scripts/generate-tokens.ts
@@ -10,9 +10,9 @@ const __dirname = path.dirname(__filename);
 
 StyleDictionary.registerFormat({
   name: "tokens/markdown",
-  format: ({ dictionary }) => {
+  format: ({ dictionary }: { dictionary: any }) => {
     const lines = dictionary.allTokens.map(
-      (t) => `| ${t.name} | ${t.value} |`,
+      (t: any) => `| ${t.name} | ${t.value} |`,
     );
     return ["| Token | Value |", "| --- | --- |", ...lines].join("\n");
   },

--- a/src/components/ui/primitives/FieldShell.tsx
+++ b/src/components/ui/primitives/FieldShell.tsx
@@ -22,7 +22,7 @@ const FieldShell = React.forwardRef<HTMLDivElement, FieldShellProps>(
         disabled && "opacity-[var(--disabled)] pointer-events-none",
         className,
       )}
-      style={{ "--focus": "hsl(var(--ring))", ...style } as React.CSSProperties}
+      style={{ "--focus": "var(--theme-ring)", ...style } as React.CSSProperties}
       {...props}
     />
   ),

--- a/style-dictionary.d.ts
+++ b/style-dictionary.d.ts
@@ -1,0 +1,1 @@
+declare module "style-dictionary";

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -366,7 +366,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                   </svg>
                   <div
                     class="relative inline-flex items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] w-full"
-                    style="--focus: hsl(var(--ring)); --control-h: 2.5rem;"
+                    style="--focus: var(--theme-ring); --control-h: 2.5rem;"
                   >
                     <input
                       autocapitalize="none"

--- a/tests/ui/__snapshots__/input.test.tsx.snap
+++ b/tests/ui/__snapshots__/input.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Input > renders default state 1`] = `
 <div
   class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
-  style="--focus: hsl(var(--ring)); --control-h: 2.5rem;"
+  style="--focus: var(--theme-ring); --control-h: 2.5rem;"
 >
   <input
     class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed data-[loading=true]:opacity-[var(--loading)]"
@@ -16,7 +16,7 @@ exports[`Input > renders default state 1`] = `
 exports[`Input > renders disabled state 1`] = `
 <div
   class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-[var(--disabled)] pointer-events-none"
-  style="--focus: hsl(var(--ring)); --control-h: 2.5rem;"
+  style="--focus: var(--theme-ring); --control-h: 2.5rem;"
 >
   <input
     class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed data-[loading=true]:opacity-[var(--loading)]"
@@ -30,7 +30,7 @@ exports[`Input > renders disabled state 1`] = `
 exports[`Input > renders error state 1`] = `
 <div
   class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-danger/60 focus-within:ring-danger/35"
-  style="--focus: hsl(var(--ring)); --control-h: 2.5rem;"
+  style="--focus: var(--theme-ring); --control-h: 2.5rem;"
 >
   <input
     aria-invalid="true"
@@ -44,7 +44,7 @@ exports[`Input > renders error state 1`] = `
 exports[`Input > renders focus state 1`] = `
 <div
   class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
-  style="--focus: hsl(var(--ring)); --control-h: 2.5rem;"
+  style="--focus: var(--theme-ring); --control-h: 2.5rem;"
 >
   <input
     class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed data-[loading=true]:opacity-[var(--loading)]"

--- a/tests/ui/__snapshots__/select.test.tsx.snap
+++ b/tests/ui/__snapshots__/select.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Select > renders default state 1`] = `
 >
   <div
     class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
-    style="--focus: hsl(var(--ring));"
+    style="--focus: var(--theme-ring);"
   >
     <select
       aria-label="test"
@@ -51,7 +51,7 @@ exports[`Select > renders disabled state 1`] = `
 >
   <div
     class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-[--focus] focus-within:ring-offset-0 data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-[var(--disabled)] pointer-events-none group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)] cursor-not-allowed focus-within:ring-0 focus-within:shadow-none"
-    style="--focus: hsl(var(--ring));"
+    style="--focus: var(--theme-ring);"
   >
     <select
       aria-label="test"
@@ -92,7 +92,7 @@ exports[`Select > renders error state 1`] = `
 >
   <div
     class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-danger/60 focus-within:ring-danger/35 group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
-    style="--focus: hsl(var(--ring));"
+    style="--focus: var(--theme-ring);"
   >
     <select
       aria-describedby=":r2:-error"
@@ -140,7 +140,7 @@ exports[`Select > renders focus state 1`] = `
 >
   <div
     class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
-    style="--focus: hsl(var(--ring));"
+    style="--focus: var(--theme-ring);"
   >
     <select
       aria-label="test"
@@ -185,7 +185,7 @@ exports[`Select > renders success state 1`] = `
 >
   <div
     class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)] border-[--theme-ring] focus-within:ring-[--theme-ring]"
-    style="--focus: hsl(var(--ring));"
+    style="--focus: var(--theme-ring);"
   >
     <select
       aria-describedby=":r3:-success"

--- a/tests/ui/__snapshots__/textarea.test.tsx.snap
+++ b/tests/ui/__snapshots__/textarea.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Textarea > renders default state 1`] = `
 <div
   class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
-  style="--focus: hsl(var(--ring));"
+  style="--focus: var(--theme-ring);"
 >
   <textarea
     class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
@@ -16,7 +16,7 @@ exports[`Textarea > renders default state 1`] = `
 exports[`Textarea > renders disabled state 1`] = `
 <div
   class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-[var(--disabled)] pointer-events-none"
-  style="--focus: hsl(var(--ring));"
+  style="--focus: var(--theme-ring);"
 >
   <textarea
     class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
@@ -30,7 +30,7 @@ exports[`Textarea > renders disabled state 1`] = `
 exports[`Textarea > renders error state 1`] = `
 <div
   class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-danger/60 focus-within:ring-danger/35"
-  style="--focus: hsl(var(--ring));"
+  style="--focus: var(--theme-ring);"
 >
   <textarea
     aria-invalid="true"
@@ -44,7 +44,7 @@ exports[`Textarea > renders error state 1`] = `
 exports[`Textarea > renders focus state 1`] = `
 <div
   class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
-  style="--focus: hsl(var(--ring));"
+  style="--focus: var(--theme-ring);"
 >
   <textarea
     class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"


### PR DESCRIPTION
## Summary
- alias FieldShell focus ring to `--theme-ring` for backwards compatibility
- add `style-dictionary` module stub and typings to token generator
- update snapshots for new focus ring token

## Testing
- `npm run regen-ui`
- `npm test -- -u`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c1a64f54f4832c80385e606278cdb4