### PR TITLE
Add flag icon to goals header

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -183,13 +183,18 @@ export default function GoalsPage() {
         : "Pick a duration and focus.";
 
   return (
-    <main id="goals-main" aria-labelledby="goals-header" className="page-shell py-6 space-y-6">
+    <main
+      id="goals-main"
+      aria-labelledby="goals-header"
+      className="page-shell py-6 space-y-6"
+    >
       {/* ======= HEADER ======= */}
       <Header
         id="goals-header"
         eyebrow="Goals"
         heading="Today"
         subtitle={summary}
+        icon={<Flag className="opacity-80" />}
         sticky
         barClassName="flex-col items-start justify-start gap-2 sm:flex-row sm:items-center sm:justify-between"
         right={


### PR DESCRIPTION
## Summary
- display flag icon in Goals page header for clearer context

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c368b9c108832c840433d6bde06238