### PR TITLE
refactor planner state and persistence

### DIFF
--- a/docs/planner-modules.md
+++ b/docs/planner-modules.md
@@ -2,7 +2,7 @@
 
 This directory splits the planner logic into focused modules:
 
-- `plannerStore.ts` – React context with persistent planner data (`days`, `focus`, and selection). Wrap planner pages with `PlannerProvider` and consume the raw store via `usePlannerContext`.
+- `plannerStore.ts` – React contexts with persistent planner data (`days`, `focus`, and selection). Wrap planner pages with `PlannerProvider` and consume state via `useDays`, `useFocus`, and `useSelection`.
 - `plannerCrud.ts` – Factory for project and task CRUD helpers. Given a day ISO string and an `upsertDay` function, it returns operations like `addProject` and `toggleTask`.
 - `usePlannerStore.ts` – Hook exposing persistent planner state and CRUD helpers for the current focus day.
 - `useFocusDate.ts` – Hooks for managing the focused date and deriving week information.

--- a/src/components/planner/TaskList.tsx
+++ b/src/components/planner/TaskList.tsx
@@ -4,14 +4,13 @@ import * as React from "react";
 import Input from "@/components/ui/primitives/Input";
 import EmptyRow from "./EmptyRow";
 import TaskRow from "./TaskRow";
-
-type Task = { id: string; text: string; done: boolean; projectId?: string };
+import type { DayTask } from "./plannerStore";
 
 type Props = {
-  tasks: Task[];
+  tasks: DayTask[];
   selectedProjectId: string;
   addTask: (title: string, projectId?: string) => string | undefined;
-  renameTask: (id: string, text: string) => void;
+  renameTask: (id: string, title: string) => void;
   toggleTask: (id: string) => void;
   deleteTask: (id: string) => void;
   setSelectedTaskId: (id: string) => void;
@@ -74,7 +73,7 @@ export default function TaskList({
                   deleteTask(t.id);
                   setSelectedTaskId("");
                 }}
-                onEdit={(text) => renameTask(t.id, text)}
+                onEdit={(title) => renameTask(t.id, title)}
                 onSelect={() => setSelectedTaskId(t.id)}
               />
             ))}

