### PR TITLE
refactor utilities and weekly stats

### DIFF
--- a/src/components/home/QuickActions.tsx
+++ b/src/components/home/QuickActions.tsx
@@ -14,39 +14,50 @@ interface QuickActionsProps {
 
 export default function QuickActions({ theme, setTheme }: QuickActionsProps) {
   const router = useRouter();
+  const goPlanner = React.useCallback(() => router.push("/planner"), [router]);
+  const goGoals = React.useCallback(() => router.push("/goals"), [router]);
+  const goReviews = React.useCallback(() => router.push("/reviews"), [router]);
+  const onVariantChange = React.useCallback(
+    (v: ThemeState["variant"]) => setTheme((prev) => ({ ...prev, variant: v })),
+    [setTheme],
+  );
+  const onBgChange = React.useCallback(
+    (b: ThemeState["bg"]) => setTheme((prev) => ({ ...prev, bg: b })),
+    [setTheme],
+  );
 
   return (
     <section aria-label="Quick actions" className="grid gap-4">
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
         <Button
           className="rounded-full shadow-neo-inset focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
-          onClick={() => router.push("/planner")}
+          onClick={goPlanner}
         >
           Planner Today
         </Button>
         <Button
           className="rounded-full shadow-neo-inset focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
           tone="accent"
-          onClick={() => router.push("/goals")}
+          onClick={goGoals}
         >
           New Goal
         </Button>
         <Button
           className="rounded-full shadow-neo-inset focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
           tone="accent"
-          onClick={() => router.push("/reviews")}
+          onClick={goReviews}
         >
           New Review
         </Button>
         <div className="flex items-center gap-4">
           <ThemePicker
             variant={theme.variant}
-            onVariantChange={v => setTheme(prev => ({ ...prev, variant: v }))}
+            onVariantChange={onVariantChange}
             className="shrink-0"
           />
           <BackgroundPicker
             bg={theme.bg}
-            onBgChange={b => setTheme(prev => ({ ...prev, bg: b }))}
+            onBgChange={onBgChange}
             className="shrink-0"
           />
         </div>

--- a/src/components/planner/useWeekData.ts
+++ b/src/components/planner/useWeekData.ts
@@ -8,15 +8,24 @@ export function useWeekData(days: ISODate[]) {
   const { days: map } = usePlannerStore();
 
   return React.useMemo(() => {
+    let weekDone = 0;
+    let weekTotal = 0;
     const per = days.map((iso) => {
       const rec = ensureDay(map, iso);
-      const pDone = rec.projects.filter((p) => p?.done).length;
-      const tDone = rec.tasks.filter((t) => t?.done).length;
-      const total = rec.projects.length + rec.tasks.length;
-      return { iso, done: pDone + tDone, total };
+      let done = 0;
+      let total = 0;
+      for (const p of rec.projects) {
+        total++;
+        if (p?.done) done++;
+      }
+      for (const t of rec.tasks) {
+        total++;
+        if (t?.done) done++;
+      }
+      weekDone += done;
+      weekTotal += total;
+      return { iso, done, total };
     });
-    const weekDone = per.reduce((a, b) => a + b.done, 0);
-    const weekTotal = per.reduce((a, b) => a + b.total, 0);
     return { per, weekDone, weekTotal };
   }, [days, map]);
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -34,17 +34,37 @@ export function slugify(s?: string): string {
     .slice(0, 64);
 }
 
+/** Escape mappings for sanitizeText */
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+/**
+ * Clone data using structuredClone with JSON fallback.
+ */
+export function safeClone<T>(value: T): T {
+  if (typeof structuredClone === "function") {
+    try {
+      return structuredClone(value);
+    } catch {
+      // fall through to JSON
+    }
+  }
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return value;
+  }
+}
+
 /**
  * sanitizeText — escape HTML-unsafe characters to prevent node injection.
  * Minimal on purpose; more heavy sanitizers can be added if needed.
  */
 export function sanitizeText(input: string): string {
-  const map: Record<string, string> = {
-    "&": "&amp;",
-    "<": "&lt;",
-    ">": "&gt;",
-    '"': "&quot;",
-    "'": "&#39;",
-  };
-  return input.replace(/[&<>"']/g, (c) => map[c]);
+  return input.replace(/[&<>"']/g, (c) => HTML_ESCAPE_MAP[c]);
 }


### PR DESCRIPTION
## Summary
- add reusable HTML_ESCAPE_MAP and safeClone utilities
- simplify writeLocal and usePersistentState cloning logic
- compute week data without intermediate arrays
- memoize QuickActions handlers

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68c2ec639430832c958d579533738b1f