### PR TITLE
chore: allow ReactNode labels in header tabs

### DIFF
--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -124,7 +124,7 @@ export default function Header({
 
 export interface HeaderTab<Key extends string = string> {
   key: Key;
-  label: string;
+  label: React.ReactNode;
   hint?: string;
   icon?: React.ReactNode;
 }


### PR DESCRIPTION
## Summary
- allow `HeaderTab` labels to accept `ReactNode`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c3994e41c8832cb1fc43859d903803