### PR TITLE
refactor: use grid spans for reviews page layout

### DIFF
--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -163,10 +163,10 @@ export default function ReviewsPage({
 
       <div
         className={cn(
-          "grid grid-cols-1 items-start gap-6 md:grid-cols-[24rem_1fr]",
+          "grid grid-cols-1 items-start gap-6 md:grid-cols-12",
         )}
       >
-        <nav aria-label="Review list" className="md:w-96">
+        <nav aria-label="Review list" className="md:col-span-4">
           <div className="card-neo-soft rounded-card r-card-lg overflow-hidden bg-card/50 shadow-neo-strong">
             <div className="section-b">
               <div className="mb-2 text-sm text-muted-foreground">
@@ -185,7 +185,7 @@ export default function ReviewsPage({
             </div>
           </div>
         </nav>
-        <div aria-live="polite">
+        <div aria-live="polite" className="md:col-span-8">
           {!active ? (
             <ReviewPanel
               className={cn(

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -773,11 +773,11 @@ exports[`ReviewsPage > renders default state 1`] = `
       </div>
     </section>
     <div
-      class="grid grid-cols-1 items-start gap-6 md:grid-cols-[24rem_1fr]"
+      class="grid grid-cols-1 items-start gap-6 md:grid-cols-12"
     >
       <nav
         aria-label="Review list"
-        class="md:w-96"
+        class="md:col-span-4"
       >
         <div
           class="card-neo-soft rounded-card r-card-lg overflow-hidden bg-card/50 shadow-neo-strong"
@@ -936,6 +936,7 @@ exports[`ReviewsPage > renders default state 1`] = `
       </nav>
       <div
         aria-live="polite"
+        class="md:col-span-8"
       >
         <div
           aria-live="polite"


### PR DESCRIPTION
## Summary
- shift reviews page to a responsive 12-column grid
- assign sidebar and panel fixed spans
- update snapshot

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c3a5d70c3c832c9db7eac4abbb1023