### PR TITLE
refactor: migrate grids to 12-column layout

### DIFF
--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -234,15 +234,16 @@ export default function Reminders() {
           </div>
 
           {/* Cards grid */}
-          <div className="grid card-neo-soft gap-3 sm:gap-4 md:grid-cols-2">
+          <div className="grid card-neo-soft gap-3 sm:gap-4 md:grid-cols-12">
             {filtered.map((r) => (
-              <ReminderCard
-                key={r.id}
-                value={r}
-                onChange={(p) => patch(r.id, p)}
-                onDelete={() => del(r.id)}
-                onDuplicate={() => dup(r.id)}
-              />
+              <div key={r.id} className="md:col-span-6">
+                <ReminderCard
+                  value={r}
+                  onChange={(p) => patch(r.id, p)}
+                  onDelete={() => del(r.id)}
+                  onDuplicate={() => dup(r.id)}
+                />
+              </div>
             ))}
 
             {filtered.length === 0 && (

--- a/src/components/team/Builder.tsx
+++ b/src/components/team/Builder.tsx
@@ -184,21 +184,23 @@ export default function Builder() {
       <div className="mt-6">
         <SectionCard className="card-neo-soft glitch-card">
           <SectionCard.Body>
-            <div className="grid grid-cols-1 md:grid-cols-[1fr_var(--spacing-3)_1fr] gap-6">
+            <div className="grid grid-cols-1 md:grid-cols-12 gap-6">
               {/* Allies */}
-              <SideEditor
-                title="Allies"
-                icon={<Shield />}
-                value={state.allies}
-                onLane={(lane, v) => setLane("allies", lane, v)}
-                onNotes={(v) => setNotes("allies", v)}
-                onClear={() => clearSide("allies")}
-                onCopy={() => copy("allies")}
-                count={filledCount.allies}
-              />
+              <div className="md:col-span-5">
+                <SideEditor
+                  title="Allies"
+                  icon={<Shield />}
+                  value={state.allies}
+                  onLane={(lane, v) => setLane("allies", lane, v)}
+                  onNotes={(v) => setNotes("allies", v)}
+                  onClear={() => clearSide("allies")}
+                  onCopy={() => copy("allies")}
+                  count={filledCount.allies}
+                />
+              </div>
 
               {/* Center spine (md+) */}
-              <div className="hidden md:block relative">
+              <div className="hidden md:block relative md:col-span-2">
                 <span
                   aria-hidden
                   className="absolute left-1/2 top-0 -translate-x-1/2 h-full w-px bg-border"
@@ -206,16 +208,18 @@ export default function Builder() {
               </div>
 
               {/* Enemies */}
-              <SideEditor
-                title="Enemies"
-                icon={<Swords />}
-                value={state.enemies}
-                onLane={(lane, v) => setLane("enemies", lane, v)}
-                onNotes={(v) => setNotes("enemies", v)}
-                onClear={() => clearSide("enemies")}
-                onCopy={() => copy("enemies")}
-                count={filledCount.enemies}
-              />
+              <div className="md:col-span-5">
+                <SideEditor
+                  title="Enemies"
+                  icon={<Swords />}
+                  value={state.enemies}
+                  onLane={(lane, v) => setLane("enemies", lane, v)}
+                  onNotes={(v) => setNotes("enemies", v)}
+                  onClear={() => clearSide("enemies")}
+                  onCopy={() => copy("enemies")}
+                  count={filledCount.enemies}
+                />
+              </div>
             </div>
           </SectionCard.Body>
         </SectionCard>


### PR DESCRIPTION
## Summary
- adapt reminders grid to 12-column layout with tokenized gaps
- restructure team builder grid into 12-column layout

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c40b9cc75c832c9b4ebc941ae858e1