### PR TITLE
Refine reminders and timer headers

### DIFF
--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -292,50 +292,50 @@ export default function RemindersTab() {
   }));
 
   return (
-    <SectionCard className="goal-card">
-      <SectionCard.Header>
-        {/* Hero with domain sub-tabs and bottom search */}
-        <Hero
-          eyebrow={domain}
-          heading="Reminders"
-          subtitle="Tiny brain pings you’ll totally ignore until 23:59."
-          dividerTint={domain === "Life" ? "life" : "primary"}
-          subTabs={{
-            items: DOMAIN_ITEMS,
-            value: domain,
-            onChange: (k: Domain) => setDomain(k),
-            align: "end",
-            size: "md",
-            ariaLabel: "Reminder domain",
-            showBaseline: true,
-          }}
-          search={{
-            value: query,
-            onValueChange: setQuery,
-            placeholder: "Search title, text, tags…",
-            debounceMs: 80,
-            right: (
-              <div className="flex items-center gap-2">
-                <span className="text-label font-medium tracking-[0.02em] opacity-75">{filtered.length}</span>
-                <Search className="opacity-80" size={16} />
-              </div>
-            ),
-          }}
-          actions={
-            <Button
-              variant="primary"
-              size="md"
-              className="px-4 whitespace-nowrap"
-              onClick={() => addNew()}
-            >
-              <Plus />
-              <span>New Reminder</span>
-            </Button>
-          }
-        />
-      </SectionCard.Header>
+    <>
+      <Hero
+        frame={false}
+        topClassName="top-[var(--header-stack)]"
+        eyebrow={domain}
+        heading="Reminders"
+        subtitle="Tiny brain pings you’ll totally ignore until 23:59."
+        dividerTint={domain === "Life" ? "life" : "primary"}
+        subTabs={{
+          items: DOMAIN_ITEMS,
+          value: domain,
+          onChange: (k: Domain) => setDomain(k),
+          align: "end",
+          size: "md",
+          ariaLabel: "Reminder domain",
+          showBaseline: true,
+        }}
+        search={{
+          value: query,
+          onValueChange: setQuery,
+          placeholder: "Search title, text, tags…",
+          debounceMs: 80,
+          right: (
+            <div className="flex items-center gap-2">
+              <span className="text-label font-medium tracking-[0.02em] opacity-75">{filtered.length}</span>
+              <Search className="opacity-80" size={16} />
+            </div>
+          ),
+        }}
+        actions={
+          <Button
+            variant="primary"
+            size="md"
+            className="px-4 whitespace-nowrap"
+            onClick={() => addNew()}
+          >
+            <Plus />
+            <span>New Reminder</span>
+          </Button>
+        }
+      />
 
-      <SectionCard.Body>
+      <SectionCard className="goal-card">
+        <SectionCard.Body>
           <div className="grid gap-3">
             {/* Quick Add row — now INSIDE the same panel as the cards */}
             <form
@@ -440,55 +440,56 @@ export default function RemindersTab() {
             {filtered.length === 0 && <EmptyState />}
           </div>
         </SectionCard.Body>
-
-        {/* Local styles: keep neon-note flicker; divider is handled by Hero */}
-        <style jsx>{`
-          .neon-primary {
-            --neon: var(--primary);
-          }
-          .neon-life {
-            --neon: var(--accent);
-          }
-
-          .neon-note {
-            margin-top: calc(var(--space-1) * -1.5);
-            padding-left: calc(var(--space-1) / 2);
-            animation: neon-flicker 4s infinite;
-          }
-
-          @keyframes neon-flicker {
-            0%,
-            17%,
-            22%,
-            26%,
-            52%,
-            100% {
-              opacity: 1;
-            }
-            18% {
-              opacity: 0.72;
-            }
-            24% {
-              opacity: 0.55;
-            }
-            54% {
-              opacity: 0.78;
-            }
-            70% {
-              opacity: 0.62;
-            }
-            74% {
-              opacity: 1;
-            }
-          }
-
-          @media (prefers-reduced-motion: reduce) {
-            .neon-note {
-              animation: none;
-            }
-          }
-        `}</style>
       </SectionCard>
+
+      {/* Local styles: keep neon-note flicker; divider is handled by Hero */}
+      <style jsx>{`
+        .neon-primary {
+          --neon: var(--primary);
+        }
+        .neon-life {
+          --neon: var(--accent);
+        }
+
+        .neon-note {
+          margin-top: calc(var(--space-1) * -1.5);
+          padding-left: calc(var(--space-1) / 2);
+          animation: neon-flicker 4s infinite;
+        }
+
+        @keyframes neon-flicker {
+          0%,
+          17%,
+          22%,
+          26%,
+          52%,
+          100% {
+            opacity: 1;
+          }
+          18% {
+            opacity: 0.72;
+          }
+          24% {
+            opacity: 0.55;
+          }
+          54% {
+            opacity: 0.78;
+          }
+          70% {
+            opacity: 0.62;
+          }
+          74% {
+            opacity: 1;
+          }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .neon-note {
+            animation: none;
+          }
+        }
+      `}</style>
+    </>
   );
 }
 

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -253,27 +253,28 @@ export default function TimerTab() {
   }, []);
 
   return (
-    <SectionCard className="goal-card no-hover">
-      <SectionCard.Header>
-        <Hero
-          eyebrow="Focus"
-          heading="Timer"
-          subtitle="Pick a duration and focus."
-          subTabs={{
-            items: tabItems,
-            value: profile,
-            onChange: (k: string) => setProfile(k as ProfileKey),
-            size: "md",
-            align: "between",
-            ariaLabel: "Timer profiles",
-            right: rightSlot,
-            showBaseline: true,
-            className: "overflow-x-auto",
-          }}
-        />
-      </SectionCard.Header>
+    <>
+      <Hero
+        frame={false}
+        topClassName="top-[var(--header-stack)]"
+        eyebrow="Focus"
+        heading="Timer"
+        subtitle="Pick a duration and focus."
+        subTabs={{
+          items: tabItems,
+          value: profile,
+          onChange: (k: string) => setProfile(k as ProfileKey),
+          size: "md",
+          align: "between",
+          ariaLabel: "Timer profiles",
+          right: rightSlot,
+          showBaseline: true,
+          className: "overflow-x-auto",
+        }}
+      />
 
-      <SectionCard.Body>
+      <SectionCard className="goal-card no-hover">
+        <SectionCard.Body>
           <div className="relative mx-auto w-full max-w-sm rounded-2xl border border-card-hairline/60 bg-background/30 p-[var(--space-8)] backdrop-blur-xl shadow-card">
             {/* plus/minus */}
             <IconButton
@@ -378,5 +379,6 @@ export default function TimerTab() {
           </div>
         </SectionCard.Body>
       </SectionCard>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- move the Reminders hero out of the card header and render it as a page-level hero without the neon frame
- do the same for the Timer tab so its controls sit under a frame-free page hero

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c86283fb3c832c9bf1137bb7e3ca59