### PR TITLE
Refactor planner day notes state into shared hook

### DIFF
--- a/src/components/planner/FocusPanel.tsx
+++ b/src/components/planner/FocusPanel.tsx
@@ -14,40 +14,14 @@ import * as React from "react";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import Input from "@/components/ui/primitives/Input";
 import Button from "@/components/ui/primitives/Button";
-import { usePlannerStore } from "./usePlannerStore";
+import { useDayNotes } from "./useDayNotes";
 import type { ISODate } from "./plannerStore";
 
 type Props = { iso: ISODate };
 
 export default function FocusPanel({ iso }: Props) {
-  const { day, setNotes } = usePlannerStore();
-
-  // Initialize from current day.notes; safe because usePersistentState returns initial on first render.
-  const [value, setValue] = React.useState<string>(day.notes ?? "");
-
-  // When the underlying day notes change (due to iso switch or cross-tab sync), refresh local state.
-  React.useEffect(() => {
-    setValue(day.notes ?? "");
-  }, [day.notes]);
-
-  // Derived flags
-  const trimmed = value.trim();
-  const original = (day.notes ?? "").trim();
-  const isDirty = trimmed !== original;
-  const [saving, setSaving] = React.useState(false);
-  const lastSavedRef = React.useRef(original);
-
-  const commit = React.useCallback(async () => {
-    if (!isDirty) return;
-    setSaving(true);
-    try {
-      // Persist to local DB via planner hook
-      await Promise.resolve(setNotes(trimmed));
-      lastSavedRef.current = trimmed;
-    } finally {
-      setSaving(false);
-    }
-  }, [isDirty, setNotes, trimmed]);
+  const { value, setValue, saving, isDirty, lastSavedRef, commit } =
+    useDayNotes();
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/planner/WeekNotes.tsx
+++ b/src/components/planner/WeekNotes.tsx
@@ -10,34 +10,14 @@ import "./style.css";
 import * as React from "react";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import Textarea from "@/components/ui/primitives/Textarea";
-import { usePlannerStore } from "./usePlannerStore";
+import { useDayNotes } from "./useDayNotes";
 import type { ISODate } from "./plannerStore";
 
 type Props = { iso: ISODate };
 
 export default function WeekNotes({ iso }: Props) {
-  const { day, setNotes } = usePlannerStore();
-  const [value, setValue] = React.useState(day.notes ?? "");
-  const trimmed = value.trim();
-  const original = (day.notes ?? "").trim();
-  const isDirty = trimmed !== original;
-  const [saving, setSaving] = React.useState(false);
-  const lastSavedRef = React.useRef(original);
-
-  const commit = React.useCallback(async () => {
-    if (!isDirty) return;
-    setSaving(true);
-    try {
-      await Promise.resolve(setNotes(trimmed));
-      lastSavedRef.current = trimmed;
-    } finally {
-      setSaving(false);
-    }
-  }, [isDirty, setNotes, trimmed]);
-
-  React.useEffect(() => {
-    setValue(day.notes ?? "");
-  }, [day.notes]);
+  const { value, setValue, saving, isDirty, lastSavedRef, commit } =
+    useDayNotes();
 
   return (
     <SectionCard className="card-neo-soft">

--- a/src/components/planner/useDayNotes.ts
+++ b/src/components/planner/useDayNotes.ts
@@ -1,0 +1,35 @@
+// src/components/planner/useDayNotes.ts
+"use client";
+
+import * as React from "react";
+import { usePlannerStore } from "./usePlannerStore";
+
+export function useDayNotes() {
+  const { day, setNotes } = usePlannerStore();
+  const [value, setValue] = React.useState<string>(() => day.notes ?? "");
+  const [saving, setSaving] = React.useState(false);
+  const lastSavedRef = React.useRef((day.notes ?? "").trim());
+
+  const trimmed = value.trim();
+  const original = (day.notes ?? "").trim();
+  const isDirty = trimmed !== original;
+
+  const commit = React.useCallback(async () => {
+    if (!isDirty) return;
+    setSaving(true);
+    try {
+      setNotes(trimmed);
+      lastSavedRef.current = trimmed;
+    } finally {
+      setSaving(false);
+    }
+  }, [isDirty, setNotes, trimmed]);
+
+  React.useEffect(() => {
+    const nextValue = day.notes ?? "";
+    setValue(nextValue);
+    lastSavedRef.current = nextValue.trim();
+  }, [day.notes]);
+
+  return { value, setValue, saving, isDirty, lastSavedRef, commit } as const;
+}


### PR DESCRIPTION
## Summary
- add a `useDayNotes` hook to centralize day note state, commit handling, and dirty tracking
- update `FocusPanel` and `WeekNotes` to rely on the shared hook instead of duplicating logic

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c888a7db04832c99d527d04e07000d