### PR TITLE
fix: move home page metadata to server wrapper

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,123 +1,16 @@
-"use client";
+// src/app/page.tsx
+// Server wrapper for the client HomePage
 
 import * as React from "react";
-import { Suspense } from "react";
 import type { Metadata } from "next";
-import { Home } from "lucide-react";
-import {
-  QuickActions,
-  TodayCard,
-  GoalsCard,
-  ReviewsCard,
-  TeamPromptsCard,
-  BottomNav,
-  IsometricRoom,
-} from "@/components/home";
-import Hero from "@/components/ui/layout/Hero";
-import Header from "@/components/ui/layout/Header";
-import { Spinner } from "@/components/ui";
-import { useRouter, usePathname, useSearchParams } from "next/navigation";
-import { useTheme } from "@/lib/theme-context";
-import {
-  VARIANTS,
-  BG_CLASSES,
-  type Variant,
-  type Background,
-} from "@/lib/theme";
+import { HomePage } from "@/components/home";
 
 export const metadata: Metadata = {
   title: "Planner",
   description: "Plan your day, track goals, and review games.",
 };
 
-function HomePageContent() {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const [theme, setTheme] = useTheme();
-
-  React.useEffect(() => {
-    if (typeof window === "undefined") return;
-    const themeParam = searchParams.get("theme");
-    const bgParam = searchParams.get("bg");
-    setTheme((prev) => {
-      const next = { ...prev };
-      if (themeParam && VARIANTS.some((v) => v.id === themeParam)) {
-        next.variant = themeParam as Variant;
-      }
-      if (bgParam) {
-        const idx = Number(bgParam);
-        if (!Number.isNaN(idx) && idx >= 0 && idx < BG_CLASSES.length) {
-          next.bg = idx as Background;
-        }
-      }
-      if (next.variant === prev.variant && next.bg === prev.bg) {
-        return prev;
-      }
-      return next;
-    });
-  }, [searchParams, setTheme]);
-
-  React.useEffect(() => {
-    const currentTheme = searchParams.get("theme");
-    const currentBg = searchParams.get("bg");
-    if (currentTheme === theme.variant && currentBg === String(theme.bg)) {
-      return;
-    }
-    const params = new URLSearchParams(searchParams.toString());
-    params.set("theme", theme.variant);
-    params.set("bg", String(theme.bg));
-    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
-  }, [theme, router, pathname, searchParams]);
-
-  return (
-    <main
-      aria-labelledby="home-header"
-      className="page-shell py-6 space-y-6 md:space-y-8"
-    >
-      <Header
-        id="home-header"
-        heading="Welcome to Planner"
-        subtitle="Plan your day, track goals, and review games."
-        icon={<Home className="opacity-80" />}
-      />
-      <Hero
-        topClassName="top-[var(--header-stack)]"
-        heading="Your day at a glance"
-      />
-      <div className="grid gap-4 md:grid-cols-2 items-start">
-        <QuickActions theme={theme} setTheme={setTheme} />
-        <IsometricRoom variant={theme.variant} />
-      </div>
-      <section className="grid grid-cols-1 gap-6 md:grid-cols-12">
-        <div className="md:col-span-4">
-          <TodayCard />
-        </div>
-        <div className="md:col-span-4">
-          <GoalsCard />
-        </div>
-        <div className="md:col-span-4">
-          <ReviewsCard />
-        </div>
-        <div className="md:col-span-12">
-          <TeamPromptsCard />
-        </div>
-      </section>
-      <BottomNav />
-    </main>
-  );
-}
-
 export default function Page() {
-  return (
-    <Suspense
-      fallback={
-        <div className="flex justify-center p-6">
-          <Spinner />
-        </div>
-      }
-    >
-      <HomePageContent />
-    </Suspense>
-  );
+  return <HomePage />;
 }
+

--- a/src/components/home/HomePage.tsx
+++ b/src/components/home/HomePage.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import * as React from "react";
+import { Suspense } from "react";
+import { Home } from "lucide-react";
+import {
+  QuickActions,
+  TodayCard,
+  GoalsCard,
+  ReviewsCard,
+  TeamPromptsCard,
+  BottomNav,
+  IsometricRoom,
+} from "@/components/home";
+import Hero from "@/components/ui/layout/Hero";
+import Header from "@/components/ui/layout/Header";
+import { Spinner } from "@/components/ui";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { useTheme } from "@/lib/theme-context";
+import {
+  VARIANTS,
+  BG_CLASSES,
+  type Variant,
+  type Background,
+} from "@/lib/theme";
+
+function HomePageContent() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [theme, setTheme] = useTheme();
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    const themeParam = searchParams.get("theme");
+    const bgParam = searchParams.get("bg");
+    setTheme((prev) => {
+      const next = { ...prev };
+      if (themeParam && VARIANTS.some((v) => v.id === themeParam)) {
+        next.variant = themeParam as Variant;
+      }
+      if (bgParam) {
+        const idx = Number(bgParam);
+        if (!Number.isNaN(idx) && idx >= 0 && idx < BG_CLASSES.length) {
+          next.bg = idx as Background;
+        }
+      }
+      if (next.variant === prev.variant && next.bg === prev.bg) {
+        return prev;
+      }
+      return next;
+    });
+  }, [searchParams, setTheme]);
+
+  React.useEffect(() => {
+    const currentTheme = searchParams.get("theme");
+    const currentBg = searchParams.get("bg");
+    if (currentTheme === theme.variant && currentBg === String(theme.bg)) {
+      return;
+    }
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("theme", theme.variant);
+    params.set("bg", String(theme.bg));
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+  }, [theme, router, pathname, searchParams]);
+
+  return (
+    <main
+      aria-labelledby="home-header"
+      className="page-shell py-6 space-y-6 md:space-y-8"
+    >
+      <Header
+        id="home-header"
+        heading="Welcome to Planner"
+        subtitle="Plan your day, track goals, and review games."
+        icon={<Home className="opacity-80" />}
+      />
+      <Hero
+        topClassName="top-[var(--header-stack)]"
+        heading="Your day at a glance"
+      />
+      <div className="grid gap-4 md:grid-cols-2 items-start">
+        <QuickActions theme={theme} setTheme={setTheme} />
+        <IsometricRoom variant={theme.variant} />
+      </div>
+      <section className="grid grid-cols-1 gap-6 md:grid-cols-12">
+        <div className="md:col-span-4">
+          <TodayCard />
+        </div>
+        <div className="md:col-span-4">
+          <GoalsCard />
+        </div>
+        <div className="md:col-span-4">
+          <ReviewsCard />
+        </div>
+        <div className="md:col-span-12">
+          <TeamPromptsCard />
+        </div>
+      </section>
+      <BottomNav />
+    </main>
+  );
+}
+
+export default function HomePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center p-6">
+          <Spinner />
+        </div>
+      }
+    >
+      <HomePageContent />
+    </Suspense>
+  );
+}
+

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -7,3 +7,4 @@ export { default as QuickActions } from "./QuickActions";
 export { default as TeamPromptsCard } from "./TeamPromptsCard";
 export { default as BottomNav } from "./BottomNav";
 export { default as IsometricRoom } from "./IsometricRoom";
+export { default as HomePage } from "./HomePage";


### PR DESCRIPTION
## Summary
- split home page into server wrapper and client component to allow metadata export
- expose new HomePage component in home index

## Testing
- `npm run check`
- `npx --no-install npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c3bdd63a90832caf523119f9d244fd