### PR TITLE
refactor: unify React imports

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import * as React from "react";
-import { Suspense } from "react";
 import type { Metadata } from "next";
 import { Home } from "lucide-react";
 import {
@@ -110,7 +109,7 @@ function HomePageContent() {
 
 export default function Page() {
   return (
-    <Suspense
+    <React.Suspense
       fallback={
         <div className="flex justify-center p-6">
           <Spinner />
@@ -118,6 +117,6 @@ export default function Page() {
       }
     >
       <HomePageContent />
-    </Suspense>
+    </React.Suspense>
   );
 }

--- a/src/components/planner/TodayHero.tsx
+++ b/src/components/planner/TodayHero.tsx
@@ -6,7 +6,7 @@
  * - Animated progress bar for the selected project's tasks.
  */
 
-import { useMemo, useRef, useState, useEffect } from "react";
+import * as React from "react";
 import { cn } from "@/lib/utils";
 import { toISODate } from "@/lib/date";
 import { useFocusDate } from "./useFocusDate";
@@ -17,18 +17,17 @@ import CheckCircle from "@/components/ui/toggles/CheckCircle";
 import Input from "@/components/ui/primitives/Input";
 import IconButton from "@/components/ui/primitives/IconButton";
 import { Pencil, Trash2, Calendar } from "lucide-react";
-import type React from "react";
 
 type DateInputWithPicker = HTMLInputElement & { showPicker?: () => void };
 type Props = { iso?: ISODate };
 
 export default function TodayHero({ iso }: Props) {
-  const nowISO = useMemo(() => toISODate(), []);
+  const nowISO = React.useMemo(() => toISODate(), []);
   const { iso: isoActive, setIso, today } = useFocusDate();
   const viewIso = iso ?? isoActive;
   const isToday = viewIso === today;
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (iso && iso !== isoActive) setIso(iso);
   }, [iso, isoActive, setIso]);
 
@@ -50,26 +49,26 @@ export default function TodayHero({ iso }: Props) {
   const [, setSelTaskId] = useSelectedTask(viewIso);
 
   // If selected project disappears, clear selection
-  useEffect(() => {
+  React.useEffect(() => {
     if (selProjectId && !projects.some((p) => p.id === selProjectId))
       setSelProjectId("");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projects.length, viewIso]);
 
   // Local edit state
-  const [editingProjectId, setEditingProjectId] = useState<string | null>(null);
-  const [editingProjectName, setEditingProjectName] = useState("");
-  const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
-  const [editingTaskText, setEditingTaskText] = useState("");
-  const [projectName, setProjectName] = useState("");
+  const [editingProjectId, setEditingProjectId] = React.useState<string | null>(null);
+  const [editingProjectName, setEditingProjectName] = React.useState("");
+  const [editingTaskId, setEditingTaskId] = React.useState<string | null>(null);
+  const [editingTaskText, setEditingTaskText] = React.useState("");
+  const [projectName, setProjectName] = React.useState("");
 
   // Progress of selected project only (animated)
-  const scopedTasks = useMemo(
+  const scopedTasks = React.useMemo(
     () =>
       selProjectId ? tasks.filter((t) => t.projectId === selProjectId) : [],
     [tasks, selProjectId],
   );
-  const { done, total } = useMemo(
+  const { done, total } = React.useMemo(
     () =>
       tasks.reduce(
         (acc, t) => {
@@ -86,7 +85,7 @@ export default function TodayHero({ iso }: Props) {
   const pct = total === 0 ? 0 : Math.round((done / total) * 100);
 
   // Date picker
-  const dateRef = useRef<HTMLInputElement>(null);
+  const dateRef = React.useRef<HTMLInputElement>(null);
   const openPicker = () => {
     const el = dateRef.current as DateInputWithPicker | null;
     if (el?.showPicker) el.showPicker();

--- a/src/components/reviews/ReviewList.tsx
+++ b/src/components/reviews/ReviewList.tsx
@@ -1,7 +1,7 @@
 // src/components/reviews/ReviewList.tsx
 "use client";
 
-import React from "react";
+import * as React from "react";
 import type { Review } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import ReviewListItem from "./ReviewListItem";

--- a/src/components/reviews/ReviewListItem.tsx
+++ b/src/components/reviews/ReviewListItem.tsx
@@ -1,7 +1,7 @@
 // src/components/reviews/ReviewListItem.tsx
 "use client";
 
-import React from "react";
+import * as React from "react";
 import { cn } from "@/lib/utils";
 import type { Review } from "@/lib/types";
 import { Badge } from "@/components/ui";

--- a/src/components/reviews/ReviewPage.tsx
+++ b/src/components/reviews/ReviewPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import * as React from "react";
 import type { Review } from "@/lib/types";
 import { usePersistentState, uid } from "@/lib/db";
 import ReviewsPage from "./ReviewsPage";
@@ -11,23 +11,23 @@ import ReviewsPage from "./ReviewsPage";
 */
 export default function ReviewPage() {
   const [reviews, setReviews] = usePersistentState<Review[]>("reviews.v1", []);
-  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = React.useState<string | null>(null);
 
   // After local DB hydration, select the first review if none is chosen
-  useEffect(() => {
+  React.useEffect(() => {
     if (!selectedId && reviews.length > 0) {
       setSelectedId(reviews[0].id);
     }
   }, [reviews, selectedId]);
 
   // Auto-heal selection if the selected review gets deleted or doesn't exist yet
-  useEffect(() => {
+  React.useEffect(() => {
     if (selectedId && !reviews.some(r => r.id === selectedId)) {
       setSelectedId(reviews[0]?.id ?? null);
     }
   }, [reviews, selectedId]);
 
-  const onCreate = useCallback(() => {
+  const onCreate = React.useCallback(() => {
     const now = Date.now();
     const fresh: Review = {
       id: uid("rev"),
@@ -48,34 +48,34 @@ export default function ReviewPage() {
     setSelectedId(fresh.id);
   }, [setReviews]);
 
-  const onSelect = useCallback((id: string) => setSelectedId(id), []);
+  const onSelect = React.useCallback((id: string) => setSelectedId(id), []);
 
-  const patchById = useCallback((id: string, patch: Partial<Review>) => {
+  const patchById = React.useCallback((id: string, patch: Partial<Review>) => {
     setReviews(prev => prev.map(r => (r.id === id ? { ...r, ...patch } : r)));
   }, [setReviews]);
 
-  const onRename = useCallback((id: string, nextTitle: string) => {
+  const onRename = React.useCallback((id: string, nextTitle: string) => {
     patchById(id, { title: (nextTitle || "").trim() || "Untitled Review" });
   }, [patchById]);
 
-  const onDelete = useCallback((id: string) => {
+  const onDelete = React.useCallback((id: string) => {
     setReviews(prev => prev.filter(r => r.id !== id));
     setSelectedId(prev => (prev === id ? null : prev));
   }, [setReviews]);
 
-  const onChangeNotes = useCallback((id: string, nextNotes: string) => {
+  const onChangeNotes = React.useCallback((id: string, nextNotes: string) => {
     patchById(id, { notes: nextNotes });
   }, [patchById]);
 
-  const onChangeTags = useCallback((id: string, nextTags: string[]) => {
+  const onChangeTags = React.useCallback((id: string, nextTags: string[]) => {
     patchById(id, { tags: nextTags });
   }, [patchById]);
 
-  const onChangeMeta = useCallback((id: string, patch: Partial<Review>) => {
+  const onChangeMeta = React.useCallback((id: string, patch: Partial<Review>) => {
     patchById(id, patch);
   }, [patchById]);
 
-  const safeSelectedId = useMemo(
+  const safeSelectedId = React.useMemo(
     () => (reviews.some(r => r.id === selectedId) ? selectedId : null),
     [reviews, selectedId]
   );

--- a/src/components/reviews/ReviewPanel.tsx
+++ b/src/components/reviews/ReviewPanel.tsx
@@ -1,11 +1,11 @@
-import React, { type HTMLAttributes } from "react";
+import * as React from "react";
 import { cn } from "@/lib/utils";
 import { Card } from "@/components/ui";
 
 export default function ReviewPanel({
   className,
   ...props
-}: HTMLAttributes<HTMLDivElement>) {
+}: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <Card
       aria-live="polite"

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
+import * as React from "react";
 import type { Review } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import ReviewList from "./ReviewList";
@@ -38,16 +38,16 @@ export default function ReviewsPage({
   onChangeTags,
   onChangeMeta,
 }: ReviewsPageProps) {
-  const [q, setQ] = useState("");
-  const [sort, setSort] = useState<SortKey>("newest");
-  const [panelMode, setPanelMode] = useState<"summary" | "edit">("summary");
+  const [q, setQ] = React.useState("");
+  const [sort, setSort] = React.useState<SortKey>("newest");
+  const [panelMode, setPanelMode] = React.useState<"summary" | "edit">("summary");
 
-  const base = useMemo<Review[]>(
+  const base = React.useMemo<Review[]>(
     () => (Array.isArray(reviews) ? reviews : []),
     [reviews],
   );
 
-  const filtered = useMemo(() => {
+  const filtered = React.useMemo(() => {
     const ts = (v: unknown): number => {
       if (typeof v === "number") return v;
       if (v instanceof Date) return +v;

--- a/src/components/team/JungleClears.tsx
+++ b/src/components/team/JungleClears.tsx
@@ -11,7 +11,7 @@ import "./style.css";
  * - Titles and timers now use glitch-title + glitch-flicker + title-glow.
  */
 
-import React, { useMemo, useState } from "react";
+import * as React from "react";
 import Hero from "@/components/ui/layout/Hero";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import IconButton from "@/components/ui/primitives/IconButton";
@@ -42,15 +42,15 @@ const SPEED_TIME: Record<ClearSpeed, string> = {
 
 export default function JungleClears() {
   const [items, setItems] = usePersistentState<JunglerRow[]>(STORE_KEY, SEEDS);
-  const [query, setQuery] = useState("");
-  const [editing, setEditing] = useState<{
+  const [query, setQuery] = React.useState("");
+  const [editing, setEditing] = React.useState<{
     id: string;
     champ: string;
     type: string;
     notes: string;
   } | null>(null);
 
-  const filtered = useMemo(() => {
+  const filtered = React.useMemo(() => {
     const q = query.trim().toLowerCase();
     return items.filter((r) => {
       if (!q) return true;
@@ -59,7 +59,7 @@ export default function JungleClears() {
     });
   }, [query, items]);
 
-  const exampleByBucket = useMemo(() => {
+  const exampleByBucket = React.useMemo(() => {
     const map = {} as Record<ClearSpeed, string>;
     for (const b of BUCKETS) {
       const row = items.find((r) => r.speed === b && r.champ.trim());

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -13,7 +13,7 @@
  */
 import "./style.css";
 
-import React, { useState } from "react";
+import * as React from "react";
 import { Users2, BookOpenText, Hammer, Timer } from "lucide-react";
 import Header, {
   HeaderTabs,
@@ -48,7 +48,7 @@ const TABS: HeaderTab<Tab>[] = [
 ];
 
 export default function TeamCompPage() {
-  const [tab, setTab] = useState<Tab>("cheat");
+  const [tab, setTab] = React.useState<Tab>("cheat");
   const active = TABS.find((t) => t.key === tab);
   const cheatRef = React.useRef<HTMLDivElement>(null);
   const builderRef = React.useRef<HTMLDivElement>(null);

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -9,7 +9,6 @@
  */
 
 import * as React from "react";
-import { useId } from "react";
 import { cn } from "@/lib/utils";
 
 export type TabItem<K extends string = string> = {
@@ -61,7 +60,7 @@ export default function TabBar<K extends string = string>({
   showBaseline = false,
   linkPanels = true,
 }: TabBarProps<K>) {
-  const uid = useId();
+  const uid = React.useId();
   const isControlled = value !== undefined;
   const [internal, setInternal] = React.useState<K>(() => {
     if (value !== undefined) return value;

--- a/tests/goals/goals-page.test.tsx
+++ b/tests/goals/goals-page.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   render,
   screen,

--- a/tests/goals/timer-tab.test.tsx
+++ b/tests/goals/timer-tab.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import TimerTab from "@/components/goals/TimerTab";

--- a/tests/home/HomePage.test.tsx
+++ b/tests/home/HomePage.test.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { Suspense } from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import Page from "@/app/page";
@@ -14,9 +13,9 @@ describe("Home page", () => {
   it("renders navigation links", () => {
     render(
       <ThemeProvider>
-        <Suspense fallback="loading">
+        <React.Suspense fallback="loading">
           <Page />
-        </Suspense>
+        </React.Suspense>
       </ThemeProvider>,
     );
     const goals = screen.getByRole("link", { name: "Goals" });

--- a/tests/primitives/button.test.tsx
+++ b/tests/primitives/button.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, cleanup, fireEvent } from "@testing-library/react";
 import { describe, it, expect, afterEach, vi } from "vitest";
 import {

--- a/tests/primitives/glitch-segmented.test.tsx
+++ b/tests/primitives/glitch-segmented.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from "react";
 import { render, cleanup } from '@testing-library/react';
 import { describe, it, expect, afterEach } from 'vitest';
 import { GlitchSegmentedGroup, GlitchSegmentedButton } from '../../src/components/ui/primitives/GlitchSegmented';

--- a/tests/primitives/icon-button.test.tsx
+++ b/tests/primitives/icon-button.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, cleanup } from "@testing-library/react";
 import { describe, it, expect, afterEach } from "vitest";
 import IconButton from "../../src/components/ui/primitives/IconButton";

--- a/tests/primitives/search-bar.test.tsx
+++ b/tests/primitives/search-bar.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from "react";
 import { render, cleanup, fireEvent } from '@testing-library/react';
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { SearchBar } from '@/components/ui';

--- a/tests/prompts/prompts-compose-panel.test.tsx
+++ b/tests/prompts/prompts-compose-panel.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { PromptsComposePanel } from "@/components/prompts";

--- a/tests/prompts/prompts-demos.test.tsx
+++ b/tests/prompts/prompts-demos.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, screen, cleanup } from "@testing-library/react";
 import { describe, it, expect, afterEach } from "vitest";
 import { PromptsDemos } from "@/components/prompts";

--- a/tests/prompts/prompts-header.test.tsx
+++ b/tests/prompts/prompts-header.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { PromptsHeader } from "@/components/prompts";

--- a/tests/prompts/prompts-page.test.tsx
+++ b/tests/prompts/prompts-page.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   render,
   screen,

--- a/tests/reviews/ReviewListItem.test.tsx
+++ b/tests/reviews/ReviewListItem.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from "react";
 import { render, cleanup } from '@testing-library/react';
 import { describe, it, expect, afterEach } from 'vitest';
 import ReviewListItem from '../../src/components/reviews/ReviewListItem';

--- a/tests/reviews/ReviewsPage.test.tsx
+++ b/tests/reviews/ReviewsPage.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   render,
   screen,

--- a/tests/ui/animated-select.test.tsx
+++ b/tests/ui/animated-select.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from "react";
 import { render, cleanup, fireEvent } from '@testing-library/react';
 import { describe, it, expect, afterEach } from 'vitest';
 import Select from '../../src/components/ui/Select';

--- a/tests/ui/animation-toggle.test.tsx
+++ b/tests/ui/animation-toggle.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from "react";
 import { render, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { AnimationToggle } from '@/components/ui';

--- a/tests/ui/badge.test.tsx
+++ b/tests/ui/badge.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from "react";
 import { render, cleanup } from '@testing-library/react';
 import { describe, it, expect, afterEach } from 'vitest';
 import { Badge } from '@/components/ui';

--- a/tests/ui/input.test.tsx
+++ b/tests/ui/input.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, cleanup, fireEvent } from "@testing-library/react";
 import { describe, it, expect, afterEach } from "vitest";
 import { Input } from "@/components/ui";

--- a/tests/ui/label.test.tsx
+++ b/tests/ui/label.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from "react";
 import { render, cleanup } from '@testing-library/react';
 import { describe, it, expect, afterEach } from 'vitest';
 import { Label } from '@/components/ui';

--- a/tests/ui/select.test.tsx
+++ b/tests/ui/select.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from "react";
 import { render, cleanup, fireEvent } from '@testing-library/react';
 import { describe, it, expect, afterEach } from 'vitest';
 import Select from '../../src/components/ui/Select';

--- a/tests/ui/spinner.test.tsx
+++ b/tests/ui/spinner.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from "react";
 import { render } from '@testing-library/react';
 import Spinner from '@/components/ui/feedback/Spinner';
 import { describe, expect, it } from 'vitest';

--- a/tests/ui/tab-bar.test.tsx
+++ b/tests/ui/tab-bar.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { describe, it, expect, afterEach } from "vitest";
 import { Header, HeaderTabs, Hero } from "@/components/ui";

--- a/tests/ui/textarea.test.tsx
+++ b/tests/ui/textarea.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from "react";
 import { render, cleanup, fireEvent } from '@testing-library/react';
 import { describe, it, expect, afterEach } from 'vitest';
 import Textarea from '../../src/components/ui/primitives/Textarea';

--- a/tests/ui/toggle.test.tsx
+++ b/tests/ui/toggle.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from "react";
 import { render, cleanup } from '@testing-library/react';
 import { describe, it, expect, afterEach } from 'vitest';
 import { Toggle } from '@/components/ui';


### PR DESCRIPTION
## Summary
- switch to `import * as React` across app and tests
- update calls to use `React.useState`, `React.Suspense`, etc.
- remove remaining default React imports

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68c3bae49744832cb4c76902feed9318