### PR TITLE
feat: add minimal header variant

### DIFF
--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -1,41 +1,98 @@
 import * as React from "react";
-import { PageHeader, Button, ThemeToggle } from "@/components/ui";
+import {
+  PageHeader,
+  Header,
+  Button,
+  ThemeToggle,
+  type HeaderTab,
+} from "@/components/ui";
+
+type MinimalTab = "overview" | "schedule" | "insights";
+
+const minimalTabs: HeaderTab<MinimalTab>[] = [
+  { key: "overview", label: "Overview" },
+  { key: "schedule", label: "Schedule" },
+  { key: "insights", label: "Insights" },
+];
+
+const tabCopy: Record<MinimalTab, string> = {
+  overview: "Track meetings, reviews, and highlights in one streamlined view.",
+  schedule: "Preview your agenda and slot new scrim blocks without leaving the dashboard.",
+  insights: "Surface trends and callouts tailored to your current sprint focus.",
+};
 
 export default function PageHeaderDemo() {
+  const [activeTab, setActiveTab] = React.useState<MinimalTab>("overview");
+
   return (
-    <PageHeader
-      id="page-header-demo"
-      aria-labelledby="page-header-demo-heading"
-      header={{
-        heading: (
-          <span id="page-header-demo-heading">Welcome to Planner</span>
-        ),
-        subtitle: "Plan your day, track goals, and review games.",
-        icon: (
-          <img
-            src="https://chatgpt.com/backend-api/estuary/content?id=file-PYBH1vD28Bzi3KruKxaiXa&ts=488268&p=fs&cid=1&sig=1e357c5433df95c196bb9530996ae68bb6ef1b29fde1a5dc741cdc1fce727ecb&v=0"
-            alt=""
-            className="h-12 w-auto object-contain"
-          />
-        ),
-        sticky: false,
-        rail: false,
-        barClassName: "p-0",
-      }}
-      hero={{
-        heading: "Your day at a glance",
-        actions: (
-          <>
-            <ThemeToggle className="shrink-0" />
-            <Button variant="primary" size="sm" className="px-4 whitespace-nowrap">
-              Plan Week
+    <div className="space-y-6">
+      <Header
+        variant="minimal"
+        eyebrow="Planner"
+        heading="Minimal Header"
+        subtitle="Lean chrome with neon focus"
+        sticky={false}
+        topClassName="top-0"
+        rail={false}
+        right={<ThemeToggle ariaLabel="Toggle theme" className="shrink-0" />}
+        tabs={{
+          items: minimalTabs,
+          value: activeTab,
+          onChange: setActiveTab,
+          ariaLabel: "Switch dashboard view",
+        }}
+      >
+        <div className="flex flex-wrap items-center gap-3">
+          <p className="text-sm text-muted-foreground">{tabCopy[activeTab]}</p>
+          <div className="flex items-center gap-2">
+            <Button size="sm" variant="secondary">
+              Invite teammate
             </Button>
-          </>
-        ),
-        sticky: false,
-        topClassName: "top-0",
-        barClassName: "p-0",
-      }}
-    />
+            <Button size="sm" variant="primary">
+              Create objective
+            </Button>
+          </div>
+        </div>
+      </Header>
+
+      <PageHeader
+        id="page-header-demo"
+        aria-labelledby="page-header-demo-heading"
+        header={{
+          heading: (
+            <span id="page-header-demo-heading">Welcome to Planner</span>
+          ),
+          subtitle: "Plan your day, track goals, and review games.",
+          icon: (
+            <img
+              src="https://chatgpt.com/backend-api/estuary/content?id=file-PYBH1vD28Bzi3KruKxaiXa&ts=488268&p=fs&cid=1&sig=1e357c5433df95c196bb9530996ae68bb6ef1b29fde1a5dc741cdc1fce727ecb&v=0"
+              alt=""
+              className="h-12 w-auto object-contain"
+            />
+          ),
+          sticky: false,
+          rail: false,
+          barClassName: "p-0",
+        }}
+        hero={{
+          heading: "Your day at a glance",
+          actions: (
+            <>
+              <ThemeToggle className="shrink-0" />
+              <Button
+                variant="primary"
+                size="sm"
+                className="px-4 whitespace-nowrap"
+              >
+                Plan Week
+              </Button>
+            </>
+          ),
+          sticky: false,
+          topClassName: "top-0",
+          barClassName: "p-0",
+        }}
+      />
+    </div>
   );
 }

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -146,7 +146,7 @@ exports[`ReviewsPage > renders default state 1`] = `
           class="relative z-[2] space-y-2"
         >
           <header
-            class="z-[999] relative isolate overflow-hidden after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent"
+            class="z-[999] relative isolate after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent"
             id="reviews-header"
           >
             <div


### PR DESCRIPTION
## Summary
- add a minimal header variant without the neo frame while preserving the neon underline
- allow header tabs and the right action slot to coexist so controls like ThemeToggle render beside segmented tabs
- showcase the minimal header style alongside the existing page header demo in the prompts gallery

## Testing
- npm run regen-ui
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c84ad216d4832c9c281f5f16060ac6