### PR TITLE
refactor planner styles to use design tokens

### DIFF
--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -13,14 +13,18 @@
   min-height: var(--scroll-min);
   max-height: clamp(var(--scroll-min), var(--scroll-ideal), var(--scroll-max));
   border-radius: calc(var(--radius-lg) - var(--space-1));
-  background: hsl(var(--background) / .25);
-  box-shadow: inset 0 0 0 var(--hairline-w) hsl(var(--card-hairline) / .55);
+  background: hsl(var(--background) / 0.25);
+  box-shadow: inset 0 0 0 var(--hairline-w) hsl(var(--card-hairline) / 0.55);
 }
 
 @media (max-width: 639px) {
-  .daycard .overflow-y-auto { --scroll-ideal: 28vh; }
+  .daycard .overflow-y-auto {
+    --scroll-ideal: 28vh;
+  }
   .daycard > :nth-child(1),
-  .daycard > :nth-child(3) { padding: var(--space-3); }
+  .daycard > :nth-child(3) {
+    padding: var(--space-3);
+  }
 }
 
 /* ============ Row action buttons ============ */
@@ -33,7 +37,9 @@
 
 /* Reveal actions on hover or focus-within for a11y */
 .daycard .group:hover .iconbtn,
-.daycard .group:focus-within .iconbtn { opacity: 1; }
+.daycard .group:focus-within .iconbtn {
+  opacity: 1;
+}
 
 /* ============ Project cards (left column) ============ */
 .proj-card {
@@ -46,21 +52,22 @@
   padding-top: var(--space-2);
   padding-bottom: var(--space-2);
   border: var(--hairline-w) solid hsl(var(--card-hairline));
-  background: hsl(var(--card) / .55);
+  background: hsl(var(--card) / 0.55);
   transition:
-    background .15s var(--ease-out),
-    border-color .15s var(--ease-out),
-    box-shadow .15s var(--ease-out);
+    background 0.15s var(--ease-out),
+    border-color 0.15s var(--ease-out),
+    box-shadow 0.15s var(--ease-out);
 }
 .proj-card:hover {
-  background: hsl(var(--card) / .70);
-  border-color: hsl(var(--ring) / .45);
+  background: hsl(var(--card) / 0.7);
+  border-color: hsl(var(--ring) / 0.45);
 }
 .proj-card--active {
   border-color: hsl(var(--ring));
   box-shadow:
-    inset 0 0 0 calc(var(--hairline-w) * 2) hsl(var(--ring) / .30),
-    0 10px 24px hsl(var(--shadow-color) / .26);
+    inset 0 0 0 calc(var(--hairline-w) * 2) hsl(var(--ring) / 0.3),
+    0 calc(var(--space-3) - var(--space-1) / 2) var(--space-5)
+      hsl(var(--shadow-color) / 0.26);
   position: relative;
 }
 .proj-card--active::after {
@@ -68,24 +75,36 @@
   position: absolute;
   inset: var(--hairline-w);
   border-radius: calc(var(--radius-lg) - var(--hairline-w) * 2);
-  background: var(--edge-iris, linear-gradient(90deg, hsl(var(--accent)), hsl(var(--primary))));
-  -webkit-mask: linear-gradient(hsl(var(--foreground)) 0 0) content-box, linear-gradient(hsl(var(--foreground)) 0 0);
-          mask: linear-gradient(hsl(var(--foreground)) 0 0) content-box, linear-gradient(hsl(var(--foreground)) 0 0);
+  background: var(
+    --edge-iris,
+    linear-gradient(90deg, hsl(var(--accent)), hsl(var(--primary)))
+  );
+  -webkit-mask:
+    linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+    linear-gradient(hsl(var(--foreground)) 0 0);
+  mask:
+    linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+    linear-gradient(hsl(var(--foreground)) 0 0);
   -webkit-mask-composite: xor;
-          mask-composite: exclude;
+  mask-composite: exclude;
   pointer-events: none;
-  opacity: .42;
+  opacity: 0.42;
   animation: sheen-rotate 6s linear infinite;
 }
 
-@keyframes sheen-rotate { to { transform: rotate(360deg); } }
+@keyframes sheen-rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
 
 .proj-card__title {
   color: hsl(var(--foreground));
   letter-spacing: -0.01em;
 }
 .proj-card:hover .proj-card__title {
-  text-shadow: 0 0 10px hsl(var(--accent) / .18);
+  text-shadow: 0 0 calc(var(--space-3) - var(--space-1) / 2)
+    hsl(var(--accent) / 0.18);
 }
 
 /* ============ Task rows (right column) ============ */
