### PR TITLE
tweak: soften header glow and rail bloom

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -244,10 +244,10 @@ html.bg-intense body::after {
       hsl(var(--ring) / 0.35),
       transparent 70%
     );
-    filter: blur(6px);
+    filter: blur(4px);
     mix-blend-mode: screen;
     animation: hero-rail-flicker 3.2s steps(24, end) infinite alternate;
-    opacity: 0.5;
+    opacity: 0.3;
   }
 }
 
@@ -1069,13 +1069,13 @@ textarea:-webkit-autofill {
 }
 
 /* Compact pill */
-  .pill-compact {
-    @apply inline-flex items-center rounded-full border border-card-hairline px-2 py-1 text-label font-medium tracking-[0.02em] leading-tight;
-    background-color: hsl(var(--muted) / 0.18);
-  }
-  .pill-compact:hover {
-    background-color: hsl(var(--muted) / 0.28);
-  }
+.pill-compact {
+  @apply inline-flex items-center rounded-full border border-card-hairline px-2 py-1 text-label font-medium tracking-[0.02em] leading-tight;
+  background-color: hsl(var(--muted) / 0.18);
+}
+.pill-compact:hover {
+  background-color: hsl(var(--muted) / 0.28);
+}
 .pill-compact--primary {
   @apply border-ring;
   background-color: hsl(var(--primary-soft) / 0.25);

--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -74,7 +74,7 @@ export default function Header<Key extends string = string>({
 
         // Card look: no border, soft glow
         "rounded-card r-card-lg bg-card/70 backdrop-blur-md",
-        "shadow-[0_0_18px_hsl(var(--ring)/.35),0_0_32px_hsl(var(--accent)/.25)]",
+        "shadow-[0_0_10px_hsl(var(--ring)/.25),0_0_20px_hsl(var(--accent)/.15)]",
 
         // Safety: never let children bleed outside
         "overflow-hidden",
@@ -201,8 +201,8 @@ function TabsNav<Key extends string = string>({
       {items.map((t, i) => {
         const active = value === t.key;
         return (
-            <SegmentedButton
-              key={t.key}
+          <SegmentedButton
+            key={t.key}
             ref={setBtnRef(i) as (el: HTMLButtonElement | null) => void}
             role="tab"
             aria-selected={active}

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`ReviewsPage > renders default state 1`] = `
       class="space-y-[var(--spacing-2)]"
     >
       <header
-        class="z-[999] relative isolate rounded-card r-card-lg bg-card/70 backdrop-blur-md shadow-[0_0_18px_hsl(var(--ring)/.35),0_0_32px_hsl(var(--accent)/.25)] overflow-hidden after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent"
+        class="z-[999] relative isolate rounded-card r-card-lg bg-card/70 backdrop-blur-md shadow-[0_0_10px_hsl(var(--ring)/.25),0_0_20px_hsl(var(--accent)/.15)] overflow-hidden after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent"
         id="reviews-header"
       >
         <div


### PR DESCRIPTION
## Summary
- soften Header's neon glow with a more subtle shadow
- reduce header rail bloom blur and opacity
- update snapshot for ReviewsPage

## Testing
- `npx prettier src/components/ui/layout/Header.tsx src/app/globals.css --write`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c4c34c9da8832cbddfa79da1611bec