### PR TITLE
Refine day notes hook

### DIFF
--- a/src/components/planner/useDayNotes.ts
+++ b/src/components/planner/useDayNotes.ts
@@ -10,11 +10,10 @@ export function useDayNotes() {
   const [saving, setSaving] = React.useState(false);
   const lastSavedRef = React.useRef((day.notes ?? "").trim());
 
-  const trimmed = value.trim();
-  const original = (day.notes ?? "").trim();
-  const isDirty = trimmed !== original;
+  const trimmed = React.useMemo(() => value.trim(), [value]);
+  const isDirty = trimmed !== lastSavedRef.current;
 
-  const commit = React.useCallback(async () => {
+  const commit = React.useCallback(() => {
     if (!isDirty) return;
     setSaving(true);
     try {


### PR DESCRIPTION
## Summary
- update `useDayNotes` to share trimmed value logic and centralize dirty state tracking for day notes consumers
- keep the hook responsible for synchronously committing planner notes updates so FocusPanel and WeekNotes stay lean

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c89c236ce8832c8d6bbef18a2ccf1f