### PR TITLE
Improve TaskRow accessibility

### DIFF
--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -35,6 +35,22 @@ export default function TaskRow({
 
   useAutoFocus({ ref: inputRef, when: editing });
 
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.target !== event.currentTarget) return;
+      if (
+        event.key === "Enter" ||
+        event.key === " " ||
+        event.key === "Space" ||
+        event.key === "Spacebar"
+      ) {
+        event.preventDefault();
+        onSelect();
+      }
+    },
+    [onSelect],
+  );
+
   function start() {
     setEditing(true);
   }
@@ -58,12 +74,16 @@ export default function TaskRow({
   return (
     <li className="group">
       <div
+        role="button"
+        tabIndex={0}
         className={cn(
-          "relative [overflow:visible] grid min-h-12 min-w-0 grid-cols-[auto,1fr,auto] items-center gap-4 rounded-card r-card-lg border pl-4 pr-2 py-2",
-          "bg-card/55 hover:bg-card/70",
+          "relative [overflow:visible] grid min-h-12 min-w-0 grid-cols-[auto,1fr,auto] items-center gap-4 rounded-card r-card-lg border pl-4 pr-2 py-2 transition-colors",
+          "bg-card/55 hover:bg-card/70 focus-visible:bg-card/70 active:bg-card/80",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
           "focus-within:ring-2 focus-within:ring-ring",
         )}
         onClick={onSelect}
+        onKeyDown={handleKeyDown}
       >
         <div className="shrink-0 ml-1" onClick={(e) => e.stopPropagation()}>
           <CheckCircle


### PR DESCRIPTION
## Summary
- make the TaskRow container operable via keyboard by adding button semantics and handlers
- align TaskRow focus treatments with design tokens while keeping existing hover and active behavior

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8923dfbdc832cb01408fb81a67a4d