### PR TITLE
Add shared useMounted hook for UI hydration guards

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { createPortal } from "react-dom";
 import Card from "./primitives/Card";
 import { useDialogTrap } from "./hooks/useDialogTrap";
+import useMounted from "@/lib/useMounted";
 import { cn } from "@/lib/utils";
 
 export interface ModalProps extends React.ComponentProps<typeof Card> {
@@ -18,9 +19,8 @@ export default function Modal({
   children,
   ...props
 }: ModalProps) {
-  const [mounted, setMounted] = React.useState(false);
+  const mounted = useMounted();
   const dialogRef = React.useRef<HTMLDivElement>(null);
-  React.useEffect(() => setMounted(true), []);
 
   useDialogTrap({ open: open && mounted, onClose, ref: dialogRef });
 

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -6,6 +6,7 @@ import { createPortal } from "react-dom";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { Check, ChevronDown } from "lucide-react";
 import FieldShell from "./primitives/FieldShell";
+import useMounted from "@/lib/useMounted";
 import { cn, slugify } from "@/lib/utils";
 
 /** Option item */
@@ -169,8 +170,7 @@ const AnimatedSelectImpl = React.forwardRef<
   ref,
 ) {
   // Hydration-safe portal
-  const [mounted, setMounted] = React.useState(false);
-  React.useEffect(() => setMounted(true), []);
+  const mounted = useMounted();
 
   const [open, setOpen] = React.useState(false);
   const [activeIndex, setActiveIndex] = React.useState<number>(() =>

--- a/src/components/ui/Sheet.tsx
+++ b/src/components/ui/Sheet.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import { motion, useReducedMotion } from "framer-motion";
 import Card from "./primitives/Card";
 import { useDialogTrap } from "./hooks/useDialogTrap";
+import useMounted from "@/lib/useMounted";
 import { cn } from "@/lib/utils";
 
 export interface SheetProps extends React.ComponentProps<typeof Card> {
@@ -21,10 +22,9 @@ export default function Sheet({
   children,
   ...props
 }: SheetProps) {
-  const [mounted, setMounted] = React.useState(false);
+  const mounted = useMounted();
   const dialogRef = React.useRef<HTMLDivElement>(null);
   const reduceMotion = useReducedMotion();
-  React.useEffect(() => setMounted(true), []);
 
   useDialogTrap({ open: open && mounted, onClose, ref: dialogRef });
 

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import Card from "./primitives/Card";
 import IconButton from "./primitives/IconButton";
 import { X } from "lucide-react";
+import useMounted from "@/lib/useMounted";
 import { cn } from "@/lib/utils";
 
 export interface ToastProps extends React.ComponentProps<typeof Card> {
@@ -23,8 +24,7 @@ export default function Toast({
   children,
   ...props
 }: ToastProps) {
-  const [mounted, setMounted] = React.useState(false);
-  React.useEffect(() => setMounted(true), []);
+  const mounted = useMounted();
 
   React.useEffect(() => {
     if (!open) return;

--- a/src/components/ui/theme/ThemeToggle.tsx
+++ b/src/components/ui/theme/ThemeToggle.tsx
@@ -4,6 +4,7 @@
 import * as React from "react";
 import { Image as ImageIcon } from "lucide-react";
 import { Select, type SelectItem } from "@/components/ui";
+import useMounted from "@/lib/useMounted";
 import { useTheme } from "@/lib/theme-context";
 import {
   VARIANTS,
@@ -27,17 +28,22 @@ export default function ThemeToggle({
 }: ThemeToggleProps) {
   const aria = ariaLabel ?? ariaLabelAttr ?? "Theme";
 
-  const [mounted, setMounted] = React.useState(false);
+  const mounted = useMounted();
   const [state, setState] = useTheme();
   const { variant } = state;
-
-  React.useEffect(() => {
-    setMounted(true);
-  }, []);
 
   function setVariantPersist(v: Variant) {
     setState((prev) => ({ variant: v, bg: prev.bg }));
   }
+  const items: SelectItem[] = React.useMemo(
+    () =>
+      VARIANTS.map((v) => ({
+        value: v.id,
+        label: v.label,
+      })),
+    [],
+  );
+
   function cycleBg() {
     setState((prev) => ({
       ...prev,
@@ -53,11 +59,6 @@ export default function ThemeToggle({
       />
     );
   }
-
-  const items: SelectItem[] = VARIANTS.map((v) => ({
-    value: v.id,
-    label: v.label,
-  }));
 
   return (
     <div className={`flex items-center gap-2 whitespace-nowrap ${className}`}>

--- a/src/lib/useMounted.ts
+++ b/src/lib/useMounted.ts
@@ -1,0 +1,11 @@
+import * as React from "react";
+
+export default function useMounted(): boolean {
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return mounted;
+}


### PR DESCRIPTION
## Summary
- add a shared `useMounted` hook to expose a consistent client-hydration flag
- update Modal, Sheet, Select, Toast, and ThemeToggle to reuse the hook and drop duplicate state

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c88e1ff270832c88ee90ab22da3737