### PR TITLE
feat: add design lint and spacing fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,3 +48,7 @@ Rebase your branch on top of `main` before merging to maintain a clean, linear c
 
 - Keep pull requests manageable, ideally under about 300 lines of changes.
 - Open draft PRs early when you want feedback before the work is finished.
+
+## Manual QA
+
+Before submitting significant UI work, run through the [manual QA checklist](docs/qa-manual.md).

--- a/docs/qa-manual.md
+++ b/docs/qa-manual.md
@@ -1,0 +1,9 @@
+# Manual QA Checklist
+
+For each page verify:
+
+- Spacing follows the design scale.
+- Hairline borders with a single focus ring.
+- Consistent radius across components.
+- Colors originate from tokens, avoiding raw values.
+- A reduced-motion path is available and honors `prefers-reduced-motion`.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "format": "prettier --write .",
     "verify-prompts": "ts-node --esm scripts/verify-prompts.ts",
     "check-prompts": "ts-node --esm scripts/check-prompts-updated.ts",
+    "design-lint": "ts-node --esm scripts/design-lint.ts",
     "postinstall": "node scripts/regen-if-needed.js",
     "prepare": "husky"
   },

--- a/scripts/design-lint.ts
+++ b/scripts/design-lint.ts
@@ -1,0 +1,48 @@
+import fs from "fs";
+import fg from "fast-glob";
+
+const files = await fg(["src/**/*.{ts,tsx}"], { ignore: ["**/*.d.ts"] });
+
+const colorRe = /(#(?:[0-9a-fA-F]{3,8})\b|rgb[a]?\()/;
+const pxBracketRe = /p-\[[^\]]*px\]/;
+const pxClassRe = /\bpx-(5|6)\b/;
+const borderRe = /border-(\d+)/g;
+
+interface Violation {
+  file: string;
+  line: number;
+  text: string;
+  rule: string;
+}
+
+const violations: Violation[] = [];
+
+for (const file of files) {
+  const lines = fs.readFileSync(file, "utf8").split(/\r?\n/);
+  lines.forEach((line, idx) => {
+    const ln = idx + 1;
+    if (colorRe.test(line)) {
+      violations.push({ file, line: ln, text: line.trim(), rule: "color" });
+    }
+    if (pxBracketRe.test(line) || pxClassRe.test(line)) {
+      violations.push({ file, line: ln, text: line.trim(), rule: "spacing" });
+    }
+    let match;
+    while ((match = borderRe.exec(line)) !== null) {
+      if (parseInt(match[1], 10) > 1) {
+        violations.push({ file, line: ln, text: line.trim(), rule: "border" });
+      }
+    }
+  });
+}
+
+if (violations.length) {
+  console.log("Design lint found issues:\n");
+  for (const v of violations) {
+    console.log(`--- ${v.file}:${v.line}`);
+    console.log(`- ${v.text}`);
+  }
+  process.exit(1);
+} else {
+  console.log("No design lint issues found.");
+}

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -35,7 +35,12 @@ import { RoleSelector } from "@/components/reviews";
 import ReviewListItem from "@/components/reviews/ReviewListItem";
 import type { Review } from "@/lib/types";
 import { COLOR_PALETTES, defaultTheme } from "@/lib/theme";
-import { GoalsProgress, RemindersTab, TimerRing, TimerTab } from "@/components/goals";
+import {
+  GoalsProgress,
+  RemindersTab,
+  TimerRing,
+  TimerTab,
+} from "@/components/goals";
 
 type View = "components" | "colors" | "onboarding";
 type Section =
@@ -103,7 +108,7 @@ function ThemePickerDemo() {
   return (
     <ThemePicker
       variant={t.variant}
-      onVariantChange={v => setT(prev => ({ ...prev, variant: v }))}
+      onVariantChange={(v) => setT((prev) => ({ ...prev, variant: v }))}
     />
   );
 }
@@ -113,7 +118,7 @@ function BackgroundPickerDemo() {
   return (
     <BackgroundPicker
       bg={t.bg}
-      onBgChange={b => setT(prev => ({ ...prev, bg: b }))}
+      onBgChange={(b) => setT((prev) => ({ ...prev, bg: b }))}
     />
   );
 }
