### PR TITLE
feat: move hero actions to slot

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -21,13 +21,17 @@ export default function NotFound() {
         heading="Page not found"
         icon={<AlertCircle className="opacity-80" />}
       />
-      <Hero heading="This page does not exist">
+      <Hero
+        heading="This page does not exist"
+        actions={
+          <Link href="/">
+            <Button className="px-[var(--spacing-4)]">Go home</Button>
+          </Link>
+        }
+      >
         <p className="text-sm text-muted-foreground">
           The page you are looking for does not exist.
         </p>
-        <Link href="/">
-          <Button>Go home</Button>
-        </Link>
       </Hero>
     </main>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { Suspense } from "react";
 import { Home } from "lucide-react";
+import Link from "next/link";
 import {
   QuickActions,
   TodayCard,
@@ -14,7 +15,7 @@ import {
 } from "@/components/home";
 import Hero from "@/components/ui/layout/Hero";
 import Header from "@/components/ui/layout/Header";
-import { Spinner } from "@/components/ui";
+import { Button, Spinner } from "@/components/ui";
 import { useTheme } from "@/lib/theme-context";
 import { useThemeQuerySync } from "@/lib/theme-hooks";
 
@@ -36,6 +37,17 @@ function HomePageContent() {
       <Hero
         topClassName="top-[var(--header-stack)]"
         heading="Your day at a glance"
+        actions={
+          <Link href="/planner">
+            <Button
+              variant="primary"
+              size="sm"
+              className="px-[var(--spacing-4)] whitespace-nowrap"
+            >
+              Plan Week
+            </Button>
+          </Link>
+        }
       />
       <div className="grid gap-4 md:grid-cols-12 items-start">
         <div className="md:col-span-6">

--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -259,6 +259,17 @@ export default function RemindersTab() {
             </div>
           ),
         }}
+        actions={
+          <Button
+            variant="primary"
+            size="md"
+            className="px-[var(--spacing-4)] whitespace-nowrap"
+            onClick={() => addNew()}
+          >
+            <Plus />
+            <span>New Reminder</span>
+          </Button>
+        }
       />
 
       <SectionCard className="goal-card">

--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -163,6 +163,7 @@ export default function WeekPicker() {
       aria-label="Jump to top"
       onClick={jumpToTop}
       title="Jump to top"
+      className="px-[var(--spacing-4)]"
     >
       <ArrowUpToLine />
       <span>Top</span>

--- a/src/components/team/JungleClears.tsx
+++ b/src/components/team/JungleClears.tsx
@@ -15,6 +15,7 @@ import React, { useMemo, useState } from "react";
 import Hero from "@/components/ui/layout/Hero";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import IconButton from "@/components/ui/primitives/IconButton";
+import Button from "@/components/ui/primitives/Button";
 import Input from "@/components/ui/primitives/Input";
 import { usePersistentState, uid } from "@/lib/db";
 import { Timer, Pencil, Trash2, Check, X, Plus } from "lucide-react";
@@ -156,6 +157,17 @@ export default function JungleClears() {
             <span className="text-xs opacity-80">{filtered.length} shown</span>
           ),
         }}
+        actions={
+          <Button
+            variant="primary"
+            size="sm"
+            className="px-[var(--spacing-4)] whitespace-nowrap"
+            onClick={() => addRow("Medium")}
+          >
+            <Plus />
+            <span>New Row</span>
+          </Button>
+        }
       >
         <p className="text-sm text-muted-foreground">
           If you’re on a <em>Medium</em> champ, don’t race farm vs{" "}


### PR DESCRIPTION
## Summary
- add primary "New Reminder" button to Reminders hero
- wire Jungle Clears hero with add-row action
- move home and planner actions into Hero action slots and token spacing tweaks

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68c3e1c4e2cc832c847d8943566a65d6