### PR TITLE
Move timer and reminder heroes into card headers

### DIFF
--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -292,49 +292,50 @@ export default function RemindersTab() {
   }));
 
   return (
-    <div className="grid gap-4">
-      {/* Hero with domain sub-tabs and bottom search */}
-      <Hero
-        eyebrow={domain}
-        heading="Reminders"
-        subtitle="Tiny brain pings you’ll totally ignore until 23:59."
-        dividerTint={domain === "Life" ? "life" : "primary"}
-        subTabs={{
-          items: DOMAIN_ITEMS,
-          value: domain,
-          onChange: (k: Domain) => setDomain(k),
-          align: "end",
-          size: "md",
-          ariaLabel: "Reminder domain",
-          showBaseline: true,
-        }}
-        search={{
-          value: query,
-          onValueChange: setQuery,
-          placeholder: "Search title, text, tags…",
-          debounceMs: 80,
-          right: (
-            <div className="flex items-center gap-2">
-              <span className="text-label font-medium tracking-[0.02em] opacity-75">{filtered.length}</span>
-              <Search className="opacity-80" size={16} />
-            </div>
-          ),
-        }}
-        actions={
-          <Button
-            variant="primary"
-            size="md"
-            className="px-[var(--spacing-4)] whitespace-nowrap"
-            onClick={() => addNew()}
-          >
-            <Plus />
-            <span>New Reminder</span>
-          </Button>
-        }
-      />
+    <SectionCard className="goal-card">
+      <SectionCard.Header>
+        {/* Hero with domain sub-tabs and bottom search */}
+        <Hero
+          eyebrow={domain}
+          heading="Reminders"
+          subtitle="Tiny brain pings you’ll totally ignore until 23:59."
+          dividerTint={domain === "Life" ? "life" : "primary"}
+          subTabs={{
+            items: DOMAIN_ITEMS,
+            value: domain,
+            onChange: (k: Domain) => setDomain(k),
+            align: "end",
+            size: "md",
+            ariaLabel: "Reminder domain",
+            showBaseline: true,
+          }}
+          search={{
+            value: query,
+            onValueChange: setQuery,
+            placeholder: "Search title, text, tags…",
+            debounceMs: 80,
+            right: (
+              <div className="flex items-center gap-2">
+                <span className="text-label font-medium tracking-[0.02em] opacity-75">{filtered.length}</span>
+                <Search className="opacity-80" size={16} />
+              </div>
+            ),
+          }}
+          actions={
+            <Button
+              variant="primary"
+              size="md"
+              className="px-[var(--spacing-4)] whitespace-nowrap"
+              onClick={() => addNew()}
+            >
+              <Plus />
+              <span>New Reminder</span>
+            </Button>
+          }
+        />
+      </SectionCard.Header>
 
-      <SectionCard className="goal-card">
-        <SectionCard.Body>
+      <SectionCard.Body>
           <div className="grid gap-3">
             {/* Quick Add row — now INSIDE the same panel as the cards */}
             <form
@@ -488,7 +489,6 @@ export default function RemindersTab() {
           }
         `}</style>
       </SectionCard>
-    </div>
   );
 }
 

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -253,26 +253,27 @@ export default function TimerTab() {
   }, []);
 
   return (
-    <div className="grid gap-4">
-      <Hero
-        eyebrow="Focus"
-        heading="Timer"
-        subtitle="Pick a duration and focus."
-        subTabs={{
-          items: tabItems,
-          value: profile,
-          onChange: (k: string) => setProfile(k as ProfileKey),
-          size: "md",
-          align: "between",
-          ariaLabel: "Timer profiles",
-          right: rightSlot,
-          showBaseline: true,
-          className: "overflow-x-auto",
-        }}
-      />
+    <SectionCard className="goal-card no-hover">
+      <SectionCard.Header>
+        <Hero
+          eyebrow="Focus"
+          heading="Timer"
+          subtitle="Pick a duration and focus."
+          subTabs={{
+            items: tabItems,
+            value: profile,
+            onChange: (k: string) => setProfile(k as ProfileKey),
+            size: "md",
+            align: "between",
+            ariaLabel: "Timer profiles",
+            right: rightSlot,
+            showBaseline: true,
+            className: "overflow-x-auto",
+          }}
+        />
+      </SectionCard.Header>
 
-      <SectionCard className="goal-card no-hover">
-        <SectionCard.Body>
+      <SectionCard.Body>
           <div className="relative mx-auto w-full max-w-sm rounded-2xl border border-card-hairline/60 bg-background/30 p-[var(--space-8)] backdrop-blur-xl shadow-card">
             {/* plus/minus */}
             <IconButton
@@ -377,6 +378,5 @@ export default function TimerTab() {
           </div>
         </SectionCard.Body>
       </SectionCard>
-    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Place TimerTab hero inside its SectionCard header
- Place RemindersTab hero inside its SectionCard header

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c4c38c8678832c87e16275c6ac0113