### PR TITLE
Use design tokens for animation toggle button

### DIFF
--- a/src/components/ui/AnimationToggle.tsx
+++ b/src/components/ui/AnimationToggle.tsx
@@ -50,9 +50,9 @@ export default function AnimationToggle({
         aria-busy={loading}
         disabled={loading}
         className={cn(
-          "inline-flex h-9 w-9 items-center justify-center rounded-full shrink-0",
+          "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-card r-card-lg",
           "border border-border bg-card",
-          "hover:shadow-[0_0_12px_hsl(var(--ring)/.35)]",
+          "hover:shadow-glow-md",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           "active:bg-surface-1",
           "disabled:opacity-50 disabled:pointer-events-none disabled:cursor-not-allowed",


### PR DESCRIPTION
## Summary
- replace the animation toggle button's circular radius with the rounded-card token and size modifier
- switch the hover shadow to the glow token to align with design system primitives

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c89eb57778832c84c60abd97c780d3