### PR TITLE
refactor landing hero layout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,32 +28,41 @@ function HomePageContent() {
       aria-labelledby="home-header"
       className="page-shell py-6 space-y-6 md:space-y-8"
     >
-      <div className="space-y-[var(--spacing-2)]">
-        <Header
-          id="home-header"
-          heading="Welcome to Planner"
-          subtitle="Plan your day, track goals, and review games."
-          icon={<Home className="opacity-80" />}
-        />
-        <Hero
-          topClassName="top-[var(--header-stack)]"
-          heading="Your day at a glance"
-          actions={
-            <>
-              <ThemeToggle className="shrink-0" />
-              <Link href="/planner">
-                <Button
-                  variant="primary"
-                  size="sm"
-                  className="px-[var(--spacing-4)] whitespace-nowrap"
-                >
-                  Plan Week
-                </Button>
-              </Link>
-            </>
-          }
-        />
-      </div>
+      <section
+        id="landing-hero"
+        role="region"
+        aria-label="Intro"
+        className="relative grid grid-cols-12 gap-[var(--spacing-4)]"
+      >
+        <div className="col-span-12 sticky top-0">
+          <Header
+            id="home-header"
+            heading="Welcome to Planner"
+            subtitle="Plan your day, track goals, and review games."
+            icon={<Home className="opacity-80" />}
+          />
+        </div>
+        <div className="col-span-12">
+          <Hero
+            topClassName="top-[var(--header-stack)]"
+            heading="Your day at a glance"
+            actions={
+              <>
+                <ThemeToggle className="shrink-0" />
+                <Link href="/planner">
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    className="px-[var(--spacing-4)] whitespace-nowrap"
+                  >
+                    Plan Week
+                  </Button>
+                </Link>
+              </>
+            }
+          />
+        </div>
+      </section>
       <div className="grid gap-4 md:grid-cols-12 items-start">
         <div className="md:col-span-6">
           <QuickActions />


### PR DESCRIPTION
## Summary
- restructure landing hero into grid-based section with accessible region semantics
- wrap Header and Hero in col-span-12 grid cells and maintain sticky header

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c4c2760974832cb236b7954bfc2378