### PR TITLE
feat: showcase header and hero examples

### DIFF
--- a/src/app/prompts/PromptsPage.tsx
+++ b/src/app/prompts/PromptsPage.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { Header, Hero } from "@/components/ui";
-import { Sparkles } from "lucide-react";
+import { Header, Hero, Button, IconButton } from "@/components/ui";
+import { Sparkles, Plus } from "lucide-react";
 import ComponentsView from "@/components/prompts/ComponentsView";
 import ColorsView from "@/components/prompts/ColorsView";
 import OnboardingTabs from "@/components/prompts/OnboardingTabs";
@@ -108,6 +108,14 @@ function PageContent() {
           round: true,
           "aria-label": "Search components",
         }}
+        actions={
+          <div className="flex items-center gap-2">
+            <Button size="sm">Action</Button>
+            <IconButton size="sm" aria-label="Add">
+              <Plus />
+            </IconButton>
+          </div>
+        }
       />
       <section className="grid gap-6 lg:grid-cols-1">
         <div className="space-y-6 lg:col-span-full">

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -17,6 +17,8 @@ import {
   ThemePicker,
   BackgroundPicker,
   Progress,
+  Header,
+  Hero,
   Hero2,
   SectionCard as UiSectionCard,
   type HeaderTab,
@@ -105,6 +107,54 @@ function BackgroundPickerDemo() {
     <BackgroundPicker
       bg={t.bg}
       onBgChange={(b) => setT((prev) => ({ ...prev, bg: b }))}
+    />
+  );
+}
+
+function HeaderTabsDemo() {
+  const [tab, setTab] = React.useState("one");
+  const tabs: HeaderTab<string>[] = [
+    { key: "one", label: "One" },
+    { key: "two", label: "Two" },
+  ];
+  return (
+    <Header
+      heading="Header"
+      tabs={{ items: tabs, value: tab, onChange: setTab }}
+      sticky={false}
+      topClassName="top-0"
+    />
+  );
+}
+
+function HeroDemo() {
+  const [sub, setSub] = React.useState("one");
+  const [query, setQuery] = React.useState("");
+  const subTabs: HeaderTab<string>[] = [
+    { key: "one", label: "One" },
+    { key: "two", label: "Two" },
+  ];
+  return (
+    <Hero
+      heading="Hero"
+      subTabs={{ items: subTabs, value: sub, onChange: setSub }}
+      search={{
+        id: "hero-demo-search",
+        value: query,
+        onValueChange: setQuery,
+        round: true,
+        "aria-label": "Search",
+      }}
+      actions={
+        <div className="flex items-center gap-2">
+          <Button size="sm">Action</Button>
+          <IconButton size="sm" aria-label="Add">
+            <Plus />
+          </IconButton>
+        </div>
+      }
+      sticky={false}
+      topClassName="top-0"
     />
   );
 }
@@ -375,6 +425,20 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
     },
   ],
   layout: [
+    {
+      id: "header-tabs",
+      name: "Header Tabs",
+      description: "Header with segmented tabs",
+      element: <HeaderTabsDemo />,
+      tags: ["header", "tabs"],
+    },
+    {
+      id: "hero-demo",
+      name: "Hero",
+      description: "Hero with sub-tabs, search, and actions",
+      element: <HeroDemo />,
+      tags: ["hero"],
+    },
     {
       id: "card-demo",
       name: "Card",


### PR DESCRIPTION
## Summary
- add header tabs and hero demos to component gallery
- include hero actions in prompts playground

## Testing
- `npm run regen-ui`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68c3e3623504832c94ea132d98c6c83d