### PR TITLE
Fix prompts page exports for Next.js compliance

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from "next";
 import PromptsPage from "./PromptsPage";
 
-export { default as PageHeaderDemo } from "@/components/prompts/PageHeaderDemo";
-
 export const metadata: Metadata = {
   title: "Component Gallery",
   description:


### PR DESCRIPTION
## Summary
- remove the extra PageHeaderDemo re-export from the prompts page so the file only exposes valid Next.js fields

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c86170b040832ca1987f15c4466b27