### PR TITLE
feat: expand design lint and QA docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,4 +51,4 @@ Rebase your branch on top of `main` before merging to maintain a clean, linear c
 
 ## Manual QA
 
-Before submitting significant UI work, run through the [manual QA checklist](docs/qa-manual.md).
+Every page must pass the [manual QA checklist](docs/qa-manual.md) before merging.

--- a/scripts/design-lint.ts
+++ b/scripts/design-lint.ts
@@ -1,12 +1,16 @@
 import fs from "fs";
 import fg from "fast-glob";
 
-const files = await fg(["src/**/*.{ts,tsx}"], { ignore: ["**/*.d.ts"] });
+const files = await fg(["src/**/*.{ts,tsx,css}"], { ignore: ["**/*.d.ts"] });
 
-const colorRe = /(#(?:[0-9a-fA-F]{3,8})\b|rgb[a]?\()/;
-const pxBracketRe = /p-\[[^\]]*px\]/;
-const pxClassRe = /\bpx-(5|6)\b/;
+const colorRe = /(#[0-9a-fA-F]{3,8}\b|rgba?\(|hsla?\()/;
+const spacingRe = /(p|gap)-\[[^\]]*px\]/;
+const stylePxRe = /style={{[^}]*\d+px/;
+const radiusRe = /rounded-(sm|md|lg|xl|2xl|\[[^\]]+\])/;
 const borderRe = /border-(\d+)/g;
+const outlineRe = /outline-[^\s'"`]+/;
+const ringRe = /ring(?:-[^\s'"`]+)?/g;
+const rawElementRe = /<(button|input)(\s|>)/;
 
 interface Violation {
   file: string;
@@ -24,8 +28,11 @@ for (const file of files) {
     if (colorRe.test(line)) {
       violations.push({ file, line: ln, text: line.trim(), rule: "color" });
     }
-    if (pxBracketRe.test(line) || pxClassRe.test(line)) {
+    if (spacingRe.test(line) || stylePxRe.test(line)) {
       violations.push({ file, line: ln, text: line.trim(), rule: "spacing" });
+    }
+    if (radiusRe.test(line)) {
+      violations.push({ file, line: ln, text: line.trim(), rule: "radius" });
     }
     let match;
     while ((match = borderRe.exec(line)) !== null) {
@@ -33,14 +40,35 @@ for (const file of files) {
         violations.push({ file, line: ln, text: line.trim(), rule: "border" });
       }
     }
+    if (outlineRe.test(line)) {
+      violations.push({ file, line: ln, text: line.trim(), rule: "outline" });
+    }
+    const rings = line.match(ringRe);
+    if (rings && rings.length > 1) {
+      violations.push({ file, line: ln, text: line.trim(), rule: "ring" });
+    }
+    if (rawElementRe.test(line)) {
+      violations.push({ file, line: ln, text: line.trim(), rule: "element" });
+    }
   });
 }
+
+const suggestions: Record<string, string> = {
+  color: "use color tokens",
+  spacing: "use spacing tokens",
+  radius: "use radius tokens",
+  border: "use border tokens",
+  outline: "use focus ring tokens",
+  ring: "use a single ring token",
+  element: "use design system primitives",
+};
 
 if (violations.length) {
   console.log("Design lint found issues:\n");
   for (const v of violations) {
     console.log(`--- ${v.file}:${v.line}`);
     console.log(`- ${v.text}`);
+    console.log(`+ ${suggestions[v.rule]}`);
   }
   process.exit(1);
 } else {


### PR DESCRIPTION
## Summary
- expand design lint rules to scan TS and CSS and report token suggestions
- document that each page must pass manual QA checklist

## Testing
- `npm run check`
- `npm run design-lint` *(fails: reports design token violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c215e98834832c9d630773d1404176