### PR TITLE
feat: link TabBar tabs to persistent panels

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -56,9 +56,19 @@ type Spec = {
 };
 
 const VIEW_TABS: TabItem<View>[] = [
-  { key: "components", label: "Components" },
-  { key: "colors", label: "Colors" },
-  { key: "onboarding", label: "Onboarding" },
+  {
+    key: "components",
+    label: "Components",
+    id: "components-tab",
+    controls: "components-panel",
+  },
+  { key: "colors", label: "Colors", id: "colors-tab", controls: "colors-panel" },
+  {
+    key: "onboarding",
+    label: "Onboarding",
+    id: "onboarding-tab",
+    controls: "onboarding-panel",
+  },
 ];
 
 const SECTION_TABS: TabItem<Section>[] = [
@@ -597,13 +607,30 @@ export default function Page() {
         />
       </div>
       <div className="col-span-12">
-        {view === "components" ? (
+        <div
+          role="tabpanel"
+          id="components-panel"
+          aria-labelledby="components-tab"
+          hidden={view !== "components"}
+        >
           <ComponentsView query={query} />
-        ) : view === "colors" ? (
+        </div>
+        <div
+          role="tabpanel"
+          id="colors-panel"
+          aria-labelledby="colors-tab"
+          hidden={view !== "colors"}
+        >
           <ColorsView />
-        ) : (
+        </div>
+        <div
+          role="tabpanel"
+          id="onboarding-panel"
+          aria-labelledby="onboarding-tab"
+          hidden={view !== "onboarding"}
+        >
           <OnboardingTabs />
-        )}
+        </div>
       </div>
     </main>
   );

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -17,6 +17,8 @@ export type TabItem<K extends string = string> = {
   disabled?: boolean;
   badge?: React.ReactNode;
   className?: string;
+  id?: string;
+  controls?: string;
 };
 
 type Align = "start" | "center" | "end" | "between";
@@ -117,10 +119,12 @@ export default function TabBar<K extends string = string>({
             return (
               <button
                 key={item.key}
+                id={item.id}
                 role="tab"
                 type="button"
                 aria-selected={active}
                 aria-disabled={item.disabled || undefined}
+                aria-controls={item.controls}
                 tabIndex={item.disabled ? -1 : active ? 0 : -1}
                 onClick={() => !item.disabled && commitValue(item.key)}
                 className={cn(

--- a/tests/ui/tab-bar.test.tsx
+++ b/tests/ui/tab-bar.test.tsx
@@ -20,4 +20,22 @@ describe("TabBar", () => {
       screen.getByRole("tablist", { name: "Prompts gallery view" }),
     ).toBeInTheDocument();
   });
+
+  it("links tabs to panels via aria-controls", () => {
+    render(
+      <TabBar
+        items={[
+          {
+            key: "components",
+            label: "Components",
+            id: "components-tab",
+            controls: "components-panel",
+          },
+        ]}
+      />
+    );
+    const tab = screen.getByRole("tab", { name: "Components" });
+    expect(tab).toHaveAttribute("id", "components-tab");
+    expect(tab).toHaveAttribute("aria-controls", "components-panel");
+  });
 });


### PR DESCRIPTION
## Summary
- add `aria-controls` support to `TabBar` and expose tab `id`
- keep prompts page tabs mounted and hide via `hidden`
- test that TabBar associates tabs with panels

## Testing
- `npm run check`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c1acfa1db8832cb9591af38856d7e7