### PR TITLE
feat: forward ref through PageHeader

### DIFF
--- a/src/components/ui/layout/NeomorphicHeroFrame.tsx
+++ b/src/components/ui/layout/NeomorphicHeroFrame.tsx
@@ -7,15 +7,15 @@ import { NeomorphicFrameStyles } from "./NeomorphicFrameStyles";
 
 export type NeomorphicHeroFrameProps = React.HTMLAttributes<HTMLDivElement>;
 
-export default function NeomorphicHeroFrame({
-  className,
-  children,
-  ...rest
-}: NeomorphicHeroFrameProps) {
+const NeomorphicHeroFrame = React.forwardRef<
+  HTMLDivElement,
+  NeomorphicHeroFrameProps
+>(({ className, children, ...rest }, ref) => {
   return (
     <>
       <NeomorphicFrameStyles />
       <div
+        ref={ref}
         className={cn("relative overflow-hidden hero2-neomorph", className)}
         {...rest}
       >
@@ -30,4 +30,8 @@ export default function NeomorphicHeroFrame({
       </div>
     </>
   );
-}
+});
+
+NeomorphicHeroFrame.displayName = "NeomorphicHeroFrame";
+
+export default NeomorphicHeroFrame;

--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -14,11 +14,17 @@ type PageHeaderElement = Extract<
   "header" | "section" | "article" | "aside" | "main" | "div" | "nav"
 >;
 
-export interface PageHeaderProps<
+type PageHeaderElementProps = Omit<
+  React.HTMLAttributes<HTMLElement>,
+  "className" | "children"
+>;
+
+type PageHeaderFrameElement = React.ElementRef<typeof NeomorphicHeroFrame>;
+
+export interface PageHeaderBaseProps<
   HeaderKey extends string = string,
   HeroKey extends string = string,
->
-  extends Omit<React.HTMLAttributes<HTMLElement>, "className" | "children"> {
+> extends PageHeaderElementProps {
   /** Props forwarded to <Header> */
   header: HeaderProps<HeaderKey>;
   /** Props forwarded to <Hero> */
@@ -37,25 +43,36 @@ export interface PageHeaderProps<
   search?: HeroProps<HeroKey>["search"];
 }
 
+export type PageHeaderProps<
+  HeaderKey extends string = string,
+  HeroKey extends string = string,
+> = PageHeaderBaseProps<HeaderKey, HeroKey> &
+  React.RefAttributes<PageHeaderFrameElement>;
+
+export type PageHeaderRef = PageHeaderFrameElement;
+
 /**
  * PageHeader — combines <Header> and <Hero> within a neomorphic frame.
  *
  * Used for top-of-page introductions with optional actions.
  */
-export default function PageHeader<
+const PageHeaderInner = <
   HeaderKey extends string = string,
   HeroKey extends string = string,
->({
-  header,
-  hero,
-  className,
-  frameProps,
-  contentClassName,
-  as,
-  subTabs,
-  search,
-  ...elementProps
-}: PageHeaderProps<HeaderKey, HeroKey>) {
+>(
+  {
+    header,
+    hero,
+    className,
+    frameProps,
+    contentClassName,
+    as,
+    subTabs,
+    search,
+    ...elementProps
+  }: PageHeaderBaseProps<HeaderKey, HeroKey>,
+  ref: React.ForwardedRef<PageHeaderFrameElement>,
+) => {
   const Component = (as ?? "header") as PageHeaderElement;
 
   const {
@@ -82,6 +99,7 @@ export default function PageHeader<
   return (
     <Component {...(elementProps as React.HTMLAttributes<HTMLElement>)}>
       <NeomorphicHeroFrame
+        ref={ref}
         {...frameProps}
         className={cn(
           className ??
@@ -108,4 +126,20 @@ export default function PageHeader<
       </NeomorphicHeroFrame>
     </Component>
   );
-}
+};
+
+const PageHeaderWithForwardRef = React.forwardRef(PageHeaderInner);
+
+PageHeaderWithForwardRef.displayName = "PageHeader";
+
+type PageHeaderComponent = <
+  HeaderKey extends string = string,
+  HeroKey extends string = string,
+>(
+  props: PageHeaderBaseProps<HeaderKey, HeroKey> &
+    React.RefAttributes<PageHeaderFrameElement>,
+) => React.ReactElement | null;
+
+const PageHeader = PageHeaderWithForwardRef as unknown as PageHeaderComponent;
+
+export default PageHeader;


### PR DESCRIPTION
## Summary
- convert PageHeader to a forwardRef component and expose typed ref props
- pass the forwarded ref through to NeomorphicHeroFrame and update its implementation to accept refs

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c86972a3e0832c92835ff108a59528