### PR TITLE
Streamline planner days updater

### DIFF
--- a/src/components/planner/usePlannerStore.ts
+++ b/src/components/planner/usePlannerStore.ts
@@ -59,18 +59,18 @@ export function usePlannerStore() {
   const { days, setDays } = useDays();
   const { focus, setFocus } = useFocus();
 
-  React.useEffect(() => {
-    setDays((prev) => migrateLegacy(prev, focus));
-  }, [focus, setDays]);
-
   const applyDaysUpdate = React.useCallback(
     (
       updater: (prev: Record<ISODate, DayRecord>) => Record<ISODate, DayRecord>,
     ) => {
-      setDays((prev) => updater(prev));
+      setDays(updater);
     },
     [setDays],
   );
+
+  React.useEffect(() => {
+    applyDaysUpdate((prev) => migrateLegacy(prev, focus));
+  }, [applyDaysUpdate, focus]);
 
   const upsertDay = React.useCallback(
     (date: ISODate, fn: (d: DayRecord) => DayRecord) => {


### PR DESCRIPTION
## Summary
- simplify the planner store day update helper so it forwards the updater directly
- reuse the helper when running the legacy migration effect so all day mutations share the same path

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c89c12d2b8832c9301022fc4efcf5c