### PR TITLE
Use official cli-progress typings

### DIFF
--- a/cli-progress.d.ts
+++ b/cli-progress.d.ts
@@ -1,8 +1,0 @@
-declare module "cli-progress" {
-  export class MultiBar {
-    constructor(options?: any, preset?: any);
-    create(total: number, startValue?: number): any;
-    stop(): void;
-  }
-  export const Presets: any;
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@next/eslint-plugin-next": "^15.5.2",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
+        "@types/cli-progress": "^3.11.6",
         "@types/node": "^24.3.1",
         "@types/react": "^18.3.24",
         "@types/react-dom": "^18.3.7",
@@ -1916,6 +1917,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*"
+      }
+    },
+    "node_modules/@types/cli-progress": {
+      "version": "3.11.6",
+      "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.11.6.tgz",
+      "integrity": "sha512-cE3+jb9WRlu+uOSAugewNpITJDt1VF8dHOopPO4IABFc3SXYL5WE/+PTz/FCdZRRfIujiWW3n3aMbv1eIGVRWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/deep-eql": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@next/eslint-plugin-next": "^15.5.2",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
+    "@types/cli-progress": "^3.11.6",
     "@types/node": "^24.3.1",
     "@types/react": "^18.3.24",
     "@types/react-dom": "^18.3.7",


### PR DESCRIPTION
## Summary
- remove the local `cli-progress.d.ts` shim
- install the official `@types/cli-progress` package so TypeScript can use the published declarations

## Testing
- npm run typecheck
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c840d53b4c832c8fd2c2f15dafcd67