### PR TITLE
feat: move theme control to hero

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,12 +15,12 @@ import {
 } from "@/components/home";
 import Hero from "@/components/ui/layout/Hero";
 import Header from "@/components/ui/layout/Header";
-import { Button, Spinner } from "@/components/ui";
+import { Button, Spinner, ThemeToggle } from "@/components/ui";
 import { useTheme } from "@/lib/theme-context";
 import { useThemeQuerySync } from "@/lib/theme-hooks";
 
 function HomePageContent() {
-  const [theme, setTheme] = useTheme();
+  const [theme] = useTheme();
   useThemeQuerySync();
 
   return (
@@ -39,21 +39,24 @@ function HomePageContent() {
           topClassName="top-[var(--header-stack)]"
           heading="Your day at a glance"
           actions={
-            <Link href="/planner">
-              <Button
-                variant="primary"
-                size="sm"
-                className="px-[var(--spacing-4)] whitespace-nowrap"
-              >
-                Plan Week
-              </Button>
-            </Link>
+            <>
+              <ThemeToggle className="shrink-0" />
+              <Link href="/planner">
+                <Button
+                  variant="primary"
+                  size="sm"
+                  className="px-[var(--spacing-4)] whitespace-nowrap"
+                >
+                  Plan Week
+                </Button>
+              </Link>
+            </>
           }
         />
       </div>
       <div className="grid gap-4 md:grid-cols-12 items-start">
         <div className="md:col-span-6">
-          <QuickActions theme={theme} setTheme={setTheme} />
+          <QuickActions />
         </div>
         <div className="md:col-span-6">
           <IsometricRoom variant={theme.variant} />

--- a/src/components/home/QuickActions.tsx
+++ b/src/components/home/QuickActions.tsx
@@ -2,29 +2,13 @@
 
 import * as React from "react";
 import Button from "@/components/ui/primitives/Button";
-import ThemePicker from "@/components/ui/theme/ThemePicker";
-import BackgroundPicker from "@/components/ui/theme/BackgroundPicker";
 import { useRouter } from "next/navigation";
-import type { ThemeState } from "@/lib/theme";
 
-interface QuickActionsProps {
-  theme: ThemeState;
-  setTheme: React.Dispatch<React.SetStateAction<ThemeState>>;
-}
-
-export default function QuickActions({ theme, setTheme }: QuickActionsProps) {
+export default function QuickActions() {
   const router = useRouter();
   const goPlanner = React.useCallback(() => router.push("/planner"), [router]);
   const goGoals = React.useCallback(() => router.push("/goals"), [router]);
   const goReviews = React.useCallback(() => router.push("/reviews"), [router]);
-  const onVariantChange = React.useCallback(
-    (v: ThemeState["variant"]) => setTheme((prev) => ({ ...prev, variant: v })),
-    [setTheme],
-  );
-  const onBgChange = React.useCallback(
-    (b: ThemeState["bg"]) => setTheme((prev) => ({ ...prev, bg: b })),
-    [setTheme],
-  );
 
   return (
     <section aria-label="Quick actions" className="grid gap-4">
@@ -49,18 +33,6 @@ export default function QuickActions({ theme, setTheme }: QuickActionsProps) {
         >
           New Review
         </Button>
-        <div className="flex items-center gap-4">
-          <ThemePicker
-            variant={theme.variant}
-            onVariantChange={onVariantChange}
-            className="shrink-0"
-          />
-          <BackgroundPicker
-            bg={theme.bg}
-            onBgChange={onBgChange}
-            className="shrink-0"
-          />
-        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- place ThemeToggle in home hero actions and drop duplicate quick-action picker
- simplify QuickActions to navigation buttons only

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68c4b18f8a44832c8368763174329a21