### PR TITLE
Use control radius token in outline demo

### DIFF
--- a/src/components/prompts/OutlineGlowDemo.tsx
+++ b/src/components/prompts/OutlineGlowDemo.tsx
@@ -3,7 +3,11 @@ import * as React from "react";
 export default function OutlineGlowDemo() {
   return (
     <div className="mb-4">
-      <button type="button" className="p-2 rounded-md border">
+      <button
+        type="button"
+        className="p-2 border rounded-[var(--control-radius)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--focus]"
+        style={{ "--focus": "var(--theme-ring)" } as React.CSSProperties}
+      >
         Focus me to see the glow
       </button>
     </div>


### PR DESCRIPTION
## Summary
- align OutlineGlowDemo button with control-radius token and theme ring for consistent focus styling

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c1bf4988fc832c9cffe63f461a4f67