### PR TITLE
refactor: tokenized field shells and inputs

### DIFF
--- a/src/components/ui/primitives/FieldShell.tsx
+++ b/src/components/ui/primitives/FieldShell.tsx
@@ -6,13 +6,14 @@ import { cn } from "@/lib/utils";
 export interface FieldShellProps extends React.HTMLAttributes<HTMLDivElement> {
   error?: boolean;
   disabled?: boolean;
+  readOnly?: boolean;
 }
 
 const FIELD_SHELL_BASE =
-  "relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]";
+  "relative inline-flex w-full items-center rounded-[var(--control-radius)] border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--edge-iris] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]";
 
 const FieldShell = React.forwardRef<HTMLDivElement, FieldShellProps>(
-  ({ error, disabled, className, style, ...props }, ref) => (
+  ({ error, disabled, readOnly, className, style, ...props }, ref) => (
     <div
       ref={ref}
       className={cn(
@@ -20,9 +21,10 @@ const FieldShell = React.forwardRef<HTMLDivElement, FieldShellProps>(
         error &&
           "border-danger/60 focus-within:ring-danger/35",
         disabled && "opacity-[var(--disabled)] pointer-events-none",
+        readOnly && "focus-within:ring-[--ring-muted]",
         className,
       )}
-      style={{ "--focus": "var(--theme-ring)", ...style } as React.CSSProperties}
+      style={style as React.CSSProperties}
       {...props}
     />
   ),

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -58,6 +58,7 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
   const error =
     props["aria-invalid"] === true || props["aria-invalid"] === "true";
   const disabled = props.disabled;
+  const readOnly = props.readOnly;
 
   const showEndSlot = hasEndSlot || React.Children.count(children) > 0;
 
@@ -72,6 +73,7 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
     <FieldShell
       error={error}
       disabled={disabled}
+      readOnly={readOnly}
       className={className}
       style={{ "--control-h": controlHeight, ...style } as React.CSSProperties}
     >
@@ -80,7 +82,7 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
         id={finalId}
         name={finalName}
         className={cn(
-          "w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed data-[loading=true]:opacity-[var(--loading)]",
+          "w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]",
           indent && "pl-7",
           showEndSlot && "pr-7",
           inputClassName

--- a/src/components/ui/primitives/Textarea.tsx
+++ b/src/components/ui/primitives/Textarea.tsx
@@ -21,7 +21,7 @@ export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & 
 const INNER =
   "block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent " +
   "text-foreground placeholder:text-muted-foreground " +
-  "focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed";
+  "focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default";
 
 export default React.forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
   {
@@ -49,6 +49,7 @@ export default React.forwardRef<HTMLTextAreaElement, TextareaProps>(function Tex
     <FieldShell
       error={error}
       disabled={props.disabled}
+      readOnly={props.readOnly}
       className={className}
     >
       <textarea

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -365,14 +365,14 @@ exports[`ReviewsPage > renders default state 1`] = `
                     />
                   </svg>
                   <div
-                    class="relative inline-flex items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] w-full"
-                    style="--focus: var(--theme-ring); --control-h: 2.5rem;"
+                    class="relative inline-flex items-center rounded-[var(--control-radius)] border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--edge-iris] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] w-full"
+                    style="--control-h: 2.5rem;"
                   >
                     <input
                       autocapitalize="none"
                       autocomplete="off"
                       autocorrect="off"
-                      class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed data-[loading=true]:opacity-[var(--loading)] pl-7"
+                      class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)] pl-7"
                       id=":r0:"
                       name=":r0:"
                       placeholder="Search title, tags, opponent, patch…"

--- a/tests/ui/__snapshots__/input.test.tsx.snap
+++ b/tests/ui/__snapshots__/input.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`Input > renders default state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
-  style="--focus: var(--theme-ring); --control-h: 2.5rem;"
+  class="relative inline-flex w-full items-center rounded-[var(--control-radius)] border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--edge-iris] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
+  style="--control-h: 2.5rem;"
 >
   <input
-    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed data-[loading=true]:opacity-[var(--loading)]"
+    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
     id=":r0:"
     name=":r0:"
   />
@@ -15,11 +15,11 @@ exports[`Input > renders default state 1`] = `
 
 exports[`Input > renders disabled state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-[var(--disabled)] pointer-events-none"
-  style="--focus: var(--theme-ring); --control-h: 2.5rem;"
+  class="relative inline-flex w-full items-center rounded-[var(--control-radius)] border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--edge-iris] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-[var(--disabled)] pointer-events-none"
+  style="--control-h: 2.5rem;"
 >
   <input
-    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed data-[loading=true]:opacity-[var(--loading)]"
+    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
     disabled=""
     id=":r4:"
     name=":r4:"
@@ -29,12 +29,12 @@ exports[`Input > renders disabled state 1`] = `
 
 exports[`Input > renders error state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-danger/60 focus-within:ring-danger/35"
-  style="--focus: var(--theme-ring); --control-h: 2.5rem;"
+  class="relative inline-flex w-full items-center rounded-[var(--control-radius)] border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-danger/60 focus-within:ring-danger/35"
+  style="--control-h: 2.5rem;"
 >
   <input
     aria-invalid="true"
-    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed data-[loading=true]:opacity-[var(--loading)]"
+    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
     id=":r2:"
     name=":r2:"
   />
@@ -43,11 +43,11 @@ exports[`Input > renders error state 1`] = `
 
 exports[`Input > renders focus state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
-  style="--focus: var(--theme-ring); --control-h: 2.5rem;"
+  class="relative inline-flex w-full items-center rounded-[var(--control-radius)] border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--edge-iris] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
+  style="--control-h: 2.5rem;"
 >
   <input
-    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed data-[loading=true]:opacity-[var(--loading)]"
+    class="w-full bg-transparent px-4 text-sm text-foreground placeholder:text-muted-foreground/80 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
     id=":r1:"
     name=":r1:"
   />

--- a/tests/ui/__snapshots__/select.test.tsx.snap
+++ b/tests/ui/__snapshots__/select.test.tsx.snap
@@ -5,8 +5,7 @@ exports[`Select > renders default state 1`] = `
   class="space-y-1"
 >
   <div
-    class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
-    style="--focus: var(--theme-ring);"
+    class="relative inline-flex w-full items-center rounded-[var(--control-radius)] border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--edge-iris] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
   >
     <select
       aria-label="test"
@@ -50,8 +49,7 @@ exports[`Select > renders disabled state 1`] = `
   class="space-y-1"
 >
   <div
-    class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-[--focus] focus-within:ring-offset-0 data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-[var(--disabled)] pointer-events-none group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)] cursor-not-allowed focus-within:ring-0 focus-within:shadow-none"
-    style="--focus: var(--theme-ring);"
+    class="relative inline-flex w-full items-center rounded-[var(--control-radius)] border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-[--edge-iris] focus-within:ring-offset-0 data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-[var(--disabled)] pointer-events-none group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)] cursor-not-allowed focus-within:ring-0 focus-within:shadow-none"
   >
     <select
       aria-label="test"
@@ -91,8 +89,7 @@ exports[`Select > renders error state 1`] = `
   class="space-y-1"
 >
   <div
-    class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-danger/60 focus-within:ring-danger/35 group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
-    style="--focus: var(--theme-ring);"
+    class="relative inline-flex w-full items-center rounded-[var(--control-radius)] border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-danger/60 focus-within:ring-danger/35 group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
   >
     <select
       aria-describedby=":r2:-error"
@@ -139,8 +136,7 @@ exports[`Select > renders focus state 1`] = `
   class="space-y-1"
 >
   <div
-    class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
-    style="--focus: var(--theme-ring);"
+    class="relative inline-flex w-full items-center rounded-[var(--control-radius)] border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--edge-iris] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)]"
   >
     <select
       aria-label="test"
@@ -184,8 +180,7 @@ exports[`Select > renders success state 1`] = `
   class="space-y-1"
 >
   <div
-    class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)] border-[--theme-ring] focus-within:ring-[--theme-ring]"
-    style="--focus: var(--theme-ring);"
+    class="relative inline-flex w-full items-center rounded-[var(--control-radius)] border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] group jitter hover:shadow-[0_0_0_1px_hsl(var(--border)/0.2)] border-[--theme-ring] focus-within:ring-[--theme-ring]"
   >
     <select
       aria-describedby=":r3:-success"

--- a/tests/ui/__snapshots__/textarea.test.tsx.snap
+++ b/tests/ui/__snapshots__/textarea.test.tsx.snap
@@ -2,11 +2,10 @@
 
 exports[`Textarea > renders default state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
-  style="--focus: var(--theme-ring);"
+  class="relative inline-flex w-full items-center rounded-[var(--control-radius)] border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--edge-iris] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
 >
   <textarea
-    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
+    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default"
     id=":r0:"
     name="test"
   />
@@ -15,11 +14,10 @@ exports[`Textarea > renders default state 1`] = `
 
 exports[`Textarea > renders disabled state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-[var(--disabled)] pointer-events-none"
-  style="--focus: var(--theme-ring);"
+  class="relative inline-flex w-full items-center rounded-[var(--control-radius)] border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--edge-iris] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] opacity-[var(--disabled)] pointer-events-none"
 >
   <textarea
-    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
+    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default"
     disabled=""
     id=":r2:"
     name="test"
@@ -29,12 +27,11 @@ exports[`Textarea > renders disabled state 1`] = `
 
 exports[`Textarea > renders error state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-danger/60 focus-within:ring-danger/35"
-  style="--focus: var(--theme-ring);"
+  class="relative inline-flex w-full items-center rounded-[var(--control-radius)] border bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')] border-danger/60 focus-within:ring-danger/35"
 >
   <textarea
     aria-invalid="true"
-    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
+    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default"
     id=":r3:"
     name="test"
   />
@@ -43,11 +40,10 @@ exports[`Textarea > renders error state 1`] = `
 
 exports[`Textarea > renders focus state 1`] = `
 <div
-  class="relative inline-flex w-full items-center rounded-xl border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--focus] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
-  style="--focus: var(--theme-ring);"
+  class="relative inline-flex w-full items-center rounded-[var(--control-radius)] border border-border/28 bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-150 ease-out hover:border-[--hover] [--hover:hsl(var(--border)/0.38)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[--edge-iris] focus-within:ring-offset-0 focus-within:shadow-[0_0_24px_hsl(var(--accent)/0.14)] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:opacity-[0.04] after:bg-[url('/noise.svg')]"
 >
   <textarea
-    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground focus:[outline:none] focus-visible:[outline:none] disabled:opacity-50 disabled:cursor-not-allowed"
+    class="block w-full max-w-full min-h-7 px-4 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default"
     id=":r1:"
     name="test"
   />


### PR DESCRIPTION
## Summary
- use tokenized edge-iris focus ring and configurable radius in FieldShell
- support read-only inputs with muted ring and default cursor
- normalize disabled opacity tokens across textarea

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c1c06b5adc832c8e713f08309676a2