### PR TITLE
feat: extend neomorphic hero frame variants

### DIFF
--- a/src/components/prompts/NeomorphicHeroFrameDemo.tsx
+++ b/src/components/prompts/NeomorphicHeroFrameDemo.tsx
@@ -1,0 +1,188 @@
+import * as React from "react";
+import {
+  NeomorphicHeroFrame,
+  SegmentedButtons,
+  SearchBar,
+  Button,
+  ThemeToggle,
+  type TabItem,
+} from "@/components/ui";
+
+type MissionView = "missions" | "briefings" | "archive";
+
+type MissionStatus = "active" | "queued" | "paused" | "completed";
+
+const missionTabs: TabItem<MissionView>[] = [
+  { key: "missions", label: "Missions" },
+  { key: "briefings", label: "Briefings" },
+  { key: "archive", label: "Archive", disabled: true },
+];
+
+const statusTabs: TabItem<MissionStatus>[] = [
+  { key: "active", label: "Active" },
+  { key: "queued", label: "Queued" },
+  { key: "paused", label: "Paused" },
+  { key: "completed", label: "Completed" },
+];
+
+export default function NeomorphicHeroFrameDemo() {
+  const [activeView, setActiveView] = React.useState<MissionView>("missions");
+  const [status, setStatus] = React.useState<MissionStatus>("active");
+  const [query, setQuery] = React.useState("");
+  const [compactQuery, setCompactQuery] = React.useState("");
+
+  return (
+    <div className="space-y-6">
+      <NeomorphicHeroFrame
+        as="header"
+        actionArea={{
+          tabs: (
+            <SegmentedButtons
+              items={missionTabs}
+              value={activeView}
+              onValueChange={(key) => setActiveView(key as MissionView)}
+              ariaLabel="Switch mission focus"
+              right={
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="px-2 text-xs font-semibold uppercase tracking-[0.08em]"
+                >
+                  View all
+                </Button>
+              }
+              showBaseline
+            />
+          ),
+          search: (
+            <SearchBar
+              value={query}
+              onValueChange={setQuery}
+              placeholder="Search mission intel…"
+              aria-label="Search mission intel"
+              loading={activeView === "archive"}
+            />
+          ),
+          actions: (
+            <div className="flex items-center gap-2">
+              <ThemeToggle ariaLabel="Toggle theme" className="shrink-0" />
+              <Button size="sm" variant="secondary">
+                Draft
+              </Button>
+              <Button size="sm" variant="primary" loading>
+                Deploy
+              </Button>
+              <Button size="sm" variant="ghost" disabled>
+                Disabled
+              </Button>
+            </div>
+          ),
+          "aria-label": "Mission controls",
+        }}
+      >
+        <div className="grid gap-4 md:grid-cols-12 md:gap-6">
+          <div className="md:col-span-7 space-y-3">
+            <h3 className="text-title font-semibold tracking-[-0.01em] text-foreground">
+              Default neomorphic frame
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              The default variant applies the <code>r-card-lg</code> radius, border tint
+              from <code>border-border/40</code>, and responsive padding tokens
+              (<code>px-6</code>, <code>md:px-7</code>, <code>lg:px-8</code>) to stay aligned with the 12-column grid.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Tabs, search, and button actions all inherit hover, focus, active,
+              disabled, and loading states from the design system tokens—interact with
+              each control to preview the full range of feedback.
+            </p>
+          </div>
+          <dl className="md:col-span-5 grid gap-2 text-xs uppercase tracking-[0.08em] text-muted-foreground">
+            <div className="flex items-center justify-between rounded-card r-card-md border border-border/30 bg-card/60 px-3 py-2">
+              <dt className="font-semibold text-foreground">Layer tokens</dt>
+              <dd className="text-[10px]">bg-card/70 · ring-border/55</dd>
+            </div>
+            <div className="flex items-center justify-between rounded-card r-card-md border border-border/30 bg-card/60 px-3 py-2">
+              <dt className="font-semibold text-foreground">Spacing</dt>
+              <dd className="text-[10px]">gap-4 · md:gap-6</dd>
+            </div>
+            <div className="flex items-center justify-between rounded-card r-card-md border border-border/30 bg-card/60 px-3 py-2">
+              <dt className="font-semibold text-foreground">Action grid</dt>
+              <dd className="text-[10px]">md:col-span-5 / 4 / 3</dd>
+            </div>
+          </dl>
+        </div>
+      </NeomorphicHeroFrame>
+
+      <NeomorphicHeroFrame
+        as="nav"
+        variant="compact"
+        actionArea={{
+          tabs: (
+            <SegmentedButtons
+              items={statusTabs}
+              value={status}
+              onValueChange={(key) => setStatus(key as MissionStatus)}
+              ariaLabel="Filter mission status"
+              size="sm"
+            />
+          ),
+          search: (
+            <SearchBar
+              value={compactQuery}
+              onValueChange={setCompactQuery}
+              placeholder="Quick search…"
+              aria-label="Search mission status"
+              loading={status === "queued"}
+            />
+          ),
+          actions: (
+            <div className="flex items-center gap-2">
+              <Button size="sm" variant="secondary">
+                Pin view
+              </Button>
+              <Button size="sm" variant="ghost">
+                More
+              </Button>
+            </div>
+          ),
+          align: "between",
+          "aria-label": "Mission filters",
+        }}
+      >
+        <div className="grid gap-3 md:grid-cols-12 md:gap-4">
+          <div className="md:col-span-6 space-y-2">
+            <h3 className="text-ui font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              Compact layout
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              Compact frames tighten the padding to <code>px-4</code>/<code>md:px-5</code>/<code>lg:px-6</code>
+              with the <code>r-card-md</code> radius, ideal for utility nav or filter rails.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              The action row mirrors the grid: tabs span <code>md:col-span-7</code>, search spans
+              <code>md:col-span-3</code>, and button actions anchor on <code>md:col-span-2</code> for
+              consistent alignment.
+            </p>
+          </div>
+          <div className="md:col-span-6 space-y-2 text-xs text-muted-foreground">
+            <p className="font-semibold text-foreground">Interaction checklist</p>
+            <ul className="grid grid-cols-2 gap-2">
+              <li className="rounded-card r-card-md border border-border/25 bg-card/60 px-3 py-2">
+                Hover or focus the tabs to see accent glows.
+              </li>
+              <li className="rounded-card r-card-md border border-border/25 bg-card/60 px-3 py-2">
+                Toggle statuses—the queued tab marks the search as loading.
+              </li>
+              <li className="rounded-card r-card-md border border-border/25 bg-card/60 px-3 py-2">
+                Buttons surface pressed and disabled states from tokenized styles.
+              </li>
+              <li className="rounded-card r-card-md border border-border/25 bg-card/60 px-3 py-2">
+                Keyboard focus rings respect the global focus token.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </NeomorphicHeroFrame>
+    </div>
+  );
+}

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -34,7 +34,6 @@ import {
   Header,
   Hero,
   PageShell,
-  NeomorphicHeroFrame,
   SectionCard as UiSectionCard,
   FieldShell,
   SearchBar,
@@ -48,6 +47,7 @@ import SpinnerShowcase from "./SpinnerShowcase";
 import SnackbarShowcase from "./SnackbarShowcase";
 import ToggleShowcase from "./ToggleShowcase";
 import PageHeaderDemo from "./PageHeaderDemo";
+import NeomorphicHeroFrameDemo from "./NeomorphicHeroFrameDemo";
 import { DashboardCard, BottomNav, IsometricRoom } from "@/components/home";
 import {
   RoleSelector,
@@ -694,15 +694,66 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
     {
       id: "neomorphic-hero-frame",
       name: "NeomorphicHeroFrame",
-      description: "HUD-style frame shell",
-      element: (
-        <NeomorphicHeroFrame className="rounded-card r-card-lg px-4 py-4">
-          <div className="relative z-[2] text-sm">Content</div>
-        </NeomorphicHeroFrame>
-      ),
-      tags: ["hero", "layout"],
-      code: `<NeomorphicHeroFrame className="rounded-card r-card-lg px-4 py-4">
-  <div className="relative z-[2]">Content</div>
+      description:
+        "Composable neomorphic frame with semantic wrappers, tokenized spacing, and an action row for tabs, search, and buttons.",
+      element: <NeomorphicHeroFrameDemo />,
+      tags: ["hero", "layout", "tokens"],
+      code: `<NeomorphicHeroFrame
+  as="header"
+  variant="default"
+  actionArea={{
+    tabs: (
+      <SegmentedButtons
+        items={[
+          { key: "missions", label: "Missions" },
+          { key: "briefings", label: "Briefings" },
+          { key: "archive", label: "Archive", disabled: true },
+        ]}
+        value="missions"
+        onValueChange={() => {}}
+        ariaLabel="Switch mission focus"
+        showBaseline
+      />
+    ),
+    search: (
+      <SearchBar
+        value=""
+        onValueChange={() => {}}
+        placeholder="Search mission intel…"
+        aria-label="Search mission intel"
+        loading
+      />
+    ),
+    actions: (
+      <div className="flex items-center gap-2">
+        <ThemeToggle ariaLabel="Toggle theme" className="shrink-0" />
+        <Button size="sm" variant="primary" loading>
+          Deploy
+        </Button>
+        <Button size="sm" variant="ghost" disabled>
+          Disabled
+        </Button>
+      </div>
+    ),
+  }}
+>
+  <div className="grid gap-4 md:grid-cols-12">
+    <div className="md:col-span-7 space-y-3">
+      <p className="text-sm text-muted-foreground">
+        Default variant uses r-card-lg radius with px-6/md:px-7/lg:px-8 tokens and aligns content to the 12-column grid.
+      </p>
+    </div>
+  </div>
+</NeomorphicHeroFrame>
+
+<NeomorphicHeroFrame as="nav" variant="compact" actionArea={{ align: "between" }}>
+  <div className="grid gap-3 md:grid-cols-12">
+    <div className="md:col-span-6">
+      <p className="text-sm text-muted-foreground">
+        Compact variant swaps to r-card-md radius with px-4/md:px-5/lg:px-6 spacing.
+      </p>
+    </div>
+  </div>
 </NeomorphicHeroFrame>`,
     },
     {

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -325,7 +325,10 @@ export default function TeamCompPage() {
       className="py-6 space-y-6 md:grid md:grid-cols-12 md:gap-4"
       aria-labelledby="teamcomp-header"
     >
-      <NeomorphicHeroFrame className="sticky top-0 rounded-card r-card-lg px-4 py-4 md:col-span-12">
+      <NeomorphicHeroFrame
+        variant="unstyled"
+        className="sticky top-0 rounded-card r-card-lg px-4 py-4 md:col-span-12"
+      >
         <div className="relative z-[2] space-y-2">
           <Header
             id="teamcomp-header"

--- a/src/components/ui/layout/NeomorphicHeroFrame.tsx
+++ b/src/components/ui/layout/NeomorphicHeroFrame.tsx
@@ -5,32 +5,301 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 import { NeomorphicFrameStyles } from "./NeomorphicFrameStyles";
 
-export type NeomorphicHeroFrameProps = React.HTMLAttributes<HTMLDivElement>;
+type FrameElement = Extract<
+  keyof JSX.IntrinsicElements,
+  "div" | "header" | "section" | "nav" | "article" | "aside" | "main"
+>;
 
-const NeomorphicHeroFrame = React.forwardRef<
-  HTMLDivElement,
-  NeomorphicHeroFrameProps
->(({ className, children, ...rest }, ref) => {
-  return (
-    <>
-      <NeomorphicFrameStyles />
+type Align = "start" | "center" | "end" | "between";
+
+export type NeomorphicHeroFrameVariant =
+  | "default"
+  | "compact"
+  | "plain"
+  | "unstyled";
+
+export interface NeomorphicHeroFrameActionAreaProps {
+  /** Optional segmented tabs rendered on the left */
+  tabs?: React.ReactNode;
+  /** Optional primary actions rendered on the right */
+  actions?: React.ReactNode;
+  /** Optional search control rendered inline */
+  search?: React.ReactNode;
+  /** Layout alignment across the action row */
+  align?: Align;
+  /** Adds a top divider when true (default) */
+  divider?: boolean;
+  /**
+   * Additional class for the action row wrapper. Useful for controlling
+   * grid spans when composing with other primitives.
+   */
+  className?: string;
+  tabsClassName?: string;
+  actionsClassName?: string;
+  searchClassName?: string;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+}
+
+export interface NeomorphicHeroFrameProps
+  extends React.HTMLAttributes<HTMLElement> {
+  /** Semantic element for the frame */
+  as?: FrameElement;
+  /** Built-in shell styles */
+  variant?: NeomorphicHeroFrameVariant;
+  /** Toggle animated frame layers */
+  frame?: boolean;
+  /** Optional class applied to the inner content wrapper */
+  contentClassName?: string;
+  /** Optional action row (tabs, search, buttons) */
+  actionArea?: NeomorphicHeroFrameActionAreaProps | null;
+}
+
+const variantMap: Record<Exclude<NeomorphicHeroFrameVariant, "unstyled">, {
+  container: string;
+  padding: string;
+  content: string;
+  action: { mt: string; pt: string; gap: string };
+}> = {
+  default: {
+    container:
+      "rounded-card r-card-lg border border-border/40 bg-card/70 shadow-[0_0_0_1px_hsl(var(--border)/0.12)]",
+    padding: "px-6 py-6 md:px-7 md:py-7 lg:px-8 lg:py-8",
+    content: "space-y-5 md:space-y-6",
+    action: { mt: "mt-6 md:mt-7", pt: "pt-5 md:pt-6", gap: "gap-4" },
+  },
+  compact: {
+    container:
+      "rounded-card r-card-md border border-border/35 bg-card/65 shadow-[0_0_0_1px_hsl(var(--border)/0.12)]",
+    padding: "px-4 py-4 md:px-5 md:py-5 lg:px-6 lg:py-6",
+    content: "space-y-4 md:space-y-5",
+    action: { mt: "mt-4 md:mt-5", pt: "pt-4 md:pt-5", gap: "gap-3" },
+  },
+  plain: {
+    container:
+      "rounded-card r-card-md border border-border/30 bg-card/60 shadow-[0_0_0_1px_hsl(var(--border)/0.08)]",
+    padding: "px-4 py-4 md:px-5 md:py-5",
+    content: "space-y-3 md:space-y-4",
+    action: { mt: "mt-4", pt: "pt-3 md:pt-4", gap: "gap-3" },
+  },
+};
+
+function slotLayout({
+  hasTabs,
+  hasSearch,
+  hasActions,
+}: {
+  hasTabs: boolean;
+  hasSearch: boolean;
+  hasActions: boolean;
+}) {
+  if (hasTabs && hasSearch && hasActions) {
+    return {
+      tabs: "md:col-span-5",
+      search: "md:col-span-4",
+      actions: "md:col-span-3",
+    };
+  }
+  if (hasTabs && hasSearch) {
+    return {
+      tabs: "md:col-span-6",
+      search: "md:col-span-6",
+      actions: "md:col-span-12",
+    };
+  }
+  if (hasTabs && hasActions) {
+    return {
+      tabs: "md:col-span-7",
+      search: "md:col-span-12",
+      actions: "md:col-span-5",
+    };
+  }
+  if (hasSearch && hasActions) {
+    return {
+      tabs: "md:col-span-12",
+      search: "md:col-span-7",
+      actions: "md:col-span-5",
+    };
+  }
+  return {
+    tabs: "md:col-span-12",
+    search: "md:col-span-12",
+    actions: "md:col-span-12",
+  };
+}
+
+const alignClassMap: Record<Align, { tabs: string; search: string; actions: string }> = {
+  start: {
+    tabs: "md:justify-self-start",
+    search: "md:justify-self-start",
+    actions: "md:justify-self-start",
+  },
+  center: {
+    tabs: "md:justify-self-center",
+    search: "md:justify-self-center",
+    actions: "md:justify-self-center",
+  },
+  end: {
+    tabs: "md:justify-self-end",
+    search: "md:justify-self-end",
+    actions: "md:justify-self-end",
+  },
+  between: {
+    tabs: "md:justify-self-start",
+    search: "md:justify-self-stretch",
+    actions: "md:justify-self-end",
+  },
+};
+
+const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFrameProps>(
+  (
+    {
+      as,
+      variant = "default",
+      frame = true,
+      className,
+      contentClassName,
+      children,
+      actionArea,
+      ...rest
+    },
+    ref,
+  ) => {
+    const Component = (as ?? "div") as FrameElement;
+    const Comp = Component as React.ElementType;
+    const showFrame = frame !== false;
+    const variantStyles =
+      variant !== "unstyled" ? variantMap[variant] : undefined;
+
+    const hasActionArea = Boolean(
+      actionArea &&
+        (actionArea.tabs || actionArea.actions || actionArea.search),
+    );
+
+    const shouldWrapContent =
+      variant !== "unstyled" || hasActionArea || Boolean(contentClassName);
+
+    const actionAlign = actionArea?.align ?? "between";
+    const slots = slotLayout({
+      hasTabs: Boolean(actionArea?.tabs),
+      hasSearch: Boolean(actionArea?.search),
+      hasActions: Boolean(actionArea?.actions),
+    });
+    const aligns = alignClassMap[actionAlign];
+
+    const content = shouldWrapContent ? (
       <div
-        ref={ref}
-        className={cn("relative overflow-hidden hero2-neomorph", className)}
-        {...rest}
+        className={cn(
+          "relative z-[2]",
+          variantStyles?.content,
+          !variantStyles && hasActionArea && "space-y-4 md:space-y-5",
+          contentClassName,
+        )}
       >
-        <span aria-hidden className="hero2-beams" />
-        <span aria-hidden className="hero2-scanlines" />
-        <span aria-hidden className="hero2-noise opacity-[0.03]" />
         {children}
-        <div
-          aria-hidden
-          className="absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/55"
-        />
       </div>
-    </>
-  );
-});
+    ) : (
+      children
+    );
+
+    return (
+      <>
+        {showFrame ? <NeomorphicFrameStyles /> : null}
+        <Comp
+          ref={ref}
+          className={cn(
+            "relative",
+            showFrame && "overflow-hidden hero2-neomorph",
+            variantStyles?.container,
+            variantStyles?.padding,
+            className,
+          )}
+          {...rest}
+        >
+          {showFrame ? (
+            <>
+              <span aria-hidden className="hero2-beams" />
+              <span aria-hidden className="hero2-scanlines" />
+              <span aria-hidden className="hero2-noise opacity-[0.03]" />
+            </>
+          ) : null}
+
+          {content}
+
+          {hasActionArea ? (
+            <div
+              role="group"
+              aria-label={actionArea?.["aria-label"]}
+              aria-labelledby={actionArea?.["aria-labelledby"]}
+              className={cn(
+                "relative z-[2]",
+                variantStyles?.action.mt ?? "mt-4",
+                (actionArea?.divider ?? true)
+                  ? cn(
+                      "border-t border-border/35",
+                      variantStyles?.action.pt ?? "pt-4",
+                    )
+                  : null,
+                "grid gap-3 md:grid-cols-12 md:gap-4",
+                variantStyles?.action.gap,
+                actionArea?.className,
+              )}
+            >
+              {actionArea?.tabs ? (
+                <div
+                  data-area="tabs"
+                  className={cn(
+                    "flex flex-col gap-2",
+                    slots.tabs,
+                    aligns.tabs,
+                    actionArea.tabsClassName,
+                  )}
+                >
+                  {actionArea.tabs}
+                </div>
+              ) : null}
+
+              {actionArea?.search ? (
+                <div
+                  data-area="search"
+                  className={cn(
+                    "flex flex-col gap-2",
+                    slots.search,
+                    aligns.search,
+                    actionArea.searchClassName,
+                  )}
+                >
+                  {actionArea.search}
+                </div>
+              ) : null}
+
+              {actionArea?.actions ? (
+                <div
+                  data-area="actions"
+                  className={cn(
+                    "flex flex-wrap items-center justify-end gap-2",
+                    slots.actions,
+                    aligns.actions,
+                    actionArea.actionsClassName,
+                  )}
+                >
+                  {actionArea.actions}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+
+          {showFrame ? (
+            <div
+              aria-hidden
+              className="absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/55"
+            />
+          ) : null}
+        </Comp>
+      </>
+    );
+  },
+);
 
 NeomorphicHeroFrame.displayName = "NeomorphicHeroFrame";
 

--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -41,6 +41,8 @@ export interface PageHeaderBaseProps<
   subTabs?: HeroProps<HeroKey>["subTabs"];
   /** Optional hero search override */
   search?: HeroProps<HeroKey>["search"];
+  /** Optional hero actions override */
+  actions?: HeroProps<HeroKey>["actions"];
 }
 
 export type PageHeaderProps<
@@ -69,6 +71,7 @@ const PageHeaderInner = <
     as,
     subTabs,
     search,
+    actions,
     ...elementProps
   }: PageHeaderBaseProps<HeaderKey, HeroKey>,
   ref: React.ForwardedRef<PageHeaderFrameElement>,
@@ -78,6 +81,7 @@ const PageHeaderInner = <
   const {
     subTabs: heroSubTabs,
     search: heroSearch,
+    actions: heroActions,
     frame: heroFrame,
     topClassName: heroTopClassName,
     as: heroAs,
@@ -96,16 +100,19 @@ const PageHeaderInner = <
         ? null
         : { ...searchSource, round: searchSource.round ?? true };
 
+  const resolvedActions =
+    heroActions !== undefined ? heroActions : actions;
+
+  const { className: frameClassName, variant: frameVariant, ...restFrameProps } =
+    frameProps ?? {};
+
   return (
     <Component {...(elementProps as React.HTMLAttributes<HTMLElement>)}>
       <NeomorphicHeroFrame
         ref={ref}
-        {...frameProps}
-        className={cn(
-          className ??
-            "rounded-card r-card-lg border border-border/40 p-6 md:p-7 lg:p-8",
-          frameProps?.className,
-        )}
+        variant={frameVariant ?? "default"}
+        {...restFrameProps}
+        className={cn(className, frameClassName)}
       >
         <div
           className={cn(
@@ -121,6 +128,7 @@ const PageHeaderInner = <
             topClassName={cn("top-[var(--header-stack)]", heroTopClassName)}
             subTabs={resolvedSubTabs}
             search={resolvedSearch}
+            actions={resolvedActions}
           />
         </div>
       </NeomorphicHeroFrame>

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -128,7 +128,7 @@ exports[`ReviewsPage > renders default state 1`] = `
     
       </style>
       <div
-        class="overflow-hidden hero2-neomorph sticky top-0 rounded-card r-card-lg px-4 py-4"
+        class="overflow-hidden hero2-neomorph rounded-card r-card-lg border border-border/40 bg-card/70 shadow-[0_0_0_1px_hsl(var(--border)/0.12)] md:px-7 md:py-7 lg:px-8 lg:py-8 sticky top-0 rounded-card r-card-lg px-4 py-4"
       >
         <span
           aria-hidden="true"
@@ -143,68 +143,71 @@ exports[`ReviewsPage > renders default state 1`] = `
           class="hero2-noise opacity-[0.03]"
         />
         <div
-          class="relative z-[2] space-y-2"
+          class="relative z-[2] space-y-5 md:space-y-6"
         >
-          <header
-            class="z-[999] relative isolate after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent"
-            id="reviews-header"
+          <div
+            class="relative z-[2] space-y-2"
           >
-            <div
-              class="sticky top-[var(--header-stack)] relative flex items-center gap-3 sm:gap-4 px-3 sm:px-4 py-3 sm:py-4 min-h-12"
+            <header
+              class="z-[999] relative isolate after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent"
+              id="reviews-header"
             >
               <div
-                aria-hidden="true"
-                class="header-rail pointer-events-none absolute left-0 top-1 bottom-1 w-2 rounded-l-2xl"
-              />
-              <div
-                class="flex min-w-0 flex-1 items-center gap-3 sm:gap-4"
+                class="sticky top-[var(--header-stack)] relative flex items-center gap-3 sm:gap-4 px-3 sm:px-4 py-3 sm:py-4 min-h-12"
               >
                 <div
-                  class="flex min-w-0 items-center gap-2 sm:gap-3"
+                  aria-hidden="true"
+                  class="header-rail pointer-events-none absolute left-0 top-1 bottom-1 w-2 rounded-l-2xl"
+                />
+                <div
+                  class="flex min-w-0 flex-1 items-center gap-3 sm:gap-4"
                 >
-                  <span
-                    class="shrink-0 opacity-90"
-                  >
-                    <svg
-                      class="lucide lucide-book-open opacity-80"
-                      fill="none"
-                      height="24"
-                      stroke="currentColor"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M12 7v14"
-                      />
-                      <path
-                        d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"
-                      />
-                    </svg>
-                  </span>
                   <div
-                    class="min-w-0"
+                    class="flex min-w-0 items-center gap-2 sm:gap-3"
                   >
-                    <div
-                      class="flex min-w-0 items-baseline gap-2"
+                    <span
+                      class="shrink-0 opacity-90"
                     >
-                      <h1
-                        class="truncate text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow"
+                      <svg
+                        class="lucide lucide-book-open opacity-80"
+                        fill="none"
+                        height="24"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        Reviews
-                      </h1>
+                        <path
+                          d="M12 7v14"
+                        />
+                        <path
+                          d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"
+                        />
+                      </svg>
+                    </span>
+                    <div
+                      class="min-w-0"
+                    >
+                      <div
+                        class="flex min-w-0 items-baseline gap-2"
+                      >
+                        <h1
+                          class="truncate text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow"
+                        >
+                          Reviews
+                        </h1>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-          </header>
-          <header>
-            <style>
-              
+            </header>
+            <header>
+              <style>
+                
       /* === Glitch title ================================================== */
       .hero2-title {
         position: relative;
@@ -299,9 +302,9 @@ exports[`ReviewsPage > renders default state 1`] = `
         }
       }
     
-            </style>
-            <style>
-              
+              </style>
+              <style>
+                
       .hero2-beams {
         position: absolute;
         inset: calc(var(--space-1) / -2);
@@ -419,178 +422,178 @@ exports[`ReviewsPage > renders default state 1`] = `
           0 0 var(--space-4) hsl(var(--ring) / 0.25);
       }
     
-            </style>
-            <div
-              class="sticky-blur top-[var(--header-stack)]"
-            >
+              </style>
               <div
-                class="relative z-[2] flex items-center gap-3 md:gap-4 lg:gap-6 py-6"
+                class="sticky-blur top-[var(--header-stack)]"
               >
-                <span
-                  aria-hidden="true"
-                  class="rail"
-                />
                 <div
-                  class="min-w-0"
+                  class="relative z-[2] flex items-center gap-3 md:gap-4 lg:gap-6 py-6"
                 >
+                  <span
+                    aria-hidden="true"
+                    class="rail"
+                  />
                   <div
-                    class="flex items-baseline gap-2"
+                    class="min-w-0"
                   >
-                    <h2
-                      class="hero2-title title-glow text-2xl md:text-3xl font-semibold tracking-[-0.005em] truncate"
-                      data-text="Browse Reviews"
+                    <div
+                      class="flex items-baseline gap-2"
                     >
-                      Browse Reviews
-                    </h2>
-                    <span
-                      class="text-sm md:text-base font-medium text-[hsl(var(--muted-foreground))] truncate"
-                    >
-                      <span
-                        class="pill"
+                      <h2
+                        class="hero2-title title-glow text-2xl md:text-3xl font-semibold tracking-[-0.005em] truncate"
+                        data-text="Browse Reviews"
                       >
-                        Total 
-                        3
+                        Browse Reviews
+                      </h2>
+                      <span
+                        class="text-sm md:text-base font-medium text-[hsl(var(--muted-foreground))] truncate"
+                      >
+                        <span
+                          class="pill"
+                        >
+                          Total 
+                          3
+                        </span>
                       </span>
-                    </span>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="relative z-[2] mt-5 md:mt-6 flex flex-col gap-5 md:gap-6"
-              >
                 <div
-                  class="relative"
-                  style="--divider: var(--ring);"
+                  class="relative z-[2] mt-5 md:mt-6 flex flex-col gap-5 md:gap-6"
                 >
-                  <span
-                    aria-hidden="true"
-                    class="block h-px bg-[hsl(var(--divider))/0.35]"
-                  />
-                  <span
-                    aria-hidden="true"
-                    class="absolute inset-x-0 top-0 h-px blur-[6px] opacity-60 bg-[hsl(var(--divider))]"
-                  />
                   <div
-                    class="flex items-center gap-3 md:gap-4 lg:gap-6 pt-5 md:pt-6"
+                    class="relative"
+                    style="--divider: var(--ring);"
                   >
-                    <form
-                      class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"
-                      role="search"
-                    >
-                      <div
-                        class="relative min-w-0"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="lucide lucide-search pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 size-4 text-muted-foreground"
-                          fill="none"
-                          height="24"
-                          stroke="currentColor"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <circle
-                            cx="11"
-                            cy="11"
-                            r="8"
-                          />
-                          <path
-                            d="m21 21-4.3-4.3"
-                          />
-                        </svg>
-                        <div
-                          class="relative inline-flex items-center overflow-hidden border border-card-hairline bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),url('/noise.svg')] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] focus-within:after:opacity-100 w-full rounded-full [&>input]:rounded-full"
-                          style="--control-h: var(--control-h-md);"
-                        >
-                          <input
-                            autocapitalize="none"
-                            autocomplete="off"
-                            autocorrect="off"
-                            class="w-full rounded-[inherit] bg-transparent px-3 text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)] pl-7"
-                            id=":r0:"
-                            name=":r0:"
-                            placeholder="Search title, tags, opponent, patch…"
-                            spellcheck="false"
-                            type="search"
-                            value=""
-                          />
-                        </div>
-                      </div>
-                    </form>
+                    <span
+                      aria-hidden="true"
+                      class="block h-px bg-[hsl(var(--divider))/0.35]"
+                    />
+                    <span
+                      aria-hidden="true"
+                      class="absolute inset-x-0 top-0 h-px blur-[6px] opacity-60 bg-[hsl(var(--divider))]"
+                    />
                     <div
-                      class="flex items-center gap-2"
+                      class="flex items-center gap-3 md:gap-4 lg:gap-6 pt-5 md:pt-6"
                     >
-                      <div
-                        class="flex items-center gap-3"
+                      <form
+                        class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"
+                        role="search"
                       >
                         <div
-                          class="hidden sm:flex items-center gap-2 text-xs text-muted-foreground"
+                          class="relative min-w-0"
                         >
-                          <span>
-                            Sort
-                          </span>
-                          <div
-                            class="glitch-wrap "
+                          <svg
+                            aria-hidden="true"
+                            class="lucide lucide-search pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 size-4 text-muted-foreground"
+                            fill="none"
+                            height="24"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
+                            <circle
+                              cx="11"
+                              cy="11"
+                              r="8"
+                            />
+                            <path
+                              d="m21 21-4.3-4.3"
+                            />
+                          </svg>
+                          <div
+                            class="relative inline-flex items-center overflow-hidden border border-card-hairline bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),url('/noise.svg')] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] focus-within:after:opacity-100 w-full rounded-full [&>input]:rounded-full"
+                            style="--control-h: var(--control-h-md);"
+                          >
+                            <input
+                              autocapitalize="none"
+                              autocomplete="off"
+                              autocorrect="off"
+                              class="w-full rounded-[inherit] bg-transparent px-3 text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)] pl-7"
+                              id=":r0:"
+                              name=":r0:"
+                              placeholder="Search title, tags, opponent, patch…"
+                              spellcheck="false"
+                              type="search"
+                              value=""
+                            />
+                          </div>
+                        </div>
+                      </form>
+                      <div
+                        class="flex items-center gap-2"
+                      >
+                        <div
+                          class="flex items-center gap-3"
+                        >
+                          <div
+                            class="hidden sm:flex items-center gap-2 text-xs text-muted-foreground"
+                          >
+                            <span>
+                              Sort
+                            </span>
                             <div
-                              class="group inline-flex rounded-full border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0"
+                              class="glitch-wrap "
                             >
-                              <button
-                                aria-controls=":r1:-listbox"
-                                aria-expanded="false"
-                                aria-haspopup="listbox"
-                                aria-label="Select option"
-                                class="glitch-trigger relative flex items-center h-9 rounded-full px-3 overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none h-10 px-4"
-                                data-lit="true"
-                                data-open="false"
-                                type="button"
+                              <div
+                                class="group inline-flex rounded-full border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0"
                               >
-                                <span
-                                  class="font-medium glitch-text text-foreground group-hover:text-foreground"
+                                <button
+                                  aria-controls=":r1:-listbox"
+                                  aria-expanded="false"
+                                  aria-haspopup="listbox"
+                                  aria-label="Select option"
+                                  class="glitch-trigger relative flex items-center h-9 rounded-full px-3 overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none h-10 px-4"
+                                  data-lit="true"
+                                  data-open="false"
+                                  type="button"
                                 >
-                                  Newest
-                                </span>
-                                <svg
-                                  aria-hidden="true"
-                                  class="lucide lucide-chevron-down caret ml-auto size-4 shrink-0 opacity-75 "
-                                  fill="none"
-                                  height="24"
-                                  stroke="currentColor"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="2"
-                                  viewBox="0 0 24 24"
-                                  width="24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="m6 9 6 6 6-6"
+                                  <span
+                                    class="font-medium glitch-text text-foreground group-hover:text-foreground"
+                                  >
+                                    Newest
+                                  </span>
+                                  <svg
+                                    aria-hidden="true"
+                                    class="lucide lucide-chevron-down caret ml-auto size-4 shrink-0 opacity-75 "
+                                    fill="none"
+                                    height="24"
+                                    stroke="currentColor"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                    viewBox="0 0 24 24"
+                                    width="24"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m6 9 6 6 6-6"
+                                    />
+                                  </svg>
+                                  <span
+                                    aria-hidden="true"
+                                    class="gb-iris"
                                   />
-                                </svg>
-                                <span
-                                  aria-hidden="true"
-                                  class="gb-iris"
-                                />
-                                <span
-                                  aria-hidden="true"
-                                  class="gb-chroma"
-                                />
-                                <span
-                                  aria-hidden="true"
-                                  class="gb-flicker"
-                                />
-                                <span
-                                  aria-hidden="true"
-                                  class="gb-scan"
-                                />
-                              </button>
-                            </div>
-                            <style>
-                              
+                                  <span
+                                    aria-hidden="true"
+                                    class="gb-chroma"
+                                  />
+                                  <span
+                                    aria-hidden="true"
+                                    class="gb-flicker"
+                                  />
+                                  <span
+                                    aria-hidden="true"
+                                    class="gb-scan"
+                                  />
+                                </button>
+                              </div>
+                              <style>
+                                
       /* caret jitter */
       .caret {
         transition:
@@ -820,51 +823,52 @@ exports[`ReviewsPage > renders default state 1`] = `
           -0.6px 0 hsl(var(--lav-deep) / 0.45);
       }
     
-                            </style>
+                              </style>
+                            </div>
                           </div>
-                        </div>
-                        <button
-                          class="relative inline-flex items-center justify-center rounded-2xl border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 gap-2 [&_svg]:size-5 px-4 whitespace-nowrap bg-[hsl(var(--accent)/0.12)] border-[hsl(var(--accent)/0.35)] hover:bg-[hsl(var(--accent)/0.14)] hover:shadow-[0_2px_6px_-1px_hsl(var(--accent)/0.25)] active:translate-y-px active:shadow-[inset_0_0_0_1px_hsl(var(--accent)/0.6)] text-foreground"
-                          tabindex="0"
-                          type="button"
-                        >
-                          <span
-                            class="absolute inset-0 pointer-events-none rounded-2xl bg-[linear-gradient(90deg,hsl(var(--foreground)/.18),hsl(var(--foreground)/.18))]"
-                          />
-                          <span
-                            class="relative z-10 inline-flex items-center gap-2"
+                          <button
+                            class="relative inline-flex items-center justify-center rounded-2xl border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 gap-2 [&_svg]:size-5 px-4 whitespace-nowrap bg-[hsl(var(--accent)/0.12)] border-[hsl(var(--accent)/0.35)] hover:bg-[hsl(var(--accent)/0.14)] hover:shadow-[0_2px_6px_-1px_hsl(var(--accent)/0.25)] active:translate-y-px active:shadow-[inset_0_0_0_1px_hsl(var(--accent)/0.6)] text-foreground"
+                            tabindex="0"
+                            type="button"
                           >
-                            <svg
-                              class="lucide lucide-plus"
-                              fill="none"
-                              height="24"
-                              stroke="currentColor"
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                              viewBox="0 0 24 24"
-                              width="24"
-                              xmlns="http://www.w3.org/2000/svg"
+                            <span
+                              class="absolute inset-0 pointer-events-none rounded-2xl bg-[linear-gradient(90deg,hsl(var(--foreground)/.18),hsl(var(--foreground)/.18))]"
+                            />
+                            <span
+                              class="relative z-10 inline-flex items-center gap-2"
                             >
-                              <path
-                                d="M5 12h14"
-                              />
-                              <path
-                                d="M12 5v14"
-                              />
-                            </svg>
-                            <span>
-                              New Review
+                              <svg
+                                class="lucide lucide-plus"
+                                fill="none"
+                                height="24"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                viewBox="0 0 24 24"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5 12h14"
+                                />
+                                <path
+                                  d="M12 5v14"
+                                />
+                              </svg>
+                              <span>
+                                New Review
+                              </span>
                             </span>
-                          </span>
-                        </button>
+                          </button>
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-          </header>
+            </header>
+          </div>
         </div>
         <div
           aria-hidden="true"


### PR DESCRIPTION
## Summary
- extend `NeomorphicHeroFrame` with semantic `as` support, built-in variants, and token-based action rows
- update `PageHeader`/`TeamCompPage` to use the new frame API and expose hero actions
- add a comprehensive demo to the prompts gallery showing default and compact layouts with interactive states

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c873b6e194832c8313874be535146d