@@ -96,11 +115,14 @@
   text-align: left;
   cursor: pointer;
   color: hsl(var(--foreground));
-  transition: color .15s var(--ease-out), text-shadow .15s var(--ease-out);
+  transition:
+    color 0.15s var(--ease-out),
+    text-shadow 0.15s var(--ease-out);
 }
 .task-tile__text:hover {
   color: hsl(var(--primary-foreground));
-  text-shadow: 0 0 10px hsl(var(--accent) / .18);
+  text-shadow: 0 0 calc(var(--space-3) - var(--space-1) / 2)
+    hsl(var(--accent) / 0.18);
 }
 .task-tile__text:focus-visible {
   outline: calc(var(--hairline-w) * 2) solid hsl(var(--ring));
@@ -111,8 +133,8 @@
 /* Soft, readable strike-through for completed tasks */
 .line-through-soft {
   text-decoration: line-through;
-  text-decoration-color: hsl(var(--muted-foreground) / .55);
-  color: hsl(var(--muted-foreground) / .85);
+  text-decoration-color: hsl(var(--muted-foreground) / 0.55);
+  color: hsl(var(--muted-foreground) / 0.85);
 }
 
 /* Empty states */
@@ -122,24 +144,59 @@
   justify-content: center;
   min-height: calc(var(--space-8) + var(--space-5));
   padding: var(--space-3);
-  border: var(--hairline-w) dashed hsl(var(--card-hairline) / .7);
+  border: var(--hairline-w) dashed hsl(var(--card-hairline) / 0.7);
   border-radius: var(--radius-lg);
   color: hsl(var(--muted-foreground));
-  background: linear-gradient(180deg, hsl(var(--card) / .65), hsl(var(--card) / .45));
+  background: linear-gradient(
+    180deg,
+    hsl(var(--card) / 0.65),
+    hsl(var(--card) / 0.45)
+  );
 }
 
 /* ============ Week chips: hover flicker + active glitch ============ */
 @keyframes chip-flicker {
-  0%, 22%, 24%, 55%, 57%, 100% { opacity: 1; filter: none; }
-  23% { opacity: .86; filter: blur(.1px); }
-  56% { opacity: .9;  filter: blur(.15px); }
+  0%,
+  22%,
+  24%,
+  55%,
+  57%,
+  100% {
+    opacity: 1;
+    filter: none;
+  }
+  23% {
+    opacity: 0.86;
+    filter: blur(calc(var(--hairline-w) / 10));
+  }
+  56% {
+    opacity: 0.9;
+    filter: blur(calc(var(--hairline-w) * 0.15));
+  }
 }
 @keyframes chip-rgb {
-  0%,100% { transform: translate(0,0); }
-  20% { transform: translate(.3px,-.2px); }
-  40% { transform: translate(-.2px,.2px); }
-  60% { transform: translate(.2px,0); }
-  80% { transform: translate(-.2px,0); }
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+  20% {
+    transform: translate(
+      calc(var(--hairline-w) * 0.3),
+      calc(var(--hairline-w) * -0.2)
+    );
+  }
+  40% {
+    transform: translate(
+      calc(var(--hairline-w) * -0.2),
+      calc(var(--hairline-w) * 0.2)
+    );
+  }
+  60% {
+    transform: translate(calc(var(--hairline-w) * 0.2), 0);
+  }
+  80% {
+    transform: translate(calc(var(--hairline-w) * -0.2), 0);
+  }
 }
 
 .chip {
@@ -150,50 +207,62 @@
   contain: paint;
   will-change: box-shadow, background, border-color;
   --neo-shadow:
-    -2px -2px 4px hsl(var(--background) / .6),
-    2px 2px 4px hsl(var(--shadow-color) / .3);
+    calc(var(--space-1) / -2) calc(var(--space-1) / -2) var(--space-1)
+      hsl(var(--background) / 0.6),
+    calc(var(--space-1) / 2) calc(var(--space-1) / 2) var(--space-1)
+      hsl(var(--shadow-color) / 0.3);
   box-shadow: var(--neo-shadow);
 }
 .chip:hover {
-  animation: chip-flicker 3.2s steps(1,end) infinite;
-  background: color-mix(in oklab, hsl(var(--card)) 88%, hsl(var(--primary)) 12% / .08);
-  border-color: hsl(var(--primary) / .55);
+  animation: chip-flicker 3.2s steps(1, end) infinite;
+  background: color-mix(
+    in oklab,
+    hsl(var(--card)) 88%,
+    hsl(var(--primary)) 12% / 0.08
+  );
+  border-color: hsl(var(--primary) / 0.55);
   box-shadow:
     var(--neo-shadow),
-    0 6px 18px hsl(var(--shadow-color) / .18);
+    0 calc(var(--space-2) - var(--space-1) / 2)
+      calc(var(--space-4) + var(--space-1) / 2) hsl(var(--shadow-color) / 0.18);
 }
 
 .chip[data-active] {
   box-shadow:
     var(--neo-shadow),
-    0 0 0 var(--hairline-w) hsl(var(--primary) / .45),
-    0 8px 22px hsl(var(--shadow-color) / .22);
+    0 0 0 var(--hairline-w) hsl(var(--primary) / 0.45),
+    0 var(--space-2) calc(var(--space-5) - var(--space-1) / 2)
+      hsl(var(--shadow-color) / 0.22);
 }
 
 /* “Today” hint — faint ring and glow rail inside */
 .chip--today {
   box-shadow:
     var(--neo-shadow),
-    0 0 0 var(--hairline-w) hsl(var(--ring) / .55) inset,
-    0 0 0 calc(var(--hairline-w) * 2) hsl(var(--ring) / .15);
+    0 0 0 var(--hairline-w) hsl(var(--ring) / 0.55) inset,
+    0 0 0 calc(var(--hairline-w) * 2) hsl(var(--ring) / 0.15);
 }
