### PR TITLE
Enable semantic wrapper for PageHeader

### DIFF
--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -5,8 +5,11 @@ export default function PageHeaderDemo() {
   return (
     <PageHeader
       id="page-header-demo"
+      aria-labelledby="page-header-demo-heading"
       header={{
-        heading: "Welcome to Planner",
+        heading: (
+          <span id="page-header-demo-heading">Welcome to Planner</span>
+        ),
         subtitle: "Plan your day, track goals, and review games.",
         icon: (
           <img

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -627,7 +627,7 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       id: "page-header-demo",
       name: "PageHeader",
       description:
-        "Neomorphic hero header; defaults to a semantic header element and can be remapped with the as prop.",
+        "Neomorphic hero header that defaults to a semantic <header>, forwards standard HTML attributes, and can be remapped with the as prop.",
       element: <PageHeaderDemo />,
       tags: ["hero", "header"],
       code: `<PageHeaderDemo />`,

--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -9,10 +9,13 @@ import NeomorphicHeroFrame, {
 } from "./NeomorphicHeroFrame";
 import { cn } from "@/lib/utils";
 
-type PageHeaderElement = "header" | "section" | "article" | "aside" | "main" | "div" | "nav";
+type PageHeaderElement = Extract<
+  keyof JSX.IntrinsicElements,
+  "header" | "section" | "article" | "aside" | "main" | "div" | "nav"
+>;
 
 export interface PageHeaderProps
-  extends Omit<React.HTMLAttributes<HTMLElement>, "className"> {
+  extends Omit<React.HTMLAttributes<HTMLElement>, "className" | "children"> {
   /** Props forwarded to <Header> */
   header: HeaderProps;
   /** Props forwarded to <Hero> */
@@ -44,25 +47,26 @@ export default function PageHeader({
   const Component = (as ?? "header") as PageHeaderElement;
 
   return (
-    <NeomorphicHeroFrame
-      {...frameProps}
-      className={cn(
-        className ??
-          "rounded-card r-card-lg border border-border/40 p-6 md:p-7 lg:p-8",
-        frameProps?.className,
-      )}
-    >
-      <Component
-        {...elementProps}
-        className={cn("relative z-[2]", contentClassName ?? "space-y-4")}
+    <Component {...(elementProps as React.HTMLAttributes<HTMLElement>)}>
+      <NeomorphicHeroFrame
+        {...frameProps}
+        className={cn(
+          className ??
+            "rounded-card r-card-lg border border-border/40 p-6 md:p-7 lg:p-8",
+          frameProps?.className,
+        )}
       >
-        <Header {...header} underline={header.underline ?? false} />
-        <Hero
-          {...hero}
-          frame={hero.frame ?? true}
-          topClassName={cn("top-[var(--header-stack)]", hero.topClassName)}
-        />
-      </Component>
-    </NeomorphicHeroFrame>
+        <div
+          className={cn("relative z-[2]", contentClassName ?? "space-y-4")}
+        >
+          <Header {...header} underline={header.underline ?? false} />
+          <Hero
+            {...hero}
+            frame={hero.frame ?? true}
+            topClassName={cn("top-[var(--header-stack)]", hero.topClassName)}
+          />
+        </div>
+      </NeomorphicHeroFrame>
+    </Component>
   );
 }

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -6,8 +6,9 @@ exports[`ReviewsPage > renders default state 1`] = `
     aria-labelledby="reviews-header"
     class="page-shell py-6 space-y-6"
   >
-    <style>
-      
+    <header>
+      <style>
+        
       .hero2-beams {
         position: absolute;
         inset: calc(var(--space-1) / -2);
@@ -125,81 +126,81 @@ exports[`ReviewsPage > renders default state 1`] = `
           0 0 var(--space-4) hsl(var(--ring) / 0.25);
       }
     
-    </style>
-    <div
-      class="overflow-hidden hero2-neomorph sticky top-0 rounded-card r-card-lg px-4 py-4"
-    >
-      <span
-        aria-hidden="true"
-        class="hero2-beams"
-      />
-      <span
-        aria-hidden="true"
-        class="hero2-scanlines"
-      />
-      <span
-        aria-hidden="true"
-        class="hero2-noise opacity-[0.03]"
-      />
-      <header
-        class="relative z-[2] space-y-2"
+      </style>
+      <div
+        class="overflow-hidden hero2-neomorph sticky top-0 rounded-card r-card-lg px-4 py-4"
       >
-        <header
-          class="z-[999] relative isolate overflow-hidden after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent"
-          id="reviews-header"
+        <span
+          aria-hidden="true"
+          class="hero2-beams"
+        />
+        <span
+          aria-hidden="true"
+          class="hero2-scanlines"
+        />
+        <span
+          aria-hidden="true"
+          class="hero2-noise opacity-[0.03]"
+        />
+        <div
+          class="relative z-[2] space-y-2"
         >
-          <div
-            class="sticky top-[var(--header-stack)] relative flex items-center px-3 sm:px-4 py-3 sm:py-4 min-h-12"
+          <header
+            class="z-[999] relative isolate overflow-hidden after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent"
+            id="reviews-header"
           >
             <div
-              aria-hidden="true"
-              class="header-rail pointer-events-none absolute left-0 top-1 bottom-1 w-2 rounded-l-2xl"
-            />
-            <div
-              class="flex min-w-0 items-center gap-2 sm:gap-3"
+              class="sticky top-[var(--header-stack)] relative flex items-center px-3 sm:px-4 py-3 sm:py-4 min-h-12"
             >
-              <span
-                class="shrink-0 opacity-90"
-              >
-                <svg
-                  class="lucide lucide-book-open opacity-80"
-                  fill="none"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M12 7v14"
-                  />
-                  <path
-                    d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"
-                  />
-                </svg>
-              </span>
               <div
-                class="min-w-0"
+                aria-hidden="true"
+                class="header-rail pointer-events-none absolute left-0 top-1 bottom-1 w-2 rounded-l-2xl"
+              />
+              <div
+                class="flex min-w-0 items-center gap-2 sm:gap-3"
               >
-                <div
-                  class="flex min-w-0 items-baseline gap-2"
+                <span
+                  class="shrink-0 opacity-90"
                 >
-                  <h1
-                    class="truncate text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow"
+                  <svg
+                    class="lucide lucide-book-open opacity-80"
+                    fill="none"
+                    height="24"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    Reviews
-                  </h1>
+                    <path
+                      d="M12 7v14"
+                    />
+                    <path
+                      d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"
+                    />
+                  </svg>
+                </span>
+                <div
+                  class="min-w-0"
+                >
+                  <div
+                    class="flex min-w-0 items-baseline gap-2"
+                  >
+                    <h1
+                      class="truncate text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow"
+                    >
+                      Reviews
+                    </h1>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        </header>
-        <section>
-          <style>
-            
+          </header>
+          <section>
+            <style>
+              
       /* === Glitch title ================================================== */
       .hero2-title {
         position: relative;
@@ -294,9 +295,9 @@ exports[`ReviewsPage > renders default state 1`] = `
         }
       }
     
-          </style>
-          <style>
-            
+            </style>
+            <style>
+              
       .hero2-beams {
         position: absolute;
         inset: calc(var(--space-1) / -2);
@@ -414,178 +415,178 @@ exports[`ReviewsPage > renders default state 1`] = `
           0 0 var(--space-4) hsl(var(--ring) / 0.25);
       }
     
-          </style>
-          <div
-            class="sticky-blur top-[var(--header-stack)]"
-          >
+            </style>
             <div
-              class="relative z-[2] flex items-center gap-3 md:gap-4 lg:gap-6 py-6"
+              class="sticky-blur top-[var(--header-stack)]"
             >
-              <span
-                aria-hidden="true"
-                class="rail"
-              />
               <div
-                class="min-w-0"
+                class="relative z-[2] flex items-center gap-3 md:gap-4 lg:gap-6 py-6"
               >
+                <span
+                  aria-hidden="true"
+                  class="rail"
+                />
                 <div
-                  class="flex items-baseline gap-2"
+                  class="min-w-0"
                 >
-                  <h2
-                    class="hero2-title title-glow text-2xl md:text-3xl font-semibold tracking-[-0.005em] truncate"
-                    data-text="Browse Reviews"
+                  <div
+                    class="flex items-baseline gap-2"
                   >
-                    Browse Reviews
-                  </h2>
-                  <span
-                    class="text-sm md:text-base font-medium text-[hsl(var(--muted-foreground))] truncate"
-                  >
-                    <span
-                      class="pill"
+                    <h2
+                      class="hero2-title title-glow text-2xl md:text-3xl font-semibold tracking-[-0.005em] truncate"
+                      data-text="Browse Reviews"
                     >
-                      Total 
-                      3
+                      Browse Reviews
+                    </h2>
+                    <span
+                      class="text-sm md:text-base font-medium text-[hsl(var(--muted-foreground))] truncate"
+                    >
+                      <span
+                        class="pill"
+                      >
+                        Total 
+                        3
+                      </span>
                     </span>
-                  </span>
+                  </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="relative z-[2] mt-5 flex flex-col gap-5"
-            >
               <div
-                class="relative"
-                style="--divider: var(--ring);"
+                class="relative z-[2] mt-5 flex flex-col gap-5"
               >
-                <span
-                  aria-hidden="true"
-                  class="block h-px bg-[hsl(var(--divider))/0.35]"
-                />
-                <span
-                  aria-hidden="true"
-                  class="absolute inset-x-0 top-0 h-px blur-[6px] opacity-60 bg-[hsl(var(--divider))]"
-                />
                 <div
-                  class="flex items-center gap-3 md:gap-4 lg:gap-6 pt-4"
+                  class="relative"
+                  style="--divider: var(--ring);"
                 >
-                  <form
-                    class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"
-                    role="search"
-                  >
-                    <div
-                      class="relative min-w-0"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="lucide lucide-search pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 size-4 text-muted-foreground"
-                        fill="none"
-                        height="24"
-                        stroke="currentColor"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <circle
-                          cx="11"
-                          cy="11"
-                          r="8"
-                        />
-                        <path
-                          d="m21 21-4.3-4.3"
-                        />
-                      </svg>
-                      <div
-                        class="relative inline-flex items-center overflow-hidden border border-card-hairline bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),url('/noise.svg')] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] focus-within:after:opacity-100 w-full rounded-full [&>input]:rounded-full"
-                        style="--control-h: var(--control-h-md);"
-                      >
-                        <input
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          class="w-full rounded-[inherit] bg-transparent px-3 text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)] pl-7"
-                          id=":r0:"
-                          name=":r0:"
-                          placeholder="Search title, tags, opponent, patch…"
-                          spellcheck="false"
-                          type="search"
-                          value=""
-                        />
-                      </div>
-                    </div>
-                  </form>
+                  <span
+                    aria-hidden="true"
+                    class="block h-px bg-[hsl(var(--divider))/0.35]"
+                  />
+                  <span
+                    aria-hidden="true"
+                    class="absolute inset-x-0 top-0 h-px blur-[6px] opacity-60 bg-[hsl(var(--divider))]"
+                  />
                   <div
-                    class="flex items-center gap-2"
+                    class="flex items-center gap-3 md:gap-4 lg:gap-6 pt-4"
                   >
-                    <div
-                      class="flex items-center gap-3"
+                    <form
+                      class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"
+                      role="search"
                     >
                       <div
-                        class="hidden sm:flex items-center gap-2 text-xs text-muted-foreground"
+                        class="relative min-w-0"
                       >
-                        <span>
-                          Sort
-                        </span>
-                        <div
-                          class="glitch-wrap "
+                        <svg
+                          aria-hidden="true"
+                          class="lucide lucide-search pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 size-4 text-muted-foreground"
+                          fill="none"
+                          height="24"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          viewBox="0 0 24 24"
+                          width="24"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
+                          <circle
+                            cx="11"
+                            cy="11"
+                            r="8"
+                          />
+                          <path
+                            d="m21 21-4.3-4.3"
+                          />
+                        </svg>
+                        <div
+                          class="relative inline-flex items-center overflow-hidden border border-card-hairline bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),url('/noise.svg')] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] focus-within:after:opacity-100 w-full rounded-full [&>input]:rounded-full"
+                          style="--control-h: var(--control-h-md);"
+                        >
+                          <input
+                            autocapitalize="none"
+                            autocomplete="off"
+                            autocorrect="off"
+                            class="w-full rounded-[inherit] bg-transparent px-3 text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)] pl-7"
+                            id=":r0:"
+                            name=":r0:"
+                            placeholder="Search title, tags, opponent, patch…"
+                            spellcheck="false"
+                            type="search"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                    </form>
+                    <div
+                      class="flex items-center gap-2"
+                    >
+                      <div
+                        class="flex items-center gap-3"
+                      >
+                        <div
+                          class="hidden sm:flex items-center gap-2 text-xs text-muted-foreground"
+                        >
+                          <span>
+                            Sort
+                          </span>
                           <div
-                            class="group inline-flex rounded-full border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0"
+                            class="glitch-wrap "
                           >
-                            <button
-                              aria-controls=":r1:-listbox"
-                              aria-expanded="false"
-                              aria-haspopup="listbox"
-                              aria-label="Select option"
-                              class="glitch-trigger relative flex items-center h-9 rounded-full px-3 overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none h-10 px-4"
-                              data-lit="true"
-                              data-open="false"
-                              type="button"
+                            <div
+                              class="group inline-flex rounded-full border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0"
                             >
-                              <span
-                                class="font-medium glitch-text text-foreground group-hover:text-foreground"
+                              <button
+                                aria-controls=":r1:-listbox"
+                                aria-expanded="false"
+                                aria-haspopup="listbox"
+                                aria-label="Select option"
+                                class="glitch-trigger relative flex items-center h-9 rounded-full px-3 overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none h-10 px-4"
+                                data-lit="true"
+                                data-open="false"
+                                type="button"
                               >
-                                Newest
-                              </span>
-                              <svg
-                                aria-hidden="true"
-                                class="lucide lucide-chevron-down caret ml-auto size-4 shrink-0 opacity-75 "
-                                fill="none"
-                                height="24"
-                                stroke="currentColor"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="2"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="m6 9 6 6 6-6"
+                                <span
+                                  class="font-medium glitch-text text-foreground group-hover:text-foreground"
+                                >
+                                  Newest
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  class="lucide lucide-chevron-down caret ml-auto size-4 shrink-0 opacity-75 "
+                                  fill="none"
+                                  height="24"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  viewBox="0 0 24 24"
+                                  width="24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m6 9 6 6 6-6"
+                                  />
+                                </svg>
+                                <span
+                                  aria-hidden="true"
+                                  class="gb-iris"
                                 />
-                              </svg>
-                              <span
-                                aria-hidden="true"
-                                class="gb-iris"
-                              />
-                              <span
-                                aria-hidden="true"
-                                class="gb-chroma"
-                              />
-                              <span
-                                aria-hidden="true"
-                                class="gb-flicker"
-                              />
-                              <span
-                                aria-hidden="true"
-                                class="gb-scan"
-                              />
-                            </button>
-                          </div>
-                          <style>
-                            
+                                <span
+                                  aria-hidden="true"
+                                  class="gb-chroma"
+                                />
+                                <span
+                                  aria-hidden="true"
+                                  class="gb-flicker"
+                                />
+                                <span
+                                  aria-hidden="true"
+                                  class="gb-scan"
+                                />
+                              </button>
+                            </div>
+                            <style>
+                              
       /* caret jitter */
       .caret {
         transition:
@@ -815,57 +816,58 @@ exports[`ReviewsPage > renders default state 1`] = `
           -0.6px 0 hsl(var(--lav-deep) / 0.45);
       }
     
-                          </style>
+                            </style>
+                          </div>
                         </div>
-                      </div>
-                      <button
-                        class="relative inline-flex items-center justify-center rounded-2xl border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 gap-2 [&_svg]:size-5 px-4 whitespace-nowrap bg-[hsl(var(--accent)/0.12)] border-[hsl(var(--accent)/0.35)] hover:bg-[hsl(var(--accent)/0.14)] hover:shadow-[0_2px_6px_-1px_hsl(var(--accent)/0.25)] active:translate-y-px active:shadow-[inset_0_0_0_1px_hsl(var(--accent)/0.6)] text-foreground"
-                        tabindex="0"
-                        type="button"
-                      >
-                        <span
-                          class="absolute inset-0 pointer-events-none rounded-2xl bg-[linear-gradient(90deg,hsl(var(--foreground)/.18),hsl(var(--foreground)/.18))]"
-                        />
-                        <span
-                          class="relative z-10 inline-flex items-center gap-2"
+                        <button
+                          class="relative inline-flex items-center justify-center rounded-2xl border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 gap-2 [&_svg]:size-5 px-4 whitespace-nowrap bg-[hsl(var(--accent)/0.12)] border-[hsl(var(--accent)/0.35)] hover:bg-[hsl(var(--accent)/0.14)] hover:shadow-[0_2px_6px_-1px_hsl(var(--accent)/0.25)] active:translate-y-px active:shadow-[inset_0_0_0_1px_hsl(var(--accent)/0.6)] text-foreground"
+                          tabindex="0"
+                          type="button"
                         >
-                          <svg
-                            class="lucide lucide-plus"
-                            fill="none"
-                            height="24"
-                            stroke="currentColor"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            viewBox="0 0 24 24"
-                            width="24"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <span
+                            class="absolute inset-0 pointer-events-none rounded-2xl bg-[linear-gradient(90deg,hsl(var(--foreground)/.18),hsl(var(--foreground)/.18))]"
+                          />
+                          <span
+                            class="relative z-10 inline-flex items-center gap-2"
                           >
-                            <path
-                              d="M5 12h14"
-                            />
-                            <path
-                              d="M12 5v14"
-                            />
-                          </svg>
-                          <span>
-                            New Review
+                            <svg
+                              class="lucide lucide-plus"
+                              fill="none"
+                              height="24"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 24 24"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M5 12h14"
+                              />
+                              <path
+                                d="M12 5v14"
+                              />
+                            </svg>
+                            <span>
+                              New Review
+                            </span>
                           </span>
-                        </span>
-                      </button>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-        </section>
-      </header>
-      <div
-        aria-hidden="true"
-        class="absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/55"
-      />
-    </div>
+          </section>
+        </div>
+        <div
+          aria-hidden="true"
+          class="absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/55"
+        />
+      </div>
+    </header>
     <div
       class="grid grid-cols-1 items-start gap-6 md:grid-cols-12"
     >


### PR DESCRIPTION
## Summary
- allow `PageHeader` to render its outer wrapper via the `as` prop while forwarding semantic HTML attributes
- document the behavior in the prompts gallery and demo component

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c841422f1c832c90022ff8e54b0c24