### PR TITLE
feat: expand neomorphic hero frame variants

### DIFF
--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -166,6 +166,225 @@ function HeaderTabsDemo() {
   );
 }
 
+function NeomorphicHeroFrameGallery() {
+  const [primaryTab, setPrimaryTab] = React.useState<
+    "overview" | "insights" | "archive"
+  >("overview");
+  const [compactTab, setCompactTab] = React.useState<
+    "home" | "projects" | "alerts"
+  >("home");
+  const [query, setQuery] = React.useState("");
+
+  const actionStates = (
+    <div className="space-y-3" aria-labelledby="hero-frame-actions-title">
+      <p
+        id="hero-frame-actions-title"
+        className="text-label font-semibold uppercase tracking-[0.02em] text-muted-foreground"
+      >
+        Action states
+      </p>
+      <div className="flex flex-wrap gap-3">
+        <Button size="sm">Default</Button>
+        <Button size="sm" className="bg-[--hover]">
+          Hover
+        </Button>
+        <Button size="sm" className="ring-2 ring-[--focus]">
+          Focus
+        </Button>
+        <Button size="sm" className="bg-[--active]">
+          Active
+        </Button>
+        <Button size="sm" disabled>
+          Disabled
+        </Button>
+        <Button size="sm" loading>
+          Loading
+        </Button>
+      </div>
+      <div className="flex flex-wrap gap-3">
+        <IconButton size="sm" aria-label="Default state">
+          <Plus />
+        </IconButton>
+        <IconButton size="sm" className="bg-[--hover]" aria-label="Hover state">
+          <Plus />
+        </IconButton>
+        <IconButton
+          size="sm"
+          className="ring-2 ring-[--focus]"
+          aria-label="Focus state"
+        >
+          <Plus />
+        </IconButton>
+        <IconButton
+          size="sm"
+          className="bg-[--active]"
+          aria-label="Active state"
+        >
+          <Plus />
+        </IconButton>
+        <IconButton size="sm" disabled aria-label="Disabled state">
+          <Plus />
+        </IconButton>
+        <IconButton size="sm" loading aria-label="Loading state">
+          <Plus />
+        </IconButton>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="space-y-6">
+      <NeomorphicHeroFrame
+        as="header"
+        variant="neo"
+        density="default"
+        lead={
+          <div className="space-y-4" aria-labelledby="neo-frame-title">
+            <div className="space-y-2">
+              <span className="text-label font-semibold uppercase tracking-[0.02em] text-muted-foreground">
+                Overview
+              </span>
+              <h2
+                id="neo-frame-title"
+                className="text-title-lg font-semibold tracking-[-0.01em] text-foreground"
+              >
+                Neomorphic hero frame
+              </h2>
+            </div>
+            <p className="max-w-3xl text-ui text-muted-foreground">
+              Compose headers, sub-tabs, and action rows inside a 12-column
+              grid. Padding follows spacing tokens 6→8 so layouts stay aligned
+              as they scale.
+            </p>
+          </div>
+        }
+        leadClassName="md:col-span-12"
+        tabs={
+          <SegmentedButtons<"overview" | "insights" | "archive">
+            items={[
+              { key: "overview", label: "Overview" },
+              { key: "insights", label: "Insights" },
+              { key: "archive", label: "Archive", disabled: true },
+            ]}
+            value={primaryTab}
+            onValueChange={(key) => setPrimaryTab(key)}
+            ariaLabel="Primary sections"
+            align="between"
+            right={<Badge variant="accent">Design tokens</Badge>}
+          />
+        }
+        tabsClassName="md:col-span-12"
+        bodyClassName="md:col-span-8 space-y-4"
+        search={
+          <div
+            className="space-y-3"
+            aria-labelledby="hero-frame-search-title"
+          >
+            <p
+              id="hero-frame-search-title"
+              className="text-label font-semibold uppercase tracking-[0.02em] text-muted-foreground"
+            >
+              Search states
+            </p>
+            <div className="flex flex-col gap-3">
+              <SearchBar
+                value={query}
+                onValueChange={setQuery}
+                placeholder="Search components"
+                aria-label="Search components"
+              />
+              <SearchBar
+                value={query}
+                onValueChange={setQuery}
+                placeholder="Loading search"
+                aria-label="Loading search"
+                loading
+              />
+            </div>
+          </div>
+        }
+        actions={actionStates}
+        footer={
+          <p className="text-label text-muted-foreground">
+            Radii use <code className="font-mono text-xs">r-card-lg</code> and
+            the grid reserves seven columns for search with five for actions so
+            controls snap to the spacing ramp.
+          </p>
+        }
+      >
+        <div className="space-y-3 text-ui text-muted-foreground">
+          <p>
+            The body span defaults to eight columns but can be reassigned with
+            <code className="ml-1 font-mono text-xs">bodyClassName</code> to
+            create asymmetric layouts.
+          </p>
+          <ul className="list-disc space-y-2 pl-5">
+            <li>
+              Semantic wrapper defaults to
+              <code className="ml-1 font-mono text-xs">header</code>.
+            </li>
+            <li>
+              Tokens keep typography on the UI ramp and spacing on the 4px grid.
+            </li>
+          </ul>
+        </div>
+      </NeomorphicHeroFrame>
+
+      <NeomorphicHeroFrame
+        as="nav"
+        variant="plain"
+        density="compact"
+        lead={
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <span className="text-label font-semibold uppercase tracking-[0.02em] text-muted-foreground">
+              Compact navigation
+            </span>
+            <Badge variant="pill">Compact</Badge>
+          </div>
+        }
+        tabs={
+          <SegmentedButtons<"home" | "projects" | "alerts">
+            items={[
+              { key: "home", label: "Home" },
+              { key: "projects", label: "Projects" },
+              { key: "alerts", label: "Alerts" },
+            ]}
+            value={compactTab}
+            onValueChange={(key) => setCompactTab(key)}
+            ariaLabel="Navigation tabs"
+            align="start"
+            size="sm"
+          />
+        }
+        tabsClassName="md:col-span-12"
+        actions={
+          <div className="flex flex-wrap items-center gap-2">
+            <Button size="sm" variant="ghost">
+              Manage
+            </Button>
+            <IconButton size="sm" aria-label="Create shortcut">
+              <Plus />
+            </IconButton>
+          </div>
+        }
+        actionsClassName="md:col-span-4 md:justify-end"
+        bodyClassName="md:col-span-8 text-ui text-muted-foreground"
+        footer={
+          <p className="text-label text-muted-foreground">
+            Compact density maps to spacing tokens 4/5/6 while the plain variant
+            leans on the card surface for lighter sections.
+          </p>
+        }
+      >
+        <p>
+          Use semantic <code className="font-mono text-xs">nav</code> when the
+          frame wraps secondary navigation or tab rails.
+        </p>
+      </NeomorphicHeroFrame>
+    </div>
+  );
+}
+
 function CardDemo() {
   return (
     <Card>
@@ -694,15 +913,46 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
     {
       id: "neomorphic-hero-frame",
       name: "NeomorphicHeroFrame",
-      description: "HUD-style frame shell",
-      element: (
-        <NeomorphicHeroFrame className="rounded-card r-card-lg px-4 py-4">
-          <div className="relative z-[2] text-sm">Content</div>
-        </NeomorphicHeroFrame>
-      ),
-      tags: ["hero", "layout"],
-      code: `<NeomorphicHeroFrame className="rounded-card r-card-lg px-4 py-4">
-  <div className="relative z-[2]">Content</div>
+      description:
+        "Neomorphic frame with semantic wrappers, density tokens, and built-in action/search slots.",
+      element: <NeomorphicHeroFrameGallery />,
+      tags: ["hero", "layout", "header", "nav", "search", "actions"],
+      code: `<NeomorphicHeroFrame
+  as="header"
+  variant="neo"
+  density="default"
+  lead={<Header heading="Hero" sticky={false} />}
+  tabs={
+    <SegmentedButtons
+      items={[
+        { key: "overview", label: "Overview" },
+        { key: "insights", label: "Insights" },
+      ]}
+      value="overview"
+      onValueChange={() => {}}
+      ariaLabel="Primary sections"
+    />
+  }
+  search={
+    <SearchBar
+      value=""
+      onValueChange={() => {}}
+      aria-label="Search components"
+      loading
+    />
+  }
+  actions={
+    <div className="flex flex-wrap gap-3">
+      <Button size="sm">Default</Button>
+      <Button size="sm" className="bg-[--hover]">Hover</Button>
+      <Button size="sm" className="ring-2 ring-[--focus]">Focus</Button>
+      <IconButton size="sm" aria-label="Loading" loading>
+        <Plus />
+      </IconButton>
+    </div>
+  }
+>
+  <Hero heading="Hero" sticky={false} frame={false} />
 </NeomorphicHeroFrame>`,
     },
     {

--- a/src/components/ui/layout/NeomorphicHeroFrame.tsx
+++ b/src/components/ui/layout/NeomorphicHeroFrame.tsx
@@ -5,32 +5,206 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 import { NeomorphicFrameStyles } from "./NeomorphicFrameStyles";
 
-export type NeomorphicHeroFrameProps = React.HTMLAttributes<HTMLDivElement>;
+type FrameElement = Extract<
+  keyof JSX.IntrinsicElements,
+  "div" | "header" | "section" | "nav" | "article" | "aside" | "main"
+>;
+
+export type NeomorphicHeroFrameVariant = "neo" | "plain" | "ghost";
+export type NeomorphicHeroFrameDensity = "default" | "compact" | "flush";
+
+export interface NeomorphicHeroFrameProps
+  extends React.HTMLAttributes<HTMLElement> {
+  /** Semantic element for the frame container. */
+  as?: FrameElement;
+  /** Visual styling variant. */
+  variant?: NeomorphicHeroFrameVariant;
+  /** Padding density. */
+  density?: NeomorphicHeroFrameDensity;
+  /** Wrapper classes for the internal grid layout. */
+  contentClassName?: string;
+  /** Optional lead slot (hero heading, breadcrumbs, etc.). */
+  lead?: React.ReactNode;
+  leadClassName?: string;
+  /** Classes applied to the body slot that wraps `children`. */
+  bodyClassName?: string;
+  /** Optional segmented controls rendered beneath the lead. */
+  tabs?: React.ReactNode;
+  tabsClassName?: string;
+  /** Supplemental actions (buttons, icon buttons, etc.). */
+  actions?: React.ReactNode;
+  actionsClassName?: string;
+  /** Optional search region rendered alongside actions. */
+  search?: React.ReactNode;
+  searchClassName?: string;
+  /** Footer region for secondary notes or metadata. */
+  footer?: React.ReactNode;
+  footerClassName?: string;
+}
+
+const densityClasses: Record<NeomorphicHeroFrameDensity, string> = {
+  default: "px-6 py-6 md:px-7 md:py-7 lg:px-8 lg:py-8",
+  compact: "px-4 py-4 md:px-5 md:py-5 lg:px-6 lg:py-6",
+  flush: "p-0",
+};
+
+const variantClasses: Record<NeomorphicHeroFrameVariant, string> = {
+  neo: "hero2-neomorph border border-border/40",
+  plain: "bg-card/70 border border-border/35 backdrop-blur-sm",
+  ghost: "bg-card/20 border border-border/30 backdrop-blur-sm",
+};
+
+const variantRing: Partial<Record<NeomorphicHeroFrameVariant, string>> = {
+  neo: "absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/55",
+  plain: "absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/35",
+};
+
+const baseGridClass =
+  "relative z-[2] grid gap-y-5 md:gap-y-6 md:grid-cols-12 md:gap-x-6";
 
 const NeomorphicHeroFrame = React.forwardRef<
-  HTMLDivElement,
+  HTMLElement,
   NeomorphicHeroFrameProps
->(({ className, children, ...rest }, ref) => {
-  return (
-    <>
-      <NeomorphicFrameStyles />
-      <div
-        ref={ref}
-        className={cn("relative overflow-hidden hero2-neomorph", className)}
-        {...rest}
-      >
-        <span aria-hidden className="hero2-beams" />
-        <span aria-hidden className="hero2-scanlines" />
-        <span aria-hidden className="hero2-noise opacity-[0.03]" />
-        {children}
-        <div
-          aria-hidden
-          className="absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/55"
-        />
+>(
+  (
+    {
+      as,
+      variant = "neo",
+      density = "default",
+      contentClassName,
+      lead,
+      leadClassName,
+      bodyClassName,
+      tabs,
+      tabsClassName,
+      actions,
+      actionsClassName,
+      search,
+      searchClassName,
+      footer,
+      footerClassName,
+      className,
+      children,
+      ...rest
+    },
+    ref,
+  ) => {
+    const ComponentTag = (as ?? "div") as FrameElement;
+    const Component = ComponentTag as unknown as React.ElementType;
+    const showTextures = variant === "neo";
+    const hasSearch = search != null;
+    const hasActions = actions != null;
+
+    const wrapChildren =
+      lead != null ||
+      tabs != null ||
+      hasSearch ||
+      hasActions ||
+      footer != null ||
+      contentClassName != null ||
+      bodyClassName != null;
+
+    const leadNode = lead ? (
+      <div className={cn("md:col-span-12", leadClassName)} data-slot="lead">
+        {lead}
       </div>
-    </>
-  );
-});
+    ) : null;
+
+    const tabsNode = tabs ? (
+      <div
+        className={cn(
+          "md:col-span-12 flex flex-wrap items-center gap-3",
+          tabsClassName,
+        )}
+        data-slot="tabs"
+      >
+        {tabs}
+      </div>
+    ) : null;
+
+    const bodyNode = children != null ? (
+      <div className={cn("md:col-span-12", bodyClassName)} data-slot="body">
+        {children}
+      </div>
+    ) : null;
+
+    const searchNode = hasSearch ? (
+      <div
+        className={cn(
+          "flex w-full flex-col gap-3",
+          hasActions ? "md:col-span-7" : "md:col-span-12",
+          searchClassName,
+        )}
+        data-slot="search"
+      >
+        {search}
+      </div>
+    ) : null;
+
+    const actionsNode = hasActions ? (
+      <div
+        className={cn(
+          "flex w-full flex-wrap items-center gap-2 md:justify-end",
+          hasSearch ? "md:col-span-5" : "md:col-span-12",
+          actionsClassName,
+        )}
+        data-slot="actions"
+      >
+        {actions}
+      </div>
+    ) : null;
+
+    const footerNode = footer ? (
+      <div
+        className={cn("md:col-span-12", footerClassName)}
+        data-slot="footer"
+      >
+        {footer}
+      </div>
+    ) : null;
+
+    const structuredContent = (
+      <div className={cn(baseGridClass, contentClassName)}>
+        {leadNode}
+        {tabsNode}
+        {bodyNode}
+        {searchNode}
+        {actionsNode}
+        {footerNode}
+      </div>
+    );
+
+    return (
+      <>
+        <NeomorphicFrameStyles />
+        <Component
+          ref={ref}
+          data-variant={variant}
+          data-density={density}
+          className={cn(
+            "relative overflow-hidden rounded-card r-card-lg",
+            densityClasses[density],
+            variantClasses[variant],
+            className,
+          )}
+          {...rest}
+        >
+          {showTextures ? (
+            <>
+              <span aria-hidden className="hero2-beams" />
+              <span aria-hidden className="hero2-scanlines" />
+              <span aria-hidden className="hero2-noise opacity-[0.03]" />
+            </>
+          ) : null}
+          {wrapChildren ? structuredContent : children}
+          {variantRing[variant] ? (
+            <div aria-hidden className={variantRing[variant]} />
+          ) : null}
+        </Component>
+      </>
+    );
+  },
+);
 
 NeomorphicHeroFrame.displayName = "NeomorphicHeroFrame";
 

--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -41,6 +41,8 @@ export interface PageHeaderBaseProps<
   subTabs?: HeroProps<HeroKey>["subTabs"];
   /** Optional hero search override */
   search?: HeroProps<HeroKey>["search"];
+  /** Optional hero actions override */
+  actions?: HeroProps<HeroKey>["actions"];
 }
 
 export type PageHeaderProps<
@@ -69,6 +71,7 @@ const PageHeaderInner = <
     as,
     subTabs,
     search,
+    actions,
     ...elementProps
   }: PageHeaderBaseProps<HeaderKey, HeroKey>,
   ref: React.ForwardedRef<PageHeaderFrameElement>,
@@ -78,6 +81,7 @@ const PageHeaderInner = <
   const {
     subTabs: heroSubTabs,
     search: heroSearch,
+    actions: heroActions,
     frame: heroFrame,
     topClassName: heroTopClassName,
     as: heroAs,
@@ -96,33 +100,67 @@ const PageHeaderInner = <
         ? null
         : { ...searchSource, round: searchSource.round ?? true };
 
+  const resolvedActions =
+    heroActions !== undefined ? heroActions : actions;
+
+  const {
+    className: frameClassName,
+    contentClassName: frameContentClassName,
+    density: frameDensity,
+    variant: frameVariant,
+    as: frameAs,
+    lead: frameLead,
+    tabs: frameTabs,
+    actions: frameActions,
+    search: frameSearch,
+    footer: frameFooter,
+    ...frameRest
+  } = frameProps ?? {};
+
+  const headerNode = (
+    <Header {...header} underline={header.underline ?? false} />
+  );
+
+  const leadNode = frameLead ? (
+    <>
+      {frameLead}
+      {headerNode}
+    </>
+  ) : (
+    headerNode
+  );
+
   return (
     <Component {...(elementProps as React.HTMLAttributes<HTMLElement>)}>
       <NeomorphicHeroFrame
         ref={ref}
-        {...frameProps}
+        as={frameAs}
+        density={frameDensity ?? "default"}
+        variant={frameVariant ?? "neo"}
         className={cn(
-          className ??
-            "rounded-card r-card-lg border border-border/40 p-6 md:p-7 lg:p-8",
-          frameProps?.className,
+          className ?? "rounded-card r-card-lg border border-border/40",
+          frameClassName,
         )}
+        contentClassName={cn(
+          frameContentClassName,
+          contentClassName,
+        )}
+        lead={leadNode}
+        tabs={frameTabs}
+        actions={frameActions}
+        search={frameSearch}
+        footer={frameFooter}
+        {...frameRest}
       >
-        <div
-          className={cn(
-            "relative z-[2]",
-            contentClassName ?? "space-y-5 md:space-y-6",
-          )}
-        >
-          <Header {...header} underline={header.underline ?? false} />
-          <Hero
-            {...heroRest}
-            as={heroAs ?? "header"}
-            frame={heroFrame ?? true}
-            topClassName={cn("top-[var(--header-stack)]", heroTopClassName)}
-            subTabs={resolvedSubTabs}
-            search={resolvedSearch}
-          />
-        </div>
+        <Hero
+          {...heroRest}
+          as={heroAs ?? "header"}
+          frame={heroFrame ?? true}
+          topClassName={cn("top-[var(--header-stack)]", heroTopClassName)}
+          subTabs={resolvedSubTabs}
+          search={resolvedSearch}
+          actions={resolvedActions}
+        />
       </NeomorphicHeroFrame>
     </Component>
   );

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -128,7 +128,9 @@ exports[`ReviewsPage > renders default state 1`] = `
     
       </style>
       <div
-        class="overflow-hidden hero2-neomorph sticky top-0 rounded-card r-card-lg px-4 py-4"
+        class="overflow-hidden rounded-card r-card-lg md:px-7 md:py-7 lg:px-8 lg:py-8 hero2-neomorph border border-border/40 sticky top-0 rounded-card r-card-lg px-4 py-4"
+        data-density="default"
+        data-variant="neo"
       >
         <span
           aria-hidden="true"
@@ -143,68 +145,77 @@ exports[`ReviewsPage > renders default state 1`] = `
           class="hero2-noise opacity-[0.03]"
         />
         <div
-          class="relative z-[2] space-y-2"
+          class="relative z-[2] grid gap-y-5 md:gap-y-6 md:grid-cols-12 md:gap-x-6 space-y-2"
         >
-          <header
-            class="z-[999] relative isolate after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent"
-            id="reviews-header"
+          <div
+            class="md:col-span-12"
+            data-slot="lead"
           >
-            <div
-              class="sticky top-[var(--header-stack)] relative flex items-center gap-3 sm:gap-4 px-3 sm:px-4 py-3 sm:py-4 min-h-12"
+            <header
+              class="z-[999] relative isolate after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent"
+              id="reviews-header"
             >
               <div
-                aria-hidden="true"
-                class="header-rail pointer-events-none absolute left-0 top-1 bottom-1 w-2 rounded-l-2xl"
-              />
-              <div
-                class="flex min-w-0 flex-1 items-center gap-3 sm:gap-4"
+                class="sticky top-[var(--header-stack)] relative flex items-center gap-3 sm:gap-4 px-3 sm:px-4 py-3 sm:py-4 min-h-12"
               >
                 <div
-                  class="flex min-w-0 items-center gap-2 sm:gap-3"
+                  aria-hidden="true"
+                  class="header-rail pointer-events-none absolute left-0 top-1 bottom-1 w-2 rounded-l-2xl"
+                />
+                <div
+                  class="flex min-w-0 flex-1 items-center gap-3 sm:gap-4"
                 >
-                  <span
-                    class="shrink-0 opacity-90"
-                  >
-                    <svg
-                      class="lucide lucide-book-open opacity-80"
-                      fill="none"
-                      height="24"
-                      stroke="currentColor"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M12 7v14"
-                      />
-                      <path
-                        d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"
-                      />
-                    </svg>
-                  </span>
                   <div
-                    class="min-w-0"
+                    class="flex min-w-0 items-center gap-2 sm:gap-3"
                   >
-                    <div
-                      class="flex min-w-0 items-baseline gap-2"
+                    <span
+                      class="shrink-0 opacity-90"
                     >
-                      <h1
-                        class="truncate text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow"
+                      <svg
+                        class="lucide lucide-book-open opacity-80"
+                        fill="none"
+                        height="24"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        Reviews
-                      </h1>
+                        <path
+                          d="M12 7v14"
+                        />
+                        <path
+                          d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"
+                        />
+                      </svg>
+                    </span>
+                    <div
+                      class="min-w-0"
+                    >
+                      <div
+                        class="flex min-w-0 items-baseline gap-2"
+                      >
+                        <h1
+                          class="truncate text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow"
+                        >
+                          Reviews
+                        </h1>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-          </header>
-          <header>
-            <style>
-              
+            </header>
+          </div>
+          <div
+            class="md:col-span-12"
+            data-slot="body"
+          >
+            <header>
+              <style>
+                
       /* === Glitch title ================================================== */
       .hero2-title {
         position: relative;
@@ -299,9 +310,9 @@ exports[`ReviewsPage > renders default state 1`] = `
         }
       }
     
-            </style>
-            <style>
-              
+              </style>
+              <style>
+                
       .hero2-beams {
         position: absolute;
         inset: calc(var(--space-1) / -2);
@@ -419,178 +430,178 @@ exports[`ReviewsPage > renders default state 1`] = `
           0 0 var(--space-4) hsl(var(--ring) / 0.25);
       }
     
-            </style>
-            <div
-              class="sticky-blur top-[var(--header-stack)]"
-            >
+              </style>
               <div
-                class="relative z-[2] flex items-center gap-3 md:gap-4 lg:gap-6 py-6"
+                class="sticky-blur top-[var(--header-stack)]"
               >
-                <span
-                  aria-hidden="true"
-                  class="rail"
-                />
                 <div
-                  class="min-w-0"
+                  class="relative z-[2] flex items-center gap-3 md:gap-4 lg:gap-6 py-6"
                 >
+                  <span
+                    aria-hidden="true"
+                    class="rail"
+                  />
                   <div
-                    class="flex items-baseline gap-2"
+                    class="min-w-0"
                   >
-                    <h2
-                      class="hero2-title title-glow text-2xl md:text-3xl font-semibold tracking-[-0.005em] truncate"
-                      data-text="Browse Reviews"
+                    <div
+                      class="flex items-baseline gap-2"
                     >
-                      Browse Reviews
-                    </h2>
-                    <span
-                      class="text-sm md:text-base font-medium text-[hsl(var(--muted-foreground))] truncate"
-                    >
-                      <span
-                        class="pill"
+                      <h2
+                        class="hero2-title title-glow text-2xl md:text-3xl font-semibold tracking-[-0.005em] truncate"
+                        data-text="Browse Reviews"
                       >
-                        Total 
-                        3
+                        Browse Reviews
+                      </h2>
+                      <span
+                        class="text-sm md:text-base font-medium text-[hsl(var(--muted-foreground))] truncate"
+                      >
+                        <span
+                          class="pill"
+                        >
+                          Total 
+                          3
+                        </span>
                       </span>
-                    </span>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="relative z-[2] mt-5 md:mt-6 flex flex-col gap-5 md:gap-6"
-              >
                 <div
-                  class="relative"
-                  style="--divider: var(--ring);"
+                  class="relative z-[2] mt-5 md:mt-6 flex flex-col gap-5 md:gap-6"
                 >
-                  <span
-                    aria-hidden="true"
-                    class="block h-px bg-[hsl(var(--divider))/0.35]"
-                  />
-                  <span
-                    aria-hidden="true"
-                    class="absolute inset-x-0 top-0 h-px blur-[6px] opacity-60 bg-[hsl(var(--divider))]"
-                  />
                   <div
-                    class="flex items-center gap-3 md:gap-4 lg:gap-6 pt-5 md:pt-6"
+                    class="relative"
+                    style="--divider: var(--ring);"
                   >
-                    <form
-                      class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"
-                      role="search"
-                    >
-                      <div
-                        class="relative min-w-0"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="lucide lucide-search pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 size-4 text-muted-foreground"
-                          fill="none"
-                          height="24"
-                          stroke="currentColor"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <circle
-                            cx="11"
-                            cy="11"
-                            r="8"
-                          />
-                          <path
-                            d="m21 21-4.3-4.3"
-                          />
-                        </svg>
-                        <div
-                          class="relative inline-flex items-center overflow-hidden border border-card-hairline bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),url('/noise.svg')] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] focus-within:after:opacity-100 w-full rounded-full [&>input]:rounded-full"
-                          style="--control-h: var(--control-h-md);"
-                        >
-                          <input
-                            autocapitalize="none"
-                            autocomplete="off"
-                            autocorrect="off"
-                            class="w-full rounded-[inherit] bg-transparent px-3 text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)] pl-7"
-                            id=":r0:"
-                            name=":r0:"
-                            placeholder="Search title, tags, opponent, patch…"
-                            spellcheck="false"
-                            type="search"
-                            value=""
-                          />
-                        </div>
-                      </div>
-                    </form>
+                    <span
+                      aria-hidden="true"
+                      class="block h-px bg-[hsl(var(--divider))/0.35]"
+                    />
+                    <span
+                      aria-hidden="true"
+                      class="absolute inset-x-0 top-0 h-px blur-[6px] opacity-60 bg-[hsl(var(--divider))]"
+                    />
                     <div
-                      class="flex items-center gap-2"
+                      class="flex items-center gap-3 md:gap-4 lg:gap-6 pt-5 md:pt-6"
                     >
-                      <div
-                        class="flex items-center gap-3"
+                      <form
+                        class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"
+                        role="search"
                       >
                         <div
-                          class="hidden sm:flex items-center gap-2 text-xs text-muted-foreground"
+                          class="relative min-w-0"
                         >
-                          <span>
-                            Sort
-                          </span>
-                          <div
-                            class="glitch-wrap "
+                          <svg
+                            aria-hidden="true"
+                            class="lucide lucide-search pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 size-4 text-muted-foreground"
+                            fill="none"
+                            height="24"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
+                            <circle
+                              cx="11"
+                              cy="11"
+                              r="8"
+                            />
+                            <path
+                              d="m21 21-4.3-4.3"
+                            />
+                          </svg>
+                          <div
+                            class="relative inline-flex items-center overflow-hidden border border-card-hairline bg-card/60 backdrop-blur-[2px] shadow-inner shadow-[0_0_0_1px_hsl(var(--border)/0.12)] transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-[0_2px_4px_hsl(var(--shadow)/0.3)] focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),url('/noise.svg')] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] focus-within:after:opacity-100 w-full rounded-full [&>input]:rounded-full"
+                            style="--control-h: var(--control-h-md);"
+                          >
+                            <input
+                              autocapitalize="none"
+                              autocomplete="off"
+                              autocorrect="off"
+                              class="w-full rounded-[inherit] bg-transparent px-3 text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)] pl-7"
+                              id=":r0:"
+                              name=":r0:"
+                              placeholder="Search title, tags, opponent, patch…"
+                              spellcheck="false"
+                              type="search"
+                              value=""
+                            />
+                          </div>
+                        </div>
+                      </form>
+                      <div
+                        class="flex items-center gap-2"
+                      >
+                        <div
+                          class="flex items-center gap-3"
+                        >
+                          <div
+                            class="hidden sm:flex items-center gap-2 text-xs text-muted-foreground"
+                          >
+                            <span>
+                              Sort
+                            </span>
                             <div
-                              class="group inline-flex rounded-full border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0"
+                              class="glitch-wrap "
                             >
-                              <button
-                                aria-controls=":r1:-listbox"
-                                aria-expanded="false"
-                                aria-haspopup="listbox"
-                                aria-label="Select option"
-                                class="glitch-trigger relative flex items-center h-9 rounded-full px-3 overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none h-10 px-4"
-                                data-lit="true"
-                                data-open="false"
-                                type="button"
+                              <div
+                                class="group inline-flex rounded-full border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0"
                               >
-                                <span
-                                  class="font-medium glitch-text text-foreground group-hover:text-foreground"
+                                <button
+                                  aria-controls=":r1:-listbox"
+                                  aria-expanded="false"
+                                  aria-haspopup="listbox"
+                                  aria-label="Select option"
+                                  class="glitch-trigger relative flex items-center h-9 rounded-full px-3 overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none h-10 px-4"
+                                  data-lit="true"
+                                  data-open="false"
+                                  type="button"
                                 >
-                                  Newest
-                                </span>
-                                <svg
-                                  aria-hidden="true"
-                                  class="lucide lucide-chevron-down caret ml-auto size-4 shrink-0 opacity-75 "
-                                  fill="none"
-                                  height="24"
-                                  stroke="currentColor"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="2"
-                                  viewBox="0 0 24 24"
-                                  width="24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="m6 9 6 6 6-6"
+                                  <span
+                                    class="font-medium glitch-text text-foreground group-hover:text-foreground"
+                                  >
+                                    Newest
+                                  </span>
+                                  <svg
+                                    aria-hidden="true"
+                                    class="lucide lucide-chevron-down caret ml-auto size-4 shrink-0 opacity-75 "
+                                    fill="none"
+                                    height="24"
+                                    stroke="currentColor"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                    viewBox="0 0 24 24"
+                                    width="24"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m6 9 6 6 6-6"
+                                    />
+                                  </svg>
+                                  <span
+                                    aria-hidden="true"
+                                    class="gb-iris"
                                   />
-                                </svg>
-                                <span
-                                  aria-hidden="true"
-                                  class="gb-iris"
-                                />
-                                <span
-                                  aria-hidden="true"
-                                  class="gb-chroma"
-                                />
-                                <span
-                                  aria-hidden="true"
-                                  class="gb-flicker"
-                                />
-                                <span
-                                  aria-hidden="true"
-                                  class="gb-scan"
-                                />
-                              </button>
-                            </div>
-                            <style>
-                              
+                                  <span
+                                    aria-hidden="true"
+                                    class="gb-chroma"
+                                  />
+                                  <span
+                                    aria-hidden="true"
+                                    class="gb-flicker"
+                                  />
+                                  <span
+                                    aria-hidden="true"
+                                    class="gb-scan"
+                                  />
+                                </button>
+                              </div>
+                              <style>
+                                
       /* caret jitter */
       .caret {
         transition:
@@ -820,51 +831,52 @@ exports[`ReviewsPage > renders default state 1`] = `
           -0.6px 0 hsl(var(--lav-deep) / 0.45);
       }
     
-                            </style>
+                              </style>
+                            </div>
                           </div>
-                        </div>
-                        <button
-                          class="relative inline-flex items-center justify-center rounded-2xl border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 gap-2 [&_svg]:size-5 px-4 whitespace-nowrap bg-[hsl(var(--accent)/0.12)] border-[hsl(var(--accent)/0.35)] hover:bg-[hsl(var(--accent)/0.14)] hover:shadow-[0_2px_6px_-1px_hsl(var(--accent)/0.25)] active:translate-y-px active:shadow-[inset_0_0_0_1px_hsl(var(--accent)/0.6)] text-foreground"
-                          tabindex="0"
-                          type="button"
-                        >
-                          <span
-                            class="absolute inset-0 pointer-events-none rounded-2xl bg-[linear-gradient(90deg,hsl(var(--foreground)/.18),hsl(var(--foreground)/.18))]"
-                          />
-                          <span
-                            class="relative z-10 inline-flex items-center gap-2"
+                          <button
+                            class="relative inline-flex items-center justify-center rounded-2xl border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 gap-2 [&_svg]:size-5 px-4 whitespace-nowrap bg-[hsl(var(--accent)/0.12)] border-[hsl(var(--accent)/0.35)] hover:bg-[hsl(var(--accent)/0.14)] hover:shadow-[0_2px_6px_-1px_hsl(var(--accent)/0.25)] active:translate-y-px active:shadow-[inset_0_0_0_1px_hsl(var(--accent)/0.6)] text-foreground"
+                            tabindex="0"
+                            type="button"
                           >
-                            <svg
-                              class="lucide lucide-plus"
-                              fill="none"
-                              height="24"
-                              stroke="currentColor"
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                              viewBox="0 0 24 24"
-                              width="24"
-                              xmlns="http://www.w3.org/2000/svg"
+                            <span
+                              class="absolute inset-0 pointer-events-none rounded-2xl bg-[linear-gradient(90deg,hsl(var(--foreground)/.18),hsl(var(--foreground)/.18))]"
+                            />
+                            <span
+                              class="relative z-10 inline-flex items-center gap-2"
                             >
-                              <path
-                                d="M5 12h14"
-                              />
-                              <path
-                                d="M12 5v14"
-                              />
-                            </svg>
-                            <span>
-                              New Review
+                              <svg
+                                class="lucide lucide-plus"
+                                fill="none"
+                                height="24"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                viewBox="0 0 24 24"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5 12h14"
+                                />
+                                <path
+                                  d="M12 5v14"
+                                />
+                              </svg>
+                              <span>
+                                New Review
+                              </span>
                             </span>
-                          </span>
-                        </button>
+                          </button>
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-          </header>
+            </header>
+          </div>
         </div>
         <div
           aria-hidden="true"


### PR DESCRIPTION
## Summary
- extend NeomorphicHeroFrame with variant, density, semantic-as, and slot props so headers can render tabs, search, and action areas on the 12-column grid using design tokens
- update PageHeader to forward hero action overrides, adopt the new frame slots, and keep semantic markup customizable
- showcase the variants and interaction states in the prompts gallery and refresh the ReviewsPage snapshot

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c873ccc39c832cb3f851c21bd48f34