### PR TITLE
Refine hooks and tighten typings

### DIFF
--- a/scripts/generate-tokens.ts
+++ b/scripts/generate-tokens.ts
@@ -1,4 +1,7 @@
-import StyleDictionary from "style-dictionary";
+import StyleDictionary, {
+  type FormatFnArguments,
+  type TransformedToken,
+} from "style-dictionary";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -10,9 +13,9 @@ const __dirname = path.dirname(__filename);
 
 StyleDictionary.registerFormat({
   name: "tokens/markdown",
-  format: ({ dictionary }: { dictionary: any }) => {
+  format: ({ dictionary }: FormatFnArguments): string => {
     const lines = dictionary.allTokens.map(
-      (t: any) => `| ${t.name} | ${t.value} |`,
+      (t: TransformedToken) => `| ${t.name} | ${t.value} |`,
     );
     return ["| Token | Value |", "| --- | --- |", ...lines].join("\n");
   },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,26 +33,23 @@ function HomePageContent() {
   );
 
   React.useEffect(() => {
-    const t = setTimeout(() => {
-      const themeParam = searchParams.get("theme");
-      const bgParam = searchParams.get("bg");
-      setTheme(prev => {
-        const next = { ...prev };
-        if (themeParam && VARIANTS.some(v => v.id === themeParam)) {
-          next.variant = themeParam as Variant;
+    if (typeof window === "undefined") return;
+    const themeParam = searchParams.get("theme");
+    const bgParam = searchParams.get("bg");
+    setTheme(prev => {
+      const next = { ...prev };
+      if (themeParam && VARIANTS.some(v => v.id === themeParam)) {
+        next.variant = themeParam as Variant;
+      }
+      if (bgParam) {
+        const idx = Number(bgParam);
+        if (!Number.isNaN(idx) && idx >= 0 && idx < BG_CLASSES.length) {
+          next.bg = idx as Background;
         }
-        if (bgParam) {
-          const idx = Number(bgParam);
-          if (!Number.isNaN(idx) && idx >= 0 && idx < BG_CLASSES.length) {
-            next.bg = idx as Background;
-          }
-        }
-        return next;
-      });
-    }, 0);
-    return () => clearTimeout(t);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+      }
+      return next;
+    });
+  }, [searchParams, setTheme]);
 
   React.useEffect(() => {
     applyTheme(theme);

--- a/src/components/planner/ScrollTopFloatingButton.tsx
+++ b/src/components/planner/ScrollTopFloatingButton.tsx
@@ -24,7 +24,7 @@ export default function ScrollTopFloatingButton({
       obs.unobserve(target);
       obs.disconnect();
     };
-  }, [watchRef.current, watchRef]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [watchRef]);
 
   const scrollTop = () => {
     if (typeof window !== "undefined") {

--- a/tests/planner/ScrollTopFloatingButton.test.tsx
+++ b/tests/planner/ScrollTopFloatingButton.test.tsx
@@ -4,16 +4,19 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import ScrollTopFloatingButton from "@/components/planner/ScrollTopFloatingButton";
 
 describe("ScrollTopFloatingButton", () => {
-  let observerCallback: (entries: any[]) => void;
+  let observerCallback: IntersectionObserverCallback;
   beforeEach(() => {
-    (window as any).IntersectionObserver = class {
-      constructor(cb: any) {
+    const w = window as unknown as {
+      IntersectionObserver: typeof IntersectionObserver;
+    };
+    w.IntersectionObserver = class {
+      constructor(cb: IntersectionObserverCallback) {
         observerCallback = cb;
       }
       observe() {}
       unobserve() {}
       disconnect() {}
-    };
+    } as unknown as typeof IntersectionObserver;
   });
 
   afterEach(() => {
@@ -21,8 +24,8 @@ describe("ScrollTopFloatingButton", () => {
   });
 
   it("scrolls to top when clicked", () => {
-    const scrollTo = vi.fn();
-    (window as any).scrollTo = scrollTo;
+    const scrollTo = vi.fn() as unknown as typeof window.scrollTo;
+    window.scrollTo = scrollTo;
     const ref = React.createRef<HTMLElement>();
     const { getByRole } = render(
       <ScrollTopFloatingButton watchRef={ref} forceVisible />,
@@ -40,17 +43,29 @@ describe("ScrollTopFloatingButton", () => {
       <ScrollTopFloatingButton watchRef={ref} />,
     );
     act(() => {
-      observerCallback([{ target: first, isIntersecting: false }]);
+      const entry = {
+        target: first,
+        isIntersecting: false,
+      } as IntersectionObserverEntry;
+      observerCallback([entry], {} as IntersectionObserver);
     });
     expect(queryByRole("button")).not.toBeNull();
     ref.current = second;
     rerender(<ScrollTopFloatingButton watchRef={ref} />);
     act(() => {
-      observerCallback([{ target: second, isIntersecting: true }]);
+      const entry = {
+        target: second,
+        isIntersecting: true,
+      } as IntersectionObserverEntry;
+      observerCallback([entry], {} as IntersectionObserver);
     });
     expect(queryByRole("button")).toBeNull();
     act(() => {
-      observerCallback([{ target: second, isIntersecting: false }]);
+      const entry = {
+        target: second,
+        isIntersecting: false,
+      } as IntersectionObserverEntry;
+      observerCallback([entry], {} as IntersectionObserver);
     });
     expect(queryByRole("button")).not.toBeNull();
   });

--- a/tests/planner/useFocusDate.test.tsx
+++ b/tests/planner/useFocusDate.test.tsx
@@ -3,7 +3,9 @@ import { describe, it, expect, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 
 vi.mock("@/lib/db", async () => {
-  const actual: any = await vi.importActual("@/lib/db");
+  const actual = await vi.importActual<typeof import("@/lib/db")>(
+    "@/lib/db",
+  );
   return {
     ...actual,
     usePersistentState: <T,>(key: string, initial: T) => React.useState(initial),


### PR DESCRIPTION
## Summary
- depend only on watchRef for scroll-top button visibility
- clean up theme query effect deps and drop ESLint suppression
- annotate token generation with StyleDictionary types
- replace test `any` casts with precise typings

## Testing
- `npm run check` *(fails: Channel closed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cc168e18832c83dbcc93e8e3f7da