### PR TITLE
Allow Hero backdrop to be hosted externally

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,33 +34,49 @@ function HomePageContent() {
         aria-label="Intro"
         className="relative grid grid-cols-12 gap-[var(--spacing-4)]"
       >
-        <div className="col-span-12 sticky top-0">
-          <Header
-            id="home-header"
-            heading="Welcome to Planner"
-            subtitle="Plan your day, track goals, and review games."
-            icon={<Home className="opacity-80" />}
-          />
-        </div>
         <div className="col-span-12">
-          <Hero
-            topClassName="top-[var(--header-stack)]"
-            heading="Your day at a glance"
-            actions={
-              <>
-                <ThemeToggle className="shrink-0" />
-                <Link href="/planner">
-                  <Button
-                    variant="primary"
-                    size="sm"
-                    className="px-[var(--spacing-4)] whitespace-nowrap"
-                  >
-                    Plan Week
-                  </Button>
-                </Link>
-              </>
-            }
-          />
+          <div className="sticky top-0 hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4">
+            <span aria-hidden className="hero2-beams" />
+            <span aria-hidden className="hero2-scanlines" />
+            <span aria-hidden className="hero2-noise" />
+
+            <div className="relative z-[2] grid grid-cols-12 gap-[var(--spacing-4)]">
+              <div className="col-span-12 sticky top-0">
+                <Header
+                  id="home-header"
+                  heading="Welcome to Planner"
+                  subtitle="Plan your day, track goals, and review games."
+                  icon={<Home className="opacity-80" />}
+                />
+              </div>
+              <div className="col-span-12">
+                <Hero
+                  frame={false}
+                  topClassName="top-[var(--header-stack)]"
+                  heading="Your day at a glance"
+                  actions={
+                    <>
+                      <ThemeToggle className="shrink-0" />
+                      <Link href="/planner">
+                        <Button
+                          variant="primary"
+                          size="sm"
+                          className="px-[var(--spacing-4)] whitespace-nowrap"
+                        >
+                          Plan Week
+                        </Button>
+                      </Link>
+                    </>
+                  }
+                />
+              </div>
+            </div>
+
+            <div
+              aria-hidden
+              className="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
+            />
+          </div>
         </div>
       </section>
       <div className="grid gap-4 md:grid-cols-12 items-start">

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -38,6 +38,9 @@ export interface HeroProps<Key extends string = string>
   bodyClassName?: string;
   rail?: boolean;
 
+  /** Whether to include glitchy frame and background layers. */
+  frame?: boolean;
+
   /** Divider tint for neon line. */
   dividerTint?: "primary" | "life";
 
@@ -72,6 +75,7 @@ function Hero<Key extends string = string>({
   icon,
   children,
   actions,
+  frame = true,
   sticky = true,
   topClassName = "top-8",
   barClassName,
@@ -123,14 +127,20 @@ function Hero<Key extends string = string>({
       <div
         className={cx(
           sticky ? "sticky-blur" : "",
-          "hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4",
+          frame
+            ? "hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4"
+            : "",
           sticky && topClassName,
         )}
       >
-        {/* decorative layers */}
-        <span aria-hidden className="hero2-beams" />
-        <span aria-hidden className="hero2-scanlines" />
-        <span aria-hidden className="hero2-noise" />
+        {frame ? (
+          <>
+            {/* decorative layers */}
+            <span aria-hidden className="hero2-beams" />
+            <span aria-hidden className="hero2-scanlines" />
+            <span aria-hidden className="hero2-noise" />
+          </>
+        ) : null}
 
         <div
           className={cx("relative z-[2] flex items-center gap-4", barClassName)}
@@ -187,11 +197,12 @@ function Hero<Key extends string = string>({
           </div>
         ) : null}
 
-        {/* subtle rim */}
-        <div
-          aria-hidden
-          className="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
-        />
+        {frame ? (
+          <div
+            aria-hidden
+            className="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
+          />
+        ) : null}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- add optional `frame` prop so Hero can render without glitch backdrop
- wrap landing hero with background layers so Header and Hero share surface

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68c4defb1d5c832c96d76d17ffc5e66d