### PR TITLE
Default CheckCircle to small size

### DIFF
--- a/src/components/prompts/PromptsDemos.tsx
+++ b/src/components/prompts/PromptsDemos.tsx
@@ -165,7 +165,7 @@ export default function PromptsDemos() {
         <div className="flex flex-wrap items-center gap-4">
           <AnimationToggle />
           <ThemeToggle />
-          <CheckCircle checked={false} onChange={() => {}} />
+          <CheckCircle checked={false} onChange={() => {}} size="md" />
           <Toggle value="Left" onChange={() => {}} />
           <SideSelector value="Blue" onChange={() => {}} />
         </div>

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -769,13 +769,13 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       name: "CheckCircle",
       element: (
         <div className="flex gap-4">
-          <CheckCircle checked={false} onChange={() => {}} />
-          <CheckCircle checked onChange={() => {}} />
+          <CheckCircle checked={false} onChange={() => {}} size="md" />
+          <CheckCircle checked onChange={() => {}} size="md" />
         </div>
       ),
       tags: ["checkbox", "toggle"],
-      code: `<CheckCircle checked={false} onChange={() => {}} />
-<CheckCircle checked onChange={() => {}} />`,
+      code: `<CheckCircle checked={false} onChange={() => {}} size="md" />
+<CheckCircle checked onChange={() => {}} size="md" />`,
     },
   ],
   league: [

--- a/src/components/ui/toggles/CheckCircle.tsx
+++ b/src/components/ui/toggles/CheckCircle.tsx
@@ -31,7 +31,7 @@ const SIZE: Record<Size, string> = {
 export default function CheckCircle({
   checked,
   onChange = () => {},
-  size = "md",
+  size = "sm",
   className,
   disabled = false,
   "aria-label": ariaLabel = "Toggle",


### PR DESCRIPTION
## Summary
- default the CheckCircle component to the small size token
- update prompts demos and component listings to explicitly request the medium size where required

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c84fd9c270832c9ad0c1888259413e