### PR TITLE
fix: sync router params

### DIFF
--- a/src/components/prompts/usePromptsRouter.ts
+++ b/src/components/prompts/usePromptsRouter.ts
@@ -22,13 +22,13 @@ export function usePromptsRouter() {
 
   React.useEffect(() => {
     const v = (viewParam as View) || "components";
-    if (v !== view) setView(v);
-  }, [viewParam, view]);
+    setView((prev) => (v === prev ? prev : v));
+  }, [viewParam]);
 
   React.useEffect(() => {
     const s = getValidSection(sectionParam);
-    if (s !== section) setSection(s);
-  }, [sectionParam, section]);
+    setSection((prev) => (s === prev ? prev : s));
+  }, [sectionParam]);
 
   React.useEffect(() => {
     const sp = new URLSearchParams(searchParams.toString());


### PR DESCRIPTION
## Summary
- avoid stale state by removing `view` and `section` from router sync effects
- use functional state updates to satisfy eslint

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c3fb2cfc34832c8e3036c50c1effad