### PR TITLE
feat: support nested icon selectors

### DIFF
--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -13,21 +13,21 @@ export const buttonSizes = {
     padding: "px-4",
     text: "text-sm",
     gap: "gap-1",
-    icon: "[&>svg]:size-4",
+    icon: "[&_svg]:size-4",
   },
   md: {
     height: "h-10",
     padding: "px-4",
     text: "text-base",
     gap: "gap-2",
-    icon: "[&>svg]:size-5",
+    icon: "[&_svg]:size-5",
   },
   lg: {
     height: "h-11",
     padding: "px-8",
     text: "text-lg",
     gap: "gap-4",
-    icon: "[&>svg]:size-8",
+    icon: "[&_svg]:size-8",
   },
 } as const;
 

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -18,11 +18,11 @@ export type IconButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 };
 
 const iconMap: Record<Icon, string> = {
-  xs: "[&>svg]:size-4",
-  sm: "[&>svg]:size-5",
-  md: "[&>svg]:size-6",
-  lg: "[&>svg]:size-7",
-  xl: "[&>svg]:size-8",
+  xs: "[&_svg]:size-4",
+  sm: "[&_svg]:size-5",
+  md: "[&_svg]:size-6",
+  lg: "[&_svg]:size-7",
+  xl: "[&_svg]:size-8",
 };
 const getSizeClass = (s: IconButtonSize) => {
   const sizeMap: Record<IconButtonSize, string> = {

--- a/tests/primitives/button.test.tsx
+++ b/tests/primitives/button.test.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { render, cleanup, fireEvent } from "@testing-library/react";
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { Button, type ButtonSize } from "../../src/components/ui/primitives/Button";
+import {
+  Button,
+  type ButtonSize,
+} from "../../src/components/ui/primitives/Button";
 import fs from "fs";
 
 afterEach(cleanup);
@@ -49,13 +52,28 @@ describe("Button", () => {
   });
 
   it.each<[ButtonSize, string]>([
-    ["sm", "[&>svg]:size-4"],
-    ["md", "[&>svg]:size-5"],
-    ["lg", "[&>svg]:size-8"],
+    ["sm", "[&_svg]:size-4"],
+    ["md", "[&_svg]:size-5"],
+    ["lg", "[&_svg]:size-8"],
   ])("applies %s icon sizing", (size, cls) => {
     const { getByRole } = render(
       <Button size={size}>
         <svg />
+      </Button>,
+    );
+    expect(getByRole("button")).toHaveClass(cls);
+  });
+
+  it.each<[ButtonSize, string]>([
+    ["sm", "[&_svg]:size-4"],
+    ["md", "[&_svg]:size-5"],
+    ["lg", "[&_svg]:size-8"],
+  ])("applies %s icon sizing for wrapped icons", (size, cls) => {
+    const { getByRole } = render(
+      <Button size={size}>
+        <span>
+          <svg />
+        </span>
       </Button>,
     );
     expect(getByRole("button")).toHaveClass(cls);

--- a/tests/primitives/icon-button.test.tsx
+++ b/tests/primitives/icon-button.test.tsx
@@ -42,17 +42,30 @@ describe("IconButton", () => {
   });
 
   const iconCases = [
-    ["xs", "[&>svg]:size-4"],
-    ["sm", "[&>svg]:size-5"],
-    ["md", "[&>svg]:size-6"],
-    ["lg", "[&>svg]:size-7"],
-    ["xl", "[&>svg]:size-8"],
+    ["xs", "[&_svg]:size-4"],
+    ["sm", "[&_svg]:size-5"],
+    ["md", "[&_svg]:size-6"],
+    ["lg", "[&_svg]:size-7"],
+    ["xl", "[&_svg]:size-8"],
   ] as const;
 
   iconCases.forEach(([iconSize, cls]) => {
     it(`applies ${iconSize} icon size classes`, () => {
       const { getByRole } = render(
-        <IconButton iconSize={iconSize} aria-label={iconSize} />,
+        <IconButton iconSize={iconSize} aria-label={iconSize}>
+          <svg />
+        </IconButton>,
+      );
+      expect(getByRole("button").className).toContain(cls);
+    });
+
+    it(`applies ${iconSize} icon size classes for wrapped icons`, () => {
+      const { getByRole } = render(
+        <IconButton iconSize={iconSize} aria-label={iconSize}>
+          <span>
+            <svg />
+          </span>
+        </IconButton>,
       );
       expect(getByRole("button").className).toContain(cls);
     });

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -673,7 +673,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                   </div>
                 </div>
                 <button
-                  class="relative inline-flex items-center justify-center rounded-2xl border border-[--focus] font-medium transition-all duration-200 hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 text-base gap-2 [&>svg]:size-5 px-4 whitespace-nowrap bg-panel/85 overflow-hidden shadow-neo text-foreground"
+                  class="relative inline-flex items-center justify-center rounded-2xl border border-[--focus] font-medium transition-all duration-200 hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 text-base gap-2 [&_svg]:size-5 px-4 whitespace-nowrap bg-panel/85 overflow-hidden shadow-neo text-foreground"
                   tabindex="0"
                   type="button"
                 >


### PR DESCRIPTION
## Summary
- apply `[&_svg]` selectors in `Button` and `IconButton`
- expand tests for wrapped icons

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c22bd78b14832c9f24003606d41396