### PR TITLE
feat: add Hero subTabs and actions slot

### DIFF
--- a/src/app/prompts/PromptsPage.tsx
+++ b/src/app/prompts/PromptsPage.tsx
@@ -92,7 +92,7 @@ function PageContent() {
         }
         {...(view === "components"
           ? {
-              tabs: {
+              subTabs: {
                 items: SECTION_TABS,
                 value: section,
                 onChange: (k: string) => setSection(k as Section),

--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -3,8 +3,8 @@
 
 /**
  * RemindersTab — Hero header + borderless TabBar everywhere
- * - Domain tabs in Hero.right (Life | League | Learn), neon divider tint matches domain
- * - Bottom search stays in Hero.bottom
+ * - Domain sub-tabs in Hero (Life | League | Learn), neon divider tint matches domain
+ * - Bottom search uses built-in Hero search
  * - Quick Add row now lives inside the SAME panel as the cards (top of SectionCard.Body)
  * - Groups row uses TabBar (badges show per-group counts)
  * - Filters panel (toggle): Source (TabBar) + Pinned chip
@@ -21,7 +21,7 @@ import Input from "@/components/ui/primitives/Input";
 import Textarea from "@/components/ui/primitives/Textarea";
 import Button from "@/components/ui/primitives/Button";
 import IconButton from "@/components/ui/primitives/IconButton";
-import Hero, { HeroSearchBar } from "@/components/ui/layout/Hero";
+import Hero from "@/components/ui/layout/Hero";
 import TabBar from "@/components/ui/layout/TabBar";
 import SegmentedButton from "@/components/ui/primitives/SegmentedButton";
 import { uid, usePersistentState } from "@/lib/db";
@@ -220,7 +220,6 @@ export default function RemindersTab() {
   const neonClass = domain === "Life" ? "neon-life" : "neon-primary";
 
   // TabBar items
-  const DOMAIN_TABS = DOMAIN_ITEMS.map(d => ({ key: d.key, label: d.label, icon: d.icon }));
   const GROUP_TABS = GROUPS.map(g => ({
     key: g.key,
     label: g.label,
@@ -233,37 +232,33 @@ export default function RemindersTab() {
 
   return (
     <div className="grid gap-4">
-      {/* Hero with domain TabBar and bottom search */}
+      {/* Hero with domain sub-tabs and bottom search */}
       <Hero
         eyebrow={domain}
         heading="Reminders"
         subtitle="Tiny brain pings you’ll totally ignore until 23:59."
         dividerTint={domain === "Life" ? "life" : "primary"}
-        right={
-          <TabBar
-            items={DOMAIN_TABS}
-            value={domain}
-            onValueChange={(k) => setDomain(k as Domain)}
-            align="end"
-            size="md"
-            ariaLabel="Reminder domain"
-            showBaseline
-          />
-        }
-        bottom={
-          <HeroSearchBar
-            value={query}
-            onValueChange={setQuery}
-            placeholder="Search title, text, tags…"
-            debounceMs={80}
-            right={
-              <div className="flex items-center gap-2">
-                <span className="text-xs opacity-75">{filtered.length}</span>
-                <Search className="opacity-80" size={16} />
-              </div>
-            }
-          />
-        }
+        subTabs={{
+          items: DOMAIN_ITEMS,
+          value: domain,
+          onChange: (k: Domain) => setDomain(k),
+          align: "end",
+          size: "md",
+          ariaLabel: "Reminder domain",
+          showBaseline: true,
+        }}
+        search={{
+          value: query,
+          onValueChange: setQuery,
+          placeholder: "Search title, text, tags…",
+          debounceMs: 80,
+          right: (
+            <div className="flex items-center gap-2">
+              <span className="text-xs opacity-75">{filtered.length}</span>
+              <Search className="opacity-80" size={16} />
+            </div>
+          ),
+        }}
       />
 
       <SectionCard className="goal-card">

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -4,7 +4,6 @@
 import * as React from "react";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import IconButton from "@/components/ui/primitives/IconButton";
-import TabBar from "@/components/ui/layout/TabBar";
 import Hero from "@/components/ui/layout/Hero";
 import SegmentedButton from "@/components/ui/primitives/SegmentedButton";
 import TimerRing from "./TimerRing";
@@ -213,19 +212,17 @@ export default function TimerTab() {
         eyebrow="Focus"
         heading="Timer"
         subtitle="Pick a duration and focus."
-        right={
-          <TabBar
-            items={tabItems}
-            value={profile}
-            onValueChange={(k) => setProfile(k as ProfileKey)}
-            size="md"
-            align="between"
-            ariaLabel="Timer profiles"
-            right={rightSlot}
-            showBaseline
-            className="overflow-x-auto"
-          />
-        }
+        subTabs={{
+          items: tabItems,
+          value: profile,
+          onChange: (k: string) => setProfile(k as ProfileKey),
+          size: "md",
+          align: "between",
+          ariaLabel: "Timer profiles",
+          right: rightSlot,
+          showBaseline: true,
+          className: "overflow-x-auto",
+        }}
       />
 
       <SectionCard className="goal-card no-hover">

--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -155,8 +155,8 @@ export default function WeekPicker() {
     }
   };
 
-  /* Top button goes in Hero.right when applicable */
-  const right = showTop ? (
+  /* Top button goes in Hero actions when applicable */
+  const topAction = showTop ? (
     <Button
       variant="primary"
       size="sm"
@@ -177,50 +177,49 @@ export default function WeekPicker() {
         </span>
       }
       subtitle={`${isoStart} → ${isoEnd}`}
-      right={right}
+      actions={topAction}
       rail
       sticky
       dividerTint="primary"
-      bottom={
-        <div className="grid gap-3 flex-1">
-          {/* Range + totals */}
-          <div className="flex items-center justify-between gap-3">
-            <span
-              className={cn(
-                "inline-flex items-center gap-2 rounded-card r-card-lg px-3 py-2 text-sm",
-                "bg-card/72 ring-1 ring-border/55 backdrop-blur",
-              )}
-              aria-label={`Week range ${rangeLabel}`}
-            >
-              <CalendarDays className="size-4 opacity-80" />
-              <span className="opacity-90">{rangeLabel}</span>
-            </span>
+    >
+      <div className="grid gap-3 flex-1">
+        {/* Range + totals */}
+        <div className="flex items-center justify-between gap-3">
+          <span
+            className={cn(
+              "inline-flex items-center gap-2 rounded-card r-card-lg px-3 py-2 text-sm",
+              "bg-card/72 ring-1 ring-border/55 backdrop-blur",
+            )}
+            aria-label={`Week range ${rangeLabel}`}
+          >
+            <CalendarDays className="size-4 opacity-80" />
+            <span className="opacity-90">{rangeLabel}</span>
+          </span>
 
-            <span className="text-sm text-muted-foreground">
-              <span className="opacity-70">Total tasks: </span>
-              <span className="font-medium tabular-nums text-foreground">
-                {weekDone} / {weekTotal}
-              </span>
+          <span className="text-sm text-muted-foreground">
+            <span className="opacity-70">Total tasks: </span>
+            <span className="font-medium tabular-nums text-foreground">
+              {weekDone} / {weekTotal}
             </span>
-          </div>
-
-          {/* Day chips */}
-          <div className="flex gap-3 overflow-x-auto snap-x snap-mandatory lg:overflow-visible">
-            {days.map((d, i) => (
-              <DayChip
-                key={d}
-                iso={d}
-                selected={d === iso}
-                today={d === today}
-                done={per[i]?.done ?? 0}
-                total={per[i]?.total ?? 0}
-                onClick={selectOnly}
-                onDoubleClick={jumpToDay}
-              />
-            ))}
-          </div>
+          </span>
         </div>
-      }
-    />
+
+        {/* Day chips */}
+        <div className="flex gap-3 overflow-x-auto snap-x snap-mandatory lg:overflow-visible">
+          {days.map((d, i) => (
+            <DayChip
+              key={d}
+              iso={d}
+              selected={d === iso}
+              today={d === today}
+              done={per[i]?.done ?? 0}
+              total={per[i]?.total ?? 0}
+              onClick={selectOnly}
+              onDoubleClick={jumpToDay}
+            />
+          ))}
+        </div>
+      </div>
+    </Hero>
   );
 }

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -763,7 +763,16 @@ export default function ComponentGallery() {
               subtitle="Subtitle"
               sticky={false}
               topClassName="top-0"
+              subTabs={{
+                items: [
+                  { key: "one", label: "One" },
+                  { key: "two", label: "Two" },
+                ],
+                value: headerTab,
+                onChange: setHeaderTab,
+              }}
               search={{ value: "", onValueChange: () => {}, round: true }}
+              actions={<Button size="sm">Action</Button>}
             >
               <div className="text-sm text-muted-foreground">Body</div>
             </Hero>

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -20,7 +20,6 @@ import {
   Hero2,
   SectionCard as UiSectionCard,
   type HeaderTab,
-  type TabItem,
 } from "@/components/ui";
 import GoalListDemo from "./GoalListDemo";
 import PromptList from "./PromptList";
@@ -483,7 +482,7 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
   ],
 };
 
-export const SECTION_TABS: TabItem<Section>[] = (
+export const SECTION_TABS: HeaderTab<Section>[] = (
   Object.keys(SPEC_DATA) as Section[]
 ).map((key) => ({
   key,

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -11,7 +11,7 @@ import ReviewPanel from "./ReviewPanel";
 import { BookOpen, Ghost, Plus } from "lucide-react";
 
 import { Button, Select } from "@/components/ui";
-import Hero, { HeroSearchBar } from "@/components/ui/layout/Hero";
+import Hero from "@/components/ui/layout/Hero";
 import Header from "@/components/ui/layout/Header";
 
 type SortKey = "newest" | "oldest" | "title";
@@ -103,48 +103,45 @@ export default function ReviewsPage({
         topClassName="top-[var(--header-stack)]"
         heading="Browse Reviews"
         subtitle={<span className="pill">Total {base.length}</span>}
-        right={null}
-        bottom={
-          <>
-            <HeroSearchBar
-              round
-              value={q}
-              onValueChange={setQ}
-              placeholder="Search title, tags, opponent, patch…"
-              className="flex-1"
-            />
-            <div className="flex items-center gap-3">
-              <div className="hidden sm:flex items-center gap-2 text-xs text-muted-foreground">
-                <span>Sort</span>
-                <Select
-                  variant="animated"
-                  value={sort}
-                  onChange={(v) => setSort(v as SortKey)}
-                  items={[
-                    { value: "newest", label: "Newest" },
-                    { value: "oldest", label: "Oldest" },
-                    { value: "title", label: "Title" },
-                  ]}
-                  buttonClassName="h-10 px-[var(--spacing-4)]"
-                />
-              </div>
-              <Button
-                type="button"
-                variant="primary"
-                size="md"
-                className="px-[var(--spacing-4)] whitespace-nowrap"
-                onClick={() => {
-                  setQ("");
-                  setSort("newest");
-                  setPanelMode("edit");
-                  onCreate();
-                }}
-              >
-                <Plus />
-                <span>New Review</span>
-              </Button>
+        search={{
+          round: true,
+          value: q,
+          onValueChange: setQ,
+          placeholder: "Search title, tags, opponent, patch…",
+          className: "flex-1",
+        }}
+        actions={
+          <div className="flex items-center gap-3">
+            <div className="hidden sm:flex items-center gap-2 text-xs text-muted-foreground">
+              <span>Sort</span>
+              <Select
+                variant="animated"
+                value={sort}
+                onChange={(v) => setSort(v as SortKey)}
+                items={[
+                  { value: "newest", label: "Newest" },
+                  { value: "oldest", label: "Oldest" },
+                  { value: "title", label: "Title" },
+                ]}
+                buttonClassName="h-10 px-[var(--spacing-4)]"
+              />
             </div>
-          </>
+            <Button
+              type="button"
+              variant="primary"
+              size="md"
+              className="px-[var(--spacing-4)] whitespace-nowrap"
+              onClick={() => {
+                setQ("");
+                setSort("newest");
+                setPanelMode("edit");
+                onCreate();
+              }}
+            >
+              <Plus />
+              <span>New Review</span>
+            </Button>
+          </div>
         }
       />
 

--- a/src/components/team/Builder.tsx
+++ b/src/components/team/Builder.tsx
@@ -158,7 +158,7 @@ export default function Builder() {
         eyebrow="Comps"
         heading="Builder"
         subtitle="Fill allies vs enemies. Swap in one click."
-        right={
+        actions={
           <div className="flex items-center gap-2">
             <IconButton
               title="Swap Allies ↔ Enemies"

--- a/src/components/team/CheatSheetTabs.tsx
+++ b/src/components/team/CheatSheetTabs.tsx
@@ -69,10 +69,10 @@ export default function CheatSheetTabs() {
         eyebrow="Comps"
         heading="Cheat Sheet"
         subtitle={tab === "sheet" ? "Archetypes & tips" : "Your saved compositions"}
-        tabs={{
+        subTabs={{
           items: tabs,
           value: tab,
-          onChange: k => setTab(k as SubTab),
+          onChange: (k: string) => setTab(k as SubTab),
           showBaseline: true,
         }}
         search={{

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -369,9 +369,6 @@ exports[`ReviewsPage > renders default state 1`] = `
               </span>
             </div>
           </div>
-          <div
-            class="ml-auto"
-          />
         </div>
         <div
           class="relative z-[2] mt-4 flex flex-col gap-4"
@@ -435,72 +432,75 @@ exports[`ReviewsPage > renders default state 1`] = `
                 </div>
               </form>
               <div
-                class="flex items-center gap-3"
+                class="flex items-center gap-2"
               >
                 <div
-                  class="hidden sm:flex items-center gap-2 text-xs text-muted-foreground"
+                  class="flex items-center gap-3"
                 >
-                  <span>
-                    Sort
-                  </span>
                   <div
-                    class="glitch-wrap "
+                    class="hidden sm:flex items-center gap-2 text-xs text-muted-foreground"
                   >
+                    <span>
+                      Sort
+                    </span>
                     <div
-                      class="group inline-flex rounded-full border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0"
+                      class="glitch-wrap "
                     >
-                      <button
-                        aria-controls=":r1:-listbox"
-                        aria-expanded="false"
-                        aria-haspopup="listbox"
-                        aria-label="Select option"
-                        class="glitch-trigger relative flex items-center rounded-full px-3 overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition h-10 px-[var(--spacing-4)]"
-                        data-lit="true"
-                        data-open="false"
-                        type="button"
+                      <div
+                        class="group inline-flex rounded-full border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0"
                       >
-                        <span
-                          class="font-medium glitch-text text-foreground group-hover:text-foreground"
+                        <button
+                          aria-controls=":r1:-listbox"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          aria-label="Select option"
+                          class="glitch-trigger relative flex items-center rounded-full px-3 overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition h-10 px-[var(--spacing-4)]"
+                          data-lit="true"
+                          data-open="false"
+                          type="button"
                         >
-                          Newest
-                        </span>
-                        <svg
-                          aria-hidden="true"
-                          class="lucide lucide-chevron-down caret ml-auto size-4 shrink-0 opacity-75 "
-                          fill="none"
-                          height="24"
-                          stroke="currentColor"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="m6 9 6 6 6-6"
+                          <span
+                            class="font-medium glitch-text text-foreground group-hover:text-foreground"
+                          >
+                            Newest
+                          </span>
+                          <svg
+                            aria-hidden="true"
+                            class="lucide lucide-chevron-down caret ml-auto size-4 shrink-0 opacity-75 "
+                            fill="none"
+                            height="24"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="m6 9 6 6 6-6"
+                            />
+                          </svg>
+                          <span
+                            aria-hidden="true"
+                            class="gb-iris"
                           />
-                        </svg>
-                        <span
-                          aria-hidden="true"
-                          class="gb-iris"
-                        />
-                        <span
-                          aria-hidden="true"
-                          class="gb-chroma"
-                        />
-                        <span
-                          aria-hidden="true"
-                          class="gb-flicker"
-                        />
-                        <span
-                          aria-hidden="true"
-                          class="gb-scan"
-                        />
-                      </button>
-                    </div>
-                    <style>
-                      
+                          <span
+                            aria-hidden="true"
+                            class="gb-chroma"
+                          />
+                          <span
+                            aria-hidden="true"
+                            class="gb-flicker"
+                          />
+                          <span
+                            aria-hidden="true"
+                            class="gb-scan"
+                          />
+                        </button>
+                      </div>
+                      <style>
+                        
       /* caret jitter */
       .caret {
         transition:
@@ -720,45 +720,46 @@ exports[`ReviewsPage > renders default state 1`] = `
           -0.6px 0 hsl(330 100% 60% / 0.45);
       }
     
-                    </style>
+                      </style>
+                    </div>
                   </div>
-                </div>
-                <button
-                  class="relative inline-flex items-center justify-center rounded-2xl border border-[--focus] font-medium transition-all duration-200 hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 text-base gap-2 [&_svg]:size-5 px-[var(--spacing-4)] whitespace-nowrap bg-panel/85 overflow-hidden shadow-neo text-foreground"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="absolute inset-0 pointer-events-none rounded-2xl"
-                    style="background: linear-gradient(90deg, hsl(var(--foreground)/.18), hsl(var(--foreground)/.18));"
-                  />
-                  <span
-                    class="relative z-10 inline-flex items-center gap-2"
+                  <button
+                    class="relative inline-flex items-center justify-center rounded-2xl border border-[--focus] font-medium transition-all duration-200 hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 text-base gap-2 [&_svg]:size-5 px-[var(--spacing-4)] whitespace-nowrap bg-panel/85 overflow-hidden shadow-neo text-foreground"
+                    tabindex="0"
+                    type="button"
                   >
-                    <svg
-                      class="lucide lucide-plus"
-                      fill="none"
-                      height="24"
-                      stroke="currentColor"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <span
+                      class="absolute inset-0 pointer-events-none rounded-2xl"
+                      style="background: linear-gradient(90deg, hsl(var(--foreground)/.18), hsl(var(--foreground)/.18));"
+                    />
+                    <span
+                      class="relative z-10 inline-flex items-center gap-2"
                     >
-                      <path
-                        d="M5 12h14"
-                      />
-                      <path
-                        d="M12 5v14"
-                      />
-                    </svg>
-                    <span>
-                      New Review
+                      <svg
+                        class="lucide lucide-plus"
+                        fill="none"
+                        height="24"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5 12h14"
+                        />
+                        <path
+                          d="M12 5v14"
+                        />
+                      </svg>
+                      <span>
+                        New Review
+                      </span>
                     </span>
-                  </span>
-                </button>
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/tests/ui/tab-bar.test.tsx
+++ b/tests/ui/tab-bar.test.tsx
@@ -39,7 +39,7 @@ describe("navigation tabs", () => {
     rerender(
       <Hero
         heading="Components"
-        tabs={{
+        subTabs={{
           items: [
             { key: "buttons", label: "Buttons" },
             { key: "inputs", label: "Inputs" },


### PR DESCRIPTION
## Summary
- add `subTabs` prop and `actions` slot to `Hero`
- remove legacy `right`/`bottom` usage across features
- showcase sub-tabs and actions in component gallery

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68c3d4ba39e0832c8eeec7e849205365