### PR TITLE
Switch lint to flat ESLint configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "extends": [
-    "next/core-web-vitals",
-    "next/typescript"
-  ]
-}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "generate-tokens": "ts-node --esm scripts/generate-tokens.ts",
     "build": "ts-node --esm scripts/regen-if-needed.ts && npm run generate-tokens && next build",
     "start": "next start -p 3000",
-    "lint": "next lint",
+    "lint": "node -r ./scripts/setup-eslint-flat.cjs ./node_modules/eslint/bin/eslint.js src",
     "typecheck": "ts-node --esm scripts/typecheck.ts",
     "test": "vitest",
     "check": "concurrently \"npm test -- --run\" \"npm run lint\" \"npm run typecheck\"",
@@ -68,6 +68,6 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,css,md}": "prettier --write",
-    "*.{js,jsx,ts,tsx}": "next lint --fix --file"
+    "*.{js,jsx,ts,tsx}": "node -r ./scripts/setup-eslint-flat.cjs ./node_modules/eslint/bin/eslint.js --fix"
   }
 }

--- a/scripts/setup-eslint-flat.cjs
+++ b/scripts/setup-eslint-flat.cjs
@@ -1,0 +1,1 @@
+process.env.ESLINT_USE_FLAT_CONFIG = "true";


### PR DESCRIPTION
## Summary
- remove the legacy `.eslintrc.json` so the project relies on the flat config
- add a helper to set `ESLINT_USE_FLAT_CONFIG` and update lint scripts to call `eslint` directly

## Testing
- npm run lint
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c838d27d98832c8aad466b1cc35f88