--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -6,14 +6,13 @@ import IconButton from "@/components/ui/primitives/IconButton";
 import CheckCircle from "@/components/ui/toggles/CheckCircle";
 import { Pencil, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
-
-type Task = { id: string; text: string; done: boolean; projectId?: string };
+import type { DayTask } from "./plannerStore";
 
 type Props = {
-  task: Task;
+  task: DayTask;
   onToggle: () => void;
   onDelete: () => void;
-  onEdit: (text: string) => void;
+  onEdit: (title: string) => void;
   onSelect: () => void;
 };
 
@@ -25,7 +24,7 @@ export default function TaskRow({
   onSelect,
 }: Props) {
   const [editing, setEditing] = React.useState(false);
-  const [text, setText] = React.useState(task.text);
+  const [title, setTitle] = React.useState(task.title);
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   React.useEffect(() => {
@@ -36,13 +35,13 @@ export default function TaskRow({
     setEditing(true);
   }
   function commit() {
-    const v = text.trim();
+    const v = title.trim();
     setEditing(false);
-    if (v && v !== task.text) onEdit(v);
+    if (v && v !== task.title) onEdit(v);
   }
   function cancel() {
     setEditing(false);
-    setText(task.text);
+    setTitle(task.title);
   }
 
   return (
@@ -87,15 +86,15 @@ export default function TaskRow({
                   task.done && "line-through-soft",
                 )}
               >
-                {task.text}
+                {task.title}
               </span>
             </button>
           ) : (
             <Input
               name={`dc-rename-task-${task.id}`}
               ref={inputRef}
-              value={text}
-              onChange={(e) => setText(e.target.value)}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
               onBlur={commit}
               onKeyDown={(e) => {
                 if (e.key === "Enter") commit();

--- a/src/components/planner/TodayHero.tsx
+++ b/src/components/planner/TodayHero.tsx
@@ -344,16 +344,16 @@ export default function TodayHero({ iso }: Props) {
                           onChange={(e) => setEditingTaskText(e.target.value)}
                           onKeyDown={(e) => {
                             if (e.key === "Enter") {
-                              renameTask(t.id, editingTaskText || t.text);
+                              renameTask(t.id, editingTaskText || t.title);
                               setEditingTaskId(null);
                             }
                             if (e.key === "Escape") setEditingTaskId(null);
                           }}
                           onBlur={() => {
-                            renameTask(t.id, editingTaskText || t.text);
+                            renameTask(t.id, editingTaskText || t.title);
                             setEditingTaskId(null);
                           }}
-                          aria-label={`Rename task ${t.text}`}
+                          aria-label={`Rename task ${t.title}`}
                         />
                       ) : (
                         <button
@@ -369,21 +369,21 @@ export default function TodayHero({ iso }: Props) {
                               setEditingTaskId(t.id);
                             }
                           }}
-                          aria-label={`Edit task ${t.text}`}
+                          aria-label={`Edit task ${t.title}`}
                           title="Edit task"
                         >
-                          {t.text}
+                          {t.title}
                         </button>
                       )}
                     </div>
 
                     <div className="flex items-center gap-2">
                       <IconButton
-                        aria-label={`Edit task ${t.text}`}
+                        aria-label={`Edit task ${t.title}`}
                         title="Edit"
                         onClick={() => {
                           setEditingTaskId(t.id);
-                          setEditingTaskText(t.text);
+                          setEditingTaskText(t.title);
                           setSelTaskId(t.id);
                         }}
                         size="sm"

--- a/src/components/planner/useDay.ts
+++ b/src/components/planner/useDay.ts
@@ -10,18 +10,7 @@ export function useDay(iso: ISODate) {
 
   const rec = React.useMemo(() => ensureDay(days, iso), [days, iso]);
 
-  const tasks = React.useMemo(
-    () =>
-      rec.tasks.map((t) => ({
-        id: t.id,
-        title: t.title,
-        text: t.title,
-        done: t.done,
-        projectId: t.projectId,
-        createdAt: t.createdAt,
-      })),
-    [rec.tasks],
-  );
+  const tasks = React.useMemo(() => rec.tasks, [rec.tasks]);
 
   const crud = React.useMemo(() => makeCrud(iso, upsertDay), [iso, upsertDay]);
 

--- a/src/components/planner/useFocusDate.ts
+++ b/src/components/planner/useFocusDate.ts
@@ -2,14 +2,14 @@
 
 import * as React from "react";
 import { addDays, toISODate, weekRangeFromISO } from "@/lib/date";
-import { todayISO, usePlannerContext, type ISODate } from "./plannerStore";
+import { todayISO, useFocus, type ISODate } from "./plannerStore";
 
 /**
  * Exposes the currently focused ISO date and helper to update it.
  * @returns Current focus ISO date, setter, and today's ISO string.
  */
 export function useFocusDate() {
-  const { focus, setFocus } = usePlannerContext();
+  const { focus, setFocus } = useFocus();
   const today = todayISO();
   return { iso: focus, setIso: setFocus, today } as const;
 }

--- a/src/components/planner/useSelection.ts
+++ b/src/components/planner/useSelection.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { ensureDay, usePlannerContext, type ISODate } from "./plannerStore";
+import { ensureDay, useSelection, useDays, type ISODate } from "./plannerStore";
 
 /**
  * Manages the selected project for a given day.
@@ -10,11 +10,11 @@ import { ensureDay, usePlannerContext, type ISODate } from "./plannerStore";
  * @returns Tuple of current project ID and setter.
  */
 export function useSelectedProject(iso: ISODate) {
-  const { selected, setSelected } = usePlannerContext();
+  const { selected, setSelected } = useSelection();
   const current = selected[iso]?.projectId ?? "";
   const set = React.useCallback(
     (projectId: string) => {
-      setSelected(prev => ({
+      setSelected((prev) => ({
         ...prev,
         [iso]: projectId ? { projectId } : {},
       }));
@@ -31,18 +31,19 @@ export function useSelectedProject(iso: ISODate) {
  * @returns Tuple of current task ID and setter.
  */
 export function useSelectedTask(iso: ISODate) {
-  const { selected, setSelected, days } = usePlannerContext();
+  const { selected, setSelected } = useSelection();
+  const { days } = useDays();
   const current = selected[iso]?.taskId ?? "";
 
   const set = React.useCallback(
     (taskId: string) => {
       if (!taskId) {
-        setSelected(prev => ({ ...prev, [iso]: {} }));
+        setSelected((prev) => ({ ...prev, [iso]: {} }));
         return;
       }
       const rec = ensureDay(days, iso);
-      const projectId = rec.tasks.find(t => t.id === taskId)?.projectId;
-      setSelected(prev => ({
+      const projectId = rec.tasks.find((t) => t.id === taskId)?.projectId;
+      setSelected((prev) => ({
         ...prev,
         [iso]: { taskId, projectId },
       }));

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -99,8 +99,20 @@ const demoProjects = [
 ];
 
 const demoTasks = [
-  { id: "t1", text: "Task A", done: false, projectId: "p1" },
-  { id: "t2", text: "Task B", done: true, projectId: "p1" },
+  {
+    id: "t1",
+    title: "Task A",
+    done: false,
+    projectId: "p1",
+    createdAt: Date.now(),
+  },
+  {
+    id: "t2",
+    title: "Task B",
+    done: true,
+    projectId: "p1",
+    createdAt: Date.now(),
+  },
 ];
 
 export default function ComponentGallery() {
@@ -471,7 +483,12 @@ export default function ComponentGallery() {
         element: (
           <ul className="w-64">
             <TaskRow
-              task={{ id: "t1", text: "Sample", done: false }}
+              task={{
+                id: "t1",
+                title: "Sample",
+                done: false,
+                createdAt: Date.now(),
+              }}
               onToggle={() => {}}
               onDelete={() => {}}
               onEdit={() => {}}
@@ -752,10 +769,7 @@ export default function ComponentGallery() {
         label: "Header + Hero",
         element: (
           <div className="w-56 h-56 overflow-auto space-y-6">
-            <Header
-              heading="Stacked"
-              icon={<Star className="opacity-80" />}
-            />
+            <Header heading="Stacked" icon={<Star className="opacity-80" />} />
             <Hero heading="Stacked" topClassName="top-[var(--header-stack)]" />
             <div className="h-96" />
           </div>

--- a/tests/lib/usePersistentState.test.ts
+++ b/tests/lib/usePersistentState.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { usePersistentState, createStorageKey } from "@/lib/db";
+
+describe("usePersistentState", () => {
+  it("ignores unchanged storage values", () => {
+    let renders = 0;
+    const { result } = renderHook(() => {
+      renders++;
+      return usePersistentState("ps-key", 1);
+    });
+    act(() => {
+      const e = new StorageEvent("storage", {
+        key: createStorageKey("ps-key"),
+        newValue: "1",
+        storageArea: window.localStorage,
+      });
+      window.dispatchEvent(e);
+    });
+    expect(renders).toBe(1);
+    act(() => {
+      const e = new StorageEvent("storage", {
+        key: createStorageKey("ps-key"),
+        newValue: "2",
+        storageArea: window.localStorage,
+      });
+      window.dispatchEvent(e);
+    });
+    expect(result.current[0]).toBe(2);
+    expect(renders).toBe(2);
+  });
+});

--- a/tests/planner/TaskRow.test.tsx
+++ b/tests/planner/TaskRow.test.tsx
@@ -9,7 +9,12 @@ describe("TaskRow", () => {
   it("focuses input when entering edit mode", async () => {
     render(
       <TaskRow
-        task={{ id: "1", text: "Test task", done: false }}
+        task={{
+          id: "1",
+          title: "Test task",
+          done: false,
+          createdAt: Date.now(),
+        }}
         onToggle={noop}
         onDelete={noop}
         onEdit={noop}
@@ -30,7 +35,12 @@ describe("TaskRow", () => {
     const onDelete = vi.fn();
     render(
       <TaskRow
-        task={{ id: "1", text: "Test task", done: false }}
+        task={{
+          id: "1",
+          title: "Test task",
+          done: false,
+          createdAt: Date.now(),
+        }}
         onToggle={onToggle}
         onDelete={onDelete}
         onEdit={noop}


### PR DESCRIPTION
## Summary
- group day tasks by project and split planner context into focused providers
- simplify task objects and remove redundant mapping
- optimize persistence writes with smarter cloning and debounced legacy sync

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68c3805f9c70832cb20fd5f75e1d21de