### PR TITLE
fix style-dictionary type usage

### DIFF
--- a/scripts/generate-tokens.ts
+++ b/scripts/generate-tokens.ts
@@ -1,7 +1,8 @@
-import StyleDictionary, {
-  type FormatFnArguments,
-  type TransformedToken,
-} from "style-dictionary";
+import StyleDictionary from "style-dictionary";
+import type {
+  FormatFnArguments,
+  TransformedToken,
+} from "style-dictionary/types";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/style-dictionary.d.ts
+++ b/style-dictionary.d.ts
@@ -1,1 +1,0 @@
-declare module "style-dictionary";

--- a/tests/planner/ScrollTopFloatingButton.test.tsx
+++ b/tests/planner/ScrollTopFloatingButton.test.tsx
@@ -46,7 +46,7 @@ describe("ScrollTopFloatingButton", () => {
       const entry = {
         target: first,
         isIntersecting: false,
-      } as IntersectionObserverEntry;
+      } as unknown as IntersectionObserverEntry;
       observerCallback([entry], {} as IntersectionObserver);
     });
     expect(queryByRole("button")).not.toBeNull();
@@ -56,7 +56,7 @@ describe("ScrollTopFloatingButton", () => {
       const entry = {
         target: second,
         isIntersecting: true,
-      } as IntersectionObserverEntry;
+      } as unknown as IntersectionObserverEntry;
       observerCallback([entry], {} as IntersectionObserver);
     });
     expect(queryByRole("button")).toBeNull();
@@ -64,7 +64,7 @@ describe("ScrollTopFloatingButton", () => {
       const entry = {
         target: second,
         isIntersecting: false,
-      } as IntersectionObserverEntry;
+      } as unknown as IntersectionObserverEntry;
       observerCallback([entry], {} as IntersectionObserver);
     });
     expect(queryByRole("button")).not.toBeNull();


### PR DESCRIPTION
## Summary
- use Style Dictionary's published types instead of local shim
- silence IntersectionObserverEntry cast warnings in ScrollTopFloatingButton tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run` *(fails: Channel closed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d1641730832cb8919c489f05adea