### PR TITLE
fix: hide select prefix glyph from screen readers

### DIFF
--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -432,7 +432,11 @@ const AnimatedSelectImpl = React.forwardRef<
           data-lit={lit ? "true" : "false"}
           data-open={open ? "true" : "false"}
         >
-          {prefixLabel ? <span className="opacity-70">❯</span> : null}
+          {prefixLabel ? (
+            <span aria-hidden="true" className="opacity-70">
+              ❯
+            </span>
+          ) : null}
 
           <span
             className={[


### PR DESCRIPTION
## Summary
- hide the decorative select prefix glyph from assistive technologies by marking it aria-hidden
- keep the prefix indicator styling intact while improving accessibility

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c86e0ea41c832caa64c6c8b0d28f30