### PR TITLE
Adjust toast position for safe areas

### DIFF
--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -34,7 +34,9 @@ export default function Toast({
 
   if (!open || !mounted) return null;
   return createPortal(
-    <div className="fixed bottom-4 right-4 z-50">
+    <div
+      className="fixed bottom-[calc(theme(spacing.4)+env(safe-area-inset-bottom))] right-[calc(theme(spacing.4)+env(safe-area-inset-right))] z-50"
+    >
       <Card
         role="status"
         aria-live="polite"


### PR DESCRIPTION
## Summary
- update the toast container offsets to include safe area insets
- use the spacing token for the offset baseline instead of hard-coded values

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c86c35214c832c85c5c5e8c8cd36f4