### PR TITLE
Update auto focus hook to guard on activation

### DIFF
--- a/src/lib/useAutoFocus.ts
+++ b/src/lib/useAutoFocus.ts
@@ -11,9 +11,13 @@ export default function useAutoFocus<T extends FocusableElement>({
   ref,
   when,
 }: UseAutoFocusArgs<T>) {
-  React.useEffect(() => {
-    if (!when) return;
+  const prev = React.useRef(false);
 
-    ref.current?.focus();
+  React.useEffect(() => {
+    if (when && !prev.current) {
+      ref.current?.focus();
+    }
+
+    prev.current = when;
   }, [when, ref]);
 }


### PR DESCRIPTION
## Summary
- update `useAutoFocus` to only focus when the condition flips to `true`
- retain a typed API for sharing auto-focus behavior across editing forms

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c892c469a4832cb3392fc598be1e9a