### PR TITLE
feat: add goals hero filtering

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -17,7 +17,7 @@ import Header, { type HeaderTab } from "@/components/ui/layout/Header";
 import Hero from "@/components/ui/layout/Hero";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import { Snackbar } from "@/components/ui";
-import GoalsTabs, { FilterKey } from "./GoalsTabs";
+import { FilterKey } from "./GoalsTabs";
 import GoalForm, { GoalFormHandle } from "./GoalForm";
 import GoalsProgress from "./GoalsProgress";
 import GoalList from "./GoalList";
@@ -190,41 +190,40 @@ export default function GoalsPage() {
             <div className="grid gap-4">
               <Hero
                 eyebrow="Guide"
-                heading="Overview"
+                heading="Your Goals"
                 subtitle={`Cap ${ACTIVE_CAP}, ${remaining} remaining (${activeCount} active, ${doneCount} done)`}
+                actions={
+                  <GoalsProgress
+                    total={totalCount}
+                    pct={pctDone}
+                    onAddFirst={handleAddFirst}
+                  />
+                }
                 sticky={false}
                 topClassName="top-0"
+                subTabs={{
+                  items: [
+                    { key: "All", label: "All" },
+                    { key: "Active", label: "Active" },
+                    { key: "Done", label: "Done" },
+                  ],
+                  value: filter,
+                  onChange: (k) => setFilter(k as FilterKey),
+                  ariaLabel: "Filter goals",
+                  size: "sm",
+                }}
               />
 
-              {totalCount === 0 ? (
-                <GoalsProgress
-                  total={totalCount}
-                  pct={pctDone}
-                  onAddFirst={handleAddFirst}
-                />
-              ) : (
-                <SectionCard className="card-neo-soft">
-                  <SectionCard.Header
-                    sticky
-                    topClassName="top-0"
-                    className="flex items-center justify-between"
-                  >
-                    <div className="flex items-center gap-2 sm:gap-4">
-                      <h2 className="text-lg font-semibold">Your Goals</h2>
-                      <GoalsProgress total={totalCount} pct={pctDone} />
-                    </div>
-                    <GoalsTabs value={filter} onChange={setFilter} />
-                  </SectionCard.Header>
-                  <SectionCard.Body>
-                    <GoalList
-                      goals={filtered}
-                      onToggleDone={toggleDone}
-                      onRemove={removeGoal}
-                      onUpdate={updateGoal}
-                    />
-                  </SectionCard.Body>
-                </SectionCard>
-              )}
+              <SectionCard className="card-neo-soft">
+                <SectionCard.Body>
+                  <GoalList
+                    goals={filtered}
+                    onToggleDone={toggleDone}
+                    onRemove={removeGoal}
+                    onUpdate={updateGoal}
+                  />
+                </SectionCard.Body>
+              </SectionCard>
 
               <div ref={formRef}>
                 <GoalForm

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -33,7 +33,7 @@ import {
   type TabItem,
 } from "@/components/ui";
 import BadgePrimitive from "@/components/ui/primitives/Badge";
-import { GoalsTabs, GoalsProgress, type FilterKey } from "@/components/goals";
+import { GoalsProgress, type FilterKey } from "@/components/goals";
 import PromptsHeader from "./PromptsHeader";
 import PromptsComposePanel from "./PromptsComposePanel";
 import PromptsDemos from "./PromptsDemos";
@@ -456,11 +456,25 @@ export default function ComponentGallery() {
         element: <GoalsProgress total={5} pct={60} maxWidth={200} />,
       },
       {
-        label: "Goals Tabs",
+        label: "Goals Hero",
         element: (
-          <div className="w-56">
-            <GoalsTabs value={goalFilter} onChange={setGoalFilter} />
-          </div>
+          <Hero
+            heading="Your Goals"
+            actions={<GoalsProgress total={5} pct={60} />}
+            subTabs={{
+              items: [
+                { key: "All", label: "All" },
+                { key: "Active", label: "Active" },
+                { key: "Done", label: "Done" },
+              ],
+              value: goalFilter,
+              onChange: setGoalFilter,
+              ariaLabel: "Filter goals",
+              size: "sm",
+            }}
+            sticky={false}
+            topClassName="top-0"
+          />
         ),
       },
       {

--- a/tests/goals/goals-page.test.tsx
+++ b/tests/goals/goals-page.test.tsx
@@ -18,14 +18,45 @@ describe("GoalsPage", () => {
     window.localStorage.clear();
   });
 
-  it("renders hero heading and subtitle", () => {
+  it("renders goals hero with progress", () => {
     render(<GoalsPage />);
-    expect(
-      screen.getByRole("heading", { name: "Overview" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("Cap 3, 3 remaining (0 active, 0 done)"),
-    ).toBeInTheDocument();
+    const hero = screen.getByRole("heading", { name: "Your Goals" }).closest(
+      "section",
+    ) as HTMLElement;
+    expect(within(hero).getByText("No goals yet.")).toBeInTheDocument();
+  });
+
+  it("filters goals via hero sub-tabs", async () => {
+    render(<GoalsPage />);
+
+    const titleInput = screen.getByRole("textbox", { name: "Title" });
+    const addButton = screen.getByRole("button", { name: /add goal/i });
+
+    fireEvent.change(titleInput, { target: { value: "A" } });
+    fireEvent.click(addButton);
+    fireEvent.change(titleInput, { target: { value: "B" } });
+    fireEvent.click(addButton);
+
+    const bArticle = screen.getByText("B").closest("article") as HTMLElement;
+    const toggle = within(bArticle).getByRole("checkbox", { name: "Mark done" });
+    fireEvent.pointerDown(toggle);
+    fireEvent.click(toggle);
+    await waitFor(() =>
+      expect(within(bArticle).getByText("Done")).toBeInTheDocument(),
+    );
+
+    const tabs = screen.getByRole("tablist", { name: "Filter goals" });
+    fireEvent.click(within(tabs).getByRole("tab", { name: "Done" }));
+    expect(screen.getByText("B")).toBeInTheDocument();
+    expect(screen.queryByText("A")).not.toBeInTheDocument();
+
+    fireEvent.click(within(tabs).getByRole("tab", { name: "Active" }));
+    expect(screen.getByText("A")).toBeInTheDocument();
+    expect(screen.queryByText("B")).not.toBeInTheDocument();
+
+    fireEvent.click(within(tabs).getByRole("tab", { name: "All" }));
+    expect(screen.getByText("A")).toBeInTheDocument();
+    expect(screen.getByText("B")).toBeInTheDocument();
   });
 
   it("allows editing goal fields", async () => {


### PR DESCRIPTION
## Summary
- replace goals overview with "Your Goals" hero that shows progress and sub-tab filters
- simplify goals list container and hook hero tabs into list filtering
- document new goals hero behavior in component gallery

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test tests/goals/goals-page.test.tsx`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c3fb8ebf60832c8d2b84c09bbd4175