### PR TITLE
refactor: streamline project creation and sizing

### DIFF
--- a/src/components/planner/DayCard.tsx
+++ b/src/components/planner/DayCard.tsx
@@ -12,7 +12,6 @@ import * as React from "react";
 import { useSelectedProject, useSelectedTask } from "./useSelection";
 import type { ISODate } from "./plannerStore";
 import { useDay } from "./useDay";
-import Input from "@/components/ui/primitives/Input";
 import { cn } from "@/lib/utils";
 import DayCardHeader from "./DayCardHeader";
 import ProjectList from "./ProjectList";
@@ -39,8 +38,6 @@ export default function DayCard({ iso, isToday }: Props) {
   const [selectedProjectId, setSelectedProjectId] = useSelectedProject(iso);
   const [, setSelectedTaskId] = useSelectedTask(iso);
 
-  const [draftProject, setDraftProject] = React.useState("");
-
   React.useEffect(() => {
     if (
       selectedProjectId &&
@@ -49,14 +46,6 @@ export default function DayCard({ iso, isToday }: Props) {
       setSelectedProjectId("");
     }
   }, [projects, selectedProjectId, setSelectedProjectId]);
-
-  function addProjectCommit() {
-    const v = draftProject.trim();
-    if (!v) return;
-    const id = addProject(v);
-    setDraftProject("");
-    if (id) setSelectedProjectId(id);
-  }
 
   return (
     <section
@@ -80,22 +69,6 @@ export default function DayCard({ iso, isToday }: Props) {
         />
       </div>
 
-      <form
-        className="col-span-1 lg:col-span-3"
-        onSubmit={(e) => {
-          e.preventDefault();
-          addProjectCommit();
-        }}
-      >
-        <Input
-          className="w-full"
-          placeholder="> new project…"
-          value={draftProject}
-          onChange={(e) => setDraftProject(e.target.value)}
-          aria-label="Add project"
-        />
-      </form>
-
       <div className="col-span-1 lg:col-span-3">
         <ProjectList
           projects={projects}
@@ -105,25 +78,29 @@ export default function DayCard({ iso, isToday }: Props) {
           toggleProject={toggleProject}
           renameProject={renameProject}
           deleteProject={deleteProject}
+          onAdd={addProject}
         />
       </div>
+      {selectedProjectId && (
+        <>
+          <div
+            className="hidden lg:block lg:col-span-1 w-px mx-auto bg-card-hairline/90 rounded-full self-stretch"
+            aria-hidden
+          />
 
-      <div
-        className="hidden lg:block lg:col-span-1 w-px mx-auto bg-card-hairline/90 rounded-full self-stretch"
-        aria-hidden
-      />
-
-      <div className="col-span-1 lg:col-span-8">
-        <TaskList
-          tasks={tasks}
-          selectedProjectId={selectedProjectId}
-          addTask={addTask}
-          renameTask={renameTask}
-          toggleTask={toggleTask}
-          deleteTask={deleteTask}
-          setSelectedTaskId={setSelectedTaskId}
-        />
-      </div>
+          <div className="col-span-1 lg:col-span-8">
+            <TaskList
+              tasks={tasks}
+              selectedProjectId={selectedProjectId}
+              addTask={addTask}
+              renameTask={renameTask}
+              toggleTask={toggleTask}
+              deleteTask={deleteTask}
+              setSelectedTaskId={setSelectedTaskId}
+            />
+          </div>
+        </>
+      )}
     </section>
   );
 }

--- a/src/components/planner/ProjectList.tsx
+++ b/src/components/planner/ProjectList.tsx
@@ -17,6 +17,7 @@ type Props = {
   toggleProject: (id: string) => void;
   renameProject: (id: string, name: string) => void;
   deleteProject: (id: string) => void;
+  onAdd: (name: string) => string | void;
 };
 
 export default function ProjectList({
@@ -27,13 +28,23 @@ export default function ProjectList({
   toggleProject,
   renameProject,
   deleteProject,
+  onAdd,
 }: Props) {
   const [editingProjectId, setEditingProjectId] = React.useState<string | null>(
     null,
   );
   const [editingProjectName, setEditingProjectName] = React.useState("");
+  const [draftProject, setDraftProject] = React.useState("");
   const projectsScrollable = projects.length > 3;
   const multiple = projects.length > 1;
+
+  const addProjectCommit = React.useCallback(() => {
+    const v = draftProject.trim();
+    if (!v) return;
+    const id = onAdd(v);
+    setDraftProject("");
+    if (id) setSelectedProjectId(id);
+  }, [draftProject, onAdd, setSelectedProjectId]);
 
   const onRowKey = React.useCallback(
     (idx: number, p: Project) => (e: React.KeyboardEvent) => {
@@ -59,21 +70,35 @@ export default function ProjectList({
     <div className="flex flex-col gap-3 min-w-0">
       <div
         className={cn(
-          "mt-1 px-0 py-2 w-full",
+          "px-0 w-full",
           projectsScrollable
             ? "max-h-[260px] overflow-y-auto"
             : "overflow-visible",
         )}
       >
-        {projects.length === 0 ? (
-          <EmptyRow text="No projects yet." />
-        ) : (
-          <ul
-            className="w-full space-y-2 [&>li:first-child]:mt-2 [&>li:last-child]:mb-2"
-            role="radiogroup"
-            aria-label="Projects"
-          >
-            {projects.map((p, idx) => {
+        <ul className="w-full space-y-2 py-2" role="radiogroup" aria-label="Projects">
+          <li className="w-full">
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                addProjectCommit();
+              }}
+            >
+              <Input
+                className="w-full"
+                placeholder="> new project…"
+                value={draftProject}
+                onChange={(e) => setDraftProject(e.target.value)}
+                aria-label="Add project"
+              />
+            </form>
+          </li>
+          {projects.length === 0 ? (
+            <li>
+              <EmptyRow text="No projects yet." />
+            </li>
+          ) : (
+            projects.map((p, idx) => {
               const active = p.id === selectedProjectId;
               const isEditing = editingProjectId === p.id;
               const handleRowKey = onRowKey(idx, p);
@@ -99,7 +124,7 @@ export default function ProjectList({
                     )}
                   >
                     <span
-                      className="shrink-0 ml-1"
+                      className="shrink-0"
                       onMouseDown={(e) => e.stopPropagation()}
                       onClick={(e) => e.stopPropagation()}
                     >
@@ -175,9 +200,9 @@ export default function ProjectList({
                   </div>
                 </li>
               );
-            })}
-          </ul>
-        )}
+            })
+          )}
+        </ul>
       </div>
     </div>
   );

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -516,6 +516,7 @@ export default function ComponentGallery() {
             toggleProject={() => {}}
             renameProject={() => {}}
             deleteProject={() => {}}
+            onAdd={() => ""}
           />
         ),
         className: "sm:col-span-2 md:col-span-3",

--- a/src/components/reviews/NeonIcon.tsx
+++ b/src/components/reviews/NeonIcon.tsx
@@ -7,7 +7,7 @@ import { NeonIcon as UIToggleNeonIcon } from "@/components/ui";
 type Props = {
   kind: "clock" | "file" | "brain";
   on: boolean;
-  size?: number;
+  size?: number | string;
   className?: string;
   title?: string;
   staticGlow?: boolean;
@@ -16,7 +16,7 @@ type Props = {
 export default function NeonIcon({
   kind,
   on,
-  size = 40,
+  size = "1em",
   className,
   title,
   staticGlow = false,

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -635,7 +635,7 @@ export default function ReviewEditor({
                 })
               }
             >
-              <NeonIcon kind="brain" on={focusOn} />
+              <NeonIcon kind="brain" on={focusOn} size="1em" />
             </button>
           </div>
 
@@ -734,7 +734,7 @@ export default function ReviewEditor({
               }
               title="Timestamp mode"
             >
-              <NeonIcon kind="clock" on={useTimestamp} />
+              <NeonIcon kind="clock" on={useTimestamp} size="1em" />
             </button>
 
             <button
@@ -754,7 +754,7 @@ export default function ReviewEditor({
               }
               title="Note-only mode"
             >
-              <NeonIcon kind="file" on={!useTimestamp} />
+              <NeonIcon kind="file" on={!useTimestamp} size="1em" />
             </button>
           </div>
 

--- a/src/components/ui/toggles/NeonIcon.tsx
+++ b/src/components/ui/toggles/NeonIcon.tsx
@@ -9,7 +9,7 @@ type Phase = "steady-on" | "ignite" | "off" | "powerdown";
 type NeonIconProps = {
   icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   on: boolean;
-  size?: number;
+  size?: number | string;
   /** CSS variable name like "--accent", "--primary", "--ring" */
   colorVar?: string;
   title?: string;
@@ -29,7 +29,7 @@ type NeonVars = React.CSSProperties & {
 export function NeonIcon({
   icon: Icon,
   on,
-  size = 40,
+  size = "1em",
   colorVar = "--accent",
   title,
   className,
@@ -58,9 +58,14 @@ export function NeonIcon({
 
   const lit = phase === "ignite" || phase === "steady-on";
 
+  const sizeValue = typeof size === "number" ? `${size}px` : size;
+  const kValue =
+    typeof size === "number"
+      ? `${Math.round(size * 0.56)}px`
+      : `calc(${sizeValue} * 0.56)`;
   const styleVars: NeonVars = {
-    "--ni-size": `${size}px`,
-    "--ni-k": `${Math.round(size * 0.56)}px`,
+    "--ni-size": sizeValue,
+    "--ni-k": kValue,
     "--ni-color": `hsl(var(${colorVar}))`,
   };
 


### PR DESCRIPTION
## Summary
- move project creation input into `ProjectList` and drop manual margins
- hide `TaskList` column until a project is selected
- allow numeric or string `size` for `NeonIcon` and specify sizes in `ReviewEditor`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c436f28500832cab888e9e67bc0a8b