### PR TITLE
Host Hero backdrop in all pages

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -16,24 +16,36 @@ export default function NotFound() {
       className="flex min-h-screen flex-col items-center justify-center gap-4 p-6 text-center"
       aria-labelledby={headerId}
     >
-      <div className="space-y-[var(--spacing-2)]">
-        <Header
-          id={headerId}
-          heading="Page not found"
-          icon={<AlertCircle className="opacity-80" />}
+      <div className="hero2-frame relative overflow-hidden rounded-card r-card-lg p-4">
+        <span aria-hidden className="hero2-beams" />
+        <span aria-hidden className="hero2-scanlines" />
+        <span aria-hidden className="hero2-noise" />
+
+        <div className="relative z-[2] space-y-[var(--spacing-2)]">
+          <Header
+            id={headerId}
+            heading="Page not found"
+            icon={<AlertCircle className="opacity-80" />}
+          />
+          <Hero
+            frame={false}
+            heading="This page does not exist"
+            actions={
+              <Link href="/">
+                <Button className="px-[var(--spacing-4)]">Go home</Button>
+              </Link>
+            }
+          >
+            <p className="text-sm text-muted-foreground">
+              The page you are looking for does not exist.
+            </p>
+          </Hero>
+        </div>
+
+        <div
+          aria-hidden
+          className="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
         />
-        <Hero
-          heading="This page does not exist"
-          actions={
-            <Link href="/">
-              <Button className="px-[var(--spacing-4)]">Go home</Button>
-            </Link>
-          }
-        >
-          <p className="text-sm text-muted-foreground">
-            The page you are looking for does not exist.
-          </p>
-        </Hero>
       </div>
     </main>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,33 +34,49 @@ function HomePageContent() {
         aria-label="Intro"
         className="relative grid grid-cols-12 gap-[var(--spacing-4)]"
       >
-        <div className="col-span-12 sticky top-0">
-          <Header
-            id="home-header"
-            heading="Welcome to Planner"
-            subtitle="Plan your day, track goals, and review games."
-            icon={<Home className="opacity-80" />}
-          />
-        </div>
         <div className="col-span-12">
-          <Hero
-            topClassName="top-[var(--header-stack)]"
-            heading="Your day at a glance"
-            actions={
-              <>
-                <ThemeToggle className="shrink-0" />
-                <Link href="/planner">
-                  <Button
-                    variant="primary"
-                    size="sm"
-                    className="px-[var(--spacing-4)] whitespace-nowrap"
-                  >
-                    Plan Week
-                  </Button>
-                </Link>
-              </>
-            }
-          />
+          <div className="sticky top-0 hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4">
+            <span aria-hidden className="hero2-beams" />
+            <span aria-hidden className="hero2-scanlines" />
+            <span aria-hidden className="hero2-noise" />
+
+            <div className="relative z-[2] grid grid-cols-12 gap-[var(--spacing-4)]">
+              <div className="col-span-12 sticky top-0">
+                <Header
+                  id="home-header"
+                  heading="Welcome to Planner"
+                  subtitle="Plan your day, track goals, and review games."
+                  icon={<Home className="opacity-80" />}
+                />
+              </div>
+              <div className="col-span-12">
+                <Hero
+                  frame={false}
+                  topClassName="top-[var(--header-stack)]"
+                  heading="Your day at a glance"
+                  actions={
+                    <>
+                      <ThemeToggle className="shrink-0" />
+                      <Link href="/planner">
+                        <Button
+                          variant="primary"
+                          size="sm"
+                          className="px-[var(--spacing-4)] whitespace-nowrap"
+                        >
+                          Plan Week
+                        </Button>
+                      </Link>
+                    </>
+                  }
+                />
+              </div>
+            </div>
+
+            <div
+              aria-hidden
+              className="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
+            />
+          </div>
         </div>
       </section>
       <div className="grid gap-4 md:grid-cols-12 items-start">

--- a/src/app/prompts/PromptsPage.tsx
+++ b/src/app/prompts/PromptsPage.tsx
@@ -71,52 +71,64 @@ function PageContent() {
       className="page-shell py-6 space-y-6"
       aria-labelledby="prompts-header"
     >
-      <div className="space-y-6">
-        <Header
-          id="prompts-header"
-          heading="Prompts Playground"
-          subtitle="Explore components and tokens"
-          icon={<Sparkles className="opacity-80" />}
-          tabs={{
-            items: VIEW_TABS,
-            value: view,
-            onChange: (k) => setView(k as View),
-          }}
-        />
-        <Hero
-          topClassName="top-[var(--header-stack)]"
-          heading={
-            view === "components"
-              ? "Components"
-              : view === "colors"
-                ? "Colors"
-                : "Onboarding"
-          }
-          {...(view === "components"
-            ? {
-                subTabs: {
-                  items: SECTION_TABS,
-                  value: section,
-                  onChange: (k: string) => setSection(k as Section),
-                },
-              }
-            : {})}
-          search={{
-            id: "playground-search",
-            value: query,
-            onValueChange: setQuery,
-            debounceMs: 300,
-            round: true,
-            "aria-label": "Search components",
-          }}
-          actions={
-            <div className="flex items-center gap-2">
-              <Button size="sm">Action</Button>
-              <IconButton size="sm" aria-label="Add">
-                <Plus />
-              </IconButton>
-            </div>
-          }
+      <div className="sticky top-0 hero2-frame relative overflow-hidden rounded-card r-card-lg p-4">
+        <span aria-hidden className="hero2-beams" />
+        <span aria-hidden className="hero2-scanlines" />
+        <span aria-hidden className="hero2-noise" />
+
+        <div className="relative z-[2] space-y-6">
+          <Header
+            id="prompts-header"
+            heading="Prompts Playground"
+            subtitle="Explore components and tokens"
+            icon={<Sparkles className="opacity-80" />}
+            tabs={{
+              items: VIEW_TABS,
+              value: view,
+              onChange: (k) => setView(k as View),
+            }}
+          />
+          <Hero
+            frame={false}
+            topClassName="top-[var(--header-stack)]"
+            heading={
+              view === "components"
+                ? "Components"
+                : view === "colors"
+                  ? "Colors"
+                  : "Onboarding"
+            }
+            {...(view === "components"
+              ? {
+                  subTabs: {
+                    items: SECTION_TABS,
+                    value: section,
+                    onChange: (k: string) => setSection(k as Section),
+                  },
+                }
+              : {})}
+            search={{
+              id: "playground-search",
+              value: query,
+              onValueChange: setQuery,
+              debounceMs: 300,
+              round: true,
+              "aria-label": "Search components",
+            }}
+            actions={
+              <div className="flex items-center gap-2">
+                <Button size="sm">Action</Button>
+                <IconButton size="sm" aria-label="Add">
+                  <Plus />
+                </IconButton>
+              </div>
+            }
+          />
+        </div>
+
+        <div
+          aria-hidden
+          className="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
         />
       </div>
       <section className="grid gap-6 lg:grid-cols-1">

--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -84,16 +84,27 @@ function Inner() {
         aria-labelledby="planner-header"
       >
         {/* Week header (range, nav, totals, day chips) */}
-        <div className="space-y-2">
-          <Header
-            id="planner-header"
-            eyebrow="Planner"
-            heading="Planner for Today"
-            subtitle="Plan your week"
-            icon={<CalendarDays className="opacity-80" />}
-            right={right}
+        <div className="sticky top-0 hero2-frame relative overflow-hidden rounded-card r-card-lg p-4">
+          <span aria-hidden className="hero2-beams" />
+          <span aria-hidden className="hero2-scanlines" />
+          <span aria-hidden className="hero2-noise" />
+
+          <div className="relative z-[2] space-y-2">
+            <Header
+              id="planner-header"
+              eyebrow="Planner"
+              heading="Planner for Today"
+              subtitle="Plan your week"
+              icon={<CalendarDays className="opacity-80" />}
+              right={right}
+            />
+            <WeekPicker />
+          </div>
+
+          <div
+            aria-hidden
+            className="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
           />
-          <WeekPicker />
         </div>
 
         {/* Today + Side column */}

--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -172,6 +172,7 @@ export default function WeekPicker() {
 
   return (
     <Hero
+      frame={false}
       heading={heading}
       subtitle={`${isoStart} → ${isoEnd}`}
       actions={topAction}

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -93,57 +93,69 @@ export default function ReviewsPage({
       className="page-shell p-[var(--spacing-6)] space-y-[var(--spacing-6)]"
       aria-labelledby="reviews-header"
     >
-      <div className="space-y-[var(--spacing-2)]">
-        <Header
-          id="reviews-header"
-          heading="Reviews"
-          icon={<BookOpen className="opacity-80" />}
-          topClassName="top-[var(--header-stack)]"
-        />
-        <Hero
-          topClassName="top-[var(--header-stack)]"
-          heading="Browse Reviews"
-          subtitle={<span className="pill">Total {base.length}</span>}
-          search={{
-            round: true,
-            value: q,
-            onValueChange: setQ,
-            placeholder: "Search title, tags, opponent, patch…",
-            className: "flex-1",
-          }}
-          actions={
-            <div className="flex items-center gap-3">
-              <div className="hidden sm:flex items-center gap-2 text-xs text-muted-foreground">
-                <span>Sort</span>
-                <Select
-                  variant="animated"
-                  value={sort}
-                  onChange={(v) => setSort(v as SortKey)}
-                  items={[
-                    { value: "newest", label: "Newest" },
-                    { value: "oldest", label: "Oldest" },
-                    { value: "title", label: "Title" },
-                  ]}
-                  buttonClassName="h-10 px-[var(--spacing-4)]"
-                />
+      <div className="sticky top-0 hero2-frame relative overflow-hidden rounded-card r-card-lg p-4">
+        <span aria-hidden className="hero2-beams" />
+        <span aria-hidden className="hero2-scanlines" />
+        <span aria-hidden className="hero2-noise" />
+
+        <div className="relative z-[2] space-y-[var(--spacing-2)]">
+          <Header
+            id="reviews-header"
+            heading="Reviews"
+            icon={<BookOpen className="opacity-80" />}
+            topClassName="top-[var(--header-stack)]"
+          />
+          <Hero
+            frame={false}
+            topClassName="top-[var(--header-stack)]"
+            heading="Browse Reviews"
+            subtitle={<span className="pill">Total {base.length}</span>}
+            search={{
+              round: true,
+              value: q,
+              onValueChange: setQ,
+              placeholder: "Search title, tags, opponent, patch…",
+              className: "flex-1",
+            }}
+            actions={
+              <div className="flex items-center gap-3">
+                <div className="hidden sm:flex items-center gap-2 text-xs text-muted-foreground">
+                  <span>Sort</span>
+                  <Select
+                    variant="animated"
+                    value={sort}
+                    onChange={(v) => setSort(v as SortKey)}
+                    items={[
+                      { value: "newest", label: "Newest" },
+                      { value: "oldest", label: "Oldest" },
+                      { value: "title", label: "Title" },
+                    ]}
+                    buttonClassName="h-10 px-[var(--spacing-4)]"
+                  />
+                </div>
+                <Button
+                  type="button"
+                  variant="primary"
+                  size="md"
+                  className="px-[var(--spacing-4)] whitespace-nowrap"
+                  onClick={() => {
+                    setQ("");
+                    setSort("newest");
+                    setPanelMode("edit");
+                    onCreate();
+                  }}
+                >
+                  <Plus />
+                  <span>New Review</span>
+                </Button>
               </div>
-              <Button
-                type="button"
-                variant="primary"
-                size="md"
-                className="px-[var(--spacing-4)] whitespace-nowrap"
-                onClick={() => {
-                  setQ("");
-                  setSort("newest");
-                  setPanelMode("edit");
-                  onCreate();
-                }}
-              >
-                <Plus />
-                <span>New Review</span>
-              </Button>
-            </div>
-          }
+            }
+          />
+        </div>
+
+        <div
+          aria-hidden
+          className="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
         />
       </div>
 

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -186,6 +186,7 @@ export default function TeamCompPage() {
         subTab === "sheet" ? "cheatSheet" : "myComps";
       return (
         <Hero
+          frame={false}
           topClassName="top-[var(--header-stack)]"
           eyebrow={active?.label}
           heading="Comps"
@@ -221,6 +222,7 @@ export default function TeamCompPage() {
     if (tab === "builder") {
       return (
         <Hero
+          frame={false}
           topClassName="top-[var(--header-stack)]"
           eyebrow="Comps"
           heading="Builder"
@@ -259,6 +261,7 @@ export default function TeamCompPage() {
     }
     return (
       <Hero
+        frame={false}
         sticky={false}
         topClassName="top-[var(--header-stack)]"
         rail
@@ -320,16 +323,27 @@ export default function TeamCompPage() {
       className="page-shell py-6 space-y-6 md:grid md:grid-cols-12 md:gap-4"
       aria-labelledby="teamcomp-header"
     >
-      <div className="space-y-[var(--spacing-2)] md:col-span-12">
-        <Header
-          id="teamcomp-header"
-          eyebrow="Comps"
-          heading="Team Comps Today"
-          subtitle="Readable. Fast. On brand."
-          icon={<Users2 className="opacity-80" />}
-          tabs={{ items: TABS, value: tab, onChange: (k: Tab) => setTab(k) }}
+      <div className="sticky top-0 hero2-frame relative overflow-hidden rounded-card r-card-lg p-4 md:col-span-12">
+        <span aria-hidden className="hero2-beams" />
+        <span aria-hidden className="hero2-scanlines" />
+        <span aria-hidden className="hero2-noise" />
+
+        <div className="relative z-[2] space-y-[var(--spacing-2)]">
+          <Header
+            id="teamcomp-header"
+            eyebrow="Comps"
+            heading="Team Comps Today"
+            subtitle="Readable. Fast. On brand."
+            icon={<Users2 className="opacity-80" />}
+            tabs={{ items: TABS, value: tab, onChange: (k: Tab) => setTab(k) }}
+          />
+          {hero}
+        </div>
+
+        <div
+          aria-hidden
+          className="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
         />
-        {hero}
       </div>
 
       <section className="grid gap-4 md:col-span-12 md:grid-cols-12">

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -38,6 +38,9 @@ export interface HeroProps<Key extends string = string>
   bodyClassName?: string;
   rail?: boolean;
 
+  /** Whether to include glitchy frame and background layers. */
+  frame?: boolean;
+
   /** Divider tint for neon line. */
   dividerTint?: "primary" | "life";
 
@@ -72,6 +75,7 @@ function Hero<Key extends string = string>({
   icon,
   children,
   actions,
+  frame = true,
   sticky = true,
   topClassName = "top-8",
   barClassName,
@@ -123,14 +127,20 @@ function Hero<Key extends string = string>({
       <div
         className={cx(
           sticky ? "sticky-blur" : "",
-          "hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4",
+          frame
+            ? "hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4"
+            : "",
           sticky && topClassName,
         )}
       >
-        {/* decorative layers */}
-        <span aria-hidden className="hero2-beams" />
-        <span aria-hidden className="hero2-scanlines" />
-        <span aria-hidden className="hero2-noise" />
+        {frame ? (
+          <>
+            {/* decorative layers */}
+            <span aria-hidden className="hero2-beams" />
+            <span aria-hidden className="hero2-scanlines" />
+            <span aria-hidden className="hero2-noise" />
+          </>
+        ) : null}
 
         <div
           className={cx("relative z-[2] flex items-center gap-4", barClassName)}
@@ -187,11 +197,12 @@ function Hero<Key extends string = string>({
           </div>
         ) : null}
 
-        {/* subtle rim */}
-        <div
-          aria-hidden
-          className="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
-        />
+        {frame ? (
+          <div
+            aria-hidden
+            className="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
+          />
+        ) : null}
       </div>
     </section>
   );

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -7,64 +7,79 @@ exports[`ReviewsPage > renders default state 1`] = `
     class="page-shell p-[var(--spacing-6)] space-y-[var(--spacing-6)]"
   >
     <div
-      class="space-y-[var(--spacing-2)]"
+      class="sticky top-0 hero2-frame relative overflow-hidden rounded-card r-card-lg p-4"
     >
-      <header
-        class="z-[999] relative isolate rounded-card r-card-lg bg-card/70 backdrop-blur-md shadow-[0_0_10px_hsl(var(--ring)/.25),0_0_20px_hsl(var(--accent)/.15)] overflow-hidden after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent"
-        id="reviews-header"
+      <span
+        aria-hidden="true"
+        class="hero2-beams"
+      />
+      <span
+        aria-hidden="true"
+        class="hero2-scanlines"
+      />
+      <span
+        aria-hidden="true"
+        class="hero2-noise"
+      />
+      <div
+        class="relative z-[2] space-y-[var(--spacing-2)]"
       >
-        <div
-          class="sticky top-[var(--header-stack)] relative flex items-center px-3 sm:px-4 py-3 sm:py-4 min-h-12"
+        <header
+          class="z-[999] relative isolate rounded-card r-card-lg bg-card/70 backdrop-blur-md shadow-[0_0_10px_hsl(var(--ring)/.25),0_0_20px_hsl(var(--accent)/.15)] overflow-hidden after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent"
+          id="reviews-header"
         >
           <div
-            aria-hidden="true"
-            class="header-rail pointer-events-none absolute left-0 top-1 bottom-1 w-2 rounded-l-2xl"
-          />
-          <div
-            class="flex min-w-0 items-center gap-2 sm:gap-3"
+            class="sticky top-[var(--header-stack)] relative flex items-center px-3 sm:px-4 py-3 sm:py-4 min-h-12"
           >
-            <span
-              class="shrink-0 opacity-90"
-            >
-              <svg
-                class="lucide lucide-book-open opacity-80"
-                fill="none"
-                height="24"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M12 7v14"
-                />
-                <path
-                  d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"
-                />
-              </svg>
-            </span>
             <div
-              class="min-w-0"
+              aria-hidden="true"
+              class="header-rail pointer-events-none absolute left-0 top-1 bottom-1 w-2 rounded-l-2xl"
+            />
+            <div
+              class="flex min-w-0 items-center gap-2 sm:gap-3"
             >
-              <div
-                class="flex min-w-0 items-baseline gap-2"
+              <span
+                class="shrink-0 opacity-90"
               >
-                <h1
-                  class="truncate text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow"
+                <svg
+                  class="lucide lucide-book-open opacity-80"
+                  fill="none"
+                  height="24"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  Reviews
-                </h1>
+                  <path
+                    d="M12 7v14"
+                  />
+                  <path
+                    d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"
+                  />
+                </svg>
+              </span>
+              <div
+                class="min-w-0"
+              >
+                <div
+                  class="flex min-w-0 items-baseline gap-2"
+                >
+                  <h1
+                    class="truncate text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow"
+                  >
+                    Reviews
+                  </h1>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </header>
-      <section>
-        <style>
-          
+        </header>
+        <section>
+          <style>
+            
       /* === Hero: header background layers ================================ */
       .hero2-frame {
         --hero2-c1: hsl(var(--accent));
@@ -348,185 +363,173 @@ exports[`ReviewsPage > renders default state 1`] = `
         }
       }
     
-        </style>
-        <div
-          class="sticky-blur hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4 top-[var(--header-stack)]"
-        >
-          <span
-            aria-hidden="true"
-            class="hero2-beams"
-          />
-          <span
-            aria-hidden="true"
-            class="hero2-scanlines"
-          />
-          <span
-            aria-hidden="true"
-            class="hero2-noise"
-          />
+          </style>
           <div
-            class="relative z-[2] flex items-center gap-4"
-          >
-            <span
-              aria-hidden="true"
-              class="rail"
-            />
-            <div
-              class="min-w-0"
-            >
-              <div
-                class="flex items-baseline gap-2"
-              >
-                <h2
-                  class="hero2-title title-glow text-xl sm:text-2xl truncate"
-                  data-text="Browse Reviews"
-                >
-                  Browse Reviews
-                </h2>
-                <span
-                  class="text-xs sm:text-sm tracking-wide text-muted-foreground truncate"
-                >
-                  <span
-                    class="pill"
-                  >
-                    Total 
-                    3
-                  </span>
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            class="relative z-[2] mt-4 flex flex-col gap-4"
+            class="sticky-blur top-[var(--header-stack)]"
           >
             <div
-              class="relative hero2-sep neon-primary"
+              class="relative z-[2] flex items-center gap-4"
             >
               <span
                 aria-hidden="true"
-                class="hero2-neon-line"
+                class="rail"
               />
               <div
-                class="hero2-sep-row"
+                class="min-w-0"
               >
-                <form
-                  class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"
-                  role="search"
-                >
-                  <div
-                    class="relative min-w-0"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="lucide lucide-search pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 size-4 text-muted-foreground"
-                      fill="none"
-                      height="24"
-                      stroke="currentColor"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <circle
-                        cx="11"
-                        cy="11"
-                        r="8"
-                      />
-                      <path
-                        d="m21 21-4.3-4.3"
-                      />
-                    </svg>
-                    <div
-                      class="relative inline-flex items-center overflow-hidden border border-card-hairline bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),url('/noise.svg')] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] focus-within:after:opacity-100 w-full rounded-full [&>input]:rounded-full"
-                      style="--control-h: var(--control-h-md);"
-                    >
-                      <input
-                        autocapitalize="none"
-                        autocomplete="off"
-                        autocorrect="off"
-                        class="w-full rounded-[inherit] bg-transparent px-[var(--control-px)] text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)] pl-7"
-                        id=":r0:"
-                        name=":r0:"
-                        placeholder="Search title, tags, opponent, patch…"
-                        spellcheck="false"
-                        type="search"
-                        value=""
-                      />
-                    </div>
-                  </div>
-                </form>
                 <div
-                  class="flex items-center gap-2"
+                  class="flex items-baseline gap-2"
                 >
-                  <div
-                    class="flex items-center gap-3"
+                  <h2
+                    class="hero2-title title-glow text-xl sm:text-2xl truncate"
+                    data-text="Browse Reviews"
+                  >
+                    Browse Reviews
+                  </h2>
+                  <span
+                    class="text-xs sm:text-sm tracking-wide text-muted-foreground truncate"
+                  >
+                    <span
+                      class="pill"
+                    >
+                      Total 
+                      3
+                    </span>
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              class="relative z-[2] mt-4 flex flex-col gap-4"
+            >
+              <div
+                class="relative hero2-sep neon-primary"
+              >
+                <span
+                  aria-hidden="true"
+                  class="hero2-neon-line"
+                />
+                <div
+                  class="hero2-sep-row"
+                >
+                  <form
+                    class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"
+                    role="search"
                   >
                     <div
-                      class="hidden sm:flex items-center gap-2 text-xs text-muted-foreground"
+                      class="relative min-w-0"
                     >
-                      <span>
-                        Sort
-                      </span>
-                      <div
-                        class="glitch-wrap "
+                      <svg
+                        aria-hidden="true"
+                        class="lucide lucide-search pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 size-4 text-muted-foreground"
+                        fill="none"
+                        height="24"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
                       >
+                        <circle
+                          cx="11"
+                          cy="11"
+                          r="8"
+                        />
+                        <path
+                          d="m21 21-4.3-4.3"
+                        />
+                      </svg>
+                      <div
+                        class="relative inline-flex items-center overflow-hidden border border-card-hairline bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),url('/noise.svg')] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] focus-within:after:opacity-100 w-full rounded-full [&>input]:rounded-full"
+                        style="--control-h: var(--control-h-md);"
+                      >
+                        <input
+                          autocapitalize="none"
+                          autocomplete="off"
+                          autocorrect="off"
+                          class="w-full rounded-[inherit] bg-transparent px-[var(--control-px)] text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)] pl-7"
+                          id=":r0:"
+                          name=":r0:"
+                          placeholder="Search title, tags, opponent, patch…"
+                          spellcheck="false"
+                          type="search"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                  </form>
+                  <div
+                    class="flex items-center gap-2"
+                  >
+                    <div
+                      class="flex items-center gap-3"
+                    >
+                      <div
+                        class="hidden sm:flex items-center gap-2 text-xs text-muted-foreground"
+                      >
+                        <span>
+                          Sort
+                        </span>
                         <div
-                          class="group inline-flex rounded-full border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0"
+                          class="glitch-wrap "
                         >
-                          <button
-                            aria-controls=":r1:-listbox"
-                            aria-expanded="false"
-                            aria-haspopup="listbox"
-                            aria-label="Select option"
-                            class="glitch-trigger relative flex items-center rounded-full px-3 overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none h-10 px-[var(--spacing-4)]"
-                            data-lit="true"
-                            data-open="false"
-                            type="button"
+                          <div
+                            class="group inline-flex rounded-full border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0"
                           >
-                            <span
-                              class="font-medium glitch-text text-foreground group-hover:text-foreground"
+                            <button
+                              aria-controls=":r1:-listbox"
+                              aria-expanded="false"
+                              aria-haspopup="listbox"
+                              aria-label="Select option"
+                              class="glitch-trigger relative flex items-center rounded-full px-3 overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none h-10 px-[var(--spacing-4)]"
+                              data-lit="true"
+                              data-open="false"
+                              type="button"
                             >
-                              Newest
-                            </span>
-                            <svg
-                              aria-hidden="true"
-                              class="lucide lucide-chevron-down caret ml-auto size-4 shrink-0 opacity-75 "
-                              fill="none"
-                              height="24"
-                              stroke="currentColor"
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                              viewBox="0 0 24 24"
-                              width="24"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="m6 9 6 6 6-6"
+                              <span
+                                class="font-medium glitch-text text-foreground group-hover:text-foreground"
+                              >
+                                Newest
+                              </span>
+                              <svg
+                                aria-hidden="true"
+                                class="lucide lucide-chevron-down caret ml-auto size-4 shrink-0 opacity-75 "
+                                fill="none"
+                                height="24"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                viewBox="0 0 24 24"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="m6 9 6 6 6-6"
+                                />
+                              </svg>
+                              <span
+                                aria-hidden="true"
+                                class="gb-iris"
                               />
-                            </svg>
-                            <span
-                              aria-hidden="true"
-                              class="gb-iris"
-                            />
-                            <span
-                              aria-hidden="true"
-                              class="gb-chroma"
-                            />
-                            <span
-                              aria-hidden="true"
-                              class="gb-flicker"
-                            />
-                            <span
-                              aria-hidden="true"
-                              class="gb-scan"
-                            />
-                          </button>
-                        </div>
-                        <style>
-                          
+                              <span
+                                aria-hidden="true"
+                                class="gb-chroma"
+                              />
+                              <span
+                                aria-hidden="true"
+                                class="gb-flicker"
+                              />
+                              <span
+                                aria-hidden="true"
+                                class="gb-scan"
+                              />
+                            </button>
+                          </div>
+                          <style>
+                            
       /* caret jitter */
       .caret {
         transition:
@@ -756,55 +759,56 @@ exports[`ReviewsPage > renders default state 1`] = `
           -0.6px 0 hsl(var(--lav-deep) / 0.45);
       }
     
-                        </style>
+                          </style>
+                        </div>
                       </div>
-                    </div>
-                    <button
-                      class="relative inline-flex items-center justify-center rounded-2xl border border-[--focus] font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 gap-2 [&_svg]:size-5 px-[var(--spacing-4)] whitespace-nowrap bg-panel/85 overflow-hidden shadow-neo text-foreground"
-                      tabindex="0"
-                      type="button"
-                    >
-                      <span
-                        class="absolute inset-0 pointer-events-none rounded-2xl bg-[linear-gradient(90deg,hsl(var(--foreground)/.18),hsl(var(--foreground)/.18))]"
-                      />
-                      <span
-                        class="relative z-10 inline-flex items-center gap-2"
+                      <button
+                        class="relative inline-flex items-center justify-center rounded-2xl border border-[--focus] font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 gap-2 [&_svg]:size-5 px-[var(--spacing-4)] whitespace-nowrap bg-panel/85 overflow-hidden shadow-neo text-foreground"
+                        tabindex="0"
+                        type="button"
                       >
-                        <svg
-                          class="lucide lucide-plus"
-                          fill="none"
-                          height="24"
-                          stroke="currentColor"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          class="absolute inset-0 pointer-events-none rounded-2xl bg-[linear-gradient(90deg,hsl(var(--foreground)/.18),hsl(var(--foreground)/.18))]"
+                        />
+                        <span
+                          class="relative z-10 inline-flex items-center gap-2"
                         >
-                          <path
-                            d="M5 12h14"
-                          />
-                          <path
-                            d="M12 5v14"
-                          />
-                        </svg>
-                        <span>
-                          New Review
+                          <svg
+                            class="lucide lucide-plus"
+                            fill="none"
+                            height="24"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M5 12h14"
+                            />
+                            <path
+                              d="M12 5v14"
+                            />
+                          </svg>
+                          <span>
+                            New Review
+                          </span>
                         </span>
-                      </span>
-                    </button>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-          <div
-            aria-hidden="true"
-            class="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
-          />
-        </div>
-      </section>
+        </section>
+      </div>
+      <div
+        aria-hidden="true"
+        class="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
+      />
     </div>
     <div
       class="grid grid-cols-1 items-start gap-[var(--spacing-6)] md:grid-cols-12"


### PR DESCRIPTION
## Summary
- wrap each page's header+hero in shared `hero2-frame` container so backgrounds can be managed externally
- disable internal frame for page heroes via `frame={false}`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c4defb1d5c832c96d76d17ffc5e66d