### PR TITLE
feat(date): centralize timestamp parsing

### DIFF
--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
+import { ts } from "@/lib/date";
 import type { Review } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import ReviewList from "./ReviewList";
@@ -48,16 +49,6 @@ export default function ReviewsPage({
   );
 
   const filtered = useMemo(() => {
-    const ts = (v: unknown): number => {
-      if (typeof v === "number") return v;
-      if (v instanceof Date) return +v;
-      if (typeof v === "string") {
-        const n = Date.parse(v);
-        return Number.isNaN(n) ? 0 : n;
-      }
-      return 0;
-    };
-
     const needle = q.trim().toLowerCase();
     const list =
       needle.length === 0

--- a/src/components/reviews/index.ts
+++ b/src/components/reviews/index.ts
@@ -12,3 +12,4 @@ export { default as ReviewSummaryNotes } from "./ReviewSummaryNotes";
 export { default as RoleSelector } from "./RoleSelector";
 export { default as ReviewPanel } from "./ReviewPanel";
 export { default as NeonIcon } from "./NeonIcon";
+export { useReviewFilter } from "./useReviewFilter";

--- a/src/components/reviews/useReviewFilter.ts
+++ b/src/components/reviews/useReviewFilter.ts
@@ -1,0 +1,48 @@
+import { useMemo } from "react";
+import type { Review } from "@/lib/types";
+import { ts } from "@/lib/date";
+
+export type SortKey = "newest" | "oldest" | "title";
+
+export function useReviewFilter(
+  base: Review[],
+  q: string,
+  sort: SortKey,
+): Review[] {
+  return useMemo(() => {
+    const needle = q.trim().toLowerCase();
+    const list =
+      needle.length === 0
+        ? [...base]
+        : base.filter((r) => {
+            const blob = [
+              r?.title,
+              Array.isArray(r?.tags) ? r.tags.join(" ") : "",
+              r?.opponent,
+              r?.lane,
+              r?.side,
+              r?.result,
+              r?.patch,
+              r?.duration,
+              r?.notes,
+            ]
+              .filter(Boolean)
+              .join(" ")
+              .toLowerCase();
+            return blob.includes(needle);
+          });
+
+    if (sort === "newest")
+      list.sort((a, b) => ts(b?.createdAt) - ts(a?.createdAt));
+    if (sort === "oldest")
+      list.sort((a, b) => ts(a?.createdAt) - ts(b?.createdAt));
+    if (sort === "title")
+      list.sort((a, b) =>
+        (a?.title || "").localeCompare(b?.title || "", undefined, {
+          sensitivity: "base",
+        }),
+      );
+
+    return list;
+  }, [base, q, sort]);
+}

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -42,6 +42,20 @@ export function normalizeDate(src?: Date | number | string): Date {
   return dt;
 }
 
+/**
+ * ts — Normalize various inputs to a numeric timestamp (ms).
+ * Returns 0 for invalid values.
+ */
+export function ts(v: unknown): number {
+  if (typeof v === "number") return v;
+  if (v instanceof Date) return +v;
+  if (typeof v === "string") {
+    const n = Date.parse(v);
+    return Number.isNaN(n) ? 0 : n;
+  }
+  return 0;
+}
+
 /** toISODate — Returns local date in "YYYY-MM-DD". */
 export function toISODate(d?: Date | number | string): string {
   const date = normalizeDate(d);

--- a/tests/lib/date.test.ts
+++ b/tests/lib/date.test.ts
@@ -5,6 +5,7 @@ import {
   toISODate,
   normalizeDate,
   weekRangeFromISO,
+  ts,
 } from '../../src/lib/date';
 
 describe('fromISODate', () => {
@@ -73,6 +74,19 @@ describe('normalizeDate', () => {
     expect(dt.getFullYear()).toBe(2024);
     expect(dt.getMonth()).toBe(2); // March
     expect(dt.getDate()).toBe(1);
+  });
+});
+
+describe('ts', () => {
+  it('normalizes dates and strings', () => {
+    const d = new Date('2024-02-29T00:00:00Z');
+    expect(ts(d)).toBe(d.getTime());
+    expect(ts('2024-02-29')).toBe(Date.parse('2024-02-29'));
+  });
+
+  it('returns 0 for invalid inputs', () => {
+    expect(ts('not-a-date')).toBe(0);
+    expect(ts(null as unknown)).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- add ts helper to normalize values to timestamps
- use ts in reviews filter hook and page
- cover ts conversion cases with tests

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c3d224aa44832cb85d6d0ec561b103