### PR TITLE
Refactor dialog focus trap into reusable hook

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { createPortal } from "react-dom";
 import Card from "./primitives/Card";
+import { useDialogTrap } from "./hooks/useDialogTrap";
 import { cn } from "@/lib/utils";
 
 export interface ModalProps extends React.ComponentProps<typeof Card> {
@@ -21,43 +22,7 @@ export default function Modal({
   const dialogRef = React.useRef<HTMLDivElement>(null);
   React.useEffect(() => setMounted(true), []);
 
-  React.useEffect(() => {
-    if (!open || !mounted) return;
-    const prevActive = document.activeElement as HTMLElement | null;
-    const el = dialogRef.current;
-    const selectors =
-      "a[href], button, textarea, input, select, [tabindex]:not([tabindex='-1'])";
-    const nodes = el?.querySelectorAll<HTMLElement>(selectors) ?? [];
-    const first = nodes[0] ?? el;
-    const last = nodes[nodes.length - 1] ?? el;
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onClose();
-      } else if (e.key === "Tab") {
-        if (nodes.length === 0) {
-          e.preventDefault();
-          return;
-        }
-        if (e.shiftKey && document.activeElement === first) {
-          e.preventDefault();
-          last?.focus();
-        } else if (!e.shiftKey && document.activeElement === last) {
-          e.preventDefault();
-          first?.focus();
-        }
-      }
-    };
-    document.addEventListener("keydown", onKeyDown);
-    const prevOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    first?.focus();
-    return () => {
-      document.removeEventListener("keydown", onKeyDown);
-      document.body.style.overflow = prevOverflow;
-      prevActive?.focus?.();
-    };
-  }, [open, mounted, onClose]);
+  useDialogTrap({ open: open && mounted, onClose, ref: dialogRef });
 
   if (!open || !mounted) return null;
   return createPortal(

--- a/src/components/ui/Sheet.tsx
+++ b/src/components/ui/Sheet.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { createPortal } from "react-dom";
 import { motion, useReducedMotion } from "framer-motion";
 import Card from "./primitives/Card";
+import { useDialogTrap } from "./hooks/useDialogTrap";
 import { cn } from "@/lib/utils";
 
 export interface SheetProps extends React.ComponentProps<typeof Card> {
@@ -25,43 +26,7 @@ export default function Sheet({
   const reduceMotion = useReducedMotion();
   React.useEffect(() => setMounted(true), []);
 
-  React.useEffect(() => {
-    if (!open || !mounted) return;
-    const prevActive = document.activeElement as HTMLElement | null;
-    const el = dialogRef.current;
-    const selectors =
-      "a[href], button, textarea, input, select, [tabindex]:not([tabindex='-1'])";
-    const nodes = el?.querySelectorAll<HTMLElement>(selectors) ?? [];
-    const first = nodes[0] ?? el;
-    const last = nodes[nodes.length - 1] ?? el;
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onClose();
-      } else if (e.key === "Tab") {
-        if (nodes.length === 0) {
-          e.preventDefault();
-          return;
-        }
-        if (e.shiftKey && document.activeElement === first) {
-          e.preventDefault();
-          last?.focus();
-        } else if (!e.shiftKey && document.activeElement === last) {
-          e.preventDefault();
-          first?.focus();
-        }
-      }
-    };
-    document.addEventListener("keydown", onKeyDown);
-    const prevOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    first?.focus();
-    return () => {
-      document.removeEventListener("keydown", onKeyDown);
-      document.body.style.overflow = prevOverflow;
-      prevActive?.focus?.();
-    };
-  }, [open, mounted, onClose]);
+  useDialogTrap({ open: open && mounted, onClose, ref: dialogRef });
 
   if (!open || !mounted) return null;
   return createPortal(

--- a/src/components/ui/hooks/useDialogTrap.ts
+++ b/src/components/ui/hooks/useDialogTrap.ts
@@ -1,0 +1,67 @@
+import * as React from "react";
+
+type DialogRef =
+  | React.MutableRefObject<HTMLElement | null>
+  | React.RefObject<HTMLElement | null>;
+
+export interface UseDialogTrapOptions {
+  open: boolean;
+  onClose: () => void;
+  ref: DialogRef;
+}
+
+const FOCUSABLE_SELECTORS =
+  "a[href], button, textarea, input, select, [tabindex]:not([tabindex='-1'])";
+
+export function useDialogTrap({ open, onClose, ref }: UseDialogTrapOptions) {
+  React.useEffect(() => {
+    if (!open) return;
+
+    const element = ref.current;
+    if (!element) return;
+
+    const previouslyActive = document.activeElement as HTMLElement | null;
+    const focusable = element.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
+    const first = focusable[0] ?? element;
+    const last = focusable[focusable.length - 1] ?? element;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      if (focusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last?.focus();
+        return;
+      }
+
+      if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first?.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    first?.focus();
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+      previouslyActive?.focus?.();
+    };
+  }, [open, onClose, ref]);
+}


### PR DESCRIPTION
## Summary
- add a reusable `useDialogTrap` hook that centralizes dialog focus trapping, escape handling, and body scroll locking
- replace the duplicated effect logic in `Modal` and `Sheet` with the shared hook while preserving their unique rendering logic

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c86dfd4d20832c976ce7da1f8390ea