### PR TITLE
Rename ADC role to Bot

### DIFF
--- a/COLOR_MAPPINGS.md
+++ b/COLOR_MAPPINGS.md
@@ -51,7 +51,7 @@
 | `hsl(38 92% 60%)`                   | `hsl(var(--tone-top))`             |
 | `hsl(152 52% 44%)`                  | `hsl(var(--tone-jg))`              |
 | `hsl(265 72% 62%)`                  | `hsl(var(--tone-mid))`             |
-| `hsl(195 75% 56%)`                  | `hsl(var(--tone-adc))`             |
+| `hsl(195 75% 56%)`                  | `hsl(var(--tone-bot))`             |
 | `hsl(320 72% 60%)`                  | `hsl(var(--tone-sup))`             |
 | `hsl(350 70% 4%)`                   | `hsl(var(--noir-background))`      |
 | `hsl(0 0% 92%)`                     | `hsl(var(--noir-foreground))`      |

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -36,7 +36,7 @@
 | tone-top           | 38 92% 60%                                |
 | tone-jg            | 152 52% 44%                               |
 | tone-mid           | 265 72% 62%                               |
-| tone-adc           | 195 75% 56%                               |
+| tone-bot           | 195 75% 56%                               |
 | tone-sup           | 320 72% 60%                               |
 | aurora-g           | 150 100% 60%                              |
 | aurora-g-light     | 150 100% 85%                              |

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1151,8 +1151,8 @@ textarea:-webkit-autofill {
 .badge[data-tone="mid"] {
   border-color: hsl(var(--tone-mid));
 }
-.badge[data-tone="adc"] {
-  border-color: hsl(var(--tone-adc));
+.badge[data-tone="bot"] {
+  border-color: hsl(var(--tone-bot));
 }
 .badge[data-tone="support"] {
   border-color: hsl(var(--tone-sup));

--- a/src/components/reviews/reviewData.ts
+++ b/src/components/reviews/reviewData.ts
@@ -38,7 +38,7 @@ export const ROLE_OPTIONS: Array<{
   { value: "TOP", label: "Top", Icon: Flag },
   { value: "JUNGLE", label: "Jungle", Icon: MapPin },
   { value: "MID", label: "Mid", Icon: Target },
-  { value: "ADC", label: "ADC", Icon: Crosshair },
+  { value: "BOT", label: "Bot", Icon: Crosshair },
   { value: "SUPPORT", label: "Support", Icon: Shield },
 ];
 
@@ -73,7 +73,7 @@ export const SCORE_POOLS: Record<number, string[]> = {
     "Report the mouse.",
   ],
   1: [
-    "ADC stood for Accidentally Donated CS.",
+    "Bot stood for Accidentally Donated CS.",
     "Bought items, forgot purpose.",
     "Reinvented throwing.",
     "Hands on cooldown.",

--- a/src/components/team/Builder.tsx
+++ b/src/components/team/Builder.tsx
@@ -31,7 +31,7 @@ type Team = {
   top: string;
   jungle: string;
   mid: string;
-  adc: string;
+  bot: string;
   support: string;
   notes?: string;
 };
@@ -42,7 +42,7 @@ const EMPTY_TEAM: Team = {
   top: "",
   jungle: "",
   mid: "",
-  adc: "",
+  bot: "",
   support: "",
   notes: "",
 };
@@ -50,7 +50,7 @@ const LANES: { key: keyof Team; label: string }[] = [
   { key: "top", label: "Top" },
   { key: "jungle", label: "Jungle" },
   { key: "mid", label: "Mid" },
-  { key: "adc", label: "ADC" },
+  { key: "bot", label: "Bot" },
   { key: "support", label: "Support" },
 ];
 
@@ -61,7 +61,7 @@ function teamToLines(t: Team) {
     `Top: ${t.top || "-"}`,
     `Jungle: ${t.jungle || "-"}`,
     `Mid: ${t.mid || "-"}`,
-    `ADC: ${t.adc || "-"}`,
+    `Bot: ${t.bot || "-"}`,
     `Support: ${t.support || "-"}`,
     ...(t.notes?.trim() ? ["", `Notes: ${t.notes.trim()}`] : []),
   ].join("\n");
@@ -100,7 +100,7 @@ export default React.forwardRef<BuilderHandle, { editing?: boolean }>(
 
   const filledCount = React.useMemo(() => {
     const countTeam = (t: Team) =>
-      [t.top, t.jungle, t.mid, t.adc, t.support].filter(Boolean).length;
+      [t.top, t.jungle, t.mid, t.bot, t.support].filter(Boolean).length;
     return {
       allies: countTeam(state.allies),
       enemies: countTeam(state.enemies),

--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -5,7 +5,7 @@ import "./style.css";
 /**
  * CheatSheet — hover-only edit per card, write-through persistence.
  * Titles use Lavender-Glitch (glitch-title + glitch-flicker + title-glow).
- * Lane labels (TOP/JUNGLE/MID/ADC/SUPPORT) also flicker via team scope.
+ * Lane labels (TOP/JUNGLE/MID/BOT/SUPPORT) also flicker via team scope.
  * Scoped with data-scope="team" to avoid global glitch leakage.
  */
 
@@ -18,7 +18,7 @@ import { sanitizeText } from "@/lib/utils";
 
 /* ───────────── types ───────────── */
 
-type Role = "Top" | "Jungle" | "Mid" | "ADC" | "Support";
+type Role = "Top" | "Jungle" | "Mid" | "Bot" | "Support";
 type LaneExamples = Partial<Record<Role, string[]>>;
 
 export type Archetype = {
@@ -50,7 +50,7 @@ const DEFAULT_SHEET: Archetype[] = [
     wins: [
       "You frontload engage and kite back cleanly",
       "Enemy blows cooldowns on tanks and loses threat",
-      "Your ADC hits free DPS windows",
+      "Your Bot hits free DPS windows",
     ],
     struggles: ["Flank TP and backline dive", "Hard poke before engage"],
     tips: [
@@ -61,7 +61,7 @@ const DEFAULT_SHEET: Archetype[] = [
       Top: ["Ornn", "Sion", "Shen"],
       Jungle: ["Sejuani", "Maokai"],
       Mid: ["Orianna", "Azir"],
-      ADC: ["Jinx", "Zeri"],
+      Bot: ["Jinx", "Zeri"],
       Support: ["Braum", "Lulu"],
     },
   },
@@ -81,7 +81,7 @@ const DEFAULT_SHEET: Archetype[] = [
       Top: ["Kennen", "Camille"],
       Jungle: ["Jarvan IV", "Wukong"],
       Mid: ["Sylas", "Akali"],
-      ADC: ["Kai’Sa", "Samira"],
+      Bot: ["Kai’Sa", "Samira"],
       Support: ["Rakan", "Nautilus"],
     },
   },
@@ -100,7 +100,7 @@ const DEFAULT_SHEET: Archetype[] = [
     examples: {
       Jungle: ["Elise", "Viego"],
       Mid: ["Ahri", "Twisted Fate"],
-      ADC: ["Ashe", "Varus"],
+      Bot: ["Ashe", "Varus"],
       Support: ["Thresh", "Blitzcrank", "Rell"],
     },
   },
@@ -119,7 +119,7 @@ const DEFAULT_SHEET: Archetype[] = [
     examples: {
       Top: ["Jayce"],
       Mid: ["Zoe", "Ziggs"],
-      ADC: ["Varus", "Ezreal"],
+      Bot: ["Varus", "Ezreal"],
       Support: ["Karma", "Janna"],
     },
   },
@@ -138,7 +138,7 @@ const DEFAULT_SHEET: Archetype[] = [
     examples: {
       Top: ["Camille", "Jax", "Fiora"],
       Mid: ["Ryze", "Azir"],
-      ADC: ["Xayah"],
+      Bot: ["Xayah"],
       Support: ["Tahm Kench", "Rakan"],
     },
   },
@@ -158,7 +158,7 @@ const DEFAULT_SHEET: Archetype[] = [
       Top: ["Malphite", "Kennen"],
       Jungle: ["Sejuani", "Amumu"],
       Mid: ["Orianna", "Yasuo"],
-      ADC: ["Miss Fortune"],
+      Bot: ["Miss Fortune"],
       Support: ["Rell", "Alistar"],
     },
   },
@@ -554,7 +554,7 @@ export default function CheatSheet({
               <div>
                 <Label>Examples</Label>
                 <div className="mt-2 space-y-2">
-                  {(["Top", "Jungle", "Mid", "ADC", "Support"] as Role[]).map(
+                  {(["Top", "Jungle", "Mid", "Bot", "Support"] as Role[]).map(
                     (role) => {
                       const champs = a.examples[role];
                       const setChamps = (list: string[]) =>

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -32,7 +32,7 @@ import { sanitizeText } from "@/lib/utils";
 
 /* ───────────── Types ───────────── */
 
-type Role = "Top" | "Jungle" | "Mid" | "ADC" | "Support";
+type Role = "Top" | "Jungle" | "Mid" | "Bot" | "Support";
 
 export type TeamComp = {
   id: string;
@@ -55,7 +55,7 @@ const SEEDS: TeamComp[] = [
       Top: ["Sion"],
       Jungle: ["Sejuani"],
       Mid: ["Orianna"],
-      ADC: ["Jinx"],
+      Bot: ["Jinx"],
       Support: ["Lulu"],
     },
     notes: "Front-to-back. Track flank TPs, save Lulu ult for diver.",
@@ -68,7 +68,7 @@ const SEEDS: TeamComp[] = [
     roles: {
       Jungle: ["Rengar"],
       Mid: ["Ahri"],
-      ADC: ["Ashe"],
+      Bot: ["Ashe"],
       Support: ["Thresh", "Pyke"],
     },
     notes: "Sweep chokes first, convert pick into fast objective start.",
@@ -79,7 +79,7 @@ const SEEDS: TeamComp[] = [
 
 /* ───────────── Utils ───────────── */
 
-const ROLES: Role[] = ["Top", "Jungle", "Mid", "ADC", "Support"];
+const ROLES: Role[] = ["Top", "Jungle", "Mid", "Bot", "Support"];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -113,7 +113,7 @@ function normalize(list: unknown[]): TeamComp[] {
       return {
         id: uid("comp"),
         title: "Imported Comp",
-        roles: { Top: [], Jungle: [], Mid: [], ADC: [], Support: [] },
+        roles: { Top: [], Jungle: [], Mid: [], Bot: [], Support: [] },
         notes: "",
         createdAt: Date.now(),
         updatedAt: Date.now(),
@@ -132,7 +132,7 @@ function normalize(list: unknown[]): TeamComp[] {
       }
       roles = next;
     } else {
-      roles = { Top: [], Jungle: [], Mid: [], ADC: [], Support: [] };
+      roles = { Top: [], Jungle: [], Mid: [], Bot: [], Support: [] };
     }
     const notes = typeof raw.notes === "string" ? raw.notes : "";
     return {
@@ -280,7 +280,7 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
     const next: TeamComp = {
       id,
       title,
-      roles: { Top: [], Jungle: [], Mid: [], ADC: [], Support: [] },
+      roles: { Top: [], Jungle: [], Mid: [], Bot: [], Support: [] },
       notes: "",
       createdAt: Date.now(),
       updatedAt: Date.now(),

--- a/src/components/ui/primitives/Badge.tsx
+++ b/src/components/ui/primitives/Badge.tsx
@@ -11,7 +11,7 @@ type Tone =
   | "top"
   | "jungle"
   | "mid"
-  | "adc"
+  | "bot"
   | "support";
 
 type BadgeOwnProps<T extends React.ElementType = "span"> = {
@@ -39,7 +39,7 @@ const toneBorder: Record<Tone, string> = {
   top: "border-tone-top",
   jungle: "border-tone-jg",
   mid: "border-tone-mid",
-  adc: "border-tone-adc",
+  bot: "border-tone-bot",
   support: "border-tone-sup",
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,7 +10,7 @@ export type Pillar =
 export type Side = "Blue" | "Red";
 
 /** Single canonical Role type. Stop redefining this elsewhere. */
-export type Role = "TOP" | "JUNGLE" | "MID" | "ADC" | "SUPPORT";
+export type Role = "TOP" | "JUNGLE" | "MID" | "BOT" | "SUPPORT";
 
 export type ReviewMarker = {
   id: string;

--- a/tests/reviews/ReviewsPage.test.tsx
+++ b/tests/reviews/ReviewsPage.test.tsx
@@ -41,7 +41,7 @@ const baseReviews: Review[] = [
     pillars: [],
     createdAt: 2000,
     matchup: "Ashe vs Cait",
-    role: "ADC",
+    role: "BOT",
   },
 ];
 

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -889,7 +889,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                           <span
                             class="inline-flex items-center font-medium border rounded-2xl bg-muted/25 border-border/20 text-muted-foreground px-1 py-0 text-xs leading-none"
                           >
-                            ADC
+                            BOT
                           </span>
                         </div>
                       </div>

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -45,7 +45,7 @@
   --tone-top: 38 92% 60%;
   --tone-jg: 152 52% 44%;
   --tone-mid: 265 72% 62%;
-  --tone-adc: 195 75% 56%;
+  --tone-bot: 195 75% 56%;
   --tone-sup: 320 72% 60%;
   --aurora-g: 150 100% 60%;
   --aurora-g-light: 150 100% 85%;

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -39,7 +39,7 @@ export default {
   toneTop: "38 92% 60%",
   toneJg: "152 52% 44%",
   toneMid: "265 72% 62%",
-  toneAdc: "195 75% 56%",
+  toneBot: "195 75% 56%",
   toneSup: "320 72% 60%",
   auroraG: "150 100% 60%",
   auroraGLight: "150 100% 85%",


### PR DESCRIPTION
## Summary
- rename ADC role to BOT in shared types
- update role options, team components, and styling tokens to reference Bot
- adjust tests and snapshots for Bot label

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c45b9f5a74832cb3563ed0a7a429b3