### PR TITLE
Enforce accessible labels for IconButton

### DIFF
--- a/storybook/src/components/ui/IconButton.stories.tsx
+++ b/storybook/src/components/ui/IconButton.stories.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Cog, Trash2 } from "lucide-react";
+import { IconButton } from "@/components/ui";
+
+const meta: Meta<typeof IconButton> = {
+  title: "Primitives/IconButton",
+  component: IconButton,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Icon buttons must include either an `aria-label` or `title` when the child content is only an icon.",
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof IconButton>;
+
+export const WithAriaLabel: Story = {
+  args: {
+    variant: "ring",
+    tone: "primary",
+    size: "md",
+  },
+  render: (args) => (
+    <IconButton {...args} aria-label="Open settings">
+      <Cog />
+    </IconButton>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use `aria-label` when the icon conveys an action without visible text. This label is announced to assistive technology.",
+      },
+    },
+  },
+};
+
+export const WithTitle: Story = {
+  args: {
+    variant: "solid",
+    tone: "danger",
+    size: "md",
+  },
+  render: (args) => (
+    <IconButton {...args} title="Delete item">
+      <Trash2 />
+    </IconButton>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Providing a `title` also satisfies the accessible label requirement; the component applies it as an `aria-label` automatically.",
+      },
+    },
+  },
+};

--- a/tests/primitives/icon-button.test.tsx
+++ b/tests/primitives/icon-button.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { render, cleanup } from "@testing-library/react";
-import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup, waitFor } from "@testing-library/react";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import IconButton from "../../src/components/ui/primitives/IconButton";
 
 afterEach(cleanup);
@@ -131,5 +131,38 @@ describe("IconButton", () => {
     expect(classes).toContain("[--hover:hsl(var(--panel)/0.45)]");
     expect(classes).toContain("border-danger/35 text-danger");
     expect(classes).not.toContain("shadow-[0_0_8px_currentColor]");
+  });
+
+  it("uses title as the aria-label when no aria-label is provided", () => {
+    const { getByRole } = render(
+      <IconButton title="Open settings">
+        <svg />
+      </IconButton>,
+    );
+    const button = getByRole("button");
+    expect(button).toHaveAttribute("aria-label", "Open settings");
+    expect(button).toHaveAttribute("title", "Open settings");
+  });
+
+  it("logs an error when icon-only content is missing a label", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <IconButton
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {...({} as any)}
+      >
+        <svg />
+      </IconButton>,
+    );
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "IconButton requires an `aria-label` or `title` when rendering icon-only content.",
+        ),
+      );
+    });
+
+    errorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- require IconButton consumers to supply an accessible label and warn during runtime if icon-only content is unlabeled
- propagate title text to aria-label automatically and add regression tests covering the new safeguards
- add a Storybook example that demonstrates using aria-label or title with icon-only buttons

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c86e19eb3c832c852614cc352ddfa6