### PR TITLE
Use .nvmrc for Next.js workflow

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version-file: ".nvmrc"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary
- reference Node version from `.nvmrc` in Next.js CI workflow

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c3894290e8832c99dd1972e610bca7