### PR TITLE
chore: remove Hero demo from prompts page

### DIFF
--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -30,7 +30,6 @@ import {
   PillarBadge,
   PillarSelector,
   Header,
-  Hero,
   NeomorphicHeroFrame,
   SectionCard as UiSectionCard,
   type HeaderTab,
@@ -153,38 +152,6 @@ function HeaderTabsDemo() {
     <Header
       heading="Header"
       tabs={{ items: tabs, value: tab, onChange: setTab }}
-      sticky={false}
-      topClassName="top-0"
-    />
-  );
-}
-
-function HeroDemo() {
-  const [sub, setSub] = React.useState("one");
-  const [query, setQuery] = React.useState("");
-  const subTabs: HeaderTab<string>[] = [
-    { key: "one", label: "One" },
-    { key: "two", label: "Two" },
-  ];
-  return (
-    <Hero
-      heading="Hero"
-      subTabs={{ items: subTabs, value: sub, onChange: setSub }}
-      search={{
-        id: "hero-demo-search",
-        value: query,
-        onValueChange: setQuery,
-        round: true,
-        "aria-label": "Search",
-      }}
-      actions={
-        <div className="flex items-center gap-2">
-          <Button size="sm">Action</Button>
-          <IconButton size="sm" aria-label="Add">
-            <Plus />
-          </IconButton>
-        </div>
-      }
       sticky={false}
       topClassName="top-0"
     />
@@ -581,14 +548,6 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
   sticky={false}
   topClassName="top-0"
 />`,
-    },
-    {
-      id: "hero-demo",
-      name: "Hero",
-      description: "Hero with sub-tabs, search, and actions",
-      element: <HeroDemo />,
-      tags: ["hero"],
-      code: `<Hero heading="Hero" subTabs={{ items: [{ key: "one", label: "One" }, { key: "two", label: "Two" }], value: "one", onChange: () => {} }} search={{ id: "hero-demo-search", value: "", onValueChange: () => {}, round: true, "aria-label": "Search" }} actions={<div className="flex items-center gap-2"><Button size="sm">Action</Button><IconButton size="sm" aria-label="Add"><Plus /></IconButton></div>} sticky={false} topClassName="top-0" />`,
     },
     {
       id: "neomorphic-hero-frame",


### PR DESCRIPTION
## Summary
- remove Hero component showcase from prompts constants

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c561995558832c8028743be9087953