### PR TITLE
feat: share theme state via context

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from "next";
 import SiteChrome from "@/components/chrome/SiteChrome";
 import { themeBootstrapScript } from "@/lib/theme";
 import Script from "next/script";
+import ThemeProvider from "@/lib/theme-context";
 
 export const metadata: Metadata = {
   title: "13 League Review",
@@ -21,7 +22,11 @@ export const metadata: Metadata = {
  */
 const noFlash = themeBootstrapScript();
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     // Default SSR state: LG (dark). The no-flash script will tweak immediately.
     <html lang="en" className="theme-lg" suppressHydrationWarning>
@@ -33,10 +38,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         />
       </head>
       <body className="min-h-screen bg-background text-foreground glitch-root">
-        <SiteChrome />
-        <div className="relative z-10">
-          {children}
-        </div>
+        <ThemeProvider>
+          <SiteChrome />
+          <div className="relative z-10">{children}</div>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,14 +11,10 @@ import {
   BottomNav,
 } from "@/components/home";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
-import { usePersistentState } from "@/lib/db";
+import { useTheme } from "@/lib/theme-context";
 import {
-  applyTheme,
-  defaultTheme,
-  THEME_STORAGE_KEY,
   VARIANTS,
   BG_CLASSES,
-  type ThemeState,
   type Variant,
   type Background,
 } from "@/lib/theme";
@@ -27,18 +23,15 @@ function HomePageContent() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const [theme, setTheme] = usePersistentState<ThemeState>(
-    THEME_STORAGE_KEY,
-    defaultTheme(),
-  );
+  const [theme, setTheme] = useTheme();
 
   React.useEffect(() => {
     if (typeof window === "undefined") return;
     const themeParam = searchParams.get("theme");
     const bgParam = searchParams.get("bg");
-    setTheme(prev => {
+    setTheme((prev) => {
       const next = { ...prev };
-      if (themeParam && VARIANTS.some(v => v.id === themeParam)) {
+      if (themeParam && VARIANTS.some((v) => v.id === themeParam)) {
         next.variant = themeParam as Variant;
       }
       if (bgParam) {
@@ -55,16 +48,9 @@ function HomePageContent() {
   }, [searchParams, setTheme]);
 
   React.useEffect(() => {
-    applyTheme(theme);
-  }, [theme]);
-
-  React.useEffect(() => {
     const currentTheme = searchParams.get("theme");
     const currentBg = searchParams.get("bg");
-    if (
-      currentTheme === theme.variant &&
-      currentBg === String(theme.bg)
-    ) {
+    if (currentTheme === theme.variant && currentBg === String(theme.bg)) {
       return;
     }
     const params = new URLSearchParams(searchParams.toString());

--- a/src/components/ui/theme/ThemeToggle.tsx
+++ b/src/components/ui/theme/ThemeToggle.tsx
@@ -6,16 +6,12 @@ import { Image as ImageIcon } from "lucide-react";
 import AnimatedSelect, {
   DropItem,
 } from "@/components/ui/selects/AnimatedSelect";
-import { usePersistentState } from "@/lib/db";
+import { useTheme } from "@/lib/theme-context";
 import {
-  applyTheme,
-  defaultTheme,
-  THEME_STORAGE_KEY,
   VARIANTS,
   BG_CLASSES,
-  ThemeState,
-  Variant,
-  Background,
+  type Variant,
+  type Background,
 } from "@/lib/theme";
 
 type ThemeToggleProps = {
@@ -34,19 +30,12 @@ export default function ThemeToggle({
   const aria = ariaLabel ?? ariaLabelAttr ?? "Theme";
 
   const [mounted, setMounted] = React.useState(false);
-  const [state, setState] = usePersistentState<ThemeState>(
-    THEME_STORAGE_KEY,
-    defaultTheme(),
-  );
+  const [state, setState] = useTheme();
   const { variant } = state;
 
   React.useEffect(() => {
     setMounted(true);
   }, []);
-
-  React.useEffect(() => {
-    applyTheme(state);
-  }, [state]);
 
   function setVariantPersist(v: Variant) {
     setState((prev) => ({ variant: v, bg: prev.bg }));

--- a/src/lib/theme-context.tsx
+++ b/src/lib/theme-context.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import * as React from "react";
+import { usePersistentState } from "@/lib/db";
+import {
+  applyTheme,
+  defaultTheme,
+  THEME_STORAGE_KEY,
+  type ThemeState,
+} from "@/lib/theme";
+
+const ThemeContext = React.createContext<
+  [ThemeState, React.Dispatch<React.SetStateAction<ThemeState>>] | undefined
+>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const themeState = usePersistentState<ThemeState>(
+    THEME_STORAGE_KEY,
+    defaultTheme(),
+  );
+  const [theme] = themeState;
+
+  React.useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={themeState}>{children}</ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = React.useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error("useTheme must be used within ThemeProvider");
+  }
+  return ctx;
+}
+
+export default ThemeProvider;

--- a/tests/home/HomePage.test.tsx
+++ b/tests/home/HomePage.test.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import Page from "@/app/page";
+import { ThemeProvider } from "@/lib/theme-context";
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
   usePathname: () => "/",
@@ -12,9 +13,11 @@ vi.mock("next/navigation", () => ({
 describe("Home page", () => {
   it("renders navigation links", () => {
     render(
-      <Suspense fallback="loading">
-        <Page />
-      </Suspense>,
+      <ThemeProvider>
+        <Suspense fallback="loading">
+          <Page />
+        </Suspense>
+      </ThemeProvider>,
     );
     const goals = screen.getByRole("link", { name: "Goals" });
     const reviews = screen.getByRole("link", { name: "Reviews" });
@@ -22,7 +25,7 @@ describe("Home page", () => {
     const prompts = screen.getByRole("link", { name: "Prompts" });
     const planner = screen
       .getAllByRole("link", { name: "Planner" })
-      .find(l => l.getAttribute("href") === "/planner");
+      .find((l) => l.getAttribute("href") === "/planner");
     expect(goals).toHaveAttribute("href", "/goals");
     expect(planner).toHaveAttribute("href", "/planner");
     expect(reviews).toHaveAttribute("href", "/reviews");

--- a/tests/prompts/prompts-demos.test.tsx
+++ b/tests/prompts/prompts-demos.test.tsx
@@ -2,12 +2,17 @@ import React from "react";
 import { render, screen, cleanup } from "@testing-library/react";
 import { describe, it, expect, afterEach } from "vitest";
 import { PromptsDemos } from "@/components/prompts";
+import { ThemeProvider } from "@/lib/theme-context";
 
 afterEach(cleanup);
 
 describe("PromptsDemos", () => {
   it("renders key demo sections", () => {
-    render(<PromptsDemos />);
+    render(
+      <ThemeProvider>
+        <PromptsDemos />
+      </ThemeProvider>,
+    );
     expect(
       screen.getByRole("button", { name: "Focus me to see the glow" }),
     ).toBeInTheDocument();

--- a/tests/prompts/prompts-page.test.tsx
+++ b/tests/prompts/prompts-page.test.tsx
@@ -1,7 +1,14 @@
 import React from "react";
-import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+} from "@testing-library/react";
 import { describe, it, beforeEach, expect, afterEach, vi } from "vitest";
 import { PromptsPage } from "@/components/prompts";
+import { ThemeProvider } from "@/lib/theme-context";
 import { resetLocalStorage } from "../setup";
 
 afterEach(() => {
@@ -15,7 +22,11 @@ describe("PromptsPage", () => {
   });
 
   it("saves prompts and filters results", async () => {
-    render(<PromptsPage />);
+    render(
+      <ThemeProvider>
+        <PromptsPage />
+      </ThemeProvider>,
+    );
 
     const titleInput = screen.getByPlaceholderText("Title");
     const textArea = screen.getByPlaceholderText(
@@ -51,7 +62,11 @@ describe("PromptsPage", () => {
   });
 
   it("ignores empty saves", async () => {
-    render(<PromptsPage />);
+    render(
+      <ThemeProvider>
+        <PromptsPage />
+      </ThemeProvider>,
+    );
     const saveButton = screen.getByRole("button", { name: "Save" });
     expect(saveButton).toBeDisabled();
     fireEvent.click(saveButton);

--- a/tests/ui/site-chrome.test.tsx
+++ b/tests/ui/site-chrome.test.tsx
@@ -2,10 +2,15 @@ import * as React from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import SiteChrome from "@/components/chrome/SiteChrome";
+import { ThemeProvider } from "@/lib/theme-context";
 
 describe("SiteChrome", () => {
   it("links to the home page via the noxi brand", () => {
-    render(<SiteChrome />);
+    render(
+      <ThemeProvider>
+        <SiteChrome />
+      </ThemeProvider>,
+    );
     const homeLink = screen.getByRole("link", { name: /noxi/i });
     expect(homeLink).toHaveAttribute("href", "/");
   });


### PR DESCRIPTION
## Summary
- add ThemeContext with persistent storage and global apply
- wrap root layout with ThemeProvider
- switch ThemeToggle and home page to consume shared theme state

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68c2221a8280832ca96580122f23e346