### PR TITLE
feat: add themed isometric room

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -36,7 +36,7 @@ import { DashboardCard, BottomNav, IsometricRoom } from "@/components/home";
 import { RoleSelector } from "@/components/reviews";
 import ReviewListItem from "@/components/reviews/ReviewListItem";
 import type { Review } from "@/lib/types";
-import { COLOR_PALETTES, defaultTheme } from "@/lib/theme";
+import { COLOR_PALETTES, VARIANTS, defaultTheme } from "@/lib/theme";
 import {
   GoalsProgress,
   RemindersTab,
@@ -486,7 +486,13 @@ const SPEC_DATA: Record<Section, Spec[]> = {
       id: "isometric-room",
       name: "IsometricRoom",
       description: "Theme diorama",
-      element: <IsometricRoom variant="lg" />,
+      element: (
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
+          {VARIANTS.map((v) => (
+            <IsometricRoom key={v.id} variant={v.id} />
+          ))}
+        </div>
+      ),
       tags: ["home", "theme"],
       props: [
         {

--- a/src/components/home/IsometricRoom.tsx
+++ b/src/components/home/IsometricRoom.tsx
@@ -18,6 +18,22 @@ interface IsometricRoomProps {
   variant: Variant;
 }
 
+const VARIANT_STYLES: Record<Variant, string> = {
+  lg: "[--room-floor:var(--lg-black)] [--room-wall:var(--lg-violet)] [--room-accent:var(--lg-cyan)]",
+  aurora:
+    "[--room-floor:var(--aurora-g)] [--room-wall:var(--aurora-p)] [--room-accent:var(--aurora-g-light)]",
+  citrus:
+    "[--room-floor:var(--citrus-teal)] [--room-wall:var(--citrus-teal)] [--room-accent:var(--ring)]",
+  noir:
+    "[--room-floor:var(--noir-ink)] [--room-wall:var(--noir-rose)] [--room-accent:var(--noir-red)]",
+  ocean:
+    "[--room-floor:var(--ocean-indigo)] [--room-wall:var(--ocean-cyan)] [--room-accent:var(--ocean-cyan)]",
+  kitten:
+    "[--room-floor:var(--kitten-pink)] [--room-wall:var(--kitten-rose)] [--room-accent:var(--kitten-blush)]",
+  hardstuck:
+    "[--room-floor:var(--hardstuck-deep)] [--room-wall:var(--hardstuck-forest)] [--room-accent:var(--hardstuck-forest)]",
+};
+
 export default function IsometricRoom({ variant }: IsometricRoomProps) {
   const decor = ROOM_DECOR[variant];
   return (
@@ -25,9 +41,14 @@ export default function IsometricRoom({ variant }: IsometricRoomProps) {
       role="img"
       aria-label={`Isometric room with ${decor}`}
       tabIndex={0}
-      className="grid h-48 place-items-center focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:animate-pulse motion-reduce:animate-none forced-colors:outline"
+      className={`relative h-48 overflow-hidden bg-background border shadow transition-transform motion-reduce:transition-none hover:-translate-y-1 hover:shadow-md active:shadow focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:hover:translate-y-0 ${VARIANT_STYLES[variant]}`}
     >
-      <span className="text-sm text-muted-foreground">{decor}</span>
+      <div className="absolute inset-0 [transform-style:preserve-3d]">
+        <div className="absolute inset-x-0 bottom-0 h-1/2 bg-[hsl(var(--room-floor))] origin-bottom [transform:rotateX(90deg)]" />
+        <div className="absolute inset-y-0 left-0 w-1/2 bg-[hsl(var(--room-wall))] origin-left [transform:rotateY(90deg)]" />
+        <div className="absolute inset-y-0 right-0 w-1/2 bg-[hsl(var(--room-accent))] origin-right [transform:rotateY(-90deg)]" />
+      </div>
+      <span className="sr-only">{decor}</span>
     </Card>
   );
 }


### PR DESCRIPTION
## Summary
- add isometric room container with variant-based decor and interaction states
- showcase all room variants in prompts gallery

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c37bce6a98832c8cd94fcc1ffc4480