### PR TITLE
Avoid redundant theme sync

### DIFF
--- a/fuse.js.d.ts
+++ b/fuse.js.d.ts
@@ -1,0 +1,13 @@
+declare class Fuse<T> {
+  constructor(list: T[], options?: unknown);
+  search(pattern: string): Fuse.FuseResult<T>[];
+}
+
+declare namespace Fuse {
+  interface FuseResult<T> {
+    item: T;
+    refIndex: number;
+  }
+}
+
+export = Fuse;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,6 +47,9 @@ function HomePageContent() {
           next.bg = idx as Background;
         }
       }
+      if (next.variant === prev.variant && next.bg === prev.bg) {
+        return prev;
+      }
       return next;
     });
   }, [searchParams, setTheme]);
@@ -56,6 +59,14 @@ function HomePageContent() {
   }, [theme]);
 
   React.useEffect(() => {
+    const currentTheme = searchParams.get("theme");
+    const currentBg = searchParams.get("bg");
+    if (
+      currentTheme === theme.variant &&
+      currentBg === String(theme.bg)
+    ) {
+      return;
+    }
     const params = new URLSearchParams(searchParams.toString());
     params.set("theme", theme.variant);
     params.set("bg", String(theme.bg));


### PR DESCRIPTION
## Summary
- guard theme state to avoid unnecessary updates
- prevent redundant router.replace calls when URL already matches theme
- add Fuse.js type declarations for type checking

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c1d6f28cbc832c9f356b8125105109