### PR TITLE
Use hero2-neomorph wrapper and standard spacing

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -16,7 +16,7 @@ export default function NotFound() {
       className="flex min-h-screen flex-col items-center justify-center gap-4 p-6 text-center"
       aria-labelledby={headerId}
     >
-      <div className="hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4">
+      <div className="hero2-neomorph relative overflow-hidden rounded-card r-card-lg px-6 md:px-7 lg:px-8 py-6">
         <span aria-hidden className="hero2-beams" />
         <span aria-hidden className="hero2-scanlines" />
         <span aria-hidden className="hero2-noise" />

--- a/src/app/prompts/PromptsPage.tsx
+++ b/src/app/prompts/PromptsPage.tsx
@@ -71,7 +71,7 @@ function PageContent() {
       className="page-shell py-6 space-y-6"
       aria-labelledby="prompts-header"
     >
-      <div className="sticky top-0 hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4">
+      <div className="sticky top-0 hero2-neomorph relative overflow-hidden rounded-card r-card-lg px-6 md:px-7 lg:px-8 py-6">
         <span aria-hidden className="hero2-beams" />
         <span aria-hidden className="hero2-scanlines" />
         <span aria-hidden className="hero2-noise" />

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -93,7 +93,7 @@ export default function ReviewsPage({
       className="page-shell py-6 space-y-6"
       aria-labelledby="reviews-header"
     >
-      <div className="sticky top-0 hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4">
+      <div className="sticky top-0 hero2-neomorph relative overflow-hidden rounded-card r-card-lg px-6 md:px-7 lg:px-8 py-6">
         <span aria-hidden className="hero2-beams" />
         <span aria-hidden className="hero2-scanlines" />
         <span aria-hidden className="hero2-noise" />
@@ -159,11 +159,7 @@ export default function ReviewsPage({
         />
       </div>
 
-      <div
-        className={cn(
-          "grid grid-cols-1 items-start gap-6 md:grid-cols-12",
-        )}
-      >
+      <div className={cn("grid grid-cols-1 items-start gap-6 md:grid-cols-12")}>
         <nav aria-label="Review list" className="md:col-span-4">
           <div className="card-neo-soft rounded-card r-card-lg overflow-hidden bg-card/50 shadow-neo-strong">
             <div className="section-b">

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -152,9 +152,7 @@ export default function TeamCompPage() {
         label: "Builder",
         hint: "Fill allies vs enemies",
         icon: <Hammer />,
-        render: () => (
-          <Builder ref={builderApi} editing={editing.builder} />
-        ),
+        render: () => <Builder ref={builderApi} editing={editing.builder} />,
         ref: builderRef,
       },
       {
@@ -191,9 +189,7 @@ export default function TeamCompPage() {
           eyebrow={active?.label}
           heading="Comps"
           subtitle={
-            subTab === "sheet"
-              ? "Archetypes & tips"
-              : "Your saved compositions"
+            subTab === "sheet" ? "Archetypes & tips" : "Your saved compositions"
           }
           subTabs={{
             items: subTabs,
@@ -299,8 +295,8 @@ export default function TeamCompPage() {
         }
       >
         <p className="text-sm text-muted-foreground">
-          If you’re on a <em>Medium</em> champ, don’t race farm vs <em>Very Fast</em>.
-          Path for fights, ganks, or cross-map trades.
+          If you’re on a <em>Medium</em> champ, don’t race farm vs{" "}
+          <em>Very Fast</em>. Path for fights, ganks, or cross-map trades.
         </p>
       </Hero>
     );
@@ -323,7 +319,7 @@ export default function TeamCompPage() {
       className="page-shell py-6 space-y-6 md:grid md:grid-cols-12 md:gap-4"
       aria-labelledby="teamcomp-header"
     >
-      <div className="sticky top-0 hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4 md:col-span-12">
+      <div className="sticky top-0 hero2-neomorph relative overflow-hidden rounded-card r-card-lg px-6 md:px-7 lg:px-8 py-6 md:col-span-12">
         <span aria-hidden className="hero2-beams" />
         <span aria-hidden className="hero2-scanlines" />
         <span aria-hidden className="hero2-noise" />

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`ReviewsPage > renders default state 1`] = `
     class="page-shell py-6 space-y-6"
   >
     <div
-      class="sticky top-0 hero2-frame relative overflow-hidden rounded-card r-card-lg px-4 py-4"
+      class="sticky top-0 hero2-neomorph relative overflow-hidden rounded-card r-card-lg px-6 md:px-7 lg:px-8 py-6"
     >
       <span
         aria-hidden="true"


### PR DESCRIPTION
## Summary
- replace `hero2-frame` with `hero2-neomorph` on not found, prompts, team, and reviews pages
- standardize wrapper padding to `px-6 md:px-7 lg:px-8 py-6`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c5412ee92c832ca24429c9bb6fbf87