### PR TITLE
Add utilities for prompt card tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1802,6 +1802,14 @@ a:active .lucide {
     color: hsl(var(--muted-foreground));
   }
 
+  .bg-seg-active-grad {
+    background: var(--seg-active-grad);
+  }
+
+  .text-neon-soft {
+    color: var(--neon-soft);
+  }
+
   .sticky-blur {
     position: sticky;
     top: 0;

--- a/src/components/home/TeamPromptsCard.tsx
+++ b/src/components/home/TeamPromptsCard.tsx
@@ -36,13 +36,7 @@ export default function TeamPromptsCard() {
           title="Prompts peek"
           cta={{ label: "Explore Prompts", href: "/prompts" }}
         >
-          <div
-            className="rounded-card r-card-md p-4 text-center text-sm"
-            style={{
-              background: "var(--seg-active-grad)",
-              color: "var(--neon-soft)",
-            }}
-          >
+          <div className="rounded-card r-card-md bg-seg-active-grad p-4 text-center text-sm text-neon-soft">
             Get inspired with curated prompts
           </div>
         </DashboardCard>


### PR DESCRIPTION
## Summary
- add utility utility classes for the segmented active gradient background and neon soft text tokens
- update the TeamPromptsCard prompt preview to use the new utility classes instead of inline styles

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c88056dfa8832c9f4608aab902528b