### PR TITLE
Add aria-hidden to modal backdrops

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -27,7 +27,11 @@ export default function Modal({
   if (!open || !mounted) return null;
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center">
-      <div className="absolute inset-0 bg-background/80" onClick={onClose} />
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-background/80"
+        onClick={onClose}
+      />
       <Card
         ref={dialogRef}
         role="dialog"

--- a/src/components/ui/Sheet.tsx
+++ b/src/components/ui/Sheet.tsx
@@ -31,7 +31,11 @@ export default function Sheet({
   if (!open || !mounted) return null;
   return createPortal(
     <div className="fixed inset-0 z-50">
-      <div className="absolute inset-0 bg-background/80" onClick={onClose} />
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-background/80"
+        onClick={onClose}
+      />
       <motion.div
         initial={{ x: side === "right" ? "100%" : "-100%" }}
         animate={{ x: 0 }}


### PR DESCRIPTION
## Summary
- add aria-hidden to the modal and sheet backdrop layers so assistive tech ignores them
- confirmed other overlays (toast notifications, select dropdowns) don't introduce additional backdrop elements that need hiding

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c89a7d3184832cadffe6316ecd57c5