### PR TITLE
refactor: use card radius tokens in team prompts card

### DIFF
--- a/src/components/home/TeamPromptsCard.tsx
+++ b/src/components/home/TeamPromptsCard.tsx
@@ -11,19 +11,19 @@ export default function TeamPromptsCard() {
         <div className="grid grid-cols-2 gap-4">
           <Link
             href="/team"
-            className="rounded-full border border-[hsl(var(--border))] px-3 py-1 text-xs hover:bg-[--hover] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0"
+            className="rounded-card r-card-md border border-[hsl(var(--border))] px-3 py-1 text-xs hover:bg-[--hover] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0"
           >
             Archetypes
           </Link>
           <Link
             href="/team"
-            className="rounded-full border border-[hsl(var(--border))] px-3 py-1 text-xs hover:bg-[--hover] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0"
+            className="rounded-card r-card-md border border-[hsl(var(--border))] px-3 py-1 text-xs hover:bg-[--hover] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0"
           >
             Team Builder
           </Link>
           <Link
             href="/team"
-            className="rounded-full border border-[hsl(var(--border))] px-3 py-1 text-xs hover:bg-[--hover] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0"
+            className="rounded-card r-card-md border border-[hsl(var(--border))] px-3 py-1 text-xs hover:bg-[--hover] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0"
           >
             Jungle Clears
           </Link>
@@ -31,7 +31,7 @@ export default function TeamPromptsCard() {
       </DashboardCard>
       <DashboardCard title="Prompts peek" cta={{ label: "Explore Prompts", href: "/prompts" }}>
         <div
-          className="rounded-lg p-4 text-center text-sm"
+          className="rounded-card r-card-md p-4 text-center text-sm"
           style={{ background: "var(--seg-active-grad)", color: "var(--neon-soft)" }}
         >
           Get inspired with curated prompts


### PR DESCRIPTION
## Summary
- replace hard-coded radius with `rounded-card r-card-md` in TeamPromptsCard

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c34c0c872c832c82ce733b7ff2550a