### PR TITLE
Require accessible labels for IconButton

### DIFF
--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -18,11 +18,13 @@ type Variant = "ring" | "glow" | "solid";
 type AccessibleLabelProps =
   | {
       "aria-label": string;
+      "aria-labelledby"?: string;
       title?: string;
     }
   | {
-      title: string;
+      "aria-labelledby": string;
       "aria-label"?: string;
+      title?: string;
     };
 
 type MotionButtonProps = React.ComponentProps<typeof motion.button>;
@@ -118,6 +120,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
       children,
       title,
       "aria-label": ariaLabel,
+      "aria-labelledby": ariaLabelledBy,
       ...rest
     },
     ref,
@@ -134,20 +137,21 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
         : undefined;
     const normalizedTitle =
       trimmedTitle && trimmedTitle.length > 0 ? trimmedTitle : undefined;
-    const effectiveAriaLabel = normalizedAriaLabel ?? normalizedTitle;
-    const ariaLabelledBy = (rest as { "aria-labelledby"?: string })[
-      "aria-labelledby"
-    ];
-    const hasExternalLabel =
-      typeof ariaLabelledBy === "string" && ariaLabelledBy.trim().length > 0;
+    const trimmedAriaLabelledBy =
+      typeof ariaLabelledBy === "string" ? ariaLabelledBy.trim() : undefined;
+    const normalizedAriaLabelledBy =
+      trimmedAriaLabelledBy && trimmedAriaLabelledBy.length > 0
+        ? trimmedAriaLabelledBy
+        : undefined;
     const iconOnly = !hasTextContent(children);
-    const shouldWarn = iconOnly && !effectiveAriaLabel && !hasExternalLabel;
+    const shouldWarn =
+      iconOnly && !normalizedAriaLabel && !normalizedAriaLabelledBy;
 
     React.useEffect(() => {
       if (process.env.NODE_ENV === "production") return;
       if (!shouldWarn) return;
       console.error(
-        "IconButton requires an `aria-label` or `title` when rendering icon-only content.",
+        "IconButton requires an `aria-label` or `aria-labelledby` when rendering icon-only content.",
       );
     }, [shouldWarn]);
 
@@ -167,7 +171,8 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
         disabled={disabled || loading}
         whileHover={reduceMotion ? undefined : { scale: 1.05 }}
         whileTap={reduceMotion ? undefined : { scale: 0.95 }}
-        aria-label={effectiveAriaLabel}
+        aria-label={normalizedAriaLabel}
+        aria-labelledby={normalizedAriaLabelledBy}
         title={normalizedTitle}
         {...rest}
       >

--- a/storybook/src/components/ui/IconButton.stories.tsx
+++ b/storybook/src/components/ui/IconButton.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof IconButton> = {
     docs: {
       description: {
         component:
-          "Icon buttons must include either an `aria-label` or `title` when the child content is only an icon.",
+          "Icon buttons must include either an `aria-label` or `aria-labelledby` when the child content is only an icon. Titles may be added for tooltips but do not replace the required accessible name.",
       },
     },
   },
@@ -41,22 +41,25 @@ export const WithAriaLabel: Story = {
   },
 };
 
-export const WithTitle: Story = {
+export const WithAriaLabelledby: Story = {
   args: {
     variant: "solid",
     tone: "danger",
     size: "md",
   },
   render: (args) => (
-    <IconButton {...args} title="Delete item">
-      <Trash2 />
-    </IconButton>
+    <>
+      <span id="delete-action">Delete item</span>
+      <IconButton {...args} aria-labelledby="delete-action">
+        <Trash2 />
+      </IconButton>
+    </>
   ),
   parameters: {
     docs: {
       description: {
         story:
-          "Providing a `title` also satisfies the accessible label requirement; the component applies it as an `aria-label` automatically.",
+          "When a nearby element already provides the visible label, connect it with `aria-labelledby` so screen readers announce the same text.",
       },
     },
   },

--- a/tests/primitives/icon-button.test.tsx
+++ b/tests/primitives/icon-button.test.tsx
@@ -133,15 +133,26 @@ describe("IconButton", () => {
     expect(classes).not.toContain("shadow-glow-current");
   });
 
-  it("uses title as the aria-label when no aria-label is provided", () => {
+  it("forwards the title attribute", () => {
     const { getByRole } = render(
-      <IconButton title="Open settings">
+      <IconButton aria-label="Settings" title="Open settings">
         <svg />
       </IconButton>,
     );
     const button = getByRole("button");
-    expect(button).toHaveAttribute("aria-label", "Open settings");
+    expect(button).toHaveAttribute("aria-label", "Settings");
     expect(button).toHaveAttribute("title", "Open settings");
+  });
+
+  it("supports aria-labelledby for external labels", () => {
+    const { getByRole } = render(
+      <IconButton aria-labelledby="external-label">
+        <svg />
+      </IconButton>,
+    );
+    const button = getByRole("button");
+    expect(button).not.toHaveAttribute("aria-label");
+    expect(button).toHaveAttribute("aria-labelledby", "external-label");
   });
 
   it("logs an error when icon-only content is missing a label", async () => {
@@ -158,7 +169,7 @@ describe("IconButton", () => {
     await waitFor(() => {
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          "IconButton requires an `aria-label` or `title` when rendering icon-only content.",
+          "IconButton requires an `aria-label` or `aria-labelledby` when rendering icon-only content.",
         ),
       );
     });


### PR DESCRIPTION
## Summary
- require IconButton callers to provide either aria-label or aria-labelledby
- update runtime warning and documentation examples to highlight the new requirement
- add tests covering aria-labelledby usage and title forwarding

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c899f6c6a0832c9ee85e8944ddc9ed