### PR TITLE
chore: drop review panel padding override

### DIFF
--- a/src/components/reviews/ReviewPanel.tsx
+++ b/src/components/reviews/ReviewPanel.tsx
@@ -9,7 +9,7 @@ export default function ReviewPanel({
   return (
     <Card
       aria-live="polite"
-      className={cn("w-full container p-[var(--spacing-5)]", className)}
+      className={cn("w-full container", className)}
       {...props}
     />
   );

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -974,7 +974,7 @@ exports[`ReviewsPage > renders default state 1`] = `
       >
         <div
           aria-live="polite"
-          class="rounded-card r-card-lg border border-border/25 bg-card/60 shadow-[0_0_0_1px_hsl(var(--border)/0.12)] w-full container p-[var(--spacing-5)] mx-auto flex flex-col items-center justify-center gap-2 py-7 text-sm text-muted-foreground"
+          class="rounded-card r-card-lg p-4 border border-border/25 bg-card/60 shadow-[0_0_0_1px_hsl(var(--border)/0.12)] w-full container mx-auto flex flex-col items-center justify-center gap-2 py-7 text-sm text-muted-foreground"
         >
           <svg
             class="lucide lucide-ghost h-6 w-6 opacity-60"


### PR DESCRIPTION
## Summary
- remove hardcoded `p-[var(--spacing-5)]` from `ReviewPanel` to rely on `Card` padding

## Testing
- `npm test -- --run -u`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c4dd699918832caa2c0e954dd8d648