### PR TITLE
Respect motion preferences in goal components

### DIFF
--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -39,6 +39,9 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
   ref
 ) {
   const titleRef = React.useRef<HTMLInputElement>(null);
+  const helpId = "goal-form-help";
+  const errorId = "goal-form-error";
+  const describedBy = [helpId, err ? errorId : null].filter(Boolean).join(" ");
 
   React.useImperativeHandle(ref, () => ({
     focus: (options?: FocusOptions) => titleRef.current?.focus(options),
@@ -71,7 +74,7 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
               value={title}
               onChange={(e) => onTitleChange(e.target.value)}
               aria-required="true"
-              aria-describedby="goal-form-help goal-form-error"
+              aria-describedby={describedBy || undefined}
             />
           </Label>
 
@@ -82,7 +85,7 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
               className="h-10 text-sm tabular-nums"
               value={metric}
               onChange={(e) => onMetricChange(e.target.value)}
-              aria-describedby="goal-form-help goal-form-error"
+              aria-describedby={describedBy || undefined}
             />
           </Label>
 
@@ -93,13 +96,13 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
               textareaClassName="min-h-24 text-sm"
               value={notes}
               onChange={(e) => onNotesChange(e.target.value)}
-              aria-describedby="goal-form-help goal-form-error"
+              aria-describedby={describedBy || undefined}
             />
           </Label>
 
-          <div className="text-xs text-muted-foreground">
+          <div id={helpId} className="text-xs text-muted-foreground">
             {activeCount >= activeCap ? (
-              <span className="text-accent">
+              <span className="text-danger">
                 Cap reached. Finish one to add more.
               </span>
             ) : (
@@ -111,7 +114,12 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
           </div>
 
           {err ? (
-            <p role="status" aria-live="polite" className="text-xs text-accent">
+            <p
+              id={errorId}
+              role="status"
+              aria-live="polite"
+              className="text-xs text-danger"
+            >
               {err}
             </p>
           ) : null}

--- a/src/components/goals/GoalList.tsx
+++ b/src/components/goals/GoalList.tsx
@@ -54,8 +54,8 @@ export default function GoalList({
   return (
     <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 [grid-auto-rows:minmax(0,1fr)]">
       {goals.length === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-accent/40 bg-card/20 p-6 text-center text-sm text-muted-foreground backdrop-blur-md shadow-[0_0_16px_hsl(var(--accent)/.2)]">
-          <Flag aria-hidden className="mb-2 h-6 w-6 text-accent drop-shadow-[0_0_8px_var(--neon)] animate-bounce" />
+        <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-accent/40 bg-card/20 p-6 text-center text-sm text-muted-foreground backdrop-blur-md shadow-ring [--ring:var(--accent)]">
+          <Flag aria-hidden className="mb-2 h-6 w-6 text-accent shadow-ring motion-safe:animate-bounce [--ring:var(--accent)]" />
           <p>No goals here. Add one simple, finishable thing.</p>
         </div>
       ) : (
@@ -67,8 +67,8 @@ export default function GoalList({
               className={[
                 "relative overflow-hidden rounded-2xl p-6 min-h-8 flex flex-col",
                 "bg-card/30 backdrop-blur-md",
-                "shadow-[inset_0_0_8px_hsl(var(--accent)/.15),0_0_12px_hsl(var(--accent)/.25)]",
-                "transition-all duration-150 hover:-translate-y-1 hover:shadow-[inset_0_0_8px_hsl(var(--accent)/.25),0_0_24px_hsl(var(--accent)/.4)]",
+                "shadow-ring [--ring:var(--accent)]",
+                "transition-all duration-150 hover:-translate-y-1 hover:shadow-ring",
               ].join(" ")}
             >
               <span
@@ -121,7 +121,7 @@ export default function GoalList({
                         checked={g.done}
                         onChange={() => onToggleDone(g.id)}
                         size="lg"
-                        className="transition-transform shadow-[0_0_6px_var(--neon-soft)] hover:-translate-y-0.5 hover:shadow-[0_0_10px_var(--neon)]"
+                        className="transition-transform shadow-ring hover:-translate-y-0.5 hover:shadow-ring [--ring:var(--accent)]"
                       />
                       <IconButton
                         title="Edit"
@@ -192,7 +192,7 @@ export default function GoalList({
                       "h-2 w-2 rounded-full transition-all",
                       g.done
                         ? "bg-muted-foreground/40"
-                        : "bg-accent shadow-[0_0_6px_hsl(var(--accent))] animate-pulse",
+                        : "bg-accent shadow-ring motion-safe:animate-pulse [--ring:var(--accent)]",
                     ].join(" ")}
                   />
                   <time

--- a/src/components/goals/GoalsProgress.tsx
+++ b/src/components/goals/GoalsProgress.tsx
@@ -30,8 +30,12 @@ export default function GoalsProgress({ total, pct, onAddFirst, maxWidth }: Goal
   const circumference = 2 * Math.PI * radius;
   const offset = circumference - (v / 100) * circumference;
   return (
-    <div className="relative inline-flex items-center justify-center" style={{ width: size, height: size }} aria-label="Progress">
-      <svg className="h-full w-full rotate-[-90deg]" viewBox={`0 0 ${size} ${size}`}> 
+    <div
+      className="relative inline-flex items-center justify-center"
+      style={{ width: size, height: size }}
+      aria-label="Progress"
+    >
+      <svg className="h-full w-full rotate-[-90deg]" viewBox={`0 0 ${size} ${size}`}>
         <circle
           cx={size / 2}
           cy={size / 2}
@@ -50,11 +54,14 @@ export default function GoalsProgress({ total, pct, onAddFirst, maxWidth }: Goal
           strokeLinecap="round"
           strokeDasharray={circumference}
           strokeDashoffset={offset}
-          className="text-accent drop-shadow-[0_0_6px_var(--neon)] animate-pulse"
+          className="text-accent shadow-ring motion-safe:animate-pulse [--ring:var(--accent)]"
           fill="none"
         />
       </svg>
-      <span className="absolute inset-0 flex items-center justify-center text-xs font-medium tabular-nums">
+      <span
+        aria-live="polite"
+        className="absolute inset-0 flex items-center justify-center text-xs font-medium tabular-nums"
+      >
         {v}%
       </span>
     </div>

--- a/src/components/goals/GoalsTabs.tsx
+++ b/src/components/goals/GoalsTabs.tsx
@@ -36,7 +36,7 @@ export default function GoalsTabs({ value, onChange }: GoalsTabsProps) {
               className={cn(
                 "text-left font-mono text-sm transition",
                 "px-3 py-2 rounded-2xl",
-                "hover:-translate-y-px",
+                "motion-safe:hover:-translate-y-px",
                 "border-none outline-none focus:outline-none focus-visible:outline-none",
                 active
                   ? "font-semibold text-accent bg-accent/10"


### PR DESCRIPTION
## Summary
- Enhance GoalForm with help and error regions referenced via `aria-describedby` and danger tokens
- Tokenize shadows and respect motion preferences in GoalsProgress, GoalsTabs, and GoalList

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c1d922469c832cbfdbb1184d7b84bd