### PR TITLE
chore: enlarge review editor neon toggles

### DIFF
--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -241,7 +241,7 @@ export default function ReviewEditor({
                 })
               }
             >
-              <NeonIcon kind="brain" on={focusOn} size="1em" />
+              <NeonIcon kind="brain" on={focusOn} size={32} />
             </button>
           </div>
 

--- a/src/components/reviews/TimestampMarkers.tsx
+++ b/src/components/reviews/TimestampMarkers.tsx
@@ -151,7 +151,7 @@ function TimestampMarkers(
           }
           title="Timestamp mode"
         >
-          <NeonIcon kind="clock" on={useTimestamp} size="1em" />
+          <NeonIcon kind="clock" on={useTimestamp} size={32} />
         </button>
 
         <button
@@ -171,7 +171,7 @@ function TimestampMarkers(
           }
           title="Note-only mode"
         >
-          <NeonIcon kind="file" on={!useTimestamp} size="1em" />
+          <NeonIcon kind="file" on={!useTimestamp} size={32} />
         </button>
       </div>
 

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -536,7 +536,7 @@ exports[`ReviewEditor > renders default state 1`] = `
               aria-hidden="true"
               class="ni-root relative inline-grid place-items-center overflow-visible rounded-full border border-border bg-card/35"
               data-phase="off"
-              style="--ni-size: 1em; --ni-k: calc(1em * 0.56); --ni-color: hsl(var(--primary));"
+              style="--ni-size: 32px; --ni-k: 18px; --ni-color: hsl(var(--primary));"
             >
               <svg
                 class="lucide lucide-brain relative z-10"
@@ -1566,7 +1566,7 @@ exports[`ReviewEditor > renders default state 1`] = `
               aria-hidden="true"
               class="ni-root relative inline-grid place-items-center overflow-visible rounded-full border border-border bg-card/35"
               data-phase="steady-on"
-              style="--ni-size: 1em; --ni-k: calc(1em * 0.56); --ni-color: hsl(var(--accent));"
+              style="--ni-size: 32px; --ni-k: 18px; --ni-color: hsl(var(--accent));"
             >
               <svg
                 class="lucide lucide-clock relative z-10"
@@ -1701,7 +1701,7 @@ exports[`ReviewEditor > renders default state 1`] = `
               aria-hidden="true"
               class="ni-root relative inline-grid place-items-center overflow-visible rounded-full border border-border bg-card/35"
               data-phase="off"
-              style="--ni-size: 1em; --ni-k: calc(1em * 0.56); --ni-color: hsl(var(--ring));"
+              style="--ni-size: 32px; --ni-k: 18px; --ni-color: hsl(var(--ring));"
             >
               <svg
                 class="lucide lucide-file-text relative z-10"


### PR DESCRIPTION
## Summary
- bump ReviewEditor focus toggle to medium neon icon
- bump timestamp mode toggles to medium neon icons

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c4faf0a9bc832cb541e591a9943e9d