### PR TITLE
Add reusable auto focus hook for edit inputs

### DIFF
--- a/src/components/goals/GoalSlot.tsx
+++ b/src/components/goals/GoalSlot.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { Check, Pencil, Trash2, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import useAutoFocus from "@/lib/useAutoFocus";
 import type { Goal } from "@/lib/types";
 import { PillarBadge } from "@/components/ui";
 import Input from "@/components/ui/primitives/Input";
@@ -27,10 +28,10 @@ export default function GoalSlot({
   const editButtonRef = React.useRef<HTMLButtonElement>(null);
   const wasEditing = React.useRef(false);
 
+  useAutoFocus({ ref: inputRef, when: editing });
+
   React.useEffect(() => {
-    if (editing) {
-      inputRef.current?.focus();
-    } else if (wasEditing.current) {
+    if (!editing && wasEditing.current) {
       editButtonRef.current?.focus();
     }
     wasEditing.current = editing;

--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -21,6 +21,7 @@ import IconButton from "@/components/ui/primitives/IconButton";
 import TabBar from "@/components/ui/layout/TabBar";
 import SegmentedButton from "@/components/ui/primitives/SegmentedButton";
 import { uid, usePersistentState } from "@/lib/db";
+import useAutoFocus from "@/lib/useAutoFocus";
 import {
   Search,
   Plus,
@@ -277,7 +278,7 @@ function ReminderCard({
   const [tagsText, setTagsText] = React.useState(value.tags.join(", "));
   const titleRef = React.useRef<HTMLInputElement | null>(null);
 
-  React.useEffect(() => { if (editing) titleRef.current?.focus(); }, [editing]);
+  useAutoFocus({ ref: titleRef, when: editing });
 
   function save() {
     const cleanTags = tagsText.split(",").map(t => t.trim()).filter(Boolean);

--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -25,6 +25,7 @@ import Hero from "@/components/ui/layout/Hero";
 import TabBar from "@/components/ui/layout/TabBar";
 import SegmentedButton from "@/components/ui/primitives/SegmentedButton";
 import { uid, usePersistentState } from "@/lib/db";
+import useAutoFocus from "@/lib/useAutoFocus";
 import {
   Search,
   SlidersHorizontal,
@@ -520,9 +521,7 @@ function RemTile({
   const [tagsText, setTagsText] = React.useState(value.tags.join(", "));
   const titleRef = React.useRef<HTMLInputElement | null>(null);
 
-  React.useEffect(() => {
-    if (editing) titleRef.current?.focus();
-  }, [editing]);
+  useAutoFocus({ ref: titleRef, when: editing });
 
   function save() {
     const cleanTags = tagsText
@@ -562,7 +561,6 @@ function RemTile({
               className="font-semibold uppercase tracking-wide pr-2 title-glow glitch cursor-text leading-6 truncate"
               onClick={() => {
                 setEditing(true);
-                setTimeout(() => titleRef.current?.focus(), 0);
               }}
               role="button"
               tabIndex={0}
@@ -580,7 +578,6 @@ function RemTile({
             aria-label="Edit"
             onClick={() => {
               setEditing(true);
-              setTimeout(() => titleRef.current?.focus(), 0);
             }}
             size="sm"
             iconSize="sm"

--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -6,6 +6,7 @@ import IconButton from "@/components/ui/primitives/IconButton";
 import CheckCircle from "@/components/ui/toggles/CheckCircle";
 import { Pencil, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import useAutoFocus from "@/lib/useAutoFocus";
 import type { DayTask } from "./plannerStore";
 
 type Props = {
@@ -32,9 +33,7 @@ export default function TaskRow({
   const [imageUrl, setImageUrl] = React.useState("");
   const inputRef = React.useRef<HTMLInputElement>(null);
 
-  React.useEffect(() => {
-    if (editing) inputRef.current?.focus();
-  }, [editing]);
+  useAutoFocus({ ref: inputRef, when: editing });
 
   function start() {
     setEditing(true);

--- a/src/lib/useAutoFocus.ts
+++ b/src/lib/useAutoFocus.ts
@@ -1,0 +1,19 @@
+import * as React from "react";
+
+type FocusableElement = { focus: (options?: FocusOptions) => void };
+
+type UseAutoFocusArgs<T extends FocusableElement> = {
+  ref: React.MutableRefObject<T | null> | React.RefObject<T | null>;
+  when: boolean;
+};
+
+export default function useAutoFocus<T extends FocusableElement>({
+  ref,
+  when,
+}: UseAutoFocusArgs<T>) {
+  React.useEffect(() => {
+    if (!when) return;
+
+    ref.current?.focus();
+  }, [when, ref]);
+}


### PR DESCRIPTION
## Summary
- add a shared `useAutoFocus` hook that focuses a ref when its `when` flag becomes true
- replace local focus effects and timeouts in task and reminder editors with the hook

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c86c678a34832c8a3652c524ef4b63