@@ -468,7 +473,9 @@ function SpecCard({ name, description, element, props }: Spec) {
         <h3 className="text-base font-semibold tracking-[-0.01em]">{name}</h3>
       </header>
       {description ? (
-        <p className="text-sm font-medium text-muted-foreground">{description}</p>
+        <p className="text-sm font-medium text-muted-foreground">
+          {description}
+        </p>
       ) : null}
       <div className="rounded-xl bg-background p-4">{element}</div>
       {props ? (
@@ -503,7 +510,9 @@ function GradientSwatch() {
   return (
     <li className="col-span-12 md:col-span-6 flex flex-col items-center gap-3">
       <div className="h-16 w-full rounded-xl bg-gradient-to-r from-primary via-accent to-transparent" />
-      <span className="text-xs font-medium">from-primary via-accent to-transparent</span>
+      <span className="text-xs font-medium">
+        from-primary via-accent to-transparent
+      </span>
     </li>
   );
 }
@@ -528,8 +537,7 @@ function ComponentsView({ query }: { query: string }) {
     const q = query.toLowerCase();
     return SPEC_DATA[section].filter(
       (s) =>
-        s.name.toLowerCase().includes(q) ||
-        s.tags.some((t) => t.includes(q)),
+        s.name.toLowerCase().includes(q) || s.tags.some((t) => t.includes(q)),
     );
   }, [section, query]);
 
@@ -578,10 +586,12 @@ export default function Page() {
   const [query, setQuery] = React.useState("");
 
   return (
-    <main className="mx-auto max-w-screen-xl grid grid-cols-12 gap-x-6 px-6 py-8">
+    <main className="mx-auto max-w-screen-xl grid grid-cols-12 gap-x-6 px-8 py-8">
       <header className="col-span-12 flex items-start justify-between">
         <div>
-          <h1 className="text-2xl font-semibold tracking-[-0.01em]">Prompts Playground</h1>
+          <h1 className="text-2xl font-semibold tracking-[-0.01em]">
+            Prompts Playground
+          </h1>
           <p className="mt-1 text-sm text-muted-foreground">
             Explore components and tokens
           </p>
@@ -631,4 +641,3 @@ export default function Page() {
     </main>
   );
 }
-

--- a/src/components/goals/GoalSlot.tsx
+++ b/src/components/goals/GoalSlot.tsx
@@ -29,7 +29,7 @@ export default function GoalSlot({
   }
 
   return (
-    <div className="group relative rounded-2xl border-4 border-border bg-surface p-1 shadow-neoSoft">
+    <div className="group relative rounded-2xl border border-border bg-surface p-1 shadow-neoSoft">
       <div
         className={cn(
           "relative flex aspect-[4/3] w-full items-center justify-center rounded-2xl bg-surface-2 font-mono text-center text-sm text-foreground",

--- a/src/components/ui/feedback/Spinner.tsx
+++ b/src/components/ui/feedback/Spinner.tsx
@@ -15,8 +15,8 @@ export default function Spinner({
       role="status"
       aria-label="Loading"
       className={cn(
-        "inline-block animate-spin rounded-full border-2 border-accent border-t-transparent",
-        className
+        "inline-block animate-spin rounded-full border border-accent border-t-transparent",
+        className,
       )}
       style={{ width: size, height: size }}
     >

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -107,7 +107,7 @@ export default function Hero({
       <div
         className={cx(
           sticky ? "sticky-blur" : "",
-          "hero2-frame relative overflow-hidden rounded-2xl px-4 sm:px-5 py-4",
+          "hero2-frame relative overflow-hidden rounded-2xl px-4 py-4",
           topClassName,
         )}
       >

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -43,7 +43,7 @@ export type TabBarProps<K extends string = string> = {
 const sizeMap: Record<Size, { h: string; px: string; text: string }> = {
   sm: { h: "h-8", px: "px-3", text: "text-sm" },
   md: { h: "h-10", px: "px-4", text: "text-sm" },
-  lg: { h: "h-11", px: "px-5", text: "text-base" },
+  lg: { h: "h-11", px: "px-8", text: "text-base" },
 };
 
 export default function TabBar<K extends string = string>({
@@ -62,9 +62,7 @@ export default function TabBar<K extends string = string>({
   const [internal, setInternal] = React.useState<K>(() => {
     if (value !== undefined) return value;
     if (defaultValue) return defaultValue;
-    return (
-      items.find((i) => !i.disabled)?.key ?? items[0]?.key ?? ""
-    ) as K;
+    return (items.find((i) => !i.disabled)?.key ?? items[0]?.key ?? "") as K;
   });
 
   const activeKey = isControlled ? (value as K) : internal;

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -17,17 +17,17 @@ export const buttonSizes = {
   },
   md: {
     height: "h-10",
-    padding: "px-5",
+    padding: "px-4",
     text: "text-base",
     gap: "gap-2",
     icon: "[&>svg]:size-5",
   },
   lg: {
     height: "h-11",
-    padding: "px-6",
+    padding: "px-8",
     text: "text-lg",
-    gap: "gap-3",
-    icon: "[&>svg]:size-6",
+    gap: "gap-4",
+    icon: "[&>svg]:size-8",
   },
 } as const;
 
@@ -52,7 +52,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       type = "button",
       ...rest
     },
-    ref
+    ref,
   ) => {
     const s = buttonSizes[size];
     const base = cn(
@@ -86,8 +86,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         primary: "text-foreground",
         accent:
           "text-accent bg-accent/15 [--hover:hsl(var(--accent)/0.25)] [--active:hsl(var(--accent)/0.35)]",
-        info:
-          "text-accent-2 bg-accent-2/15 [--hover:hsl(var(--accent-2)/0.25)] [--active:hsl(var(--accent-2)/0.35)]",
+        info: "text-accent-2 bg-accent-2/15 [--hover:hsl(var(--accent-2)/0.25)] [--active:hsl(var(--accent-2)/0.35)]",
         danger:
           "text-danger bg-danger/15 [--hover:hsl(var(--danger)/0.25)] [--active:hsl(var(--danger)/0.35)]",
       },
@@ -96,8 +95,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           "text-foreground [--hover:hsl(var(--foreground)/0.1)] [--active:hsl(var(--foreground)/0.2)]",
         accent:
           "text-accent [--hover:hsl(var(--accent)/0.1)] [--active:hsl(var(--accent)/0.2)]",
-        info:
-          "text-accent-2 [--hover:hsl(var(--accent-2)/0.1)] [--active:hsl(var(--accent-2)/0.2)]",
+        info: "text-accent-2 [--hover:hsl(var(--accent-2)/0.1)] [--active:hsl(var(--accent-2)/0.2)]",
         danger:
           "text-danger [--hover:hsl(var(--danger)/0.1)] [--active:hsl(var(--danger)/0.2)]",
       },
@@ -135,8 +133,13 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       },
     } as const;
 
-    const { className: variantClass, whileHover, whileTap, overlay, contentClass } =
-      variants[variant];
+    const {
+      className: variantClass,
+      whileHover,
+      whileTap,
+      overlay,
+      contentClass,
+    } = variants[variant];
 
     return (
       <motion.button
@@ -167,11 +170,11 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {contentClass ? (
           <span className={contentClass}>{children as React.ReactNode}</span>
         ) : (
-          children as React.ReactNode
+          (children as React.ReactNode)
         )}
       </motion.button>
     );
-  }
+  },
 );
 
 Button.displayName = "Button";

--- a/tests/primitives/button.test.tsx
+++ b/tests/primitives/button.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, cleanup, fireEvent } from "@testing-library/react";
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { Button } from "../../src/components/ui/primitives/Button";
+import fs from "fs";
 
 afterEach(cleanup);
 
@@ -23,8 +24,12 @@ describe("Button", () => {
     const btn = getByRole("button");
     btn.focus();
     const style = getComputedStyle(btn);
-    expect(style.outlineStyle === "none" || style.outlineStyle === "").toBe(true);
-    expect(style.outlineWidth === "0px" || style.outlineWidth === "").toBe(true);
+    expect(style.outlineStyle === "none" || style.outlineStyle === "").toBe(
+      true,
+    );
+    expect(style.outlineWidth === "0px" || style.outlineWidth === "").toBe(
+      true,
+    );
   });
 
   it("has reduced opacity and no pointer events when disabled", () => {
@@ -46,7 +51,7 @@ describe("Button", () => {
   it.each([
     ["sm", "[&>svg]:size-4"],
     ["md", "[&>svg]:size-5"],
-    ["lg", "[&>svg]:size-6"],
+    ["lg", "[&>svg]:size-8"],
   ])("applies %s icon sizing", (size, cls) => {
     const { getByRole } = render(
       <Button size={size as any}>
@@ -59,7 +64,7 @@ describe("Button", () => {
   it.each([
     ["sm", "gap-1"],
     ["md", "gap-2"],
-    ["lg", "gap-3"],
+    ["lg", "gap-4"],
   ])("applies %s gap spacing", (size, cls) => {
     const { getByRole } = render(
       <Button size={size as any}>
@@ -68,5 +73,13 @@ describe("Button", () => {
       </Button>,
     );
     expect(getByRole("button")).toHaveClass(cls);
+  });
+
+  it("avoids disallowed px spacing", () => {
+    const content = fs.readFileSync(
+      "src/components/ui/primitives/Button.tsx",
+      "utf8",
+    );
+    expect(content).not.toMatch(/\bpx-(5|6)\b/);
   });
 });

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -270,7 +270,7 @@ exports[`ReviewsPage > renders default state 1`] = `
     
       </style>
       <div
-        class="sticky-blur hero2-frame relative overflow-hidden rounded-2xl px-4 sm:px-5 py-4 top-20"
+        class="sticky-blur hero2-frame relative overflow-hidden rounded-2xl px-4 py-4 top-20"
       >
         <span
           aria-hidden="true"


### PR DESCRIPTION
## Summary
- add basic design-lint script and npm hook
- align primitive and layout padding to spacing scale
- document manual QA expectations

## Testing
- `npm run design-lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c20ca48640832c9a595c6e76a92371