### PR TITLE
Use semantic transition durations

### DIFF
--- a/src/components/goals/GoalList.tsx
+++ b/src/components/goals/GoalList.tsx
@@ -71,7 +71,7 @@ export default function GoalList({
                   "relative overflow-hidden rounded-card r-card-lg p-6 min-h-8 flex flex-col",
                   "bg-card/30 backdrop-blur-md",
                   "shadow-ring [--ring:var(--accent)]",
-                  "transition-all duration-150 hover:-translate-y-1 hover:shadow-ring",
+                  "transition-all duration-[var(--dur-quick)] hover:-translate-y-1 hover:shadow-ring",
                 ].join(" ")}
               >
                 <span

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -73,7 +73,7 @@ const parseMmSs = (v: string) => {
 };
 
 const ADJUST_BTN_CLASS =
-  "absolute top-[var(--space-2)] sm:-top-[var(--space-4)] rounded-full bg-background/40 backdrop-blur shadow-glow transition-transform duration-150 hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-ring";
+  "absolute top-[var(--space-2)] sm:-top-[var(--space-4)] rounded-full bg-background/40 backdrop-blur shadow-glow transition-transform duration-[var(--dur-quick)] hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-ring";
 
 export default function TimerTab() {
   const [profile, setProfile] = usePersistentState<ProfileKey>(
@@ -303,7 +303,7 @@ export default function TimerTab() {
             >
               <TimerRing pct={pct} size={ringSize} />
               <div className="pointer-events-none absolute inset-0 grid place-items-center">
-                <div className="text-title font-semibold tabular-nums text-foreground drop-shadow-[0_0_var(--space-2)_hsl(var(--neon-soft))] transition-transform duration-150 group-hover:translate-y-0.5 sm:text-title-lg">
+                <div className="text-title font-semibold tabular-nums text-foreground drop-shadow-[0_0_var(--space-2)_hsl(var(--neon-soft))] transition-transform duration-[var(--dur-quick)] group-hover:translate-y-0.5 sm:text-title-lg">
                   {fmt(remaining)}
                 </div>
                 {isCustom && !running && (
@@ -324,7 +324,7 @@ export default function TimerTab() {
               <div className="relative h-2 w-full rounded-full bg-background/20 shadow-neo-inset">
                 <div className="absolute inset-0 bg-[repeating-linear-gradient(to_right,transparent,transparent_9%,hsl(var(--foreground)/0.15)_9%,hsl(var(--foreground)/0.15)_10%)]" />
                 <div
-                  className="h-full rounded-full bg-[linear-gradient(90deg,hsl(var(--accent)),hsl(var(--accent-2)))] shadow-glow transition-[width] duration-150 ease-linear"
+                  className="h-full rounded-full bg-[linear-gradient(90deg,hsl(var(--accent)),hsl(var(--accent-2)))] shadow-glow transition-[width] duration-[var(--dur-quick)] ease-linear"
                   style={{ width: `${pct}%` }}
                 />
               </div>
@@ -337,7 +337,7 @@ export default function TimerTab() {
             <div className="mt-6 flex w-full flex-wrap justify-center gap-2 overflow-x-auto">
               {!running ? (
                 <SegmentedButton
-                  className="inline-flex min-w-[4.5rem] items-center gap-2 rounded-full px-4 py-2 transition-colors duration-150 ease-in-out"
+                  className="inline-flex min-w-[4.5rem] items-center gap-2 rounded-full px-4 py-2 transition-colors duration-[var(--dur-quick)] ease-in-out"
                   onClick={start}
                   title="Start"
                 >
@@ -346,7 +346,7 @@ export default function TimerTab() {
                 </SegmentedButton>
               ) : (
                 <SegmentedButton
-                  className="inline-flex min-w-[4.5rem] items-center gap-2 rounded-full px-4 py-2 transition-colors duration-150 ease-in-out"
+                  className="inline-flex min-w-[4.5rem] items-center gap-2 rounded-full px-4 py-2 transition-colors duration-[var(--dur-quick)] ease-in-out"
                   onClick={pause}
                   title="Pause"
                   isActive
@@ -356,7 +356,7 @@ export default function TimerTab() {
                 </SegmentedButton>
               )}
               <SegmentedButton
-                className="inline-flex items-center gap-2 rounded-full px-4 py-2 transition-colors duration-150 ease-in-out"
+                className="inline-flex items-center gap-2 rounded-full px-4 py-2 transition-colors duration-[var(--dur-quick)] ease-in-out"
                 onClick={reset}
                 title="Reset"
               >

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -153,7 +153,7 @@ export default function TabBar<K extends string = string>({
                 }}
                 onClick={() => !item.disabled && commitValue(item.key)}
                 className={cn(
-                  "relative inline-flex items-center justify-center select-none rounded-full transition-[background,box-shadow,color] duration-150 ease-out",
+                  "relative inline-flex items-center justify-center select-none rounded-full transition-[background,box-shadow,color] duration-[var(--dur-quick)] ease-out",
                   s.h,
                   s.px,
                   s.text,

--- a/src/icons/TimerRingIcon.tsx
+++ b/src/icons/TimerRingIcon.tsx
@@ -43,7 +43,7 @@ export default function TimerRingIcon({ pct, size = 200 }: TimerRingIconProps) {
         strokeDasharray={circumference}
         strokeDashoffset={offset}
         className={cn(
-          "drop-shadow-[0_0_6px_hsl(var(--neon-soft))] transition-[stroke-dashoffset] duration-150 ease-linear motion-reduce:transition-none",
+          "drop-shadow-[0_0_6px_hsl(var(--neon-soft))] transition-[stroke-dashoffset] duration-[var(--dur-quick)] ease-linear motion-reduce:transition-none",
           pulse && "animate-pulse",
         )}
         fill="none"


### PR DESCRIPTION
## Summary
- replace hard-coded `duration-150` utilities with the design token `duration-[var(--dur-quick)]` across timer and tab components
- ensure timer ring, progress bar, and segmented controls continue using quick transitions tied to motion tokens

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c88d7d5b28832cbc045ad9884f6524