### PR TITLE
Improve TabBar focus management and panel accessibility

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -707,6 +707,7 @@ function PageContent() {
           id="components-panel"
           aria-labelledby="components-tab"
           hidden={view !== "components"}
+          tabIndex={0}
         >
           <ComponentsView query={query} />
         </div>
@@ -715,6 +716,7 @@ function PageContent() {
           id="colors-panel"
           aria-labelledby="colors-tab"
           hidden={view !== "colors"}
+          tabIndex={0}
         >
           <ColorsView />
         </div>
@@ -723,6 +725,7 @@ function PageContent() {
           id="onboarding-panel"
           aria-labelledby="onboarding-tab"
           hidden={view !== "onboarding"}
+          tabIndex={0}
         >
           <OnboardingTabs />
         </div>

--- a/src/components/prompts/ColorGallery.tsx
+++ b/src/components/prompts/ColorGallery.tsx
@@ -20,32 +20,42 @@ export default function ColorGallery() {
         onValueChange={setPalette}
         ariaLabel="Color palettes"
       />
-      <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
-        {palette === "aurora" && (
-          <div className="flex flex-col items-center gap-2 sm:col-span-2 md:col-span-3">
-            <span className="text-sm font-medium">Aurora Palette</span>
-            <div className="flex gap-2">
-              <div className="w-10 h-10 rounded bg-auroraG" />
-              <div className="w-10 h-10 rounded bg-auroraGLight" />
-              <div className="w-10 h-10 rounded bg-auroraP" />
-              <div className="w-10 h-10 rounded bg-auroraPLight" />
+      {paletteTabs.map((p) => (
+        <div
+          key={p.key}
+          role="tabpanel"
+          id={`${p.key}-panel`}
+          aria-labelledby={`${p.key}-tab`}
+          hidden={palette !== p.key}
+          tabIndex={0}
+          className="grid gap-8 sm:grid-cols-2 md:grid-cols-3"
+        >
+          {p.key === "aurora" && (
+            <div className="flex flex-col items-center gap-2 sm:col-span-2 md:col-span-3">
+              <span className="text-sm font-medium">Aurora Palette</span>
+              <div className="flex gap-2">
+                <div className="w-10 h-10 rounded bg-auroraG" />
+                <div className="w-10 h-10 rounded bg-auroraGLight" />
+                <div className="w-10 h-10 rounded bg-auroraP" />
+                <div className="w-10 h-10 rounded bg-auroraPLight" />
+              </div>
+              <p className="mt-2 text-center text-xs text-muted-foreground">
+                Use <code>auroraG</code>, <code>auroraGLight</code>, <code>auroraP</code>,
+                and <code>auroraPLight</code> Tailwind classes for aurora effects.
+              </p>
             </div>
-            <p className="mt-2 text-center text-xs text-muted-foreground">
-              Use <code>auroraG</code>, <code>auroraGLight</code>, <code>auroraP</code>,
-              and<code>auroraPLight</code> Tailwind classes for aurora effects.
-            </p>
-          </div>
-        )}
-        {COLOR_PALETTES[palette].map((c) => (
-          <div key={c} className="flex flex-col items-center gap-2">
-            <span className="text-xs uppercase tracking-wide text-accent">{c}</span>
-            <div
-              className="h-16 w-24 rounded-md border"
-              style={{ backgroundColor: `hsl(var(--${c}))` }}
-            />
-          </div>
-        ))}
-      </div>
+          )}
+          {COLOR_PALETTES[p.key].map((c) => (
+            <div key={c} className="flex flex-col items-center gap-2">
+              <span className="text-xs uppercase tracking-wide text-accent">{c}</span>
+              <div
+                className="h-16 w-24 rounded-md border"
+                style={{ backgroundColor: `hsl(var(--${c}))` }}
+              />
+            </div>
+          ))}
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/components/prompts/OnboardingTabs.tsx
+++ b/src/components/prompts/OnboardingTabs.tsx
@@ -31,19 +31,32 @@ export default function OnboardingTabs() {
       <p className="text-sm text-muted-foreground">
         Last updated {new Date(updatedAt).toLocaleTimeString()}
       </p>
-      {role === "designer" ? (
+      <div
+        role="tabpanel"
+        id="designer-panel"
+        aria-labelledby="designer-tab"
+        hidden={role !== "designer"}
+        tabIndex={0}
+      >
         <ul className="list-disc pl-6 space-y-1">
           <li>Review design system guidelines</li>
           <li>Audit existing components for consistency</li>
           <li>Collaborate with developers on UI implementation</li>
         </ul>
-      ) : (
+      </div>
+      <div
+        role="tabpanel"
+        id="developer-panel"
+        aria-labelledby="developer-tab"
+        hidden={role !== "developer"}
+        tabIndex={0}
+      >
         <ul className="list-disc pl-6 space-y-1">
           <li>Set up local development environment</li>
           <li>Follow project coding standards and lint rules</li>
           <li>Coordinate with designers on features</li>
         </ul>
-      )}
+      </div>
     </div>
   );
 }

--- a/tests/ui/tab-bar.test.tsx
+++ b/tests/ui/tab-bar.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { describe, it, expect, afterEach } from "vitest";
 import { TabBar } from "@/components/ui";
 
@@ -37,5 +37,85 @@ describe("TabBar", () => {
     const tab = screen.getByRole("tab", { name: "Components" });
     expect(tab).toHaveAttribute("id", "components-tab");
     expect(tab).toHaveAttribute("aria-controls", "components-panel");
+  });
+
+  it("moves focus with arrow keys", () => {
+    render(
+      <TabBar
+        items={[
+          { key: "one", label: "One" },
+          { key: "two", label: "Two" },
+        ]}
+      />
+    );
+    const tablist = screen.getByRole("tablist");
+    const first = screen.getByRole("tab", { name: "One" });
+    const second = screen.getByRole("tab", { name: "Two" });
+    first.focus();
+    fireEvent.keyDown(tablist, { key: "ArrowRight" });
+    expect(second).toHaveFocus();
+    expect(second).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("ignores arrow keys in right slot inputs", () => {
+    render(
+      <TabBar
+        items={[
+          { key: "one", label: "One" },
+          { key: "two", label: "Two" },
+        ]}
+        right={<input aria-label="search" />}
+      />
+    );
+    const input = screen.getByRole("textbox", { name: "search" });
+    input.focus();
+    fireEvent.keyDown(input, { key: "ArrowRight" });
+    const first = screen.getByRole("tab", { name: "One" });
+    expect(first).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("allows focusing active panel", () => {
+    function Wrapper() {
+      const [val, setVal] = React.useState("one");
+      return (
+        <>
+          <TabBar
+            items={[
+              { key: "one", label: "One" },
+              { key: "two", label: "Two" },
+            ]}
+            value={val}
+            onValueChange={setVal}
+          />
+          <div
+            role="tabpanel"
+            id="one-panel"
+            aria-labelledby="one-tab"
+            hidden={val !== "one"}
+            tabIndex={0}
+          >
+            One
+          </div>
+          <div
+            role="tabpanel"
+            id="two-panel"
+            aria-labelledby="two-tab"
+            hidden={val !== "two"}
+            tabIndex={0}
+          >
+            Two
+          </div>
+        </>
+      );
+    }
+
+    render(<Wrapper />);
+    const tablist = screen.getByRole("tablist");
+    const first = screen.getByRole("tab", { name: "One" });
+    first.focus();
+    fireEvent.keyDown(tablist, { key: "ArrowRight" });
+    const panel = screen.getByRole("tabpanel");
+    panel.focus();
+    expect(panel).toHaveFocus();
   });
 });


### PR DESCRIPTION
## Summary
- focus newly selected TabBar tabs via refs and scope arrow key handling to tablist
- provide ARIA-compliant tabpanels for onboarding and color gallery sections
- allow playground panels to receive focus and cover keyboard behavior in tests

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c221334b4c832ca784db87f28e4a81