### PR TITLE
Add unique names for reminders search and quick add

### DIFF
--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -174,6 +174,7 @@ export default function Reminders() {
               <Input
                 aria-label="Search reminders"
                 placeholder="Search title, text, tags…"
+                name="search-reminders"
                 className="pl-6"
                 value={query}
                 onChange={(e) => setQuery(e.currentTarget.value)}
@@ -218,6 +219,7 @@ export default function Reminders() {
             <Input
               aria-label="Quick add"
               placeholder={`Quick add to ${group === "all" ? "Pre-Game" : group.charAt(0).toUpperCase() + group.slice(1)}…`}
+              name="quick-reminder"
               value={quickAdd}
               onChange={(e) => setQuickAdd(e.currentTarget.value)}
               onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); addQuick(); } }}


### PR DESCRIPTION
## Summary
- name the reminders search input `search-reminders`
- name the quick add reminder input `quick-reminder`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68c204aec0c4832c94dfd7a6697c1a9d