### PR TITLE
feat: extract neomorphic frame styles

### DIFF
--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -25,6 +25,7 @@ export { default as Header } from "./layout/Header";
 export * from "./layout/Header";
 export { default as Hero } from "./layout/Hero";
 export * from "./layout/Hero";
+export * from "./layout/NeomorphicFrameStyles";
 export { default as NeomorphicHeroFrame } from "./layout/NeomorphicHeroFrame";
 export * from "./layout/NeomorphicHeroFrame";
 export { default as PageHeader } from "./layout/PageHeader";

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -19,6 +19,7 @@ import type { HeaderTabsProps } from "@/components/ui/layout/Header";
 import SearchBar, {
   type SearchBarProps,
 } from "@/components/ui/primitives/SearchBar";
+import { NeomorphicFrameStyles } from "./NeomorphicFrameStyles";
 
 function cx(...p: Array<string | false | null | undefined>) {
   return p.filter(Boolean).join(" ");
@@ -126,6 +127,7 @@ function Hero<Key extends string = string>({
   return (
     <section className={className} {...rest}>
       <HeroGlitchStyles />
+      <NeomorphicFrameStyles />
 
       <div
         className={cx(
@@ -303,129 +305,6 @@ export function HeroSearchBar({
 export function HeroGlitchStyles() {
   return (
     <style jsx global>{`
-      /* === Hero: header background layers ================================ */
-      .hero2-beams {
-        position: absolute;
-        inset: calc(var(--space-1) / -2);
-        border-radius: var(--radius-2xl);
-        z-index: 0;
-        pointer-events: none;
-        background:
-          linear-gradient(
-              100deg,
-              transparent 0%,
-              hsl(var(--primary) / 0.18) 10%,
-              transparent 22%
-            )
-            0 0/100% 100%,
-          linear-gradient(
-              260deg,
-              transparent 0%,
-              hsl(var(--accent) / 0.2) 8%,
-              transparent 20%
-            )
-            0 0/100% 100%;
-        mix-blend-mode: screen;
-        animation: hero2-beam-pan 7s linear infinite;
-      }
-      @media (prefers-reduced-motion: reduce) {
-        .hero2-beams {
-          animation: none;
-        }
-      }
-      @keyframes hero2-beam-pan {
-        0% {
-          transform: translateX(-3%);
-        }
-        50% {
-          transform: translateX(3%);
-        }
-        100% {
-          transform: translateX(-3%);
-        }
-      }
-      .hero2-scanlines {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        pointer-events: none;
-        background:
-          linear-gradient(
-            transparent 94%,
-            hsl(var(--foreground) / 0.5) 96%,
-            transparent 98%
-          ),
-          linear-gradient(
-            90deg,
-            transparent 94%,
-            hsl(var(--foreground) / 0.4) 96%,
-            transparent 98%
-          );
-        background-size:
-          100% calc(var(--space-4) - var(--space-1) / 2),
-          calc(var(--space-4) - var(--space-1) / 2) 100%;
-        opacity: 0.07;
-        animation: hero2-scan-move 6s linear infinite;
-      }
-      @media (prefers-reduced-motion: reduce) {
-        .hero2-scanlines {
-          animation: none;
-        }
-      }
-      @keyframes hero2-scan-move {
-        0% {
-          background-position:
-            0 0,
-            0 0;
-        }
-        100% {
-          background-position:
-            0 calc(var(--space-4) - var(--space-1) / 2),
-            calc(var(--space-4) - var(--space-1) / 2) 0;
-        }
-      }
-      .hero2-noise {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        pointer-events: none;
-        opacity: 0.03;
-        mix-blend-mode: overlay;
-        background-image: url("data:image/svg+xml;utf8,\
-        <svg xmlns='http://www.w3.org/2000/svg' width='140' height='140' viewBox='0 0 140 140'>\
-          <filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/></filter>\
-          <rect width='100%' height='100%' filter='url(%23n)' opacity='0.38'/></svg>");
-        background-size: calc(var(--space-8) * 4 + var(--space-5))
-          calc(var(--space-8) * 4 + var(--space-5));
-        animation: hero2-noise-shift 1.8s steps(2, end) infinite;
-      }
-      @media (prefers-reduced-motion: reduce) {
-        .hero2-noise {
-          animation: none;
-          background-position: 0 0;
-        }
-      }
-      @keyframes hero2-noise-shift {
-        50% {
-          background-position: 50% 50%;
-        }
-      }
-
-      /* === Neomorphic frame ============================================ */
-      .hero2-neomorph {
-        background: linear-gradient(
-          145deg,
-          hsl(var(--card)),
-          hsl(var(--panel))
-        );
-        box-shadow:
-          inset var(--space-1) var(--space-1) var(--space-2)
-            hsl(var(--background) / 0.55),
-          inset calc(-1 * var(--space-1)) calc(-1 * var(--space-1))
-            var(--space-2) hsl(var(--highlight) / 0.05),
-          0 0 var(--space-4) hsl(var(--ring) / 0.25);
-      }
-
       /* === Glitch title ================================================== */
       .hero2-title {
         position: relative;

--- a/src/components/ui/layout/NeomorphicFrameStyles.tsx
+++ b/src/components/ui/layout/NeomorphicFrameStyles.tsx
@@ -1,0 +1,130 @@
+// src/components/ui/layout/NeomorphicFrameStyles.tsx
+"use client";
+
+import * as React from "react";
+
+export function NeomorphicFrameStyles() {
+  return (
+    <style jsx global>{`
+      .hero2-beams {
+        position: absolute;
+        inset: calc(var(--space-1) / -2);
+        border-radius: var(--radius-2xl);
+        z-index: 0;
+        pointer-events: none;
+        background:
+          linear-gradient(
+              100deg,
+              transparent 0%,
+              hsl(var(--primary) / 0.18) 10%,
+              transparent 22%
+            )
+            0 0/100% 100%,
+          linear-gradient(
+              260deg,
+              transparent 0%,
+              hsl(var(--accent) / 0.2) 8%,
+              transparent 20%
+            )
+            0 0/100% 100%;
+        mix-blend-mode: screen;
+        animation: hero2-beam-pan 7s linear infinite;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .hero2-beams {
+          animation: none;
+        }
+      }
+      @keyframes hero2-beam-pan {
+        0% {
+          transform: translateX(-3%);
+        }
+        50% {
+          transform: translateX(3%);
+        }
+        100% {
+          transform: translateX(-3%);
+        }
+      }
+      .hero2-scanlines {
+        position: absolute;
+        inset: 0;
+        z-index: 1;
+        pointer-events: none;
+        background:
+          linear-gradient(
+            transparent 94%,
+            hsl(var(--foreground) / 0.5) 96%,
+            transparent 98%
+          ),
+          linear-gradient(
+            90deg,
+            transparent 94%,
+            hsl(var(--foreground) / 0.4) 96%,
+            transparent 98%
+          );
+        background-size:
+          100% calc(var(--space-4) - var(--space-1) / 2),
+          calc(var(--space-4) - var(--space-1) / 2) 100%;
+        opacity: 0.07;
+        animation: hero2-scan-move 6s linear infinite;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .hero2-scanlines {
+          animation: none;
+        }
+      }
+      @keyframes hero2-scan-move {
+        0% {
+          background-position:
+            0 0,
+            0 0;
+        }
+        100% {
+          background-position:
+            0 calc(var(--space-4) - var(--space-1) / 2),
+            calc(var(--space-4) - var(--space-1) / 2) 0;
+        }
+      }
+      .hero2-noise {
+        position: absolute;
+        inset: 0;
+        z-index: 1;
+        pointer-events: none;
+        opacity: 0.03;
+        mix-blend-mode: overlay;
+        background-image: url("data:image/svg+xml;utf8,\
+        <svg xmlns='http://www.w3.org/2000/svg' width='140' height='140' viewBox='0 0 140 140'>\
+          <filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/></filter>\
+          <rect width='100%' height='100%' filter='url(%23n)' opacity='0.38'/></svg>");
+        background-size: calc(var(--space-8) * 4 + var(--space-5))
+          calc(var(--space-8) * 4 + var(--space-5));
+        animation: hero2-noise-shift 1.8s steps(2, end) infinite;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .hero2-noise {
+          animation: none;
+          background-position: 0 0;
+        }
+      }
+      @keyframes hero2-noise-shift {
+        50% {
+          background-position: 50% 50%;
+        }
+      }
+      .hero2-neomorph {
+        background: linear-gradient(
+          145deg,
+          hsl(var(--card)),
+          hsl(var(--panel))
+        );
+        box-shadow:
+          inset var(--space-1) var(--space-1) var(--space-2)
+            hsl(var(--background) / 0.55),
+          inset calc(-1 * var(--space-1)) calc(-1 * var(--space-1))
+            var(--space-2) hsl(var(--highlight) / 0.05),
+          0 0 var(--space-4) hsl(var(--ring) / 0.25);
+      }
+    `}</style>
+  );
+}

--- a/src/components/ui/layout/NeomorphicHeroFrame.tsx
+++ b/src/components/ui/layout/NeomorphicHeroFrame.tsx
@@ -3,6 +3,7 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
+import { NeomorphicFrameStyles } from "./NeomorphicFrameStyles";
 
 export type NeomorphicHeroFrameProps = React.HTMLAttributes<HTMLDivElement>;
 
@@ -12,18 +13,21 @@ export default function NeomorphicHeroFrame({
   ...rest
 }: NeomorphicHeroFrameProps) {
   return (
-    <div
-      className={cn("relative overflow-hidden hero2-neomorph", className)}
-      {...rest}
-    >
-      <span aria-hidden className="hero2-beams" />
-      <span aria-hidden className="hero2-scanlines" />
-      <span aria-hidden className="hero2-noise opacity-[0.03]" />
-      {children}
+    <>
+      <NeomorphicFrameStyles />
       <div
-        aria-hidden
-        className="absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/55"
-      />
-    </div>
+        className={cn("relative overflow-hidden hero2-neomorph", className)}
+        {...rest}
+      >
+        <span aria-hidden className="hero2-beams" />
+        <span aria-hidden className="hero2-scanlines" />
+        <span aria-hidden className="hero2-noise opacity-[0.03]" />
+        {children}
+        <div
+          aria-hidden
+          className="absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/55"
+        />
+      </div>
+    </>
   );
 }

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -6,81 +6,8 @@ exports[`ReviewsPage > renders default state 1`] = `
     aria-labelledby="reviews-header"
     class="page-shell py-6 space-y-6"
   >
-    <div
-      class="overflow-hidden hero2-neomorph sticky top-0 rounded-card r-card-lg px-4 py-4"
-    >
-      <span
-        aria-hidden="true"
-        class="hero2-beams"
-      />
-      <span
-        aria-hidden="true"
-        class="hero2-scanlines"
-      />
-      <span
-        aria-hidden="true"
-        class="hero2-noise opacity-[0.03]"
-      />
-      <div
-        class="relative z-[2] space-y-2"
-      >
-        <header
-          class="z-[999] relative isolate overflow-hidden after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent"
-          id="reviews-header"
-        >
-          <div
-            class="sticky top-[var(--header-stack)] relative flex items-center px-3 sm:px-4 py-3 sm:py-4 min-h-12"
-          >
-            <div
-              aria-hidden="true"
-              class="header-rail pointer-events-none absolute left-0 top-1 bottom-1 w-2 rounded-l-2xl"
-            />
-            <div
-              class="flex min-w-0 items-center gap-2 sm:gap-3"
-            >
-              <span
-                class="shrink-0 opacity-90"
-              >
-                <svg
-                  class="lucide lucide-book-open opacity-80"
-                  fill="none"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M12 7v14"
-                  />
-                  <path
-                    d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"
-                  />
-                </svg>
-              </span>
-              <div
-                class="min-w-0"
-              >
-                <div
-                  class="flex min-w-0 items-baseline gap-2"
-                >
-                  <h1
-                    class="truncate text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow"
-                  >
-                    Reviews
-                  </h1>
-                </div>
-              </div>
-            </div>
-          </div>
-        </header>
-        <section>
-          <style>
-            
-      /* === Hero: header background layers ================================ */
+    <style>
+      
       .hero2-beams {
         position: absolute;
         inset: calc(var(--space-1) / -2);
@@ -184,8 +111,6 @@ exports[`ReviewsPage > renders default state 1`] = `
           background-position: 50% 50%;
         }
       }
-
-      /* === Neomorphic frame ============================================ */
       .hero2-neomorph {
         background: linear-gradient(
           145deg,
@@ -199,7 +124,82 @@ exports[`ReviewsPage > renders default state 1`] = `
             var(--space-2) hsl(var(--highlight) / 0.05),
           0 0 var(--space-4) hsl(var(--ring) / 0.25);
       }
-
+    
+    </style>
+    <div
+      class="overflow-hidden hero2-neomorph sticky top-0 rounded-card r-card-lg px-4 py-4"
+    >
+      <span
+        aria-hidden="true"
+        class="hero2-beams"
+      />
+      <span
+        aria-hidden="true"
+        class="hero2-scanlines"
+      />
+      <span
+        aria-hidden="true"
+        class="hero2-noise opacity-[0.03]"
+      />
+      <div
+        class="relative z-[2] space-y-2"
+      >
+        <header
+          class="z-[999] relative isolate overflow-hidden after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent"
+          id="reviews-header"
+        >
+          <div
+            class="sticky top-[var(--header-stack)] relative flex items-center px-3 sm:px-4 py-3 sm:py-4 min-h-12"
+          >
+            <div
+              aria-hidden="true"
+              class="header-rail pointer-events-none absolute left-0 top-1 bottom-1 w-2 rounded-l-2xl"
+            />
+            <div
+              class="flex min-w-0 items-center gap-2 sm:gap-3"
+            >
+              <span
+                class="shrink-0 opacity-90"
+              >
+                <svg
+                  class="lucide lucide-book-open opacity-80"
+                  fill="none"
+                  height="24"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 7v14"
+                  />
+                  <path
+                    d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"
+                  />
+                </svg>
+              </span>
+              <div
+                class="min-w-0"
+              >
+                <div
+                  class="flex min-w-0 items-baseline gap-2"
+                >
+                  <h1
+                    class="truncate text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow"
+                  >
+                    Reviews
+                  </h1>
+                </div>
+              </div>
+            </div>
+          </div>
+        </header>
+        <section>
+          <style>
+            
       /* === Glitch title ================================================== */
       .hero2-title {
         position: relative;
@@ -292,6 +292,126 @@ exports[`ReviewsPage > renders default state 1`] = `
           animation: none !important;
           transition: none !important;
         }
+      }
+    
+          </style>
+          <style>
+            
+      .hero2-beams {
+        position: absolute;
+        inset: calc(var(--space-1) / -2);
+        border-radius: var(--radius-2xl);
+        z-index: 0;
+        pointer-events: none;
+        background:
+          linear-gradient(
+              100deg,
+              transparent 0%,
+              hsl(var(--primary) / 0.18) 10%,
+              transparent 22%
+            )
+            0 0/100% 100%,
+          linear-gradient(
+              260deg,
+              transparent 0%,
+              hsl(var(--accent) / 0.2) 8%,
+              transparent 20%
+            )
+            0 0/100% 100%;
+        mix-blend-mode: screen;
+        animation: hero2-beam-pan 7s linear infinite;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .hero2-beams {
+          animation: none;
+        }
+      }
+      @keyframes hero2-beam-pan {
+        0% {
+          transform: translateX(-3%);
+        }
+        50% {
+          transform: translateX(3%);
+        }
+        100% {
+          transform: translateX(-3%);
+        }
+      }
+      .hero2-scanlines {
+        position: absolute;
+        inset: 0;
+        z-index: 1;
+        pointer-events: none;
+        background:
+          linear-gradient(
+            transparent 94%,
+            hsl(var(--foreground) / 0.5) 96%,
+            transparent 98%
+          ),
+          linear-gradient(
+            90deg,
+            transparent 94%,
+            hsl(var(--foreground) / 0.4) 96%,
+            transparent 98%
+          );
+        background-size:
+          100% calc(var(--space-4) - var(--space-1) / 2),
+          calc(var(--space-4) - var(--space-1) / 2) 100%;
+        opacity: 0.07;
+        animation: hero2-scan-move 6s linear infinite;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .hero2-scanlines {
+          animation: none;
+        }
+      }
+      @keyframes hero2-scan-move {
+        0% {
+          background-position:
+            0 0,
+            0 0;
+        }
+        100% {
+          background-position:
+            0 calc(var(--space-4) - var(--space-1) / 2),
+            calc(var(--space-4) - var(--space-1) / 2) 0;
+        }
+      }
+      .hero2-noise {
+        position: absolute;
+        inset: 0;
+        z-index: 1;
+        pointer-events: none;
+        opacity: 0.03;
+        mix-blend-mode: overlay;
+        background-image: url("data:image/svg+xml;utf8,        &lt;svg xmlns='http://www.w3.org/2000/svg' width='140' height='140' viewBox='0 0 140 140'&gt;          &lt;filter id='n'&gt;&lt;feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/&gt;&lt;/filter&gt;          &lt;rect width='100%' height='100%' filter='url(%23n)' opacity='0.38'/&gt;&lt;/svg&gt;");
+        background-size: calc(var(--space-8) * 4 + var(--space-5))
+          calc(var(--space-8) * 4 + var(--space-5));
+        animation: hero2-noise-shift 1.8s steps(2, end) infinite;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .hero2-noise {
+          animation: none;
+          background-position: 0 0;
+        }
+      }
+      @keyframes hero2-noise-shift {
+        50% {
+          background-position: 50% 50%;
+        }
+      }
+      .hero2-neomorph {
+        background: linear-gradient(
+          145deg,
+          hsl(var(--card)),
+          hsl(var(--panel))
+        );
+        box-shadow:
+          inset var(--space-1) var(--space-1) var(--space-2)
+            hsl(var(--background) / 0.55),
+          inset calc(-1 * var(--space-1)) calc(-1 * var(--space-1))
+            var(--space-2) hsl(var(--highlight) / 0.05),
+          0 0 var(--space-4) hsl(var(--ring) / 0.25);
       }
     
           </style>


### PR DESCRIPTION
## Summary
- encapsulate hero frame beams, scanlines, noise and neomorphic gradient in `NeomorphicFrameStyles`
- load `NeomorphicFrameStyles` inside `NeomorphicHeroFrame` and `Hero` so frame styling is self-contained

## Testing
- `npm run regen-ui`
- `npm test -- --run tests/reviews/ReviewsPage.test.tsx -u`
- `npm run check`
- `npm run storybook` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c567d7ed84832c8a2d127bf98cf657