### PR TITLE
Refactor NavBar navigation config

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,0 +1,23 @@
+# Navigation Configuration
+
+The primary navigation bar reads from [`NAV_ITEMS`](../src/components/chrome/nav-items.ts), a shared list of `{ href, label }`
+objects. Update that array when you need to rename, reorder, add, or remove top-level sections. Because the component consumes
+the exported list by default, no edits inside [`NavBar`](../src/components/chrome/NavBar.tsx) are required.
+
+For feature- or context-specific navigation, pass an `items` prop to `<NavBar />`:
+
+```tsx
+import NavBar from "@/components/chrome/NavBar";
+import { NAV_ITEMS } from "@/components/chrome/nav-items";
+
+const projectNav = [
+  ...NAV_ITEMS,
+  { href: "/projects", label: "Projects" },
+];
+
+export function ProjectChrome() {
+  return <NavBar items={projectNav} />;
+}
+```
+
+This pattern keeps the animation and active-state logic intact while allowing callers to opt into alternate menus when needed.

--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -11,25 +11,20 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { motion, useReducedMotion } from "framer-motion";
 import { cn } from "@/lib/utils";
+import { NAV_ITEMS, NavItem } from "./nav-items";
 
-const ITEMS = [
-  { href: "/reviews", label: "Reviews" },
-  { href: "/planner", label: "Planner" },
-  { href: "/goals", label: "Goals" },
-  { href: "/team", label: "Comps" },
-  { href: "/prompts", label: "Prompts" },
-] as const;
+type NavBarProps = {
+  items?: readonly NavItem[];
+};
 
-export type NavItem = (typeof ITEMS)[number];
-
-export default function NavBar() {
+export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
   const path = usePathname() ?? "/";
   const reduceMotion = useReducedMotion();
 
   return (
     <nav aria-label="Primary">
       <ul className="flex items-center gap-2">
-        {ITEMS.map(({ href, label }: NavItem) => {
+        {items.map(({ href, label }) => {
           const active = path === href || path.startsWith(href + "/");
 
           return (

--- a/src/components/chrome/nav-items.ts
+++ b/src/components/chrome/nav-items.ts
@@ -1,0 +1,15 @@
+// src/components/chrome/nav-items.ts
+// Navigation items shared across chrome components.
+
+export type NavItem = {
+  href: string;
+  label: string;
+};
+
+export const NAV_ITEMS = [
+  { href: "/reviews", label: "Reviews" },
+  { href: "/planner", label: "Planner" },
+  { href: "/goals", label: "Goals" },
+  { href: "/team", label: "Comps" },
+  { href: "/prompts", label: "Prompts" },
+] as const satisfies readonly NavItem[];


### PR DESCRIPTION
## Summary
- move the primary navigation item list into a shared chrome/nav-items module
- allow NavBar to accept an overridable items prop while keeping existing active-state behavior
- document how to update or extend the navigation without touching component internals

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c89aa69494832c93a631408cd6dc31