### PR TITLE
feat: add horned girl icon to home header

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { Suspense } from "react";
 import { Home } from "lucide-react";
 import Link from "next/link";
+import { HornedGirlIcon } from "@/icons";
 import {
   QuickActions,
   TodayCard,
@@ -39,7 +40,12 @@ function HomePageContent() {
               id: "home-header",
               heading: "Welcome to Planner",
               subtitle: "Plan your day, track goals, and review games.",
-              icon: <Home className="opacity-80" />,
+              icon: (
+                <>
+                  <Home className="opacity-80" />
+                  <HornedGirlIcon className="ml-1 h-6 w-6 opacity-80" />
+                </>
+              ),
             }}
             hero={{
               heading: "Your day at a glance",

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -60,7 +60,7 @@ import {
   TimerRing,
   TimerTab,
 } from "@/components/goals";
-import { ProgressRingIcon, TimerRingIcon } from "@/icons";
+import { ProgressRingIcon, TimerRingIcon, HornedGirlIcon } from "@/icons";
 import { Plus } from "lucide-react";
 
 export type View = "components" | "colors" | "onboarding";
@@ -948,6 +948,13 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       element: <CatCompanion />,
       tags: ["cat", "companion"],
       code: `<CatCompanion />`,
+    },
+    {
+      id: "horned-girl-icon",
+      name: "HornedGirlIcon",
+      element: <HornedGirlIcon />,
+      tags: ["icon", "avatar"],
+      code: `<HornedGirlIcon />`,
     },
   ],
 };

--- a/src/icons/HornedGirlIcon.tsx
+++ b/src/icons/HornedGirlIcon.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+export default function HornedGirlIcon(
+  props: React.SVGProps<SVGSVGElement>,
+) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      {...props}
+    >
+      <path d="M9 7V4L7 2" />
+      <path d="M15 7V4l2-2" />
+      <circle cx={12} cy={9} r={3} />
+      <path d="M5 21v-2a7 7 0 0 1 14 0v2" />
+    </svg>
+  );
+}

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -1,2 +1,3 @@
 export { default as TimerRingIcon } from "./TimerRingIcon";
 export { default as ProgressRingIcon } from "./ProgressRingIcon";
+export { default as HornedGirlIcon } from "./HornedGirlIcon";


### PR DESCRIPTION
## Summary
- add HornedGirlIcon svg
- show HornedGirlIcon beside home icon on landing header
- list HornedGirlIcon in prompts gallery

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c5545d89a0832ca41aedba732ebb35