### PR TITLE
refactor: use semantic tokens for ReviewListItem states

### DIFF
--- a/src/components/reviews/ReviewListItem.tsx
+++ b/src/components/reviews/ReviewListItem.tsx
@@ -7,11 +7,11 @@ import type { Review } from "@/lib/types";
 import { Badge } from "@/components/ui";
 
 const shellBase = cn(
-  "relative w-full text-left rounded-card r-card-lg p-3 bg-[hsl(var(--card)/0.9)] border border-[hsl(var(--border)/0.35)] transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none",
-  "hover:ring-2 hover:ring-[--theme-ring]",
-  "focus-visible:ring-2 focus-visible:ring-[--theme-ring]",
-  "active:ring-2 active:ring-[--theme-ring]",
-  "data-[selected=true]:ring-2 data-[selected=true]:ring-[--theme-accent]",
+  "relative w-full text-left rounded-card r-card-lg p-3 bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20",
+  "hover:bg-accent/10 hover:ring-2 hover:ring-theme",
+  "focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-theme",
+  "active:bg-accent/20 active:ring-2 active:ring-theme",
+  "data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent",
 );
 
 const statusDotBase = "h-2 w-2 rounded-full ring-2";
@@ -28,7 +28,7 @@ const itemLoading = cn(
 );
 const loadingLine = "h-3 rounded-md bg-muted";
 const scoreBadge =
-  "px-2 py-1 rounded-full text-xs leading-none font-medium text-background bg-gradient-to-br from-[--theme-accent] to-[--theme-accent2] ring-1 ring-[--theme-accent] [--ring:var(--theme-accent)]";
+  "px-2 py-1 rounded-full text-xs leading-none font-medium text-background bg-gradient-to-br from-accent to-accent-2 ring-1 ring-accent [--ring:hsl(var(--accent))]";
 
 export type ReviewListItemProps = {
   review?: Review;

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`ReviewListItem > renders default state 1`] = `
 <div>
   <button
     aria-label="Open review: Sample Review"
-    class="relative w-full text-left rounded-card r-card-lg p-3 bg-[hsl(var(--card)/0.9)] border border-[hsl(var(--border)/0.35)] transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none hover:ring-2 hover:ring-[--theme-ring] focus-visible:ring-2 focus-visible:ring-[--theme-ring] active:ring-2 active:ring-[--theme-ring] data-[selected=true]:ring-2 data-[selected=true]:ring-[--theme-accent]"
+    class="relative w-full text-left rounded-card r-card-lg p-3 bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-theme focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-theme active:bg-accent/20 active:ring-2 active:ring-theme data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
     data-scope="reviews"
     type="button"
   >
@@ -43,7 +43,7 @@ exports[`ReviewListItem > renders default state 1`] = `
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background bg-gradient-to-br from-[--theme-accent] to-[--theme-accent2] ring-1 ring-[--theme-accent] [--ring:var(--theme-accent)]"
+          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background bg-gradient-to-br from-accent to-accent-2 ring-1 ring-accent [--ring:hsl(var(--accent))]"
         >
           9
           /10
@@ -58,7 +58,7 @@ exports[`ReviewListItem > renders disabled state 1`] = `
 <div>
   <button
     aria-label="Open review: Sample Review"
-    class="relative w-full text-left rounded-card r-card-lg p-3 bg-[hsl(var(--card)/0.9)] border border-[hsl(var(--border)/0.35)] transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none hover:ring-2 hover:ring-[--theme-ring] focus-visible:ring-2 focus-visible:ring-[--theme-ring] active:ring-2 active:ring-[--theme-ring] data-[selected=true]:ring-2 data-[selected=true]:ring-[--theme-accent]"
+    class="relative w-full text-left rounded-card r-card-lg p-3 bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-theme focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-theme active:bg-accent/20 active:ring-2 active:ring-theme data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
     data-scope="reviews"
     disabled=""
     type="button"
@@ -98,7 +98,7 @@ exports[`ReviewListItem > renders disabled state 1`] = `
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background bg-gradient-to-br from-[--theme-accent] to-[--theme-accent2] ring-1 ring-[--theme-accent] [--ring:var(--theme-accent)]"
+          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background bg-gradient-to-br from-accent to-accent-2 ring-1 ring-accent [--ring:hsl(var(--accent))]"
         >
           9
           /10
@@ -112,7 +112,7 @@ exports[`ReviewListItem > renders disabled state 1`] = `
 exports[`ReviewListItem > renders loading state 1`] = `
 <div>
   <div
-    class="relative w-full text-left rounded-card r-card-lg p-3 bg-[hsl(var(--card)/0.9)] border border-[hsl(var(--border)/0.35)] transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none hover:ring-2 hover:ring-[--theme-ring] focus-visible:ring-2 focus-visible:ring-[--theme-ring] active:ring-2 active:ring-[--theme-ring] data-[selected=true]:ring-2 data-[selected=true]:ring-[--theme-accent] motion-safe:animate-pulse motion-reduce:animate-none"
+    class="relative w-full text-left rounded-card r-card-lg p-3 bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-theme focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-theme active:bg-accent/20 active:ring-2 active:ring-theme data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent motion-safe:animate-pulse motion-reduce:animate-none"
     data-scope="reviews"
   >
     <div
