### PR TITLE
feat: redesign role selector

### DIFF
--- a/src/components/reviews/RoleSelector.module.css
+++ b/src/components/reviews/RoleSelector.module.css
@@ -1,95 +1,161 @@
-.seg {
+.tray {
   --seg-count: 5;
   --seg-idx: 0;
   position: relative;
-  padding: var(--space-1);
-  border-radius: var(--radius-2xl);
-  background: hsl(var(--surface-2) / 0.05);
-  backdrop-filter: blur(var(--space-1));
-  border: 1px solid hsl(var(--accent) / 0.4);
-  box-shadow: inset 0 1px hsl(var(--foreground) / 0.06),
-    0 0 var(--space-2) hsl(var(--accent) / 0.15);
-  overflow: hidden;
-}
-
-.list {
-  position: relative;
-  z-index: 10;
-  display: grid;
-  gap: var(--space-1);
-}
-
-.btn {
-  height: calc(var(--space-3) * 3);
-  border-radius: var(--radius-lg);
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: calc(var(--space-1) * 1.5);
-  padding: 0 var(--space-4);
-  font-size: var(--font-ui-sm);
-  letter-spacing: 0.02em;
-  color: hsl(var(--foreground));
-  transition: opacity 0.18s ease;
-}
-
-.btnIdle {
-  opacity: 0.7;
-  text-shadow: none;
-}
-
-.btnActive {
-  opacity: 1;
-  text-shadow: 0 0 var(--space-2) hsl(var(--glow-soft));
-}
-
-.rail {
-  position: absolute;
-  top: var(--space-1);
-  bottom: var(--space-1);
-  left: var(--space-1);
+  padding: var(--space-1) var(--space-5);
+  height: var(--control-h);
   border-radius: var(--radius-lg);
-  width: calc(
-    (100% - var(--space-2) - (var(--seg-count) - 1) * var(--space-1)) /
-      var(--seg-count)
-  );
-  transform: translateX(calc(var(--seg-idx) * (100% + var(--space-1))));
-  transition: transform 0.22s cubic-bezier(0.22, 1, 0.36, 1);
-  background: hsl(var(--surface-2) / 0.15);
-  backdrop-filter: blur(var(--space-1));
-  border: 1px solid hsl(var(--accent) / 0.5);
-  box-shadow: inset 0 1px hsl(var(--foreground) / 0.15),
-    0 0 var(--space-2) hsl(var(--accent) / 0.4);
+  background: hsl(var(--surface));
+  border: 1px solid hsl(var(--card-hairline));
+  box-shadow: inset 0 1px hsl(var(--foreground) / 0.06);
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
 }
 
-.roles::before {
+.tray::-webkit-scrollbar {
+  display: none;
+}
+
+.tray::after {
   content: "";
   position: absolute;
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  background:
-    radial-gradient(
-      calc(var(--space-3) * 10) calc(var(--space-2) * 5) at 25% 50%,
-      hsl(var(--accent-2) / 0.04),
-      transparent 60%
-    ),
-    radial-gradient(
-      calc(var(--space-3) * 10) calc(var(--space-2) * 5) at 75% 50%,
-      hsl(var(--lav-deep) / 0.04),
-      transparent 60%
-    );
-  mix-blend-mode: screen;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    hsl(var(--foreground) / 0.04) 0,
+    hsl(var(--foreground) / 0.04) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  opacity: 0.08;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .rail,
-  .btn {
-    transition: none;
+.list {
+  display: flex;
+  gap: var(--space-2);
+  width: 100%;
+}
+
+.highlight {
+  position: absolute;
+  top: var(--space-1);
+  bottom: var(--space-1);
+  left: var(--space-5);
+  width: calc(
+    (100% - 2 * var(--space-5) - (var(--seg-count) - 1) * var(--space-2)) /
+      var(--seg-count)
+  );
+  border-radius: var(--radius-xl);
+  transform: translateX(calc(var(--seg-idx) * (100% + var(--space-2))));
+  transition: transform var(--dur-quick) var(--ease-out);
+  background: linear-gradient(
+    to bottom,
+    hsl(var(--accent) / 0.9),
+    hsl(var(--accent-2) / 0.9)
+  );
+  box-shadow:
+    inset 0 0 0 1px hsl(var(--ring-muted)),
+    0 2px 4px hsl(var(--shadow-color) / 0.15);
+  z-index: 1;
+}
+
+.chip {
+  position: relative;
+  z-index: 2;
+  flex: 0 0 auto;
+  height: var(--control-h);
+  padding: 0 var(--space-4);
+  border-radius: var(--radius-xl);
+  background: hsl(var(--surface-2));
+  color: hsl(var(--foreground));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  box-shadow: 0 1px 2px hsl(var(--shadow-color) / 0.15);
+  scroll-snap-align: center;
+  transition:
+    transform var(--dur-quick) var(--ease-out),
+    box-shadow var(--dur-quick) var(--ease-out);
+}
+
+.chip:focus-visible {
+  outline: 2px solid hsl(var(--focus));
+  outline-offset: 2px;
+}
+
+.chip:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 2px 4px hsl(var(--shadow-color) / 0.2);
+}
+
+.chip:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 2px hsl(var(--shadow-color) / 0.2);
+}
+
+.chip:disabled {
+  opacity: 0.6;
+  box-shadow: none;
+  pointer-events: none;
+}
+
+.idle {
+  background: hsl(var(--surface-2));
+}
+
+.active {
+  background: transparent;
+}
+
+.icon {
+  width: var(--space-5);
+  height: var(--space-5);
+}
+
+.label {
+  font-size: var(--font-ui-sm);
+}
+
+.tray:focus-within .active .label {
+  text-shadow: 0 0 var(--space-2) hsl(var(--ring) / 0.4);
+}
+
+.active::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    hsl(var(--foreground) / 0.2),
+    transparent
+  );
+  opacity: 0;
+  animation: shimmer var(--dur-chill) var(--ease-out);
+}
+
+@keyframes shimmer {
+  from {
+    opacity: 0.4;
+    transform: translateX(-100%);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(100%);
   }
 }
 
-.no-animations .rail,
-.no-animations .btn {
-  transition: none;
+@media (prefers-reduced-motion: reduce) {
+  .highlight,
+  .chip,
+  .active::after {
+    transition: none;
+    animation: none;
+  }
 }


### PR DESCRIPTION
## Summary
- convert RoleSelector into tray of scrollable chips with sliding accent highlight
- add roving tabindex, keyboard navigation, and live announcement for screen readers
- style chips with token-based spacing, focus ring, hover/press states, and subtle shimmer

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c44c36b214832c85ef5e2cd6281005