### PR TITLE
feat: make header plain by default

### DIFF
--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -49,6 +49,8 @@ export interface HeaderProps<Key extends string = string>
   rail?: boolean;
   /** Built-in top-right segmented tabs (preferred). */
   tabs?: HeaderTabsProps<Key>;
+  /** Optional card-style framing. */
+  variant?: "plain" | "neo";
 }
 
 export default function Header<Key extends string = string>({
@@ -65,16 +67,15 @@ export default function Header<Key extends string = string>({
   bodyClassName,
   rail = true,
   tabs,
+  variant = "plain",
   ...rest
 }: HeaderProps<Key>) {
   return (
     <header
       className={cx(
         "z-[999] relative isolate",
-
-        // Card look: no border, soft glow
-        "rounded-card r-card-lg bg-card/70 backdrop-blur-md",
-        "shadow-[0_0_10px_hsl(var(--ring)/.25),0_0_20px_hsl(var(--accent)/.15)]",
+        variant === "neo" &&
+          "rounded-card r-card-lg bg-card/70 backdrop-blur-md shadow-[0_0_10px_hsl(var(--ring)/.25),0_0_20px_hsl(var(--accent)/.15)]",
 
         // Safety: never let children bleed outside
         "overflow-hidden",

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`ReviewsPage > renders default state 1`] = `
       class="space-y-[var(--spacing-2)]"
     >
       <header
-        class="z-[999] relative isolate rounded-card r-card-lg bg-card/70 backdrop-blur-md shadow-[0_0_10px_hsl(var(--ring)/.25),0_0_20px_hsl(var(--accent)/.15)] overflow-hidden after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent"
+        class="z-[999] relative isolate overflow-hidden after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent"
         id="reviews-header"
       >
         <div


### PR DESCRIPTION
## Summary
- make `Header` plain by default and only add card framing for `variant="neo"`
- update reviews page snapshot after class changes

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68c4e3dd5ffc832c8901b0a70dd8f00b