### PR TITLE
fix: disable loading Select items

### DIFF
--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -351,7 +351,7 @@ const AnimatedSelectImpl = React.forwardRef<
 
   function selectByIndex(index: number) {
     const opt = items[index];
-    if (!opt || opt.disabled) return;
+    if (!opt || opt.disabled || opt.loading) return;
     onChange?.(opt.value);
     opt.onSelect?.();
     setOpen(false);
@@ -508,7 +508,7 @@ const AnimatedSelectImpl = React.forwardRef<
 
                 {items.map((it, idx) => {
                   const active = it.value === value;
-                  const disabledItem = !!it.disabled;
+                  const disabledItem = !!it.disabled || it.loading;
                   return (
                     <li key={String(it.value)}>
                       <button


### PR DESCRIPTION
## Summary
- treat `loading` Select items as disabled
- guard `selectByIndex` against selecting loading items

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c42f7c8e18832c9f3d181b7feb140e