### PR TITLE
refactor: memoize planner provider state

### DIFF
--- a/src/components/planner/plannerStore.ts
+++ b/src/components/planner/plannerStore.ts
@@ -71,15 +71,28 @@ export function PlannerProvider({ children }: { children: React.ReactNode }) {
     Record<ISODate, Selection>
   >("planner:selected", {});
 
+  const daysValue = React.useMemo(
+    () => ({ days, setDays }),
+    [days, setDays],
+  );
+  const focusValue = React.useMemo(
+    () => ({ focus, setFocus }),
+    [focus, setFocus],
+  );
+  const selectionValue = React.useMemo(
+    () => ({ selected, setSelected }),
+    [selected, setSelected],
+  );
+
   return React.createElement(
     DaysContext.Provider,
-    { value: { days, setDays } },
+    { value: daysValue },
     React.createElement(
       FocusContext.Provider,
-      { value: { focus, setFocus } },
+      { value: focusValue },
       React.createElement(
         SelectionContext.Provider,
-        { value: { selected, setSelected } },
+        { value: selectionValue },
         children as React.ReactNode,
       ),
     ),


### PR DESCRIPTION
## Summary
- memoize planner context values for days, focus, and selection

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c5614e2a94832cac8cbf63ff440ee0