@@ -129,7 +129,7 @@ exports[`ReviewListItem > renders selected state 1`] = `
 <div>
   <button
     aria-label="Open review: Sample Review"
-    class="relative w-full text-left rounded-card r-card-lg p-3 bg-[hsl(var(--card)/0.9)] border border-[hsl(var(--border)/0.35)] transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none hover:ring-2 hover:ring-[--theme-ring] focus-visible:ring-2 focus-visible:ring-[--theme-ring] active:ring-2 active:ring-[--theme-ring] data-[selected=true]:ring-2 data-[selected=true]:ring-[--theme-accent]"
+    class="relative w-full text-left rounded-card r-card-lg p-3 bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-theme focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-theme active:bg-accent/20 active:ring-2 active:ring-theme data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
     data-scope="reviews"
     data-selected="true"
     type="button"
@@ -169,7 +169,7 @@ exports[`ReviewListItem > renders selected state 1`] = `
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background bg-gradient-to-br from-[--theme-accent] to-[--theme-accent2] ring-1 ring-[--theme-accent] [--ring:var(--theme-accent)]"
+          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background bg-gradient-to-br from-accent to-accent-2 ring-1 ring-accent [--ring:hsl(var(--accent))]"
         >
           9
           /10
@@ -184,7 +184,7 @@ exports[`ReviewListItem > renders untitled state 1`] = `
 <div>
   <button
     aria-label="Open review: Untitled Review"
-    class="relative w-full text-left rounded-card r-card-lg p-3 bg-[hsl(var(--card)/0.9)] border border-[hsl(var(--border)/0.35)] transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none hover:ring-2 hover:ring-[--theme-ring] focus-visible:ring-2 focus-visible:ring-[--theme-ring] active:ring-2 active:ring-[--theme-ring] data-[selected=true]:ring-2 data-[selected=true]:ring-[--theme-accent]"
+    class="relative w-full text-left rounded-card r-card-lg p-3 bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-theme focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-theme active:bg-accent/20 active:ring-2 active:ring-theme data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
     data-scope="reviews"
     type="button"
   >
@@ -224,7 +224,7 @@ exports[`ReviewListItem > renders untitled state 1`] = `
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background bg-gradient-to-br from-[--theme-accent] to-[--theme-accent2] ring-1 ring-[--theme-accent] [--ring:var(--theme-accent)]"
+          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background bg-gradient-to-br from-accent to-accent-2 ring-1 ring-accent [--ring:hsl(var(--accent))]"
         >
           9
           /10

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -811,7 +811,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                 <li>
                   <button
                     aria-label="Open review: Alpha"
-                    class="relative w-full text-left rounded-card r-card-lg p-3 bg-[hsl(var(--card)/0.9)] border border-[hsl(var(--border)/0.35)] transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none hover:ring-2 hover:ring-[--theme-ring] focus-visible:ring-2 focus-visible:ring-[--theme-ring] active:ring-2 active:ring-[--theme-ring] data-[selected=true]:ring-2 data-[selected=true]:ring-[--theme-accent]"
+                    class="relative w-full text-left rounded-card r-card-lg p-3 bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-theme focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-theme active:bg-accent/20 active:ring-2 active:ring-theme data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
                     data-scope="reviews"
                     type="button"
                   >
@@ -855,7 +855,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                 <li>
                   <button
                     aria-label="Open review: Gamma"
-                    class="relative w-full text-left rounded-card r-card-lg p-3 bg-[hsl(var(--card)/0.9)] border border-[hsl(var(--border)/0.35)] transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none hover:ring-2 hover:ring-[--theme-ring] focus-visible:ring-2 focus-visible:ring-[--theme-ring] active:ring-2 active:ring-[--theme-ring] data-[selected=true]:ring-2 data-[selected=true]:ring-[--theme-accent]"
+                    class="relative w-full text-left rounded-card r-card-lg p-3 bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-theme focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-theme active:bg-accent/20 active:ring-2 active:ring-theme data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
                     data-scope="reviews"
                     type="button"
                   >
@@ -899,7 +899,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                 <li>
                   <button
                     aria-label="Open review: Beta"
-                    class="relative w-full text-left rounded-card r-card-lg p-3 bg-[hsl(var(--card)/0.9)] border border-[hsl(var(--border)/0.35)] transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none hover:ring-2 hover:ring-[--theme-ring] focus-visible:ring-2 focus-visible:ring-[--theme-ring] active:ring-2 active:ring-[--theme-ring] data-[selected=true]:ring-2 data-[selected=true]:ring-[--theme-accent]"
+                    class="relative w-full text-left rounded-card r-card-lg p-3 bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-theme focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-theme active:bg-accent/20 active:ring-2 active:ring-theme data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
                     data-scope="reviews"
                     type="button"
                   >


### PR DESCRIPTION
## Summary
- use token-based bg, border, ring, and state styles in `ReviewListItem`
- refresh snapshots

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c455447134832cb648bbae17398c45