### PR TITLE
Improve prompt accessibility and search

### DIFF
--- a/src/components/prompts/PromptList.tsx
+++ b/src/components/prompts/PromptList.tsx
@@ -10,6 +10,7 @@ export type PromptListProps = {
 };
 
 export default function PromptList({ prompts, query }: PromptListProps) {
+  const q = query.trim();
   return (
     <ul className="mt-4 space-y-3">
       {prompts.map((p) => (
@@ -32,10 +33,14 @@ export default function PromptList({ prompts, query }: PromptListProps) {
       ))}
       {prompts.length === 0 ? (
         <li className="text-muted-foreground flex items-center gap-1">
-          No prompts match
-          <Badge size="xs" tone="neutral">
-            {query || ""}
-          </Badge>
+          {q ? (
+            <>
+              No prompts match
+              <Badge size="xs" tone="neutral">{q}</Badge>
+            </>
+          ) : (
+            "No prompts saved yet"
+          )}
         </li>
       ) : null}
     </ul>

--- a/src/components/prompts/PromptsComposePanel.tsx
+++ b/src/components/prompts/PromptsComposePanel.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Input, Textarea } from "@/components/ui";
-import IconButton from "@/components/ui/primitives/IconButton";
+import { Input, Textarea, Label } from "@/components/ui";
 import { Check as CheckIcon } from "lucide-react";
 
 interface PromptsComposePanelProps {
@@ -19,32 +18,40 @@ export default function PromptsComposePanel({
   onTextChange,
 }: PromptsComposePanelProps) {
   const titleId = React.useId();
+  const textId = React.useId();
   return (
     <div className="space-y-3">
-      <Input
-        id={titleId}
-        placeholder="Title"
-        value={title}
-        onChange={(e) => onTitleChange(e.target.value)}
-        aria-describedby={`${titleId}-help`}
-      >
-        <IconButton
-          size="sm"
-          aria-label="Confirm"
-          className="absolute right-2 top-1/2 -translate-y-1/2"
+      <div>
+        <Label htmlFor={titleId}>Title</Label>
+        <Input
+          id={titleId}
+          placeholder="Title"
+          value={title}
+          onChange={(e) => onTitleChange(e.target.value)}
+          aria-describedby={`${titleId}-help`}
         >
-          <CheckIcon aria-hidden />
-        </IconButton>
-      </Input>
-      <p id={`${titleId}-help`} className="mt-1 text-xs text-muted-foreground">
-        Add a short title
-      </p>
-      <Textarea
-        placeholder="Write your prompt or snippet…"
-        value={text}
-        onChange={(e) => onTextChange(e.target.value)}
-        resize="resize-y"
-      />
+          <CheckIcon
+            aria-hidden="true"
+            className="absolute right-2 top-1/2 -translate-y-1/2"
+          />
+        </Input>
+        <p
+          id={`${titleId}-help`}
+          className="mt-1 text-xs text-muted-foreground"
+        >
+          Add a short title
+        </p>
+      </div>
+      <div>
+        <Label htmlFor={textId}>Prompt</Label>
+        <Textarea
+          id={textId}
+          placeholder="Write your prompt or snippet…"
+          value={text}
+          onChange={(e) => onTextChange(e.target.value)}
+          resize="resize-y"
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/prompts/PromptsHeader.tsx
+++ b/src/components/prompts/PromptsHeader.tsx
@@ -26,6 +26,12 @@ export default function PromptsHeader({
     setLocalQuery(query);
   }, [query]);
 
+  React.useEffect(() => {
+    return () => {
+      window.clearTimeout(debounceRef.current);
+    };
+  }, []);
+
   const handleChange = React.useCallback(
     (val: string) => {
       setLocalQuery(val);

--- a/src/components/prompts/usePrompts.ts
+++ b/src/components/prompts/usePrompts.ts
@@ -19,7 +19,9 @@ export function usePrompts() {
 
   const deriveTitle = React.useCallback((p: Prompt) => {
     if (p.title && p.title.trim()) return p.title.trim();
-    const firstLine = (p.text || "").split(/\r?\n/)[0]?.trim() || "";
+    const firstLine = (p.text || "")
+      .split(/\r?\n/)
+      .find((line) => line.trim())?.trim();
     return firstLine || "Untitled";
   }, []);
 

--- a/tests/prompts/prompts-compose-panel.test.tsx
+++ b/tests/prompts/prompts-compose-panel.test.tsx
@@ -9,7 +9,7 @@ describe("PromptsComposePanel", () => {
   it("renders fields and handles changes", () => {
     const handleTitle = vi.fn();
     const handleText = vi.fn();
-    render(
+    const { container } = render(
       <PromptsComposePanel
         title="Title"
         onTitleChange={handleTitle}
@@ -18,13 +18,16 @@ describe("PromptsComposePanel", () => {
       />,
     );
 
-    const titleInput = screen.getByPlaceholderText("Title");
-    const textarea = screen.getByPlaceholderText(
-      "Write your prompt or snippet…",
-    );
+    const titleInput = screen.getByLabelText("Title");
+    const textarea = screen.getByLabelText("Prompt");
     expect(titleInput).toHaveValue("Title");
     expect(textarea).toHaveValue("Text");
-    expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
+    const help = screen.getByText("Add a short title");
+    expect(titleInput).toHaveAttribute("aria-describedby", help.id);
+    expect(
+      screen.queryByRole("button", { name: "Confirm" }),
+    ).not.toBeInTheDocument();
+    expect(container.querySelector("svg[aria-hidden='true']")).toBeInTheDocument();
 
     fireEvent.change(titleInput, { target: { value: "New" } });
     expect(handleTitle).toHaveBeenCalledWith("New");

--- a/tests/prompts/prompts-header.test.tsx
+++ b/tests/prompts/prompts-header.test.tsx
@@ -53,4 +53,24 @@ describe("PromptsHeader", () => {
     fireEvent.click(save);
     expect(handleSave).toHaveBeenCalled();
   });
+
+  it("clears debounce timer on unmount", () => {
+    const handleQuery = vi.fn();
+    vi.useFakeTimers();
+    const { unmount } = render(
+      <PromptsHeader
+        count={0}
+        query=""
+        onQueryChange={handleQuery}
+        onSave={() => {}}
+        disabled={false}
+      />,
+    );
+    const search = screen.getByPlaceholderText("Search prompts…");
+    fireEvent.change(search, { target: { value: "abc" } });
+    unmount();
+    vi.advanceTimersByTime(300);
+    expect(handleQuery).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
 });

--- a/tests/prompts/prompts-page.test.tsx
+++ b/tests/prompts/prompts-page.test.tsx
@@ -28,10 +28,8 @@ describe("PromptsPage", () => {
       </ThemeProvider>,
     );
 
-    const titleInput = screen.getByPlaceholderText("Title");
-    const textArea = screen.getByPlaceholderText(
-      "Write your prompt or snippet…",
-    );
+    const titleInput = screen.getByLabelText("Title");
+    const textArea = screen.getByLabelText("Prompt");
     const saveButton = screen.getByRole("button", { name: "Save" });
 
     fireEvent.change(titleInput, { target: { value: "First" } });
@@ -58,6 +56,7 @@ describe("PromptsPage", () => {
     vi.advanceTimersByTime(300);
     await Promise.resolve();
     expect(screen.getByText("No prompts match")).toBeInTheDocument();
+    expect(screen.getByText("zzz")).toBeInTheDocument();
     vi.useRealTimers();
   });
 
@@ -73,6 +72,6 @@ describe("PromptsPage", () => {
     await waitFor(() =>
       expect(screen.getByText("0 saved")).toBeInTheDocument(),
     );
-    expect(screen.getByText(/No prompts match/)).toBeInTheDocument();
+    expect(screen.getByText("No prompts saved yet")).toBeInTheDocument();
   });
 });

--- a/tests/prompts/use-prompts.test.ts
+++ b/tests/prompts/use-prompts.test.ts
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { Prompt } from "@/components/prompts";
+
+const mockInitialPrompts: Prompt[] = [];
+
+vi.mock("@/lib/db", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/db")>("@/lib/db");
+  return {
+    ...actual,
+    usePersistentState: <T,>(key: string, initial: T) =>
+      React.useState(mockInitialPrompts as T),
+  };
+});
+
+import { usePrompts } from "@/components/prompts";
+
+describe("deriveTitle", () => {
+  it("uses the first non-empty line", () => {
+    mockInitialPrompts.length = 0;
+    mockInitialPrompts.push({
+      id: "p1",
+      title: "",
+      text: "\n\nHello world\nMore",
+      createdAt: 0,
+    });
+    const { result } = renderHook(() => usePrompts());
+    expect(result.current.filtered[0].title).toBe("Hello world");
+  });
+});


### PR DESCRIPTION
## Summary
- label title and prompt fields for better accessibility and show a static check icon
- show context-aware empty messages in prompt list and clear search debouncer on unmount
- derive prompt titles from first non-empty line and add tests for edge cases

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c3f0451288832cb016aa7a7a661fd9