### PR TITLE
refactor score badge with semantic tokens

### DIFF
--- a/src/components/reviews/ReviewListItem.tsx
+++ b/src/components/reviews/ReviewListItem.tsx
@@ -27,8 +27,13 @@ const itemLoading = cn(
   "motion-safe:animate-pulse motion-reduce:animate-none",
 );
 const loadingLine = "h-3 rounded-md bg-muted";
-const scoreBadge =
-  "px-2 py-1 rounded-full text-xs leading-none font-medium text-background bg-gradient-to-br from-accent to-accent-2 ring-1 ring-accent [--ring:hsl(var(--accent))]";
+const scoreBadge = cn(
+  "px-2 py-1 rounded-full text-xs leading-none font-medium",
+  "text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2",
+  "hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground",
+  "focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground",
+  "active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground",
+);
 
 export type ReviewListItemProps = {
   review?: Review;

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`ReviewListItem > renders default state 1`] = `
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background bg-gradient-to-br from-accent to-accent-2 ring-1 ring-accent [--ring:hsl(var(--accent))]"
+          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
         >
           9
           /10
@@ -98,7 +98,7 @@ exports[`ReviewListItem > renders disabled state 1`] = `
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background bg-gradient-to-br from-accent to-accent-2 ring-1 ring-accent [--ring:hsl(var(--accent))]"
+          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
         >
           9
           /10
@@ -169,7 +169,7 @@ exports[`ReviewListItem > renders selected state 1`] = `
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background bg-gradient-to-br from-accent to-accent-2 ring-1 ring-accent [--ring:hsl(var(--accent))]"
+          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
         >
           9
           /10
@@ -224,7 +224,7 @@ exports[`ReviewListItem > renders untitled state 1`] = `
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background bg-gradient-to-br from-accent to-accent-2 ring-1 ring-accent [--ring:hsl(var(--accent))]"
+          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
         >
           9
           /10


### PR DESCRIPTION
## Summary
- use semantic accent gradient and interactive state tokens for review score badge
- update ReviewListItem snapshots

## Testing
- `node - <<'NODE' ...` (contrast ratio)
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c458dfe538832cba091dda05b304e4