-.chip--today .chip__date { text-shadow: 0 0 8px hsl(var(--accent) / .35); }
+.chip--today .chip__date {
+  text-shadow: 0 0 var(--space-2) hsl(var(--accent) / 0.35);
+}
 
 /* Active selection: holo border + RGB split title */
 .chip--active {
   border-color: hsl(var(--ring));
   box-shadow:
-    inset 0 0 0 calc(var(--hairline-w) * 2) hsl(var(--ring) / .35),
+    inset 0 0 0 calc(var(--hairline-w) * 2) hsl(var(--ring) / 0.35),
     var(--neo-shadow),
-    0 12px 28px hsl(var(--shadow-color) / .30);
+    0 var(--space-3) calc(var(--space-6) - var(--space-1))
+      hsl(var(--shadow-color) / 0.3);
 }
 .chip--active .chip__edge {
-  opacity: .75;
+  opacity: 0.75;
   animation: sheen-rotate 8s linear infinite;
 }
 .chip--active .chip__date {
   position: relative;
-  text-shadow: 0 0 10px hsl(var(--ring) / .35);
+  text-shadow: 0 0 calc(var(--space-3) - var(--space-1) / 2)
+    hsl(var(--ring) / 0.35);
 }
 .chip--active .chip__date::before,
 .chip--active .chip__date::after {
@@ -202,17 +271,23 @@
   inset: 0;
   pointer-events: none;
   mix-blend-mode: screen;
-  opacity: .75;
+  opacity: 0.75;
 }
 .chip--active .chip__date::before {
   color: hsl(var(--accent));
-  transform: translate(.5px,-.5px);
+  transform: translate(
+    calc(var(--hairline-w) / 2),
+    calc(var(--hairline-w) / -2)
+  );
   animation: chip-rgb 2.1s linear infinite;
 }
 .chip--active .chip__date::after {
   color: hsl(var(--primary));
-  transform: translate(-.5px,.5px);
-  animation: chip-rgb 2.0s linear infinite reverse;
+  transform: translate(
+    calc(var(--hairline-w) / -2),
+    calc(var(--hairline-w) / 2)
+  );
+  animation: chip-rgb 2s linear infinite reverse;
 }
 
 /* inner scanlines layer (hover only) */
