### PR TITLE
Use IconButton for prompt confirm actions and add sidebar layout

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -737,7 +737,7 @@ function PageContent() {
   }, [query, router, searchParams]);
 
   return (
-    <main className="mx-auto max-w-screen-xl grid grid-cols-12 gap-x-6 px-8 py-8">
+    <main className="mx-auto max-w-screen-xl grid grid-cols-12 gap-6 px-8 py-8">
       <header className="col-span-12 flex items-start justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-[-0.01em]">
@@ -749,56 +749,56 @@ function PageContent() {
         </div>
         <ThemeToggle />
       </header>
-      <div className="col-span-12">
-        <label htmlFor="playground-search" className="sr-only">
-          Search components
-        </label>
-        <SearchBar
-          id="playground-search"
-          value={query}
-          onValueChange={setQuery}
-          debounceMs={300}
-        />
-      </div>
-      <div className="col-span-12">
-        <UpdatesList />
-      </div>
-      <div className="col-span-12">
+      <div className="col-span-12 lg:col-span-8 space-y-6">
+        <div>
+          <label htmlFor="playground-search" className="sr-only">
+            Search components
+          </label>
+          <SearchBar
+            id="playground-search"
+            value={query}
+            onValueChange={setQuery}
+            debounceMs={300}
+          />
+        </div>
         <TabBar
           items={VIEW_TABS}
           value={view}
           onValueChange={setView}
           ariaLabel="Playground views"
         />
+        <div>
+          <div
+            role="tabpanel"
+            id="components-panel"
+            aria-labelledby="components-tab"
+            hidden={view !== "components"}
+            tabIndex={0}
+          >
+            <ComponentsView query={query} />
+          </div>
+          <div
+            role="tabpanel"
+            id="colors-panel"
+            aria-labelledby="colors-tab"
+            hidden={view !== "colors"}
+            tabIndex={0}
+          >
+            <ColorsView />
+          </div>
+          <div
+            role="tabpanel"
+            id="onboarding-panel"
+            aria-labelledby="onboarding-tab"
+            hidden={view !== "onboarding"}
+            tabIndex={0}
+          >
+            <OnboardingTabs />
+          </div>
+        </div>
       </div>
-      <div className="col-span-12">
-        <div
-          role="tabpanel"
-          id="components-panel"
-          aria-labelledby="components-tab"
-          hidden={view !== "components"}
-          tabIndex={0}
-        >
-          <ComponentsView query={query} />
-        </div>
-        <div
-          role="tabpanel"
-          id="colors-panel"
-          aria-labelledby="colors-tab"
-          hidden={view !== "colors"}
-          tabIndex={0}
-        >
-          <ColorsView />
-        </div>
-        <div
-          role="tabpanel"
-          id="onboarding-panel"
-          aria-labelledby="onboarding-tab"
-          hidden={view !== "onboarding"}
-          tabIndex={0}
-        >
-          <OnboardingTabs />
-        </div>
+      <div className="col-span-12 lg:col-span-4 lg:sticky lg:top-8">
+        <UpdatesList />
       </div>
     </main>
   );

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -38,6 +38,7 @@ import { GoalsTabs, GoalsProgress, type FilterKey } from "@/components/goals";
 import PromptsHeader from "./PromptsHeader";
 import PromptsComposePanel from "./PromptsComposePanel";
 import PromptsDemos from "./PromptsDemos";
+import UpdatesList from "./UpdatesList";
 import ReviewPanel from "@/components/reviews/ReviewPanel";
 import ReviewListItem from "@/components/reviews/ReviewListItem";
 import Banner from "@/components/chrome/Banner";
@@ -54,7 +55,13 @@ import {
 } from "@/components/planner";
 import type { Pillar, Review } from "@/lib/types";
 import type { GameSide } from "@/components/ui/league/SideSelector";
-import { Search as SearchIcon, Star, Plus, Sun } from "lucide-react";
+import {
+  Search as SearchIcon,
+  Star,
+  Plus,
+  Sun,
+  Check as CheckIcon,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import GalleryItem from "./GalleryItem";
 
@@ -130,6 +137,9 @@ export default function ComponentGallery() {
               title="Search"
             >
               <SearchIcon />
+            </IconButton>
+            <IconButton size="sm" aria-label="Confirm" title="Confirm">
+              <CheckIcon />
             </IconButton>
           </div>
         ),
@@ -390,6 +400,29 @@ export default function ComponentGallery() {
         element: (
           <div className="w-full">
             <PromptsDemos />
+          </div>
+        ),
+        className: "sm:col-span-2 md:col-span-3 w-full",
+      },
+      {
+        label: "Prompts Layout",
+        element: (
+          <div className="w-full">
+            <div className="grid grid-cols-12 gap-6">
+              <div className="col-span-12 lg:col-span-8 space-y-6">
+                <SearchBar value="" onValueChange={() => {}} />
+                <TabBar
+                  items={[{ key: "demo", label: "Demo" }]}
+                  value="demo"
+                  onValueChange={() => {}}
+                  ariaLabel="Demo tabs"
+                />
+                <Card className="h-24" />
+              </div>
+              <div className="col-span-12 lg:col-span-4 lg:sticky lg:top-8">
+                <UpdatesList />
+              </div>
+            </div>
           </div>
         ),
         className: "sm:col-span-2 md:col-span-3 w-full",

--- a/src/components/prompts/PromptsComposePanel.tsx
+++ b/src/components/prompts/PromptsComposePanel.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { Input, Textarea } from "@/components/ui";
+import IconButton from "@/components/ui/primitives/IconButton";
 import { Check as CheckIcon } from "lucide-react";
 
 interface PromptsComposePanelProps {
@@ -27,13 +28,13 @@ export default function PromptsComposePanel({
         onChange={(e) => onTitleChange(e.target.value)}
         aria-describedby={`${titleId}-help`}
       >
-        <button
-          type="button"
+        <IconButton
+          size="sm"
           aria-label="Confirm"
-          className="absolute right-2 top-1/2 -translate-y-1/2 size-7 rounded-full grid place-items-center border border-accent/45 bg-accent/12 text-accent shadow-[0_0_0_1px_hsl(var(--accent)/0.25)] hover:shadow-[0_0_16px_hsl(var(--accent)/0.22)]"
+          className="absolute right-2 top-1/2 -translate-y-1/2"
         >
-          <CheckIcon className="size-4" />
-        </button>
+          <CheckIcon aria-hidden />
+        </IconButton>
       </Input>
       <p id={`${titleId}-help`} className="mt-1 text-xs text-muted-foreground">
         Add a short title
@@ -47,4 +48,3 @@ export default function PromptsComposePanel({
     </div>
   );
 }
-

--- a/src/components/prompts/PromptsDemos.tsx
+++ b/src/components/prompts/PromptsDemos.tsx
@@ -66,13 +66,13 @@ export default function PromptsDemos() {
             }
           />
           <Input placeholder="With action">
-            <button
-              type="button"
+            <IconButton
+              size="sm"
               aria-label="Confirm"
-              className="absolute right-2 top-1/2 -translate-y-1/2 size-7 rounded-full grid place-items-center border border-accent/45 bg-accent/12 text-accent shadow-[0_0_0_1px_hsl(var(--accent)/0.25)] hover:shadow-[0_0_16px_hsl(var(--accent)/0.22)]"
+              className="absolute right-2 top-1/2 -translate-y-1/2"
             >
-              <CheckIcon className="size-4" />
-            </button>
+              <CheckIcon aria-hidden />
+            </IconButton>
           </Input>
         </div>
       </Card>


### PR DESCRIPTION
## Summary
- replace custom confirm buttons with token-driven `IconButton` in prompts compose panel and demos
- restructure prompts playground with main column and sticky updates sidebar
- showcase new confirm button and layout in component gallery

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68c34eb4a4f0832c8728a239ebbe2aba