### PR TITLE
feat: add isometric room diorama

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,12 +4,12 @@ import * as React from "react";
 import { Suspense } from "react";
 import { Home } from "lucide-react";
 import {
-  QuickActions,
   TodayCard,
   GoalsCard,
   ReviewsCard,
   TeamPromptsCard,
   BottomNav,
+  IsometricRoom,
 } from "@/components/home";
 import Hero from "@/components/ui/layout/Hero";
 import Header from "@/components/ui/layout/Header";
@@ -74,7 +74,7 @@ function HomePageContent() {
         icon={<Home className="opacity-80" />}
       />
       <Hero topClassName="top-[var(--header-stack)]" heading="Hero" />
-      <QuickActions theme={theme} setTheme={setTheme} />
+      <IsometricRoom variant={theme.variant} />
       <section className="grid grid-cols-1 gap-6 md:grid-cols-12">
         <div className="md:col-span-4">
           <TodayCard />

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -32,7 +32,7 @@ import PromptList from "@/components/prompts/PromptList";
 import OnboardingTabs from "@/components/prompts/OnboardingTabs";
 import type { PromptWithTitle } from "@/components/prompts/usePrompts";
 import { Plus } from "lucide-react";
-import { DashboardCard, BottomNav } from "@/components/home";
+import { DashboardCard, BottomNav, IsometricRoom } from "@/components/home";
 import { RoleSelector } from "@/components/reviews";
 import ReviewListItem from "@/components/reviews/ReviewListItem";
 import type { Review } from "@/lib/types";
@@ -481,6 +481,19 @@ const SPEC_DATA: Record<Section, Spec[]> = {
       name: "BackgroundPicker",
       element: <BackgroundPickerDemo />,
       tags: ["control", "theme"],
+    },
+    {
+      id: "isometric-room",
+      name: "IsometricRoom",
+      description: "Theme diorama",
+      element: <IsometricRoom variant="lg" />,
+      tags: ["home", "theme"],
+      props: [
+        {
+          label: "variant",
+          value: "lg aurora citrus noir ocean kitten hardstuck",
+        },
+      ],
     },
     {
       id: "bottom-nav",

--- a/src/components/home/IsometricRoom.tsx
+++ b/src/components/home/IsometricRoom.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import * as React from "react";
+import Card from "@/components/ui/primitives/Card";
+import type { Variant } from "@/lib/theme";
+
+export const ROOM_DECOR: Record<Variant, string> = {
+  lg: "Glitch setup",
+  aurora: "Aurora zen",
+  citrus: "Citrus nook",
+  noir: "Noir lounge",
+  ocean: "Ocean escape",
+  kitten: "Kitten corner",
+  hardstuck: "Hardstuck grind",
+};
+
+interface IsometricRoomProps {
+  variant: Variant;
+}
+
+export default function IsometricRoom({ variant }: IsometricRoomProps) {
+  const decor = ROOM_DECOR[variant];
+  return (
+    <Card
+      role="img"
+      aria-label={`Isometric room with ${decor}`}
+      tabIndex={0}
+      className="grid h-48 place-items-center focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:animate-pulse motion-reduce:animate-none forced-colors:outline"
+    >
+      <span className="text-sm text-muted-foreground">{decor}</span>
+    </Card>
+  );
+}

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -6,3 +6,4 @@ export { default as ReviewsCard } from "./ReviewsCard";
 export { default as QuickActions } from "./QuickActions";
 export { default as TeamPromptsCard } from "./TeamPromptsCard";
 export { default as BottomNav } from "./BottomNav";
+export { default as IsometricRoom } from "./IsometricRoom";


### PR DESCRIPTION
## Summary
- add IsometricRoom component with theme-based decor mapping
- render new diorama on home page and document in prompts gallery

## Testing
- `npm run regen-ui`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c371e83578832ca5baaeb951b1849a