### PR TITLE
refine hero card styling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,10 +35,10 @@ function HomePageContent() {
         className="relative grid grid-cols-12 gap-4"
       >
         <div className="col-span-12">
-          <div className="sticky top-0 hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4">
+          <div className="sticky top-0 relative overflow-hidden rounded-2xl border border-[hsl(var(--border))/0.4] px-6 md:px-7 lg:px-8 shadow-[0_8px_24px_-12px_hsl(var(--accent)/0.35),inset_0_1px_0_hsl(var(--highlight)/0.6)] bg-[linear-gradient(180deg,hsl(var(--card)/0.9),hsl(var(--card)/0.85))]">
             <span aria-hidden className="hero2-beams" />
             <span aria-hidden className="hero2-scanlines" />
-            <span aria-hidden className="hero2-noise" />
+            <span aria-hidden className="hero2-noise opacity-[0.03]" />
 
             <div className="relative z-[2] grid grid-cols-12 gap-4">
               <div className="col-span-12 sticky top-0">

--- a/src/components/prompts/WelcomeCardDemo.tsx
+++ b/src/components/prompts/WelcomeCardDemo.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { Header, Hero, Button, ThemeToggle } from "@/components/ui";
+import { Home } from "lucide-react";
+
+export default function WelcomeCardDemo() {
+  return (
+    <div className="relative overflow-hidden rounded-2xl border border-[hsl(var(--border))/0.4] px-6 md:px-7 lg:px-8 shadow-[0_8px_24px_-12px_hsl(var(--accent)/0.35),inset_0_1px_0_hsl(var(--highlight)/0.6)] bg-[linear-gradient(180deg,hsl(var(--card)/0.9),hsl(var(--card)/0.85))] space-y-4">
+      <Header
+        heading="Welcome to Planner"
+        subtitle="Plan your day, track goals, and review games."
+        icon={<Home className="opacity-70" />}
+        sticky={false}
+        rail={false}
+        barClassName="p-0"
+      />
+      <Hero
+        frame={false}
+        heading="Your day at a glance"
+        actions={
+          <>
+            <ThemeToggle className="shrink-0" />
+            <Button
+              variant="primary"
+              size="sm"
+              className="px-4 whitespace-nowrap"
+            >
+              Plan Week
+            </Button>
+          </>
+        }
+        sticky={false}
+        topClassName="top-0"
+        barClassName="p-0"
+      />
+    </div>
+  );
+}

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -38,6 +38,7 @@ import SelectShowcase from "./SelectShowcase";
 import SpinnerShowcase from "./SpinnerShowcase";
 import SnackbarShowcase from "./SnackbarShowcase";
 import ToggleShowcase from "./ToggleShowcase";
+import WelcomeCardDemo from "./WelcomeCardDemo";
 import { DashboardCard, BottomNav, IsometricRoom } from "@/components/home";
 import {
   RoleSelector,
@@ -574,6 +575,13 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       code: `<Hero heading="Hero" subTabs={{ items: [{ key: "one", label: "One" }, { key: "two", label: "Two" }], value: "one", onChange: () => {} }} search={{ id: "hero-demo-search", value: "", onValueChange: () => {}, round: true, "aria-label": "Search" }} actions={<div className="flex items-center gap-2"><Button size="sm">Action</Button><IconButton size="sm" aria-label="Add"><Plus /></IconButton></div>} sticky={false} topClassName="top-0" />`,
     },
     {
+      id: "welcome-card-demo",
+      name: "WelcomeCard",
+      element: <WelcomeCardDemo />,
+      tags: ["hero", "header"],
+      code: `<WelcomeCardDemo />`,
+    },
+    {
       id: "card-demo",
       name: "Card",
       element: <CardDemo />,
@@ -640,7 +648,10 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       id: "split",
       name: "Split",
       element: (
-        <Split left={<div className="p-4">Left</div>} right={<div className="p-4">Right</div>} />
+        <Split
+          left={<div className="p-4">Left</div>}
+          right={<div className="p-4">Right</div>}
+        />
       ),
       tags: ["split", "layout"],
       code: `<Split left={<div>Left</div>} right={<div>Right</div>} />`,
@@ -649,7 +660,13 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       id: "tab-bar",
       name: "TabBar",
       element: (
-        <TabBar items={[{ key: "a", label: "A" }, { key: "b", label: "B" }]} defaultValue="a" />
+        <TabBar
+          items={[
+            { key: "a", label: "A" },
+            { key: "b", label: "B" },
+          ]}
+          defaultValue="a"
+        />
       ),
       tags: ["tabs"],
       code: `<TabBar items={[{ key: "a", label: "A" }, { key: "b", label: "B" }]} defaultValue="a" />`,
@@ -779,11 +796,7 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       id: "result-score-section",
       name: "ResultScoreSection",
       element: (
-        <ResultScoreSection
-          result="Win"
-          score={5}
-          commitMeta={() => {}}
-        />
+        <ResultScoreSection result="Win" score={5} commitMeta={() => {}} />
       ),
       tags: ["result", "score"],
       code: `<ResultScoreSection result="Win" score={5} commitMeta={() => {}} />`,

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -391,7 +391,7 @@ const AnimatedSelectImpl = React.forwardRef<
 
   // ── Trigger (glitch chrome + stays lit on selection) ──
   const triggerCls = [
-    "glitch-trigger relative flex items-center rounded-full px-3 overflow-hidden",
+    "glitch-trigger relative flex items-center h-9 rounded-full px-3 overflow-hidden",
     "bg-muted/12 hover:bg-muted/18",
     "focus:[outline:none] focus-visible:[outline:none]",
     "transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none",

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -89,6 +89,9 @@ function Hero<Key extends string = string>({
   ...rest
 }: HeroProps<Key>) {
   const headingStr = typeof heading === "string" ? heading : undefined;
+  const dividerStyle = {
+    "--divider": dividerTint === "life" ? "var(--accent)" : "var(--ring)",
+  } as React.CSSProperties;
 
   // Compose right area: prefer built-in sub-tabs if provided.
   const subTabsNode = subTabs ? (
@@ -128,25 +131,31 @@ function Hero<Key extends string = string>({
         className={cx(
           sticky ? "sticky-blur" : "",
           frame
-            ? "hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4"
+            ? "relative overflow-hidden rounded-2xl border border-[hsl(var(--border))/0.4] px-6 md:px-7 lg:px-8 shadow-[0_8px_24px_-12px_hsl(var(--accent)/0.35),inset_0_1px_0_hsl(var(--highlight)/0.6)] bg-[linear-gradient(180deg,hsl(var(--card)/0.9),hsl(var(--card)/0.85))]"
             : "",
           sticky && topClassName,
         )}
       >
         {frame ? (
           <>
-            {/* decorative layers */}
             <span aria-hidden className="hero2-beams" />
             <span aria-hidden className="hero2-scanlines" />
-            <span aria-hidden className="hero2-noise" />
+            <span aria-hidden className="hero2-noise opacity-[0.03]" />
           </>
         ) : null}
 
         <div
-          className={cx("relative z-[2] flex items-center gap-4", barClassName)}
+          className={cx(
+            "relative z-[2] flex items-center gap-3 md:gap-4 lg:gap-6 py-6",
+            barClassName,
+          )}
         >
           {rail ? <span aria-hidden className="rail" /> : null}
-          {icon ? <div className="opacity-90">{icon}</div> : null}
+          {icon ? (
+            <div className="opacity-70 hover:opacity-100 focus-visible:opacity-100 transition-opacity">
+              {icon}
+            </div>
+          ) : null}
 
           <div className="min-w-0">
             {eyebrow ? (
@@ -157,13 +166,13 @@ function Hero<Key extends string = string>({
 
             <div className="flex items-baseline gap-2">
               <h2
-                className="hero2-title title-glow text-xl sm:text-2xl truncate"
+                className="hero2-title title-glow text-2xl md:text-3xl font-semibold tracking-[-0.005em] truncate"
                 data-text={headingStr}
               >
                 {heading}
               </h2>
               {subtitle ? (
-                <span className="text-xs sm:text-sm tracking-wide text-muted-foreground truncate">
+                <span className="text-sm md:text-base font-medium text-[hsl(var(--muted-foreground))] truncate">
                   {subtitle}
                 </span>
               ) : null}
@@ -174,19 +183,21 @@ function Hero<Key extends string = string>({
         </div>
 
         {children || search || actions ? (
-          <div className="relative z-[2] mt-4 flex flex-col gap-4">
+          <div className="relative z-[2] mt-5 flex flex-col gap-5">
             {children ? (
               <div className={cx(bodyClassName)}>{children}</div>
             ) : null}
             {search || actions ? (
-              <div
-                className={cx(
-                  "relative hero2-sep",
-                  dividerTint === "life" ? "neon-life" : "neon-primary",
-                )}
-              >
-                <span aria-hidden className="hero2-neon-line" />
-                <div className="hero2-sep-row">
+              <div className="relative" style={dividerStyle}>
+                <span
+                  aria-hidden
+                  className="block h-px bg-[hsl(var(--divider))/0.35]"
+                />
+                <span
+                  aria-hidden
+                  className="absolute inset-x-0 top-0 h-px blur-[6px] opacity-60 bg-[hsl(var(--divider))]"
+                />
+                <div className="flex items-center gap-3 md:gap-4 lg:gap-6 pt-4">
                   {search ? <HeroSearchBar {...search} /> : null}
                   {actions ? (
                     <div className="flex items-center gap-2">{actions}</div>
@@ -200,7 +211,7 @@ function Hero<Key extends string = string>({
         {frame ? (
           <div
             aria-hidden
-            className="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
+            className="absolute inset-0 rounded-2xl ring-1 ring-inset ring-border/55"
           />
         ) : null}
       </div>
@@ -293,33 +304,6 @@ export function HeroGlitchStyles() {
   return (
     <style jsx global>{`
       /* === Hero: header background layers ================================ */
-      .hero2-frame {
-        --hero2-c1: hsl(var(--accent));
-        --hero2-c2: hsl(var(--primary));
-        --hero2-bloom: hsl(var(--shadow-color) / 0.85);
-        box-shadow:
-          0 calc(var(--space-3) _-_var(--space-1) / 2)
-            calc(var(--space-6) _+_var(--space-2))
-            calc(-1 * var(--space-5) _+_var(--space-2) _-_var(--space-1) / 2)
-            var(--hero2-bloom),
-          inset 0 0 0 var(--hairline-w) hsl(var(--border) / 0.55);
-        background:
-          radial-gradient(
-            120% 120% at 0% 0%,
-            hsl(var(--accent) / 0.14) 0%,
-            transparent 55%
-          ),
-          radial-gradient(
-            120% 120% at 100% 0%,
-            hsl(var(--primary) / 0.12) 0%,
-            transparent 55%
-          ),
-          linear-gradient(
-            0deg,
-            hsl(var(--card) / 0.82),
-            hsl(var(--card) / 0.82)
-          );
-      }
       .hero2-beams {
         position: absolute;
         inset: calc(var(--space-1) / -2);
@@ -405,7 +389,7 @@ export function HeroGlitchStyles() {
         inset: 0;
         z-index: 1;
         pointer-events: none;
-        opacity: 0.08;
+        opacity: 0.03;
         mix-blend-mode: overlay;
         background-image: url("data:image/svg+xml;utf8,\
         <svg xmlns='http://www.w3.org/2000/svg' width='140' height='140' viewBox='0 0 140 140'>\
@@ -513,66 +497,9 @@ export function HeroGlitchStyles() {
       .neon-life {
         --neon: var(--accent);
       }
-      .hero2-sep {
-        position: relative;
-        padding-top: var(--space-4);
-      }
-      .hero2-neon-line {
-        position: absolute;
-        left: calc(-1 * var(--space-2));
-        right: calc(-1 * var(--space-2));
-        top: 0;
-        height: var(--hairline-w);
-        pointer-events: none;
-        background: linear-gradient(
-          90deg,
-          transparent,
-          hsl(var(--neon)),
-          transparent
-        );
-        box-shadow:
-          0 0 var(--space-1) hsl(var(--neon) / 0.55),
-          0 0 var(--space-3) hsl(var(--neon) / 0.35),
-          0 0 var(--space-5) hsl(var(--neon) / 0.2);
-        animation: neon-flicker 3.4s infinite;
-        opacity: 0.95;
-      }
-      .hero2-sep-row {
-        display: flex;
-        align-items: center;
-        gap: var(--spacing-3);
-        justify-content: space-between;
-      }
-      @keyframes neon-flicker {
-        0%,
-        17%,
-        22%,
-        26%,
-        52%,
-        100% {
-          opacity: 1;
-        }
-        18% {
-          opacity: 0.72;
-        }
-        24% {
-          opacity: 0.55;
-        }
-        54% {
-          opacity: 0.78;
-        }
-        70% {
-          opacity: 0.62;
-        }
-        74% {
-          opacity: 1;
-        }
-      }
-
       @media (prefers-reduced-motion: reduce) {
         .hero2-title::before,
-        .hero2-title::after,
-        .hero2-neon-line {
+        .hero2-title::after {
           animation: none !important;
           transition: none !important;
         }

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -93,10 +93,10 @@ export const variants: Record<
   }
 > = {
   primary: {
-    className: "bg-panel/85 overflow-hidden shadow-neo",
+    className:
+      "bg-[hsl(var(--accent)/0.12)] text-[hsl(var(--accent-foreground))] border-[hsl(var(--accent)/0.35)] hover:bg-[hsl(var(--accent)/0.14)] hover:shadow-[0_2px_6px_-1px_hsl(var(--accent)/0.25)] active:translate-y-px active:shadow-[inset_0_0_0_1px_hsl(var(--accent)/0.6)]",
     whileTap: {
-      scale: 0.96,
-      boxShadow: neuInset(10) as CSSProperties["boxShadow"],
+      scale: 0.97,
     },
     contentClass: "relative z-10 inline-flex items-center gap-2",
   },
@@ -133,7 +133,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const isDisabled = disabled || loading;
     const s = buttonSizes[size];
     const base = cn(
-      "relative inline-flex items-center justify-center rounded-2xl border border-[--focus] font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)]",
+      "relative inline-flex items-center justify-center rounded-2xl border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)]",
       s.height,
       s.padding,
       s.text,

--- a/src/components/ui/theme/ThemeToggle.tsx
+++ b/src/components/ui/theme/ThemeToggle.tsx
@@ -68,7 +68,7 @@ export default function ThemeToggle({
         aria-label={`${aria}: cycle background`}
         onClick={cycleBg}
         title="Change background"
-        className="inline-flex h-9 w-9 items-center justify-center rounded-full shrink-0 border border-border bg-card hover:shadow-[0_0_12px_hsl(var(--ring)/.35)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="inline-flex h-9 w-9 items-center justify-center rounded-full shrink-0 border border-border bg-card opacity-70 hover:opacity-100 focus-visible:opacity-100 hover:shadow-[0_0_12px_hsl(var(--ring)/.35)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         <ImageIcon className="h-4 w-4" />
       </button>

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -81,33 +81,6 @@ exports[`ReviewsPage > renders default state 1`] = `
           <style>
             
       /* === Hero: header background layers ================================ */
-      .hero2-frame {
-        --hero2-c1: hsl(var(--accent));
-        --hero2-c2: hsl(var(--primary));
-        --hero2-bloom: hsl(var(--shadow-color) / 0.85);
-        box-shadow:
-          0 calc(var(--space-3) _-_var(--space-1) / 2)
-            calc(var(--space-6) _+_var(--space-2))
-            calc(-1 * var(--space-5) _+_var(--space-2) _-_var(--space-1) / 2)
-            var(--hero2-bloom),
-          inset 0 0 0 var(--hairline-w) hsl(var(--border) / 0.55);
-        background:
-          radial-gradient(
-            120% 120% at 0% 0%,
-            hsl(var(--accent) / 0.14) 0%,
-            transparent 55%
-          ),
-          radial-gradient(
-            120% 120% at 100% 0%,
-            hsl(var(--primary) / 0.12) 0%,
-            transparent 55%
-          ),
-          linear-gradient(
-            0deg,
-            hsl(var(--card) / 0.82),
-            hsl(var(--card) / 0.82)
-          );
-      }
       .hero2-beams {
         position: absolute;
         inset: calc(var(--space-1) / -2);
@@ -193,7 +166,7 @@ exports[`ReviewsPage > renders default state 1`] = `
         inset: 0;
         z-index: 1;
         pointer-events: none;
-        opacity: 0.08;
+        opacity: 0.03;
         mix-blend-mode: overlay;
         background-image: url("data:image/svg+xml;utf8,        &lt;svg xmlns='http://www.w3.org/2000/svg' width='140' height='140' viewBox='0 0 140 140'&gt;          &lt;filter id='n'&gt;&lt;feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/&gt;&lt;/filter&gt;          &lt;rect width='100%' height='100%' filter='url(%23n)' opacity='0.38'/&gt;&lt;/svg&gt;");
         background-size: calc(var(--space-8) * 4_+_var(--space-5))
@@ -298,66 +271,9 @@ exports[`ReviewsPage > renders default state 1`] = `
       .neon-life {
         --neon: var(--accent);
       }
-      .hero2-sep {
-        position: relative;
-        padding-top: var(--space-4);
-      }
-      .hero2-neon-line {
-        position: absolute;
-        left: calc(-1 * var(--space-2));
-        right: calc(-1 * var(--space-2));
-        top: 0;
-        height: var(--hairline-w);
-        pointer-events: none;
-        background: linear-gradient(
-          90deg,
-          transparent,
-          hsl(var(--neon)),
-          transparent
-        );
-        box-shadow:
-          0 0 var(--space-1) hsl(var(--neon) / 0.55),
-          0 0 var(--space-3) hsl(var(--neon) / 0.35),
-          0 0 var(--space-5) hsl(var(--neon) / 0.2);
-        animation: neon-flicker 3.4s infinite;
-        opacity: 0.95;
-      }
-      .hero2-sep-row {
-        display: flex;
-        align-items: center;
-        gap: var(--spacing-3);
-        justify-content: space-between;
-      }
-      @keyframes neon-flicker {
-        0%,
-        17%,
-        22%,
-        26%,
-        52%,
-        100% {
-          opacity: 1;
-        }
-        18% {
-          opacity: 0.72;
-        }
-        24% {
-          opacity: 0.55;
-        }
-        54% {
-          opacity: 0.78;
-        }
-        70% {
-          opacity: 0.62;
-        }
-        74% {
-          opacity: 1;
-        }
-      }
-
       @media (prefers-reduced-motion: reduce) {
         .hero2-title::before,
-        .hero2-title::after,
-        .hero2-neon-line {
+        .hero2-title::after {
           animation: none !important;
           transition: none !important;
         }
@@ -368,7 +284,7 @@ exports[`ReviewsPage > renders default state 1`] = `
             class="sticky-blur top-[var(--header-stack)]"
           >
             <div
-              class="relative z-[2] flex items-center gap-4"
+              class="relative z-[2] flex items-center gap-3 md:gap-4 lg:gap-6 py-6"
             >
               <span
                 aria-hidden="true"
@@ -381,13 +297,13 @@ exports[`ReviewsPage > renders default state 1`] = `
                   class="flex items-baseline gap-2"
                 >
                   <h2
-                    class="hero2-title title-glow text-xl sm:text-2xl truncate"
+                    class="hero2-title title-glow text-2xl md:text-3xl font-semibold tracking-[-0.005em] truncate"
                     data-text="Browse Reviews"
                   >
                     Browse Reviews
                   </h2>
                   <span
-                    class="text-xs sm:text-sm tracking-wide text-muted-foreground truncate"
+                    class="text-sm md:text-base font-medium text-[hsl(var(--muted-foreground))] truncate"
                   >
                     <span
                       class="pill"
@@ -400,17 +316,22 @@ exports[`ReviewsPage > renders default state 1`] = `
               </div>
             </div>
             <div
-              class="relative z-[2] mt-4 flex flex-col gap-4"
+              class="relative z-[2] mt-5 flex flex-col gap-5"
             >
               <div
-                class="relative hero2-sep neon-primary"
+                class="relative"
+                style="--divider: var(--ring);"
               >
                 <span
                   aria-hidden="true"
-                  class="hero2-neon-line"
+                  class="block h-px bg-[hsl(var(--divider))/0.35]"
+                />
+                <span
+                  aria-hidden="true"
+                  class="absolute inset-x-0 top-0 h-px blur-[6px] opacity-60 bg-[hsl(var(--divider))]"
                 />
                 <div
-                  class="hero2-sep-row"
+                  class="flex items-center gap-3 md:gap-4 lg:gap-6 pt-4"
                 >
                   <form
                     class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"
@@ -483,7 +404,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                               aria-expanded="false"
                               aria-haspopup="listbox"
                               aria-label="Select option"
-                              class="glitch-trigger relative flex items-center rounded-full px-3 overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none h-10 px-4"
+                              class="glitch-trigger relative flex items-center h-9 rounded-full px-3 overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none h-10 px-4"
                               data-lit="true"
                               data-open="false"
                               type="button"
@@ -763,7 +684,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                         </div>
                       </div>
                       <button
-                        class="relative inline-flex items-center justify-center rounded-2xl border border-[--focus] font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 gap-2 [&_svg]:size-5 px-4 whitespace-nowrap bg-panel/85 overflow-hidden shadow-neo text-foreground"
+                        class="relative inline-flex items-center justify-center rounded-2xl border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 gap-2 [&_svg]:size-5 px-4 whitespace-nowrap bg-[hsl(var(--accent)/0.12)] border-[hsl(var(--accent)/0.35)] hover:bg-[hsl(var(--accent)/0.14)] hover:shadow-[0_2px_6px_-1px_hsl(var(--accent)/0.25)] active:translate-y-px active:shadow-[inset_0_0_0_1px_hsl(var(--accent)/0.6)] text-foreground"
                         tabindex="0"
                         type="button"
                       >

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -20,6 +20,7 @@
   --accent-2: 192 100% 25%;
   --accent-foreground: 0 0% 100%;
   --accent-soft: 292 90% 15%;
+  --highlight: 0 0% 100%;
   --glow: 292 90% 35%;
   --ring-muted: 248 20% 22%;
   --danger: 0 84% 60%;

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -20,6 +20,7 @@ export default {
   accent2: "192 100% 25%",
   accentForeground: "0 0% 100%",
   accentSoft: "292 90% 15%",
+  highlight: "0 0% 100%",
   glow: "292 90% 35%",
   ringMuted: "248 20% 22%",
   danger: "0 84% 60%",


### PR DESCRIPTION
## Summary
- polish hero header styling with accent-driven shadows and typography
- tune button/select heights and theme toggle states
- document updated hero in prompts gallery

## Testing
- `npm test -- -u`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c4fa3703b0832c9042efc94c7337b4