### PR TITLE
feat: update page header visuals

### DIFF
--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -1,15 +1,19 @@
 import * as React from "react";
 import { PageHeader, Button, ThemeToggle } from "@/components/ui";
-import { Home } from "lucide-react";
 
 export default function PageHeaderDemo() {
   return (
     <PageHeader
-      className="px-6 md:px-7 lg:px-8"
       header={{
         heading: "Welcome to Planner",
         subtitle: "Plan your day, track goals, and review games.",
-        icon: <Home className="opacity-70" />,
+        icon: (
+          <img
+            src="https://chatgpt.com/backend-api/estuary/content?id=file-PYBH1vD28Bzi3KruKxaiXa&ts=488268&p=fs&cid=1&sig=1e357c5433df95c196bb9530996ae68bb6ef1b29fde1a5dc741cdc1fce727ecb&v=0"
+            alt=""
+            className="h-12 w-auto object-contain"
+          />
+        ),
         sticky: false,
         rail: false,
         barClassName: "p-0",

--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -51,6 +51,8 @@ export interface HeaderProps<Key extends string = string>
   tabs?: HeaderTabsProps<Key>;
   /** Optional card-style framing. */
   variant?: "plain" | "neo";
+  /** Show neon underline */
+  underline?: boolean;
 }
 
 export default function Header<Key extends string = string>({
@@ -68,6 +70,7 @@ export default function Header<Key extends string = string>({
   rail = true,
   tabs,
   variant = "plain",
+  underline = true,
   ...rest
 }: HeaderProps<Key>) {
   return (
@@ -81,7 +84,8 @@ export default function Header<Key extends string = string>({
         "overflow-hidden",
 
         // Neon underline
-        "after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent",
+        underline &&
+          "after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent",
 
         className,
       )}

--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -35,15 +35,15 @@ export default function PageHeader({
     <NeomorphicHeroFrame
       {...frameProps}
       className={cn(
-        "rounded-2xl border border-[hsl(var(--border))/0.4] px-6 md:px-7 lg:px-8",
+        "rounded-card r-card-lg border border-border/40 p-6 md:p-7 lg:p-8",
         className,
       )}
     >
       <div className="relative z-[2] space-y-4">
-        <Header {...header} />
+        <Header {...header} underline={header.underline ?? false} />
         <Hero
           {...hero}
-          frame={hero.frame ?? false}
+          frame={hero.frame ?? true}
           topClassName={cn("top-[var(--header-stack)]", hero.topClassName)}
         />
       </div>


### PR DESCRIPTION
## Summary
- remove neon underline from PageHeader header and normalize neomorphic frame styling
- show left-side image in PageHeader demo with responsive sizing

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c56f58eaa8832cbe9c501f4e8d0b40