### PR TITLE
Add accessible label to TimerRingIcon

### DIFF
--- a/src/icons/TimerRingIcon.tsx
+++ b/src/icons/TimerRingIcon.tsx
@@ -11,10 +11,13 @@ export default function TimerRingIcon({ pct, size = 200 }: TimerRingIconProps) {
   const circumference = 2 * Math.PI * radius;
   const offset = circumference - (pct / 100) * circumference;
   const pulse = pct >= 90;
+  const accessibleLabel = `Timer ${pct}% complete`;
   return (
     <svg
       className="h-full w-full rotate-[-90deg]"
       viewBox={`0 0 ${size} ${size}`}
+      role="img"
+      aria-label={accessibleLabel}
     >
       <defs>
         <linearGradient id="timer-ring-grad" x1="0%" y1="0%" x2="100%" y2="0%">

--- a/tests/icons/TimerRingIcon.test.tsx
+++ b/tests/icons/TimerRingIcon.test.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { render, cleanup, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import TimerRingIcon from "@/icons/TimerRingIcon";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("TimerRingIcon", () => {
+  it("announces timer progress via an accessible label", () => {
+    render(<TimerRingIcon pct={72} />);
+
+    expect(
+      screen.getByRole("img", { name: "Timer 72% complete" }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- annotate `TimerRingIcon`'s SVG with a role and accessible label so screen readers announce timer progress
- add a unit test covering the new accessibility label behavior

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c86c3b7318832c8f5542c28efeac75