### PR TITLE
refactor: replace spacing variables with tokens

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -16,7 +16,7 @@ export default function NotFound() {
       className="flex min-h-screen flex-col items-center justify-center gap-4 p-6 text-center"
       aria-labelledby={headerId}
     >
-      <div className="space-y-[var(--spacing-2)]">
+      <div className="space-y-2">
         <Header
           id={headerId}
           heading="Page not found"
@@ -26,7 +26,7 @@ export default function NotFound() {
           heading="This page does not exist"
           actions={
             <Link href="/">
-              <Button className="px-[var(--spacing-4)]">Go home</Button>
+              <Button className="px-4">Go home</Button>
             </Link>
           }
         >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,7 +32,7 @@ function HomePageContent() {
         id="landing-hero"
         role="region"
         aria-label="Intro"
-        className="relative grid grid-cols-12 gap-[var(--spacing-4)]"
+        className="relative grid grid-cols-12 gap-4"
       >
         <div className="col-span-12">
           <div className="sticky top-0 hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4">
@@ -40,7 +40,7 @@ function HomePageContent() {
             <span aria-hidden className="hero2-scanlines" />
             <span aria-hidden className="hero2-noise" />
 
-            <div className="relative z-[2] grid grid-cols-12 gap-[var(--spacing-4)]">
+            <div className="relative z-[2] grid grid-cols-12 gap-4">
               <div className="col-span-12 sticky top-0">
                 <Header
                   id="home-header"
@@ -61,7 +61,7 @@ function HomePageContent() {
                         <Button
                           variant="primary"
                           size="sm"
-                          className="px-[var(--spacing-4)] whitespace-nowrap"
+                          className="px-4 whitespace-nowrap"
                         >
                           Plan Week
                         </Button>
@@ -79,25 +79,25 @@ function HomePageContent() {
           </div>
         </div>
       </section>
-      <div className="grid gap-4 md:grid-cols-12 items-start">
-        <div className="md:col-span-6">
+      <div className="grid grid-cols-12 gap-4 items-start">
+        <div className="col-span-12 md:col-span-6">
           <QuickActions />
         </div>
-        <div className="md:col-span-6">
+        <div className="col-span-12 md:col-span-6">
           <IsometricRoom variant={theme.variant} />
         </div>
       </div>
-      <section className="grid grid-cols-1 gap-6 md:grid-cols-12">
-        <div className="md:col-span-4">
+      <section className="grid grid-cols-12 gap-6">
+        <div className="col-span-12 md:col-span-4">
           <TodayCard />
         </div>
-        <div className="md:col-span-4">
+        <div className="col-span-12 md:col-span-4">
           <GoalsCard />
         </div>
-        <div className="md:col-span-4">
+        <div className="col-span-12 md:col-span-4">
           <ReviewsCard />
         </div>
-        <div className="md:col-span-12">
+        <div className="col-span-12">
           <TeamPromptsCard />
         </div>
       </section>

--- a/src/components/goals/GoalSlot.tsx
+++ b/src/components/goals/GoalSlot.tsx
@@ -119,7 +119,7 @@ export default function GoalSlot({
               <button
                 type="button"
                 className={cn(
-                  "absolute bottom-1 right-1 flex rounded-md bg-surface p-[var(--spacing-1)] text-foreground transition-colors hover:bg-surface-2 active:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] disabled:opacity-50 disabled:pointer-events-none",
+                  "absolute bottom-1 right-1 flex rounded-md bg-surface p-1 text-foreground transition-colors hover:bg-surface-2 active:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] disabled:opacity-50 disabled:pointer-events-none",
                   goal?.done && "text-success",
                 )}
                 aria-label={goal.done ? "Mark goal undone" : "Mark goal done"}
@@ -131,7 +131,7 @@ export default function GoalSlot({
               <button
                 ref={editButtonRef}
                 type="button"
-                className="absolute bottom-1 left-1 flex rounded-md bg-surface p-[var(--spacing-1)] text-foreground opacity-0 transition-opacity transition-colors group-hover:opacity-100 hover:bg-surface-2 active:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] disabled:opacity-50 disabled:pointer-events-none"
+                className="absolute bottom-1 left-1 flex rounded-md bg-surface p-1 text-foreground opacity-0 transition-opacity transition-colors group-hover:opacity-100 hover:bg-surface-2 active:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] disabled:opacity-50 disabled:pointer-events-none"
                 aria-label="Edit goal"
                 onClick={startEdit}
               >
@@ -139,7 +139,7 @@ export default function GoalSlot({
               </button>
               <button
                 type="button"
-                className="absolute bottom-1 left-7 flex rounded-md bg-surface p-[var(--spacing-1)] text-foreground opacity-0 transition-opacity transition-colors group-hover:opacity-100 hover:bg-surface-2 active:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] disabled:opacity-50 disabled:pointer-events-none"
+                className="absolute bottom-1 left-7 flex rounded-md bg-surface p-1 text-foreground opacity-0 transition-opacity transition-colors group-hover:opacity-100 hover:bg-surface-2 active:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] disabled:opacity-50 disabled:pointer-events-none"
                 aria-label="Delete goal"
                 onClick={() => onDelete?.(goal.id)}
               >

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -160,9 +160,10 @@ export default function GoalsPage() {
       aria-labelledby="goals-header"
       className="page-shell py-6"
     >
-      <div className="grid gap-6">
+      <div className="grid grid-cols-12 gap-6">
         {/* ======= HEADER ======= */}
         <Header
+          className="col-span-12"
           id="goals-header"
           eyebrow="Goals"
           heading="Today’s Goals"
@@ -186,10 +187,11 @@ export default function GoalsPage() {
           hidden={tab !== "goals"}
           tabIndex={tab === "goals" ? 0 : -1}
           ref={goalsRef}
+          className="col-span-12"
         >
           {tab === "goals" && (
-            <div className="grid gap-4">
-              <div className="space-y-[var(--spacing-2)]">
+            <div className="grid grid-cols-12 gap-4">
+              <div className="col-span-12 space-y-2">
                 <Hero
                   eyebrow="Guide"
                   heading="Overview"
@@ -229,7 +231,7 @@ export default function GoalsPage() {
                 )}
               </div>
 
-              <div ref={formRef}>
+              <div ref={formRef} className="col-span-12">
                 <GoalForm
                   ref={titleInputRef}
                   title={title}
@@ -246,11 +248,13 @@ export default function GoalsPage() {
               </div>
 
               {lastDeleted && (
-                <Snackbar
-                  message={<>Deleted “{lastDeleted.title}”.</>}
-                  actionLabel="Undo"
-                  onAction={handleUndo}
-                />
+                <div className="col-span-12">
+                  <Snackbar
+                    message={<>Deleted “{lastDeleted.title}”.</>}
+                    actionLabel="Undo"
+                    onAction={handleUndo}
+                  />
+                </div>
               )}
             </div>
           )}
@@ -263,9 +267,13 @@ export default function GoalsPage() {
           hidden={tab !== "reminders"}
           tabIndex={tab === "reminders" ? 0 : -1}
           ref={remindersRef}
-          className="grid gap-4"
+          className="col-span-12 grid grid-cols-12 gap-4"
         >
-          {tab === "reminders" && <RemindersTab />}
+          {tab === "reminders" && (
+            <div className="col-span-12">
+              <RemindersTab />
+            </div>
+          )}
         </div>
 
         <div
@@ -275,9 +283,13 @@ export default function GoalsPage() {
           hidden={tab !== "timer"}
           tabIndex={tab === "timer" ? 0 : -1}
           ref={timerRef}
-          className="grid gap-4"
+          className="col-span-12 grid grid-cols-12 gap-4"
         >
-          {tab === "timer" && <TimerTab />}
+          {tab === "timer" && (
+            <div className="col-span-12">
+              <TimerTab />
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -325,7 +325,7 @@ export default function RemindersTab() {
             <Button
               variant="primary"
               size="md"
-              className="px-[var(--spacing-4)] whitespace-nowrap"
+              className="px-4 whitespace-nowrap"
               onClick={() => addNew()}
             >
               <Plus />
@@ -336,14 +336,14 @@ export default function RemindersTab() {
       </SectionCard.Header>
 
       <SectionCard.Body>
-          <div className="grid gap-3">
+          <div className="grid grid-cols-12 gap-3">
             {/* Quick Add row — now INSIDE the same panel as the cards */}
             <form
               onSubmit={(e) => {
                 e.preventDefault();
                 if (quickAdd.trim()) addNew(quickAdd);
               }}
-              className="rounded-card flex items-center gap-2 sm:gap-6 glitch"
+              className="col-span-12 rounded-card flex items-center gap-2 sm:gap-6 glitch"
             >
               <Input
                 aria-label="Quick add reminder"
@@ -379,7 +379,7 @@ export default function RemindersTab() {
                 ariaLabel="Reminder group"
                 size="md"
                 align="between"
-                className="overflow-x-auto"
+                className="col-span-12 overflow-x-auto"
                 right={
                   <SegmentedButton
                     className="inline-flex items-center gap-1"
@@ -397,7 +397,7 @@ export default function RemindersTab() {
 
             {/* Filters panel (collapsible) */}
             {showFilters && (
-              <div className="flex flex-wrap items-center gap-4 pl-1">
+              <div className="col-span-12 flex flex-wrap items-center gap-4 pl-1">
                 <TabBar
                   items={SOURCE_TABS}
                   value={source}
@@ -422,7 +422,7 @@ export default function RemindersTab() {
             )}
 
             {/* Cards grid */}
-            <div className="grid grid-cols-12 gap-3">
+            <div className="col-span-12 grid grid-cols-12 gap-3">
               {filtered.map((r) => (
                 <div
                   key={r.id}

--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -163,7 +163,7 @@ export default function WeekPicker() {
       aria-label="Jump to top"
       onClick={jumpToTop}
       title="Jump to top"
-      className="px-[var(--spacing-4)]"
+      className="px-4"
     >
       <ArrowUpToLine />
       <span>Top</span>
@@ -179,9 +179,9 @@ export default function WeekPicker() {
       sticky
       dividerTint="primary"
     >
-      <div className="grid gap-3 flex-1">
+      <div className="grid grid-cols-12 gap-3 flex-1">
         {/* Range + totals */}
-        <div className="flex items-center justify-between gap-3">
+        <div className="col-span-12 flex items-center justify-between gap-3">
           <span
             className={cn(
               "inline-flex items-center gap-2 rounded-card r-card-lg px-3 py-2 text-sm",
@@ -202,7 +202,7 @@ export default function WeekPicker() {
         </div>
 
         {/* Day chips */}
-        <div className="flex gap-3 overflow-x-auto snap-x snap-mandatory lg:overflow-visible">
+        <div className="col-span-12 flex gap-3 overflow-x-auto snap-x snap-mandatory lg:overflow-visible">
           {days.map((d, i) => (
             <DayChip
               key={d}

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -90,10 +90,10 @@ export default function ReviewsPage({
 
   return (
     <main
-      className="page-shell p-[var(--spacing-6)] space-y-[var(--spacing-6)]"
+      className="page-shell p-6 space-y-6"
       aria-labelledby="reviews-header"
     >
-      <div className="space-y-[var(--spacing-2)]">
+      <div className="space-y-2">
         <Header
           id="reviews-header"
           heading="Reviews"
@@ -124,14 +124,14 @@ export default function ReviewsPage({
                     { value: "oldest", label: "Oldest" },
                     { value: "title", label: "Title" },
                   ]}
-                  buttonClassName="h-10 px-[var(--spacing-4)]"
+                  buttonClassName="h-10 px-4"
                 />
               </div>
               <Button
                 type="button"
                 variant="primary"
                 size="md"
-                className="px-[var(--spacing-4)] whitespace-nowrap"
+                className="px-4 whitespace-nowrap"
                 onClick={() => {
                   setQ("");
                   setSort("newest");
@@ -149,10 +149,10 @@ export default function ReviewsPage({
 
       <div
         className={cn(
-          "grid grid-cols-1 items-start gap-[var(--spacing-6)] md:grid-cols-12",
+          "grid grid-cols-12 items-start gap-6",
         )}
       >
-        <nav aria-label="Review list" className="md:col-span-4">
+        <nav aria-label="Review list" className="col-span-12 md:col-span-4">
           <div className="card-neo-soft rounded-card r-card-lg overflow-hidden bg-card/50 shadow-neo-strong">
             <div className="section-b">
               <div className="mb-2 text-sm text-muted-foreground">
@@ -171,7 +171,7 @@ export default function ReviewsPage({
             </div>
           </div>
         </nav>
-        <div aria-live="polite" className="md:col-span-8">
+        <div aria-live="polite" className="col-span-12 md:col-span-8">
           {!active ? (
             <ReviewPanel
               className={cn(

--- a/src/components/team/Builder.tsx
+++ b/src/components/team/Builder.tsx
@@ -156,12 +156,12 @@ export default React.forwardRef<BuilderHandle, { editing?: boolean }>(
   }));
 
   return (
-    <div data-scope="team" className="w-full mt-[var(--spacing-6)]">
+    <div data-scope="team" className="w-full mt-6">
       <SectionCard className="card-neo-soft glitch-card">
         <SectionCard.Body>
-          <div className="grid grid-cols-1 md:grid-cols-12 gap-[var(--spacing-6)]">
+          <div className="grid grid-cols-12 gap-6">
             {/* Allies */}
-            <div className="md:col-span-5">
+            <div className="col-span-12 md:col-span-5">
               <SideEditor
                 title="Allies"
                 icon={<Shield />}
@@ -175,7 +175,7 @@ export default React.forwardRef<BuilderHandle, { editing?: boolean }>(
             </div>
 
               {/* Center spine (md+) */}
-            <div className="hidden md:block relative md:col-span-2">
+            <div className="hidden md:block md:col-span-2 relative">
               <span
                 aria-hidden
                 className="absolute left-1/2 top-0 -translate-x-1/2 h-full w-px bg-border"
@@ -183,7 +183,7 @@ export default React.forwardRef<BuilderHandle, { editing?: boolean }>(
             </div>
 
               {/* Enemies */}
-            <div className="md:col-span-5">
+            <div className="col-span-12 md:col-span-5">
               <SideEditor
                 title="Enemies"
                 icon={<Swords />}
@@ -217,11 +217,11 @@ function SideEditor(props: {
   const { title, icon, value, onLane, onNotes, onClear, onCopy, count } = props;
 
   return (
-    <div className="rounded-card p-[var(--spacing-4)] glitch-card card-neo relative">
+    <div className="rounded-card p-4 glitch-card card-neo relative">
       {/* neon rail */}
       <span aria-hidden className="glitch-rail" />
 
-      <header className="mb-[var(--spacing-3)] flex items-center gap-[var(--spacing-2)]">
+      <header className="mb-3 flex items-center gap-2">
         {/* glitchy side title */}
         <span
           className="glitch-title glitch-flicker title-glow inline-flex items-center gap-2"
@@ -236,11 +236,11 @@ function SideEditor(props: {
         </span>
       </header>
 
-      <div className="grid gap-[var(--spacing-3)]">
+      <div className="grid grid-cols-12 gap-3">
         {LANES.map(({ key, label }) => (
           <div
             key={key}
-            className="grid grid-cols-[calc(var(--spacing-8)+var(--spacing-5))_1fr] items-center gap-[var(--spacing-3)]"
+            className="col-span-12 grid grid-cols-[calc(var(--spacing-8)+var(--spacing-5))_1fr] items-center gap-3"
           >
             <label
               className="glitch-title glitch-flicker text-label font-medium tracking-[0.02em] text-muted-foreground"
@@ -257,11 +257,12 @@ function SideEditor(props: {
           </div>
         ))}
 
-        <div className="grid gap-[var(--spacing-3)]">
-          <label className="text-label font-medium tracking-[0.02em] text-muted-foreground inline-flex items-center gap-2">
+        <div className="grid grid-cols-12 gap-3">
+          <label className="col-span-12 text-label font-medium tracking-[0.02em] text-muted-foreground inline-flex items-center gap-2">
             <NotebookPen className="opacity-80" /> Notes
           </label>
           <Textarea
+            className="col-span-12"
             aria-label={`${title} notes`}
             placeholder="Short plan, spikes, target calls…"
             value={value.notes ?? ""}

--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -455,7 +455,7 @@ export default function CheatSheet({
     <section
       data-scope="team"
       className={[
-        "grid gap-[var(--spacing-4)] sm:gap-[var(--spacing-6)] md:grid-cols-2 xl:grid-cols-3",
+        "grid grid-cols-12 gap-4 sm:gap-6",
         className,
       ].join(" ")}
     >
@@ -466,10 +466,8 @@ export default function CheatSheet({
           <article
             key={a.id}
             className={[
-              "group glitch-card card-neo relative h-full",
-              dense
-                ? "p-[var(--spacing-4)]"
-                : "p-[var(--spacing-5)]",
+              "group glitch-card card-neo relative h-full col-span-12 md:col-span-6 xl:col-span-4",
+              dense ? "p-4" : "p-5",
             ].join(" ")}
           >
             {/* Hover-only top-right edit/save button */}
@@ -501,7 +499,7 @@ export default function CheatSheet({
             <span aria-hidden className="glitch-rail" />
 
             {/* Title + description */}
-            <header className="mb-[var(--spacing-3)]">
+            <header className="mb-3">
               <TitleEdit
                 value={a.title}
                 editing={isEditing}
@@ -515,8 +513,8 @@ export default function CheatSheet({
             </header>
 
             {/* Body */}
-            <div className="grid grid-cols-1 gap-[var(--spacing-4)]">
-              <div>
+            <div className="grid grid-cols-12 gap-4">
+              <div className="col-span-12">
                 <Label>Wins when</Label>
                 <BulletListEdit
                   items={a.wins}
@@ -527,7 +525,7 @@ export default function CheatSheet({
               </div>
 
               {a.struggles?.length || isEditing ? (
-                <div>
+                <div className="col-span-12">
                   <Label>Struggles vs</Label>
                   <BulletListEdit
                     items={a.struggles ?? []}
@@ -539,7 +537,7 @@ export default function CheatSheet({
               ) : null}
 
               {a.tips?.length || isEditing ? (
-                <div>
+                <div className="col-span-12">
                   <Label>Tips</Label>
                   <BulletListEdit
                     items={a.tips ?? []}
@@ -551,7 +549,7 @@ export default function CheatSheet({
               ) : null}
 
               {/* Examples with fixed role column */}
-              <div>
+              <div className="col-span-12">
                 <Label>Examples</Label>
                 <div className="mt-2 space-y-2">
                   {(["Top", "Jungle", "Mid", "Bot", "Support"] as Role[]).map(

--- a/src/components/team/JungleClears.tsx
+++ b/src/components/team/JungleClears.tsx
@@ -157,8 +157,8 @@ export default React.forwardRef<
   React.useImperativeHandle(ref, () => ({ addRow }));
 
   return (
-    <div data-scope="team" className="grid gap-[var(--spacing-4)] sm:gap-[var(--spacing-6)]">
-      <div className="grid grid-cols-12 gap-[var(--spacing-6)]">
+    <div data-scope="team" className="grid grid-cols-12 gap-4 sm:gap-6">
+      <div className="col-span-12 grid grid-cols-12 gap-6">
         {BUCKETS.map((bucket) => {
           const rowsAll = items.filter((r) => r.speed === bucket);
           const rows = filtered.filter((r) => r.speed === bucket);
@@ -168,7 +168,7 @@ export default React.forwardRef<
               <SectionCard.Header
                 sticky
                 title={
-                  <div className="flex items-center gap-[var(--spacing-2)]">
+                  <div className="flex items-center gap-2">
                     <Timer className="opacity-80" />
                     {/* Glitch title + glow */}
                     <span
@@ -192,7 +192,7 @@ export default React.forwardRef<
                 }
               />
               <SectionCard.Body>
-                <div className="mb-[var(--spacing-2)] flex flex-wrap items-center gap-[var(--spacing-2)]">
+                <div className="mb-2 flex flex-wrap items-center gap-2">
                   <span className="rounded-full border border-border bg-card px-2 py-1 text-xs tracking-wide uppercase">
                     {SPEED_PERSONA[bucket].tag}
                   </span>
@@ -202,7 +202,7 @@ export default React.forwardRef<
                 </div>
 
                 {/* Example row (canonical pills) */}
-                <div className="mb-[var(--spacing-3)] flex flex-wrap items-center gap-[var(--spacing-2)]">
+                <div className="mb-3 flex flex-wrap items-center gap-2">
                   <span className="text-muted-foreground text-sm">
                     Example:
                   </span>
@@ -215,7 +215,7 @@ export default React.forwardRef<
                 </div>
 
                 {editing && (
-                  <div className="mb-[var(--spacing-2)] flex justify-end">
+                  <div className="mb-2 flex justify-end">
                     <IconButton
                       size="sm"
                       iconSize="xs"
@@ -297,7 +297,7 @@ export default React.forwardRef<
                               />
                             </td>
                             <td className="py-2 pr-3">
-                              <div className="flex gap-[var(--spacing-1)]">
+                              <div className="flex gap-1">
                                 <IconButton
                                   size="sm"
                                   iconSize="xs"
@@ -325,7 +325,7 @@ export default React.forwardRef<
                           >
                             <td className="py-2 pr-3 font-medium">{r.champ}</td>
                             <td className="py-2 pr-3">
-                              <div className="flex flex-wrap gap-[var(--spacing-2)]">
+                              <div className="flex flex-wrap gap-2">
                                 {(r.type ?? []).map((t) => (
                                   <span
                                     key={t}
@@ -339,7 +339,7 @@ export default React.forwardRef<
                             <td className="py-2 pr-3">{r.notes ?? "-"}</td>
                             <td className="py-2 pr-3">
                               {editing && (
-                                <div className="flex gap-[var(--spacing-1)]">
+                                <div className="flex gap-1">
                                   <IconButton
                                     size="sm"
                                     iconSize="xs"

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -302,7 +302,7 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
           {editing && (
             <form
               onSubmit={addNew}
-              className="rounded-card flex items-left gap-[var(--spacing-6)] glitch"
+              className="rounded-card flex items-left gap-6 glitch"
             >
               <Input
                 dir="ltr"
@@ -328,27 +328,27 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
 
           {/* Empty states */}
           {items.length === 0 ? (
-            <div className="rounded-card r-card-lg p-[var(--spacing-6)] text-ui font-medium text-muted-foreground border border-border">
+            <div className="rounded-card r-card-lg p-6 text-ui font-medium text-muted-foreground border border-border">
               No comps yet. Type a title above and press Enter.
             </div>
           ) : filtered.length === 0 ? (
-            <div className="rounded-card r-card-lg p-[var(--spacing-6)] text-ui font-medium text-muted-foreground border border-border">
+            <div className="rounded-card r-card-lg p-6 text-ui font-medium text-muted-foreground border border-border">
               Nothing matches your search.
             </div>
           ) : null}
 
           {/* Cards grid */}
-          <div className="grid grid-cols-12 gap-[var(--spacing-4)]">
+          <div className="grid grid-cols-12 gap-4">
             {filtered.map((c) => {
               const editingCard = editingId === c.id;
 
               return (
                 <article
                   key={c.id}
-                  className="col-span-12 md:col-span-6 xl:col-span-4 group card-neo glitch-card relative p-[var(--spacing-7)]"
+                  className="col-span-12 md:col-span-6 xl:col-span-4 group card-neo glitch-card relative p-7"
                 >
                   {/* hover edit/save + delete + copy */}
-                  <div className="absolute right-2 top-2 z-10 flex items-left gap-[var(--spacing-1)] opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto">
+                  <div className="absolute right-2 top-2 z-10 flex items-left gap-1 opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto">
                     {!editingCard ? (
                       <>
                         <IconButton
@@ -401,7 +401,7 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
                   <span aria-hidden className="glitch-rail" />
 
                   {/* header */}
-                  <header className="mb-[var(--spacing-3)]">
+                  <header className="mb-3">
                     {!editingCard ? (
                       <h3
                         className="glitch-title glitch-flicker title-glow text-title sm:text-title-lg font-semibold tracking-[-0.01em]"

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -226,7 +226,7 @@ export default function TeamCompPage() {
           heading="Builder"
           subtitle="Fill allies vs enemies. Swap in one click."
           actions={
-            <div className="flex items-center gap-[var(--spacing-2)]">
+            <div className="flex items-center gap-2">
               <IconButton
                 title="Swap Allies ↔ Enemies"
                 aria-label="Swap Allies and Enemies"
@@ -275,11 +275,11 @@ export default function TeamCompPage() {
           ),
         }}
         actions={
-          <div className="flex items-center gap-[var(--spacing-2)]">
+          <div className="flex items-center gap-2">
             <Button
               variant="primary"
               size="sm"
-              className="px-[var(--spacing-4)] whitespace-nowrap"
+              className="px-4 whitespace-nowrap"
               onClick={() => clearsApi.current?.addRow("Medium")}
             >
               <Plus />
@@ -317,10 +317,10 @@ export default function TeamCompPage() {
 
   return (
     <main
-      className="page-shell py-6 space-y-6 md:grid md:grid-cols-12 md:gap-4"
+      className="page-shell grid grid-cols-12 gap-6 md:gap-4 py-6"
       aria-labelledby="teamcomp-header"
     >
-      <div className="space-y-[var(--spacing-2)] md:col-span-12">
+      <div className="col-span-12 space-y-2">
         <Header
           id="teamcomp-header"
           eyebrow="Comps"
@@ -332,7 +332,7 @@ export default function TeamCompPage() {
         {hero}
       </div>
 
-      <section className="grid gap-4 md:col-span-12 md:grid-cols-12">
+      <section className="grid grid-cols-12 gap-4 col-span-12">
         {TABS.map((t) => (
           <div
             key={t.key}
@@ -342,7 +342,7 @@ export default function TeamCompPage() {
             hidden={tab !== t.key}
             tabIndex={tab === t.key ? 0 : -1}
             ref={t.ref}
-            className="md:col-span-12"
+            className="col-span-12"
           >
             {tab === t.key && t.render()}
           </div>

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -4,10 +4,10 @@ exports[`ReviewsPage > renders default state 1`] = `
 <div>
   <main
     aria-labelledby="reviews-header"
-    class="page-shell p-[var(--spacing-6)] space-y-[var(--spacing-6)]"
+    class="page-shell p-6 space-y-6"
   >
     <div
-      class="space-y-[var(--spacing-2)]"
+      class="space-y-2"
     >
       <header
         class="z-[999] relative isolate rounded-card r-card-lg bg-card/70 backdrop-blur-md shadow-[0_0_10px_hsl(var(--ring)/.25),0_0_20px_hsl(var(--accent)/.15)] overflow-hidden after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent"
@@ -480,7 +480,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                             aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-label="Select option"
-                            class="glitch-trigger relative flex items-center rounded-full px-3 overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none h-10 px-[var(--spacing-4)]"
+                            class="glitch-trigger relative flex items-center rounded-full px-3 overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none h-10 px-4"
                             data-lit="true"
                             data-open="false"
                             type="button"
@@ -760,7 +760,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                       </div>
                     </div>
                     <button
-                      class="relative inline-flex items-center justify-center rounded-2xl border border-[--focus] font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 gap-2 [&_svg]:size-5 px-[var(--spacing-4)] whitespace-nowrap bg-panel/85 overflow-hidden shadow-neo text-foreground"
+                      class="relative inline-flex items-center justify-center rounded-2xl border border-[--focus] font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 gap-2 [&_svg]:size-5 px-4 whitespace-nowrap bg-panel/85 overflow-hidden shadow-neo text-foreground"
                       tabindex="0"
                       type="button"
                     >
@@ -807,11 +807,11 @@ exports[`ReviewsPage > renders default state 1`] = `
       </section>
     </div>
     <div
-      class="grid grid-cols-1 items-start gap-[var(--spacing-6)] md:grid-cols-12"
+      class="grid grid-cols-12 items-start gap-6"
     >
       <nav
         aria-label="Review list"
-        class="md:col-span-4"
+        class="col-span-12 md:col-span-4"
       >
         <div
           class="card-neo-soft rounded-card r-card-lg overflow-hidden bg-card/50 shadow-neo-strong"
@@ -970,7 +970,7 @@ exports[`ReviewsPage > renders default state 1`] = `
       </nav>
       <div
         aria-live="polite"
-        class="md:col-span-8"
+        class="col-span-12 md:col-span-8"
       >
         <div
           aria-live="polite"

--- a/tests/team/TeamCompPage.test.tsx
+++ b/tests/team/TeamCompPage.test.tsx
@@ -11,7 +11,7 @@ describe("TeamCompPage builder tab", () => {
     const heroHeading = screen.getByRole("heading", { name: "Builder" });
     expect(heroHeading).toBeInTheDocument();
     const cardParent = screen.getByText("Allies").closest("section")?.parentElement;
-    expect(cardParent).toHaveClass("mt-[var(--spacing-6)]");
+    expect(cardParent).toHaveClass("mt-6");
   });
 });
 


### PR DESCRIPTION
## Summary
- replace `var(--spacing-*)` utilities with Tailwind spacing tokens
- standardize grids to 12 columns and apply col-span utilities
- update tests and snapshots for new class names

## Testing
- `npm test -- -u`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68c4e67d95d4832cbdf540cd7fc00b5a