### PR TITLE
Add compact header navigation layout

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -4,7 +4,7 @@ import PromptsPage from "./PromptsPage";
 export const metadata: Metadata = {
   title: "Component Gallery",
   description:
-    "Browse and explore UI components like NeoCard and the PageHeader hero variant.",
+    "Browse and explore UI components like NeoCard, the PageHeader hero variant, and the compact header navigation demo.",
 };
 
 export default function PromptsRoute() {

--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -5,8 +5,24 @@ import {
   Hero,
   Button,
   ThemeToggle,
+  IconButton,
   type HeaderTab,
 } from "@/components/ui";
+import { Bell, CircleUser } from "lucide-react";
+
+type CompactNav = "summary" | "timeline" | "reports";
+
+const compactNavItems: Array<{ key: CompactNav; label: string }> = [
+  { key: "summary", label: "Summary" },
+  { key: "timeline", label: "Timeline" },
+  { key: "reports", label: "Reports" },
+];
+
+const compactNavCopy: Record<CompactNav, string> = {
+  summary: "Monitor your squad's prep work and alignment at a glance.",
+  timeline: "Track scrims and reviews across the day with zero context loss.",
+  reports: "Spin up shareable insights from the latest competitive sessions.",
+};
 
 type MinimalTab = "overview" | "schedule" | "insights";
 
@@ -40,12 +56,95 @@ const heroFilterCopy: Record<HeroFilter, string> = {
 };
 
 export default function PageHeaderDemo() {
+  const [activePrimaryNav, setActivePrimaryNav] =
+    React.useState<CompactNav>("summary");
+  const [profileOpen, setProfileOpen] = React.useState(false);
   const [activeTab, setActiveTab] = React.useState<MinimalTab>("overview");
   const [activeFilter, setActiveFilter] = React.useState<HeroFilter>("all");
   const [query, setQuery] = React.useState("");
 
+  const primaryNav = (
+    <nav aria-label="Planner views" className="w-full">
+      <ul className="flex items-center gap-1 list-none">
+        {compactNavItems.map((item) => {
+          const isActive = activePrimaryNav === item.key;
+          return (
+            <li key={item.key}>
+              <button
+                type="button"
+                onClick={() => setActivePrimaryNav(item.key)}
+                data-state={isActive ? "active" : "inactive"}
+                aria-pressed={isActive}
+                className="inline-flex items-center rounded-full border border-transparent px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.08em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=inactive]:hover:bg-[--hover] data-[state=inactive]:hover:text-foreground data-[state=active]:bg-[hsl(var(--card)/0.85)] data-[state=active]:text-foreground data-[state=active]:shadow-[0_0_0_1px_hsl(var(--ring)/0.35)]"
+              >
+                {item.label}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+
+  const utilityControls = (
+    <>
+      <ThemeToggle ariaLabel="Toggle theme" className="shrink-0" />
+      <IconButton
+        size="sm"
+        aria-label="Show notifications"
+        aria-pressed
+        className="text-muted-foreground data-[state=active]:text-foreground"
+        data-state="active"
+      >
+        <Bell className="h-4 w-4" />
+      </IconButton>
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={profileOpen}
+        onClick={() => setProfileOpen((prev) => !prev)}
+        onBlur={() => setProfileOpen(false)}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            setProfileOpen(false);
+            event.currentTarget.blur();
+          }
+        }}
+        data-state={profileOpen ? "open" : "inactive"}
+        className="inline-flex items-center gap-2 rounded-full border border-transparent bg-[hsl(var(--card)/0.55)] px-3 py-1.5 text-sm font-medium transition-colors hover:bg-[--hover] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=open]:bg-[hsl(var(--card)/0.85)]"
+      >
+        <CircleUser className="h-4 w-4" />
+        <span className="hidden sm:inline">Profile</span>
+      </button>
+    </>
+  );
+
   return (
     <div className="space-y-6">
+      <Header
+        eyebrow="Planner"
+        heading="Compact Header"
+        subtitle="Navigation & utilities"
+        compact
+        sticky={false}
+        topClassName="top-0"
+        nav={primaryNav}
+        utilities={utilityControls}
+        right={
+          <Button
+            size="sm"
+            variant="primary"
+            className="whitespace-nowrap"
+          >
+            Start session
+          </Button>
+        }
+      >
+        <p className="text-sm text-muted-foreground">
+          {compactNavCopy[activePrimaryNav]}
+        </p>
+      </Header>
+
       <Header
         variant="minimal"
         eyebrow="Planner"

--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -42,8 +42,12 @@ export interface HeaderProps<Key extends string = string>
   heading: React.ReactNode;
   subtitle?: React.ReactNode;
   icon?: React.ReactNode;
+  /** Primary navigation rendered to the left of tabs. */
+  nav?: React.ReactNode;
   /** Right slot for actions (renders alongside tabs). */
   right?: React.ReactNode;
+  /** Utility controls rendered at the far right (e.g., theme toggle, profile). */
+  utilities?: React.ReactNode;
   children?: React.ReactNode;
   /** Still overridable, but true by default */
   sticky?: boolean;
@@ -52,6 +56,8 @@ export interface HeaderProps<Key extends string = string>
   barClassName?: string;
   bodyClassName?: string;
   rail?: boolean;
+  /** Reduce vertical padding and height, ideal for denser layouts. */
+  compact?: boolean;
   /** Built-in top-right segmented tabs (preferred). */
   tabs?: HeaderTabsProps<Key>;
   /** Optional card-style framing. */
@@ -65,7 +71,9 @@ export default function Header<Key extends string = string>({
   heading,
   subtitle,
   icon,
+  nav,
   right,
+  utilities,
   children,
   sticky = true,
   topClassName = "top-[var(--header-stack)]", // sync with --header-stack token
@@ -73,6 +81,7 @@ export default function Header<Key extends string = string>({
   barClassName,
   bodyClassName,
   rail = true,
+  compact = false,
   tabs,
   variant = "plain",
   underline = true,
@@ -110,6 +119,20 @@ export default function Header<Key extends string = string>({
 
   const hasTabs = Boolean(tabControl);
   const hasRight = right != null;
+  const hasUtilities = utilities != null;
+  const hasNav = nav != null;
+  const showRightStack = hasTabs || hasRight || hasUtilities;
+
+  const barPadding = compact
+    ? isMinimal
+      ? "px-4 py-[var(--space-3)]"
+      : "px-3 sm:px-4 py-[var(--space-3)]"
+    : isMinimal
+      ? "px-4 py-4"
+      : "px-3 sm:px-4 py-3 sm:py-4";
+  const minHeightClass = compact
+    ? "min-h-[var(--control-h-sm)]"
+    : "min-h-12";
 
   return (
     <header
@@ -131,9 +154,10 @@ export default function Header<Key extends string = string>({
       <div
         className={cx(
           sticky && cx("sticky", topClassName),
-          "relative flex items-center",
-          isMinimal ? "px-4 py-4" : "px-3 sm:px-4 py-3 sm:py-4",
-          "min-h-12",
+          "relative flex items-center gap-3 sm:gap-4",
+          barPadding,
+          minHeightClass,
+          hasNav && "flex-wrap gap-y-2 sm:flex-nowrap",
           barClassName,
         )}
       >
@@ -145,33 +169,63 @@ export default function Header<Key extends string = string>({
         ) : null}
 
         {/* Left: icon + text */}
-        <div className="flex min-w-0 items-center gap-2 sm:gap-3">
-          {icon ? <span className="shrink-0 opacity-90">{icon}</span> : null}
-          <div className="min-w-0">
-            {eyebrow ? (
-              <div className="mb-1 truncate text-label font-medium tracking-[0.02em] uppercase text-muted-foreground">
-                {eyebrow}
-              </div>
-            ) : null}
-            <div className="flex min-w-0 items-baseline gap-2">
-              <h1 className="truncate text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow">
-                {heading}
-              </h1>
-              {subtitle ? (
-                <span className="hidden truncate text-label font-medium tracking-[0.02em] text-muted-foreground sm:inline">
-                  {subtitle}
-                </span>
+        <div
+          className={cx(
+            "flex min-w-0 flex-1 items-center gap-3 sm:gap-4",
+            hasNav && "flex-wrap gap-y-2 sm:flex-nowrap",
+          )}
+        >
+          <div className="flex min-w-0 items-center gap-2 sm:gap-3">
+            {icon ? <span className="shrink-0 opacity-90">{icon}</span> : null}
+            <div className="min-w-0">
+              {eyebrow ? (
+                <div className="mb-1 truncate text-label font-medium tracking-[0.02em] uppercase text-muted-foreground">
+                  {eyebrow}
+                </div>
               ) : null}
+              <div className="flex min-w-0 items-baseline gap-2">
+                <h1 className="truncate text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow">
+                  {heading}
+                </h1>
+                {subtitle ? (
+                  <span className="hidden truncate text-label font-medium tracking-[0.02em] text-muted-foreground sm:inline">
+                    {subtitle}
+                  </span>
+                ) : null}
+              </div>
             </div>
           </div>
+          {hasNav ? (
+            <div
+              className={cx(
+                "flex min-w-0 flex-1 items-center gap-1 overflow-x-auto whitespace-nowrap text-xs font-medium text-muted-foreground sm:text-sm sm:overflow-visible",
+                "[&_[data-state=active]]:text-foreground [&_[data-state=active]]:opacity-100",
+                "[&_[data-state=inactive]]:text-muted-foreground [&_[data-state=inactive]:hover]:text-foreground [&_[data-state=inactive]:focus-visible]:text-foreground",
+              )}
+              data-slot="primary-nav"
+            >
+              {nav}
+            </div>
+          ) : null}
         </div>
 
         {/* Right slot / tabs */}
-        {hasTabs || hasRight ? (
-          <div className="ml-auto flex min-w-0 items-center gap-3">
+        {showRightStack ? (
+          <div className="ml-auto flex min-w-0 items-center gap-3 sm:gap-4">
             {hasTabs ? tabControl : null}
             {hasRight ? (
               <div className="flex shrink-0 items-center gap-2">{right}</div>
+            ) : null}
+            {hasUtilities ? (
+              <div
+                className={cx(
+                  "flex shrink-0 items-center gap-2 text-muted-foreground",
+                  "[&_[data-state=active]]:text-foreground [&_[data-state=open]]:text-foreground",
+                )}
+                data-slot="utilities"
+              >
+                {utilities}
+              </div>
             ) : null}
           </div>
         ) : null}

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -150,49 +150,53 @@ exports[`ReviewsPage > renders default state 1`] = `
             id="reviews-header"
           >
             <div
-              class="sticky top-[var(--header-stack)] relative flex items-center px-3 sm:px-4 py-3 sm:py-4 min-h-12"
+              class="sticky top-[var(--header-stack)] relative flex items-center gap-3 sm:gap-4 px-3 sm:px-4 py-3 sm:py-4 min-h-12"
             >
               <div
                 aria-hidden="true"
                 class="header-rail pointer-events-none absolute left-0 top-1 bottom-1 w-2 rounded-l-2xl"
               />
               <div
-                class="flex min-w-0 items-center gap-2 sm:gap-3"
+                class="flex min-w-0 flex-1 items-center gap-3 sm:gap-4"
               >
-                <span
-                  class="shrink-0 opacity-90"
-                >
-                  <svg
-                    class="lucide lucide-book-open opacity-80"
-                    fill="none"
-                    height="24"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M12 7v14"
-                    />
-                    <path
-                      d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"
-                    />
-                  </svg>
-                </span>
                 <div
-                  class="min-w-0"
+                  class="flex min-w-0 items-center gap-2 sm:gap-3"
                 >
-                  <div
-                    class="flex min-w-0 items-baseline gap-2"
+                  <span
+                    class="shrink-0 opacity-90"
                   >
-                    <h1
-                      class="truncate text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow"
+                    <svg
+                      class="lucide lucide-book-open opacity-80"
+                      fill="none"
+                      height="24"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      Reviews
-                    </h1>
+                      <path
+                        d="M12 7v14"
+                      />
+                      <path
+                        d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"
+                      />
+                    </svg>
+                  </span>
+                  <div
+                    class="min-w-0"
+                  >
+                    <div
+                      class="flex min-w-0 items-baseline gap-2"
+                    >
+                      <h1
+                        class="truncate text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow"
+                      >
+                        Reviews
+                      </h1>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- add a `compact` mode plus primary navigation and utility slots to the Header component while keeping sticky styling intact
- demonstrate the compact header in the PageHeader demo and reference it from the prompts route metadata
- refresh the ReviewsPage snapshot to reflect the updated Header markup

## Testing
- npm run regen-ui
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c863f54838832c946e5d49c9ce109b