### PR TITLE
refactor: use text token for Header eyebrow

### DIFF
--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -86,7 +86,7 @@ export default function Header({
           {icon ? <span className="shrink-0 opacity-90">{icon}</span> : null}
           <div className="min-w-0">
             {eyebrow ? (
-              <div className="mb-1 truncate text-[0.6875rem] uppercase tracking-wide text-muted-foreground">
+              <div className="mb-1 truncate text-xs uppercase tracking-wide text-muted-foreground">
                 {eyebrow}
               </div>
             ) : null}


### PR DESCRIPTION
## Summary
- swap hard-coded eyebrow font size for design token

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c212f2c4a0832cbc5e3c6a716c67ea