### PR TITLE
fix: use radius tokens consistently

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -873,7 +873,7 @@ html.bg-intense body::after {
   font-size: 10px;
   line-height: 1;
   padding: 0.45rem 0.55rem;
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
   border: 1px solid var(--b);
   background: linear-gradient(180deg, var(--bg), hsl(var(--card)));
   color: hsl(var(--muted-foreground));
@@ -1303,6 +1303,7 @@ textarea:-webkit-autofill {
   /* Radius tokens */
   --radius-md: 8px;
   --radius-2xl: 16px;
+  --radius-full: 9999px;
 }
 
 @layer components {

--- a/src/components/home/DashboardCard.tsx
+++ b/src/components/home/DashboardCard.tsx
@@ -17,13 +17,13 @@ export default function DashboardCard({
   actions,
 }: DashboardCardProps) {
   return (
-    <div className="card-neo-soft rounded-card r-card-lg border border-[hsl(var(--border))] p-4 md:p-6 space-y-4">
+    <div className="card-neo-soft rounded-card r-card-lg border border-border p-4 md:p-6 space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-base font-semibold tracking-[-0.01em]">{title}</h2>
         {actions}
       </div>
       {children && (
-        <div className="border-t border-[hsl(var(--border))] pt-4 space-y-4">
+        <div className="border-t border-border pt-4 space-y-4">
           {children}
         </div>
       )}

--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -105,7 +105,7 @@
 .task-tile__text:focus-visible {
   outline: 2px solid hsl(var(--ring));
   outline-offset: 2px;
-  border-radius: var(--radius-md, 6px);
+  border-radius: var(--radius-md);
 }
 
 /* Soft, readable strike-through for completed tasks */

--- a/src/components/ui/toggles/CheckCircle.tsx
+++ b/src/components/ui/toggles/CheckCircle.tsx
@@ -340,7 +340,7 @@ export default function CheckCircle({
         .ccx-glow {
           position: absolute;
           inset: -2px;
-          border-radius: 9999px;
+          border-radius: inherit;
           pointer-events: none;
         }
         .ccx-glow::before,


### PR DESCRIPTION
## Summary
- ensure CheckCircle glow inherits parent radius
- rely on radius tokens for planner focus ring
- use semantic border color in DashboardCard
- add `--radius-full` token and apply to meta-strip pills

## Testing
- `npx prettier src/components/ui/toggles/CheckCircle.tsx src/components/planner/style.css src/components/home/DashboardCard.tsx src/app/globals.css --check` *(fails: code style issues found in 3 files)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c2fd942898832cb70e203415236fce