### PR TITLE
feat: add neomorphic hero frame component

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,7 +1,12 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { AlertCircle } from "lucide-react";
-import { Button, Header, Hero } from "@/components/ui";
+import {
+  Button,
+  Header,
+  Hero,
+  NeomorphicHeroFrame,
+} from "@/components/ui";
 
 export const metadata: Metadata = {
   title: "Page Not Found",
@@ -16,11 +21,7 @@ export default function NotFound() {
       className="flex min-h-screen flex-col items-center justify-center gap-4 p-6 text-center"
       aria-labelledby={headerId}
     >
-      <div className="hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4">
-        <span aria-hidden className="hero2-beams" />
-        <span aria-hidden className="hero2-scanlines" />
-        <span aria-hidden className="hero2-noise" />
-
+      <NeomorphicHeroFrame className="rounded-card r-card-lg px-4 py-4">
         <div className="relative z-[2] space-y-2">
           <Header
             id={headerId}
@@ -41,12 +42,7 @@ export default function NotFound() {
             </p>
           </Hero>
         </div>
-
-        <div
-          aria-hidden
-          className="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
-        />
-      </div>
+      </NeomorphicHeroFrame>
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,7 +15,12 @@ import {
 } from "@/components/home";
 import Hero from "@/components/ui/layout/Hero";
 import Header from "@/components/ui/layout/Header";
-import { Button, Spinner, ThemeToggle } from "@/components/ui";
+import {
+  Button,
+  Spinner,
+  ThemeToggle,
+  NeomorphicHeroFrame,
+} from "@/components/ui";
 import { useTheme } from "@/lib/theme-context";
 import { useThemeQuerySync } from "@/lib/theme-hooks";
 
@@ -35,11 +40,7 @@ function HomePageContent() {
         className="relative grid grid-cols-12 gap-4"
       >
         <div className="col-span-12">
-          <div className="sticky top-0 relative overflow-hidden rounded-2xl border border-[hsl(var(--border))/0.4] px-6 md:px-7 lg:px-8 hero2-neomorph">
-            <span aria-hidden className="hero2-beams" />
-            <span aria-hidden className="hero2-scanlines" />
-            <span aria-hidden className="hero2-noise opacity-[0.03]" />
-
+          <NeomorphicHeroFrame className="sticky top-0 rounded-2xl border border-[hsl(var(--border))/0.4] px-6 md:px-7 lg:px-8">
             <div className="relative z-[2] grid grid-cols-12 gap-4">
               <div className="col-span-12 sticky top-0">
                 <Header
@@ -71,12 +72,7 @@ function HomePageContent() {
                 />
               </div>
             </div>
-
-            <div
-              aria-hidden
-              className="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
-            />
-          </div>
+          </NeomorphicHeroFrame>
         </div>
       </section>
       <div className="grid gap-4 md:grid-cols-12 items-start">

--- a/src/app/prompts/PromptsPage.tsx
+++ b/src/app/prompts/PromptsPage.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import * as React from "react";
-import { Header, Hero, Button, IconButton } from "@/components/ui";
+import {
+  Header,
+  Hero,
+  Button,
+  IconButton,
+  NeomorphicHeroFrame,
+} from "@/components/ui";
 import { Sparkles, Plus } from "lucide-react";
 import ComponentsView from "@/components/prompts/ComponentsView";
 import ColorsView from "@/components/prompts/ColorsView";
@@ -71,11 +77,7 @@ function PageContent() {
       className="page-shell py-6 space-y-6"
       aria-labelledby="prompts-header"
     >
-      <div className="sticky top-0 hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4">
-        <span aria-hidden className="hero2-beams" />
-        <span aria-hidden className="hero2-scanlines" />
-        <span aria-hidden className="hero2-noise" />
-
+      <NeomorphicHeroFrame className="sticky top-0 rounded-card r-card-lg px-4 py-4">
         <div className="relative z-[2] space-y-6">
           <Header
             id="prompts-header"
@@ -125,12 +127,7 @@ function PageContent() {
             }
           />
         </div>
-
-        <div
-          aria-hidden
-          className="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
-        />
-      </div>
+      </NeomorphicHeroFrame>
       <section className="grid gap-6 lg:grid-cols-1">
         <div className="space-y-6 lg:col-span-full">
           <div>

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -30,6 +30,7 @@ import {
   PillarSelector,
   Header,
   Hero,
+  NeomorphicHeroFrame,
   SectionCard as UiSectionCard,
   type HeaderTab,
 } from "@/components/ui";
@@ -574,6 +575,20 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       element: <HeroDemo />,
       tags: ["hero"],
       code: `<Hero heading="Hero" subTabs={{ items: [{ key: "one", label: "One" }, { key: "two", label: "Two" }], value: "one", onChange: () => {} }} search={{ id: "hero-demo-search", value: "", onValueChange: () => {}, round: true, "aria-label": "Search" }} actions={<div className="flex items-center gap-2"><Button size="sm">Action</Button><IconButton size="sm" aria-label="Add"><Plus /></IconButton></div>} sticky={false} topClassName="top-0" />`,
+    },
+    {
+      id: "neomorphic-hero-frame",
+      name: "NeomorphicHeroFrame",
+      description: "HUD-style frame shell",
+      element: (
+        <NeomorphicHeroFrame className="rounded-card r-card-lg px-4 py-4">
+          <div className="relative z-[2] text-sm">Content</div>
+        </NeomorphicHeroFrame>
+      ),
+      tags: ["hero", "layout"],
+      code: `<NeomorphicHeroFrame className="rounded-card r-card-lg px-4 py-4">
+  <div className="relative z-[2]">Content</div>
+</NeomorphicHeroFrame>`,
     },
     {
       id: "welcome-card-demo",

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -10,7 +10,7 @@ import ReviewSummary from "./ReviewSummary";
 import ReviewPanel from "./ReviewPanel";
 import { BookOpen, Ghost, Plus } from "lucide-react";
 
-import { Button, Select } from "@/components/ui";
+import { Button, Select, NeomorphicHeroFrame } from "@/components/ui";
 import Hero from "@/components/ui/layout/Hero";
 import Header from "@/components/ui/layout/Header";
 
@@ -93,11 +93,7 @@ export default function ReviewsPage({
       className="page-shell py-6 space-y-6"
       aria-labelledby="reviews-header"
     >
-      <div className="sticky top-0 hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4">
-        <span aria-hidden className="hero2-beams" />
-        <span aria-hidden className="hero2-scanlines" />
-        <span aria-hidden className="hero2-noise" />
-
+      <NeomorphicHeroFrame className="sticky top-0 rounded-card r-card-lg px-4 py-4">
         <div className="relative z-[2] space-y-2">
           <Header
             id="reviews-header"
@@ -152,12 +148,7 @@ export default function ReviewsPage({
             }
           />
         </div>
-
-        <div
-          aria-hidden
-          className="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
-        />
-      </div>
+      </NeomorphicHeroFrame>
 
       <div
         className={cn(

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -31,6 +31,7 @@ import MyComps from "./MyComps";
 import { usePersistentState } from "@/lib/db";
 import IconButton from "@/components/ui/primitives/IconButton";
 import Button from "@/components/ui/primitives/Button";
+import { NeomorphicHeroFrame } from "@/components/ui";
 
 type Tab = "cheat" | "builder" | "clears";
 type SubTab = "sheet" | "comps";
@@ -323,11 +324,7 @@ export default function TeamCompPage() {
       className="page-shell py-6 space-y-6 md:grid md:grid-cols-12 md:gap-4"
       aria-labelledby="teamcomp-header"
     >
-      <div className="sticky top-0 hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4 md:col-span-12">
-        <span aria-hidden className="hero2-beams" />
-        <span aria-hidden className="hero2-scanlines" />
-        <span aria-hidden className="hero2-noise" />
-
+      <NeomorphicHeroFrame className="sticky top-0 rounded-card r-card-lg px-4 py-4 md:col-span-12">
         <div className="relative z-[2] space-y-2">
           <Header
             id="teamcomp-header"
@@ -339,12 +336,7 @@ export default function TeamCompPage() {
           />
           {hero}
         </div>
-
-        <div
-          aria-hidden
-          className="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
-        />
-      </div>
+      </NeomorphicHeroFrame>
 
       <section className="grid gap-4 md:col-span-12 md:grid-cols-12">
         {TABS.map((t) => (

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -21,6 +21,8 @@ export { default as Header } from "./layout/Header";
 export * from "./layout/Header";
 export { default as Hero } from "./layout/Hero";
 export * from "./layout/Hero";
+export { default as NeomorphicHeroFrame } from "./layout/NeomorphicHeroFrame";
+export * from "./layout/NeomorphicHeroFrame";
 export { default as SectionCard } from "./layout/SectionCard";
 export * from "./layout/SectionCard";
 export { default as Split } from "./layout/Split";

--- a/src/components/ui/layout/NeomorphicHeroFrame.tsx
+++ b/src/components/ui/layout/NeomorphicHeroFrame.tsx
@@ -1,0 +1,29 @@
+// src/components/ui/layout/NeomorphicHeroFrame.tsx
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type NeomorphicHeroFrameProps = React.HTMLAttributes<HTMLDivElement>;
+
+export default function NeomorphicHeroFrame({
+  className,
+  children,
+  ...rest
+}: NeomorphicHeroFrameProps) {
+  return (
+    <div
+      className={cn("relative overflow-hidden hero2-neomorph", className)}
+      {...rest}
+    >
+      <span aria-hidden className="hero2-beams" />
+      <span aria-hidden className="hero2-scanlines" />
+      <span aria-hidden className="hero2-noise opacity-[0.03]" />
+      {children}
+      <div
+        aria-hidden
+        className="absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/55"
+      />
+    </div>
+  );
+}

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`ReviewsPage > renders default state 1`] = `
     class="page-shell py-6 space-y-6"
   >
     <div
-      class="sticky top-0 hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4"
+      class="overflow-hidden hero2-neomorph sticky top-0 rounded-card r-card-lg px-4 py-4"
     >
       <span
         aria-hidden="true"
@@ -19,7 +19,7 @@ exports[`ReviewsPage > renders default state 1`] = `
       />
       <span
         aria-hidden="true"
-        class="hero2-noise"
+        class="hero2-noise opacity-[0.03]"
       />
       <div
         class="relative z-[2] space-y-2"
@@ -743,7 +743,7 @@ exports[`ReviewsPage > renders default state 1`] = `
       </div>
       <div
         aria-hidden="true"
-        class="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
+        class="absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/55"
       />
     </div>
     <div


### PR DESCRIPTION
## Summary
- add `NeomorphicHeroFrame` wrapper for HUD-style hero frames
- replace manual hero frame markup with reusable component
- showcase `NeomorphicHeroFrame` in prompts gallery and export via UI index

## Testing
- `npm test tests/reviews/ReviewsPage.test.tsx -- -u`
- `npm run regen-ui`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c53c85474c832cb8e71b4b9e27b05e