### PR TITLE
Stack quick action buttons vertically

### DIFF
--- a/src/components/home/QuickActions.tsx
+++ b/src/components/home/QuickActions.tsx
@@ -28,7 +28,7 @@ export default function QuickActions({ theme, setTheme }: QuickActionsProps) {
 
   return (
     <section aria-label="Quick actions" className="grid gap-4">
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+      <div className="flex flex-col gap-4">
         <Button
           className="rounded-full focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
           onClick={goPlanner}


### PR DESCRIPTION
## Summary
- stack home quick action buttons vertically for simpler layout
- keep theme/background pickers aligned horizontally within their row

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68c37e1356a0832c918067f868339b12