### PR TITLE
Use grid layout with standard spacing

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -13,10 +13,10 @@ export default function NotFound() {
 
   return (
     <main
-      className="flex min-h-screen flex-col items-center justify-center gap-4 p-6 text-center"
+      className="grid min-h-screen grid-cols-12 gap-4 place-content-center p-6 text-center"
       aria-labelledby={headerId}
     >
-      <div className="space-y-[var(--spacing-2)]">
+      <div className="col-span-12 space-y-2">
         <Header
           id={headerId}
           heading="Page not found"

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -158,9 +158,9 @@ export default function GoalsPage() {
     <main
       id="goals-main"
       aria-labelledby="goals-header"
-      className="page-shell py-6"
+      className="page-shell grid grid-cols-12 gap-4 py-6"
     >
-      <div className="grid gap-6">
+      <div className="col-span-12 grid gap-6">
         {/* ======= HEADER ======= */}
         <Header
           id="goals-header"
@@ -189,7 +189,7 @@ export default function GoalsPage() {
         >
           {tab === "goals" && (
             <div className="grid gap-4">
-              <div className="space-y-[var(--spacing-2)]">
+              <div className="space-y-2">
                 <Hero
                   eyebrow="Guide"
                   heading="Overview"
@@ -212,7 +212,9 @@ export default function GoalsPage() {
                       className="flex items-center justify-between"
                     >
                       <div className="flex items-center gap-2 sm:gap-4">
-                        <h2 className="text-title font-semibold tracking-[-0.01em]">Your Goals</h2>
+                        <h2 className="text-title font-semibold tracking-[-0.01em]">
+                          Your Goals
+                        </h2>
                         <GoalsProgress total={totalCount} pct={pctDone} />
                       </div>
                       <GoalsTabs value={filter} onChange={setFilter} />

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -90,10 +90,10 @@ export default function ReviewsPage({
 
   return (
     <main
-      className="page-shell p-[var(--spacing-6)] space-y-[var(--spacing-6)]"
+      className="page-shell grid grid-cols-12 gap-4 p-[var(--spacing-6)]"
       aria-labelledby="reviews-header"
     >
-      <div className="space-y-[var(--spacing-2)]">
+      <div className="col-span-12 space-y-2">
         <Header
           id="reviews-header"
           heading="Reviews"
@@ -149,7 +149,7 @@ export default function ReviewsPage({
 
       <div
         className={cn(
-          "grid grid-cols-1 items-start gap-[var(--spacing-6)] md:grid-cols-12",
+          "col-span-12 grid grid-cols-1 items-start gap-[var(--spacing-6)] md:grid-cols-12",
         )}
       >
         <nav aria-label="Review list" className="md:col-span-4">

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -152,9 +152,7 @@ export default function TeamCompPage() {
         label: "Builder",
         hint: "Fill allies vs enemies",
         icon: <Hammer />,
-        render: () => (
-          <Builder ref={builderApi} editing={editing.builder} />
-        ),
+        render: () => <Builder ref={builderApi} editing={editing.builder} />,
         ref: builderRef,
       },
       {
@@ -190,9 +188,7 @@ export default function TeamCompPage() {
           eyebrow={active?.label}
           heading="Comps"
           subtitle={
-            subTab === "sheet"
-              ? "Archetypes & tips"
-              : "Your saved compositions"
+            subTab === "sheet" ? "Archetypes & tips" : "Your saved compositions"
           }
           subTabs={{
             items: subTabs,
@@ -296,8 +292,8 @@ export default function TeamCompPage() {
         }
       >
         <p className="text-sm text-muted-foreground">
-          If you’re on a <em>Medium</em> champ, don’t race farm vs <em>Very Fast</em>.
-          Path for fights, ganks, or cross-map trades.
+          If you’re on a <em>Medium</em> champ, don’t race farm vs{" "}
+          <em>Very Fast</em>. Path for fights, ganks, or cross-map trades.
         </p>
       </Hero>
     );
@@ -317,10 +313,10 @@ export default function TeamCompPage() {
 
   return (
     <main
-      className="page-shell py-6 space-y-6 md:grid md:grid-cols-12 md:gap-4"
+      className="page-shell grid grid-cols-12 gap-4 py-6"
       aria-labelledby="teamcomp-header"
     >
-      <div className="space-y-[var(--spacing-2)] md:col-span-12">
+      <div className="col-span-12 space-y-2">
         <Header
           id="teamcomp-header"
           eyebrow="Comps"
@@ -332,7 +328,7 @@ export default function TeamCompPage() {
         {hero}
       </div>
 
-      <section className="grid gap-4 md:col-span-12 md:grid-cols-12">
+      <section className="col-span-12 grid gap-4 md:grid-cols-12">
         {TABS.map((t) => (
           <div
             key={t.key}

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -4,10 +4,10 @@ exports[`ReviewsPage > renders default state 1`] = `
 <div>
   <main
     aria-labelledby="reviews-header"
-    class="page-shell p-[var(--spacing-6)] space-y-[var(--spacing-6)]"
+    class="page-shell grid grid-cols-12 gap-4 p-[var(--spacing-6)]"
   >
     <div
-      class="space-y-[var(--spacing-2)]"
+      class="col-span-12 space-y-2"
     >
       <header
         class="z-[999] relative isolate rounded-card r-card-lg bg-card/70 backdrop-blur-md shadow-[0_0_10px_hsl(var(--ring)/.25),0_0_20px_hsl(var(--accent)/.15)] overflow-hidden after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent"
@@ -807,7 +807,7 @@ exports[`ReviewsPage > renders default state 1`] = `
       </section>
     </div>
     <div
-      class="grid grid-cols-1 items-start gap-[var(--spacing-6)] md:grid-cols-12"
+      class="col-span-12 grid grid-cols-1 items-start gap-[var(--spacing-6)] md:grid-cols-12"
     >
       <nav
         aria-label="Review list"


### PR DESCRIPTION
## Summary
- convert main containers to a 12-column grid layout with gap-4 and col-span assignments
- replace `space-y-[var(--spacing-2)]` with `space-y-2` across pages and snapshots

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c4e680aafc832ca29d7ac30d4930ca