### PR TITLE
refactor: use design tokens for review list item

### DIFF
--- a/src/components/reviews/ReviewListItem.tsx
+++ b/src/components/reviews/ReviewListItem.tsx
@@ -12,10 +12,10 @@ const shellBase = cn(
   "data-[selected=true]:ring-2 data-[selected=true]:ring-[--theme-accent]",
 );
 
-const statusDotBase = "h-2 w-2 rounded-full shadow-[0_0_4px_currentColor]";
-const statusDotWin = "bg-success";
-const statusDotLoss = "bg-danger";
-const statusDotDefault = "bg-muted-foreground";
+const statusDotBase = "h-2 w-2 rounded-full ring-2";
+const statusDotWin = "bg-success ring-success";
+const statusDotLoss = "bg-danger ring-danger";
+const statusDotDefault = "bg-muted-foreground ring-muted-foreground";
 const statusDotPulse =
   "motion-safe:animate-[pulse_2s_ease-in-out_infinite] motion-reduce:animate-none";
 const statusDotBlink =
@@ -26,7 +26,7 @@ const itemLoading = cn(
 );
 const loadingLine = "h-3 rounded bg-muted";
 const scoreBadge =
-  "px-2 py-0.5 rounded-full text-xs font-medium text-background bg-gradient-to-br from-[--theme-accent] to-[--theme-accent2] shadow-[0_0_6px_var(--theme-accent)]";
+  "px-2 py-0.5 rounded-full text-xs font-medium text-background bg-gradient-to-br from-[--theme-accent] to-[--theme-accent2] ring-1 ring-[--theme-accent]";
 
 export type ReviewListItemProps = {
   review?: Review;
@@ -95,19 +95,22 @@ export default function ReviewListItem({
                 review?.result === "Win"
                   ? statusDotWin
                   : review?.result === "Loss"
-                  ? statusDotLoss
-                  : statusDotDefault,
+                    ? statusDotLoss
+                    : statusDotDefault,
                 review?.status === "new" && statusDotPulse,
               )}
             />
             {role ? (
-              <Badge variant="neutral" className="px-1 py-0 text-[10px]">
+              <Badge variant="neutral" className="px-1 py-0 text-xs">
                 {role}
               </Badge>
             ) : null}
           </div>
           {typeof score === "number" ? (
-            <span className={scoreBadge} aria-label={`Rating ${score} out of 10`}>
+            <span
+              className={scoreBadge}
+              aria-label={`Rating ${score} out of 10`}
+            >
               {score}/10
             </span>
           ) : null}

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -33,17 +33,17 @@ exports[`ReviewListItem > renders default state 1`] = `
         >
           <span
             aria-hidden="true"
-            class="h-2 w-2 rounded-full shadow-[0_0_4px_currentColor] motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success"
+            class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex items-center font-medium border rounded-md bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-[10px]"
+            class="inline-flex items-center font-medium border rounded-md bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-xs"
           >
             MID
           </span>
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-2 py-0.5 rounded-full text-xs font-medium text-background bg-gradient-to-br from-[--theme-accent] to-[--theme-accent2] shadow-[0_0_6px_var(--theme-accent)]"
+          class="px-2 py-0.5 rounded-full text-xs font-medium text-background bg-gradient-to-br from-[--theme-accent] to-[--theme-accent2] ring-1 ring-[--theme-accent]"
         >
           9
           /10
@@ -104,17 +104,17 @@ exports[`ReviewListItem > renders selected state 1`] = `
         >
           <span
             aria-hidden="true"
-            class="h-2 w-2 rounded-full shadow-[0_0_4px_currentColor] motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success"
+            class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex items-center font-medium border rounded-md bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-[10px]"
+            class="inline-flex items-center font-medium border rounded-md bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-xs"
           >
             MID
           </span>
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-2 py-0.5 rounded-full text-xs font-medium text-background bg-gradient-to-br from-[--theme-accent] to-[--theme-accent2] shadow-[0_0_6px_var(--theme-accent)]"
+          class="px-2 py-0.5 rounded-full text-xs font-medium text-background bg-gradient-to-br from-[--theme-accent] to-[--theme-accent2] ring-1 ring-[--theme-accent]"
         >
           9
           /10
@@ -159,17 +159,17 @@ exports[`ReviewListItem > renders untitled state 1`] = `
         >
           <span
             aria-hidden="true"
-            class="h-2 w-2 rounded-full shadow-[0_0_4px_currentColor] motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success"
+            class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex items-center font-medium border rounded-md bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-[10px]"
+            class="inline-flex items-center font-medium border rounded-md bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-xs"
           >
             MID
           </span>
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-2 py-0.5 rounded-full text-xs font-medium text-background bg-gradient-to-br from-[--theme-accent] to-[--theme-accent2] shadow-[0_0_6px_var(--theme-accent)]"
+          class="px-2 py-0.5 rounded-full text-xs font-medium text-background bg-gradient-to-br from-[--theme-accent] to-[--theme-accent2] ring-1 ring-[--theme-accent]"
         >
           9
           /10

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -775,10 +775,10 @@ exports[`ReviewsPage > renders default state 1`] = `
                         >
                           <span
                             aria-hidden="true"
-                            class="h-2 w-2 rounded-full shadow-[0_0_4px_currentColor] motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground"
+                            class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
                           />
                           <span
-                            class="inline-flex items-center font-medium border rounded-md bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-[10px]"
+                            class="inline-flex items-center font-medium border rounded-md bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-xs"
                           >
                             MID
                           </span>
@@ -819,10 +819,10 @@ exports[`ReviewsPage > renders default state 1`] = `
                         >
                           <span
                             aria-hidden="true"
-                            class="h-2 w-2 rounded-full shadow-[0_0_4px_currentColor] motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground"
+                            class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
                           />
                           <span
-                            class="inline-flex items-center font-medium border rounded-md bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-[10px]"
+                            class="inline-flex items-center font-medium border rounded-md bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-xs"
                           >
                             ADC
                           </span>
@@ -863,10 +863,10 @@ exports[`ReviewsPage > renders default state 1`] = `
                         >
                           <span
                             aria-hidden="true"
-                            class="h-2 w-2 rounded-full shadow-[0_0_4px_currentColor] motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground"
+                            class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
                           />
                           <span
-                            class="inline-flex items-center font-medium border rounded-md bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-[10px]"
+                            class="inline-flex items-center font-medium border rounded-md bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-xs"
                           >
                             TOP
                           </span>


### PR DESCRIPTION
## Summary
- replace hard-coded status and score shadows with ring-based design tokens
- align role badge with text token and keep layout

## Testing
- `npm test -- -u`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68c1cbc22a78832c893537df160ff9ea