### PR TITLE
chore: standardize radius tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -588,7 +588,7 @@ html.bg-intense body::after {
   }
 
   .btn-glitch {
-    border-radius: var(--radius-lg);
+    border-radius: var(--radius-2xl);
     color: hsl(var(--primary-foreground));
     background: var(--seg-active-grad);
     box-shadow:
@@ -603,7 +603,7 @@ html.bg-intense body::after {
   }
 
   .btn-lift {
-    border-radius: var(--radius-lg);
+    border-radius: var(--radius-2xl);
     background: hsl(var(--card));
     border: 1px solid hsl(var(--card-hairline));
     box-shadow: 0 6px 18px hsl(var(--shadow-color) / 0.18);
@@ -617,7 +617,7 @@ html.bg-intense body::after {
 
   /* Inputs */
   .input-base {
-    @apply rounded-xl border text-sm;
+    @apply rounded-2xl border text-sm;
     height: var(--control-h);
     padding: 0 var(--control-px);
     font-size: var(--control-fs);
@@ -1302,9 +1302,7 @@ textarea:-webkit-autofill {
 
   /* Radius tokens */
   --radius-md: 8px;
-  --radius-lg: 12px;
-  --radius-xl: 16px;
-  --radius-2xl: 24px; /* 24px */
+  --radius-2xl: 16px;
 }
 
 @layer components {
@@ -1798,7 +1796,7 @@ a:active .lucide {
     --radius-card: var(--radius-md);
   }
   .r-card-md {
-    --radius-card: var(--radius-lg);
+    --radius-card: var(--radius-2xl);
   }
   .r-card-lg {
     --radius-card: var(--radius-xl);
@@ -1906,7 +1904,7 @@ a:active .lucide {
 
 @layer components {
   .goal-card {
-    @apply relative overflow-hidden rounded-xl border border-border;
+    @apply relative overflow-hidden rounded-2xl border border-border;
     background: linear-gradient(
       135deg,
       hsl(var(--surface-2)),

--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -27,8 +27,7 @@ export default function NavBar() {
     <nav aria-label="Primary">
       <ul className="flex items-center gap-2">
         {ITEMS.map((it) => {
-          const active =
-            path === it.href || path.startsWith(it.href + "/");
+          const active = path === it.href || path.startsWith(it.href + "/");
 
           return (
             <li key={it.href} className="relative">
@@ -36,11 +35,11 @@ export default function NavBar() {
                 href={it.href}
                 aria-current={active ? "page" : undefined}
                 className={cn(
-                  "relative inline-flex items-center rounded-xl border px-4 py-2 font-mono text-sm transition",
+                  "relative inline-flex items-center rounded-2xl border px-4 py-2 font-mono text-sm transition",
                   "bg-[color:color-mix(in_oklab,hsl(var(--card))_85%,transparent)]",
                   active
                     ? "text-foreground border-ring shadow-[0_0_0_1px_hsl(var(--ring)/.35),0_8px_24px_hsl(var(--ring)/.2)]"
-                    : "text-muted-foreground border-transparent hover:border-border"
+                    : "text-muted-foreground border-transparent hover:border-border",
                 )}
               >
                 <span className="relative z-10">{it.label}</span>
@@ -48,7 +47,7 @@ export default function NavBar() {
                 {/* hover sheen */}
                 <span
                   aria-hidden
-                  className="pointer-events-none absolute inset-0 rounded-xl opacity-0 transition hover:opacity-100"
+                  className="pointer-events-none absolute inset-0 rounded-2xl opacity-0 transition hover:opacity-100"
                   style={{
                     background:
                       "linear-gradient(90deg,hsl(var(--primary)/.15),transparent 40%,transparent 60%,hsl(var(--accent)/.15))",
@@ -58,7 +57,7 @@ export default function NavBar() {
                 {/* faint scanlines */}
                 <span
                   aria-hidden
-                  className="pointer-events-none absolute inset-0 rounded-xl opacity-20"
+                  className="pointer-events-none absolute inset-0 rounded-2xl opacity-20"
                   style={{
                     background:
                       "repeating-linear-gradient(0deg,hsl(var(--foreground)/0.04) 0 1px,transparent 1px 3px)",
@@ -74,7 +73,11 @@ export default function NavBar() {
                       background:
                         "linear-gradient(90deg,hsl(var(--primary)),hsl(var(--accent)),hsl(var(--primary)))",
                     }}
-                    transition={{ type: "tween", duration: 0.25, ease: "easeOut" }}
+                    transition={{
+                      type: "tween",
+                      duration: 0.25,
+                      ease: "easeOut",
+                    }}
                   />
                 )}
               </Link>

--- a/src/components/goals/GoalSlot.tsx
+++ b/src/components/goals/GoalSlot.tsx
@@ -13,7 +13,12 @@ interface GoalSlotProps {
   onDelete?: (id: string) => void;
 }
 
-export default function GoalSlot({ goal, onToggleDone, onEdit, onDelete }: GoalSlotProps) {
+export default function GoalSlot({
+  goal,
+  onToggleDone,
+  onEdit,
+  onDelete,
+}: GoalSlotProps) {
   function handleEdit() {
     if (!goal || !onEdit) return;
     const t = window.prompt("Edit goal title", goal.title);
@@ -24,19 +29,26 @@ export default function GoalSlot({ goal, onToggleDone, onEdit, onDelete }: GoalS
   }
 
   return (
-    <div className="group relative rounded-lg border-4 border-border bg-surface p-1 shadow-neoSoft">
+    <div className="group relative rounded-2xl border-4 border-border bg-surface p-1 shadow-neoSoft">
       <div
         className={cn(
-          "relative flex aspect-[4/3] w-full items-center justify-center rounded-sm bg-surface-2 font-mono text-center text-sm text-foreground",
+          "relative flex aspect-[4/3] w-full items-center justify-center rounded-2xl bg-surface-2 font-mono text-center text-sm text-foreground",
           goal?.done && "bg-muted text-muted-foreground",
         )}
       >
         {goal ? (
           <>
             <div className="flex flex-col items-center">
-              <span className={cn("block", goal?.done && "line-through")}>{goal.title}</span>
+              <span className={cn("block", goal?.done && "line-through")}>
+                {goal.title}
+              </span>
               {goal.pillar && (
-                <PillarBadge pillar={goal.pillar} size="sm" className="mt-1" as="span" />
+                <PillarBadge
+                  pillar={goal.pillar}
+                  size="sm"
+                  className="mt-1"
+                  as="span"
+                />
               )}
             </div>
             <button
@@ -75,4 +87,3 @@ export default function GoalSlot({ goal, onToggleDone, onEdit, onDelete }: GoalS
     </div>
   );
 }
-

--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -67,7 +67,7 @@ export default function TaskRow({
         <div className="flex-1 min-w-0 px-1">
           {!editing ? (
             <button
-              className="task-tile__text block w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md"
+              className="task-tile__text block w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-2xl"
               onClick={onToggle}
               onDoubleClick={start}
               aria-pressed={task.done}

--- a/src/components/planner/WeekSummary.tsx
+++ b/src/components/planner/WeekSummary.tsx
@@ -44,10 +44,10 @@ export default function WeekSummary({
   const { getDay } = usePlannerStore();
 
   const stats = React.useMemo(() => {
-    return weekDays.map(d => {
+    return weekDays.map((d) => {
       const rec = getDay(d);
       const total = rec.tasks.length;
-      const done = rec.tasks.filter(t => t.done).length;
+      const done = rec.tasks.filter((t) => t.done).length;
       return { iso: d, done, total };
     });
   }, [weekDays, getDay]);
@@ -56,7 +56,9 @@ export default function WeekSummary({
   const doneAll = stats.reduce((a, s) => a + s.done, 0);
 
   const rangeLabel =
-    weekDays.length === 7 ? `${fmtDay(weekDays[0])} — ${fmtDay(weekDays[6])}` : "";
+    weekDays.length === 7
+      ? `${fmtDay(weekDays[0])} — ${fmtDay(weekDays[6])}`
+      : "";
 
   const grid =
     variant === "inline"
@@ -96,7 +98,7 @@ export default function WeekSummary({
 
   const tiles = (
     <div className={grid} role="list" aria-label="Week days summary">
-      {stats.map(s => {
+      {stats.map((s) => {
         const today = isToday(s.iso);
         const empty = s.total === 0;
         return (
@@ -105,16 +107,21 @@ export default function WeekSummary({
             role="listitem"
             className={cn(
               "ws-tile group",
-              variant === "inline" ? "p-2 rounded-lg" : "p-3 rounded-xl",
+              variant === "inline" ? "p-2 rounded-2xl" : "p-3 rounded-2xl",
               today && "ws-tile--today",
-              empty && "ws-tile--empty"
+              empty && "ws-tile--empty",
             )}
             data-today={today || undefined}
             tabIndex={0}
             aria-label={`${s.iso}: ${s.done} of ${s.total} done`}
           >
             <div className="ws-tile__date">{s.iso}</div>
-            <div className={cn("ws-tile__counts", variant === "inline" ? "text-base" : "text-lg")}>
+            <div
+              className={cn(
+                "ws-tile__counts",
+                variant === "inline" ? "text-base" : "text-lg",
+              )}
+            >
               <span className="tabular-nums">{s.done}</span>
               <span className="opacity-60"> / </span>
               <span className="tabular-nums">{s.total}</span>

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -9,15 +9,19 @@ export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   variant?: BadgeVariant;
 }
 
-export default function Badge({ variant = "neutral", className, children, ...props }: BadgeProps) {
+export default function Badge({
+  variant = "neutral",
+  className,
+  children,
+  ...props
+}: BadgeProps) {
   const base = "inline-flex items-center text-xs font-medium border";
   const variants: Record<BadgeVariant, string> = {
     neutral:
-      "rounded-md px-2 py-1 bg-muted/25 border-border/20 text-muted-foreground",
+      "rounded-2xl px-2 py-1 bg-muted/25 border-border/20 text-muted-foreground",
     accent:
-      "rounded-md px-2 py-1 bg-accent/15 border-accent/35 text-accent shadow-[0_0_8px_hsl(var(--accent)/0.3)]",
-    pill:
-      "rounded-full px-2 py-1 bg-accent/15 border-accent/35 text-accent",
+      "rounded-2xl px-2 py-1 bg-accent/15 border-accent/35 text-accent shadow-[0_0_8px_hsl(var(--accent)/0.3)]",
+    pill: "rounded-full px-2 py-1 bg-accent/15 border-accent/35 text-accent",
   };
 
   return (

--- a/src/components/ui/primitives/Card.tsx
+++ b/src/components/ui/primitives/Card.tsx
@@ -9,13 +9,13 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
       <div
         ref={ref}
         className={cn(
-          "rounded-xl p-4 border border-border/25 bg-card/60 shadow-[0_0_0_1px_hsl(var(--border)/0.12)]",
-          className
+          "rounded-2xl p-4 border border-border/25 bg-card/60 shadow-[0_0_0_1px_hsl(var(--border)/0.12)]",
+          className,
         )}
         {...props}
       />
     );
-  }
+  },
 );
 Card.displayName = "Card";
 

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`ReviewListItem > renders default state 1`] = `
             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex items-center font-medium border rounded-md bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-xs leading-none"
+            class="inline-flex items-center font-medium border rounded-2xl bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-xs leading-none"
           >
             MID
           </span>
@@ -107,7 +107,7 @@ exports[`ReviewListItem > renders selected state 1`] = `
             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex items-center font-medium border rounded-md bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-xs leading-none"
+            class="inline-flex items-center font-medium border rounded-2xl bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-xs leading-none"
           >
             MID
           </span>
@@ -162,7 +162,7 @@ exports[`ReviewListItem > renders untitled state 1`] = `
             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex items-center font-medium border rounded-md bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-xs leading-none"
+            class="inline-flex items-center font-medium border rounded-2xl bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-xs leading-none"
           >
             MID
           </span>

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -738,7 +738,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                shown
             </div>
             <div
-              class="rounded-xl border border-border/25 bg-card/60 shadow-[0_0_0_1px_hsl(var(--border)/0.12)] w-full mx-auto backdrop-blur-sm max-h-screen overflow-auto p-2"
+              class="rounded-2xl border border-border/25 bg-card/60 shadow-[0_0_0_1px_hsl(var(--border)/0.12)] w-full mx-auto backdrop-blur-sm max-h-screen overflow-auto p-2"
             >
               <ul
                 class="flex flex-col gap-3"
@@ -778,7 +778,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
                           />
                           <span
-                            class="inline-flex items-center font-medium border rounded-md bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-xs leading-none"
+                            class="inline-flex items-center font-medium border rounded-2xl bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-xs leading-none"
                           >
                             MID
                           </span>
@@ -822,7 +822,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
                           />
                           <span
-                            class="inline-flex items-center font-medium border rounded-md bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-xs leading-none"
+                            class="inline-flex items-center font-medium border rounded-2xl bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-xs leading-none"
                           >
                             ADC
                           </span>
@@ -866,7 +866,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
                           />
                           <span
-                            class="inline-flex items-center font-medium border rounded-md bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-xs leading-none"
+                            class="inline-flex items-center font-medium border rounded-2xl bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-xs leading-none"
                           >
                             TOP
                           </span>
@@ -885,7 +885,7 @@ exports[`ReviewsPage > renders default state 1`] = `
       >
         <div
           aria-live="polite"
-          class="rounded-xl border border-border/25 bg-card/60 shadow-[0_0_0_1px_hsl(var(--border)/0.12)] w-full max-w-[880px] p-5 mx-auto flex flex-col items-center justify-center gap-2 py-7 text-sm text-muted-foreground"
+          class="rounded-2xl border border-border/25 bg-card/60 shadow-[0_0_0_1px_hsl(var(--border)/0.12)] w-full max-w-[880px] p-5 mx-auto flex flex-col items-center justify-center gap-2 py-7 text-sm text-muted-foreground"
         >
           <svg
             class="lucide lucide-ghost h-6 w-6 opacity-60"


### PR DESCRIPTION
## Summary
- use rounded-2xl radius across nav bar, badges, cards, goals, week summary tiles, and task rows
- migrate global CSS utilities to 2xl radius token

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c1d9e29a50832cbb5ecd9775436721