### PR TITLE
Wrap home page content in Suspense

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { Suspense } from "react";
 import {
   QuickActions,
   TodayCard,
@@ -22,7 +23,7 @@ import {
   type Background,
 } from "@/lib/theme";
 
-export default function Page() {
+function HomePageContent() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -89,5 +90,13 @@ export default function Page() {
       </section>
       <BottomNav />
     </main>
+  );
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={null}>
+      <HomePageContent />
+    </Suspense>
   );
 }

--- a/tests/home/HomePage.test.tsx
+++ b/tests/home/HomePage.test.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Suspense } from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import Page from "@/app/page";
@@ -10,7 +11,11 @@ vi.mock("next/navigation", () => ({
 
 describe("Home page", () => {
   it("renders navigation links", () => {
-    render(<Page />);
+    render(
+      <Suspense fallback="loading">
+        <Page />
+      </Suspense>,
+    );
     const goals = screen.getByRole("link", { name: "Goals" });
     const reviews = screen.getByRole("link", { name: "Reviews" });
     const team = screen.getByRole("link", { name: "Team" });


### PR DESCRIPTION
## Summary
- Refactor home page to isolate search-param logic in a `HomePageContent` client component wrapped by `Suspense`.
- Adjust HomePage test to render within a `Suspense` boundary.

## Testing
- `npm run check`
- `npx --no-install next build`


------
https://chatgpt.com/codex/tasks/task_e_68c1b0afa2e4832c9fb31149ab5e7177