### PR TITLE
Add focus-visible ring to DayRow sections

### DIFF
--- a/src/components/planner/DayRow.tsx
+++ b/src/components/planner/DayRow.tsx
@@ -11,14 +11,15 @@ const DayRow = React.memo(
         id={`day-${iso}`}
         role="listitem"
         aria-label={`Day ${iso}${isToday ? " (Today)" : ""}`}
-        className="w-full scroll-m-24"
+        className="w-full scroll-m-24 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         tabIndex={-1}
       >
         <DayCard iso={iso} isToday={isToday} />
       </section>
     );
   },
-  (a: Readonly<DayRowProps>, b: Readonly<DayRowProps>) => a.iso === b.iso && a.isToday === b.isToday,
+  (a: Readonly<DayRowProps>, b: Readonly<DayRowProps>) =>
+    a.iso === b.iso && a.isToday === b.isToday,
 );
 
 export default DayRow;


### PR DESCRIPTION
## Summary
- ensure each day section shows a focus ring when navigated via keyboard by adding design-token based `focus-visible` styles

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c32c1a92bc832cb59460b7351ffe36