### PR TITLE
Add hero sub-tabs and pill search support

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from "next";
 import PromptsPage from "./PromptsPage";
 
+export { default as PageHeaderDemo } from "@/components/prompts/PageHeaderDemo";
+
 export const metadata: Metadata = {
   title: "Component Gallery",
-  description: "Browse and explore UI components like NeoCard.",
+  description:
+    "Browse and explore UI components like NeoCard and the PageHeader hero variant.",
 };
 
 export default function PromptsRoute() {

--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import {
   PageHeader,
   Header,
+  Hero,
   Button,
   ThemeToggle,
   type HeaderTab,
@@ -9,20 +10,39 @@ import {
 
 type MinimalTab = "overview" | "schedule" | "insights";
 
+type HeroFilter = "all" | "flagged" | "reviewed";
+
 const minimalTabs: HeaderTab<MinimalTab>[] = [
   { key: "overview", label: "Overview" },
   { key: "schedule", label: "Schedule" },
   { key: "insights", label: "Insights" },
 ];
 
+const heroFilters: HeaderTab<HeroFilter>[] = [
+  { key: "all", label: "All" },
+  { key: "flagged", label: "Flagged" },
+  { key: "reviewed", label: "Reviewed" },
+];
+
 const tabCopy: Record<MinimalTab, string> = {
   overview: "Track meetings, reviews, and highlights in one streamlined view.",
-  schedule: "Preview your agenda and slot new scrim blocks without leaving the dashboard.",
+  schedule:
+    "Preview your agenda and slot new scrim blocks without leaving the dashboard.",
   insights: "Surface trends and callouts tailored to your current sprint focus.",
+};
+
+const heroFilterCopy: Record<HeroFilter, string> = {
+  all: "Monitor every scrim log and draft update with real-time filters.",
+  flagged:
+    "Follow up on clips that analysts flagged for fast review and follow-through.",
+  reviewed:
+    "Archive of plays already reviewed—perfect for pattern spotting and sharing.",
 };
 
 export default function PageHeaderDemo() {
   const [activeTab, setActiveTab] = React.useState<MinimalTab>("overview");
+  const [activeFilter, setActiveFilter] = React.useState<HeroFilter>("all");
+  const [query, setQuery] = React.useState("");
 
   return (
     <div className="space-y-6">
@@ -55,9 +75,62 @@ export default function PageHeaderDemo() {
         </div>
       </Header>
 
+      <Hero
+        as="header"
+        eyebrow="Scouting Hub"
+        heading="Draft Intel"
+        subtitle="Live scrim insights"
+        sticky={false}
+        topClassName="top-0"
+        subTabs={{
+          items: heroFilters,
+          value: activeFilter,
+          onChange: (key) => setActiveFilter(key as HeroFilter),
+          ariaLabel: "Filter scouting intel",
+        }}
+        search={{
+          id: "hero-demo-search",
+          value: query,
+          onValueChange: setQuery,
+          debounceMs: 150,
+          placeholder: "Search champions, comps, or notes…",
+          "aria-label": "Search scouting intel",
+        }}
+        actions={
+          <div className="flex items-center gap-2">
+            <ThemeToggle ariaLabel="Toggle theme" className="shrink-0" />
+            <Button
+              size="sm"
+              variant="primary"
+              className="px-4 whitespace-nowrap"
+            >
+              New report
+            </Button>
+          </div>
+        }
+      >
+        <p className="text-sm text-muted-foreground">
+          {heroFilterCopy[activeFilter]}
+        </p>
+      </Hero>
+
       <PageHeader
         id="page-header-demo"
         aria-labelledby="page-header-demo-heading"
+        subTabs={{
+          items: heroFilters,
+          value: activeFilter,
+          onChange: (key) => setActiveFilter(key as HeroFilter),
+          ariaLabel: "Filter planner highlights",
+        }}
+        search={{
+          id: "page-header-demo-search",
+          value: query,
+          onValueChange: setQuery,
+          debounceMs: 200,
+          placeholder: "Search upcoming scrims…",
+          "aria-label": "Search planner highlights",
+        }}
         header={{
           heading: (
             <span id="page-header-demo-heading">Welcome to Planner</span>
@@ -75,10 +148,17 @@ export default function PageHeaderDemo() {
           barClassName: "p-0",
         }}
         hero={{
+          eyebrow: "Daily briefing",
           heading: "Your day at a glance",
+          subtitle: "Stay synced with the squad",
+          children: (
+            <p className="text-sm text-muted-foreground">
+              {heroFilterCopy[activeFilter]}
+            </p>
+          ),
           actions: (
             <>
-              <ThemeToggle className="shrink-0" />
+              <ThemeToggle ariaLabel="Toggle theme" className="shrink-0" />
               <Button
                 variant="primary"
                 size="sm"

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -25,6 +25,11 @@ function cx(...p: Array<string | false | null | undefined>) {
   return p.filter(Boolean).join(" ");
 }
 
+type HeroElement = Extract<
+  keyof JSX.IntrinsicElements,
+  "header" | "section" | "article" | "aside" | "div" | "main" | "nav"
+>;
+
 export interface HeroProps<Key extends string = string>
   extends Omit<React.HTMLAttributes<HTMLElement>, "title"> {
   eyebrow?: React.ReactNode;
@@ -44,6 +49,9 @@ export interface HeroProps<Key extends string = string>
 
   /** Divider tint for neon line. */
   dividerTint?: "primary" | "life";
+
+  /** Semantic wrapper element (defaults to `section`). */
+  as?: HeroElement;
 
   /** Built-in top-right sub-tabs (preferred). */
   subTabs?: HeaderTabsProps<Key> & {
@@ -87,12 +95,15 @@ function Hero<Key extends string = string>({
   tabs,
   search,
   className,
+  as,
   ...rest
 }: HeroProps<Key>) {
   const headingStr = typeof heading === "string" ? heading : undefined;
   const dividerStyle = {
     "--divider": dividerTint === "life" ? "var(--accent)" : "var(--ring)",
   } as React.CSSProperties;
+
+  const Component = (as ?? "section") as HeroElement;
 
   // Compose right area: prefer built-in sub-tabs if provided.
   const subTabsNode = subTabs ? (
@@ -124,8 +135,16 @@ function Hero<Key extends string = string>({
     />
   ) : null;
 
+  const searchProps =
+    search != null
+      ? {
+          ...search,
+          round: search.round ?? true,
+        }
+      : search;
+
   return (
-    <section className={className} {...rest}>
+    <Component className={className} {...(rest as React.HTMLAttributes<HTMLElement>)}>
       <HeroGlitchStyles />
       <NeomorphicFrameStyles />
 
@@ -184,12 +203,12 @@ function Hero<Key extends string = string>({
           {subTabsNode ? <div className="ml-auto">{subTabsNode}</div> : null}
         </div>
 
-        {children || search || actions ? (
-          <div className="relative z-[2] mt-5 flex flex-col gap-5">
+        {children || searchProps || actions ? (
+          <div className="relative z-[2] mt-5 md:mt-6 flex flex-col gap-5 md:gap-6">
             {children ? (
               <div className={cx(bodyClassName)}>{children}</div>
             ) : null}
-            {search || actions ? (
+            {searchProps || actions ? (
               <div className="relative" style={dividerStyle}>
                 <span
                   aria-hidden
@@ -199,8 +218,8 @@ function Hero<Key extends string = string>({
                   aria-hidden
                   className="absolute inset-x-0 top-0 h-px blur-[6px] opacity-60 bg-[hsl(var(--divider))]"
                 />
-                <div className="flex items-center gap-3 md:gap-4 lg:gap-6 pt-4">
-                  {search ? <HeroSearchBar {...search} /> : null}
+                <div className="flex items-center gap-3 md:gap-4 lg:gap-6 pt-5 md:pt-6">
+                  {searchProps ? <HeroSearchBar {...searchProps} /> : null}
                   {actions ? (
                     <div className="flex items-center gap-2">{actions}</div>
                   ) : null}
@@ -217,7 +236,7 @@ function Hero<Key extends string = string>({
           />
         ) : null}
       </div>
-    </section>
+    </Component>
   );
 }
 

--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -14,12 +14,15 @@ type PageHeaderElement = Extract<
   "header" | "section" | "article" | "aside" | "main" | "div" | "nav"
 >;
 
-export interface PageHeaderProps
+export interface PageHeaderProps<
+  HeaderKey extends string = string,
+  HeroKey extends string = string,
+>
   extends Omit<React.HTMLAttributes<HTMLElement>, "className" | "children"> {
   /** Props forwarded to <Header> */
-  header: HeaderProps;
+  header: HeaderProps<HeaderKey>;
   /** Props forwarded to <Hero> */
-  hero: HeroProps;
+  hero: HeroProps<HeroKey>;
   /** Optional className for the outer frame */
   className?: string;
   /** Additional props for the outer frame */
@@ -28,6 +31,10 @@ export interface PageHeaderProps
   contentClassName?: string;
   /** Semantic element for the header container */
   as?: PageHeaderElement;
+  /** Optional hero sub-tabs override */
+  subTabs?: HeroProps<HeroKey>["subTabs"];
+  /** Optional hero search override */
+  search?: HeroProps<HeroKey>["search"];
 }
 
 /**
@@ -35,16 +42,42 @@ export interface PageHeaderProps
  *
  * Used for top-of-page introductions with optional actions.
  */
-export default function PageHeader({
+export default function PageHeader<
+  HeaderKey extends string = string,
+  HeroKey extends string = string,
+>({
   header,
   hero,
   className,
   frameProps,
   contentClassName,
   as,
+  subTabs,
+  search,
   ...elementProps
-}: PageHeaderProps) {
+}: PageHeaderProps<HeaderKey, HeroKey>) {
   const Component = (as ?? "header") as PageHeaderElement;
+
+  const {
+    subTabs: heroSubTabs,
+    search: heroSearch,
+    frame: heroFrame,
+    topClassName: heroTopClassName,
+    as: heroAs,
+    ...heroRest
+  } = hero;
+
+  const resolvedSubTabs =
+    heroSubTabs !== undefined ? heroSubTabs : subTabs;
+
+  const searchSource =
+    heroSearch !== undefined ? heroSearch : search;
+  const resolvedSearch =
+    searchSource === undefined
+      ? undefined
+      : searchSource === null
+        ? null
+        : { ...searchSource, round: searchSource.round ?? true };
 
   return (
     <Component {...(elementProps as React.HTMLAttributes<HTMLElement>)}>
@@ -57,13 +90,19 @@ export default function PageHeader({
         )}
       >
         <div
-          className={cn("relative z-[2]", contentClassName ?? "space-y-4")}
+          className={cn(
+            "relative z-[2]",
+            contentClassName ?? "space-y-5 md:space-y-6",
+          )}
         >
           <Header {...header} underline={header.underline ?? false} />
           <Hero
-            {...hero}
-            frame={hero.frame ?? true}
-            topClassName={cn("top-[var(--header-stack)]", hero.topClassName)}
+            {...heroRest}
+            as={heroAs ?? "header"}
+            frame={heroFrame ?? true}
+            topClassName={cn("top-[var(--header-stack)]", heroTopClassName)}
+            subTabs={resolvedSubTabs}
+            search={resolvedSearch}
           />
         </div>
       </NeomorphicHeroFrame>

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -198,7 +198,7 @@ exports[`ReviewsPage > renders default state 1`] = `
               </div>
             </div>
           </header>
-          <section>
+          <header>
             <style>
               
       /* === Glitch title ================================================== */
@@ -452,7 +452,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                 </div>
               </div>
               <div
-                class="relative z-[2] mt-5 flex flex-col gap-5"
+                class="relative z-[2] mt-5 md:mt-6 flex flex-col gap-5 md:gap-6"
               >
                 <div
                   class="relative"
@@ -467,7 +467,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                     class="absolute inset-x-0 top-0 h-px blur-[6px] opacity-60 bg-[hsl(var(--divider))]"
                   />
                   <div
-                    class="flex items-center gap-3 md:gap-4 lg:gap-6 pt-4"
+                    class="flex items-center gap-3 md:gap-4 lg:gap-6 pt-5 md:pt-6"
                   >
                     <form
                       class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"
@@ -860,7 +860,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                 </div>
               </div>
             </div>
-          </section>
+          </header>
         </div>
         <div
           aria-hidden="true"


### PR DESCRIPTION
## Summary
- allow `Hero` to render as a semantic `<header>`, apply 5/6 vertical rhythm, and default the built-in search to a pill
- let `PageHeader` forward top-level `subTabs`/`search` overrides and ensure the hero uses a header wrapper
- showcase the standalone hero in `PageHeaderDemo`, expose it on the prompts page, and refresh the affected review snapshot

## Testing
- npm run regen-ui
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c852d5f3c4832c995cc17f005aba23