### PR TITLE
feat: bump control radius to 16px

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -73,7 +73,7 @@
 | control-h-md         | 40px                                                   |
 | control-h-lg         | 44px                                                   |
 | control-h            | var(--control-h-md)                                    |
-| control-radius       | var(--radius-lg)                                       |
+| control-radius       | var(--radius-xl)                                       |
 | control-fs           | 0.9rem                                                 |
 | control-px           | var(--spacing-3)                                       |
 | header-stack         | calc(var(--spacing-8) + var(--spacing-4))              |

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -76,7 +76,7 @@
   --control-h-md: 40px;
   --control-h-lg: 44px;
   --control-h: var(--control-h-md);
-  --control-radius: var(--radius-lg);
+  --control-radius: var(--radius-xl);
   --control-fs: 0.9rem;
   --control-px: var(--spacing-3);
   --header-stack: calc(var(--spacing-8) + var(--spacing-4));

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -76,7 +76,7 @@ export default {
   controlHMd: "40px",
   controlHLg: "44px",
   controlH: "var(--control-h-md)",
-  controlRadius: "var(--radius-lg)",
+  controlRadius: "var(--radius-xl)",
   controlFs: "0.9rem",
   controlPx: "var(--spacing-3)",
   headerStack: "calc(var(--spacing-8) + var(--spacing-4))",


### PR DESCRIPTION
## Summary
- use `--radius-xl` for `--control-radius`
- regenerate tokens and docs

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c4c6588498832cb1b9ad9136f73239