@@ -221,17 +296,18 @@
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  background:
-    repeating-linear-gradient(
-      to bottom,
-      hsl(var(--foreground)/0.06) 0 var(--hairline-w),
-      transparent var(--hairline-w) calc(var(--space-1) - var(--hairline-w))
-    );
+  background: repeating-linear-gradient(
+    to bottom,
+    hsl(var(--foreground) / 0.06) 0 var(--hairline-w),
+    transparent var(--hairline-w) calc(var(--space-1) - var(--hairline-w))
+  );
   mix-blend-mode: overlay;
   opacity: 0;
-  transition: opacity .18s var(--ease-out);
+  transition: opacity 0.18s var(--ease-out);
 }
-.chip:hover .chip__scan { opacity: .45; }
+.chip:hover .chip__scan {
+  opacity: 0.45;
+}
 
 /* holographic edge (active) */
 .chip__edge {
@@ -242,16 +318,20 @@
   padding: var(--hairline-w);
   background: linear-gradient(
     90deg,
-    hsl(var(--primary) / .55),
-    hsl(var(--accent) / .45),
-    hsl(var(--ring) / .55),
-    hsl(var(--accent) / .45),
-    hsl(var(--primary) / .55)
+    hsl(var(--primary) / 0.55),
+    hsl(var(--accent) / 0.45),
+    hsl(var(--ring) / 0.55),
+    hsl(var(--accent) / 0.45),
+    hsl(var(--primary) / 0.55)
   );
-  -webkit-mask: linear-gradient(hsl(var(--foreground)) 0 0) content-box, linear-gradient(hsl(var(--foreground)) 0 0);
-          mask: linear-gradient(hsl(var(--foreground)) 0 0) content-box, linear-gradient(hsl(var(--foreground)) 0 0);
+  -webkit-mask:
+    linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+    linear-gradient(hsl(var(--foreground)) 0 0);
+  mask:
+    linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+    linear-gradient(hsl(var(--foreground)) 0 0);
   -webkit-mask-composite: xor;
-          mask-composite: exclude;
+  mask-composite: exclude;
   opacity: 0;
   pointer-events: none;
 }
@@ -259,7 +339,7 @@
 /* compact internals */
 .chip__date {
   font-size: calc(var(--space-4) * 0.6875);
-  letter-spacing: .02em;
+  letter-spacing: 0.02em;
   color: hsl(var(--muted-foreground));
 }
 .chip__counts {
@@ -270,24 +350,37 @@
 
 /* ============ Motion safety ============ */
 @media (prefers-reduced-motion: reduce) {
-  .proj-card--active::after { animation: none; }
-  .chip, .chip__scan, .chip__edge { animation: none !important; transition: none !important; }
+  .proj-card--active::after {
+    animation: none;
+  }
+  .chip,
+  .chip__scan,
+  .chip__edge {
+    animation: none !important;
+    transition: none !important;
+  }
 }
 
 /* ============ Full-bleed header helper ============ */
 .hero-bleed-row {
-  margin-left: calc(var(--space-4) * -1);  margin-right: calc(var(--space-4) * -1);
-  padding-left: var(--space-4);  padding-right: var(--space-4);
+  margin-left: calc(var(--space-4) * -1);
+  margin-right: calc(var(--space-4) * -1);
+  padding-left: var(--space-4);
+  padding-right: var(--space-4);
 }
 @media (min-width: 640px) {
   .hero-bleed-row {
-    margin-left: calc((var(--space-4) + var(--space-1)) * -1); margin-right: calc((var(--space-4) + var(--space-1)) * -1);
-    padding-left: calc(var(--space-4) + var(--space-1)); padding-right: calc(var(--space-4) + var(--space-1));
+    margin-left: calc((var(--space-4) + var(--space-1)) * -1);
+    margin-right: calc((var(--space-4) + var(--space-1)) * -1);
+    padding-left: calc(var(--space-4) + var(--space-1));
+    padding-right: calc(var(--space-4) + var(--space-1));
   }
 }
 @media (min-width: 1024px) {
   .hero-bleed-row {
-    margin-left: calc(var(--space-5) * -1); margin-right: calc(var(--space-5) * -1);
-    padding-left: var(--space-5); padding-right: var(--space-5);
+    margin-left: calc(var(--space-5) * -1);
+    margin-right: calc(var(--space-5) * -1);
+    padding-left: var(--space-5);
+    padding-right: var(--space-5);
   }
 }


### PR DESCRIPTION
## Summary
- replace pixel lengths in planner styles with design token variables
- use token-based calculations for chip effects and shadows

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c3b13746c8832cbd83f9b1ccf2528d