### PR TITLE
Add presentation role to select menu items

### DIFF
--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -517,7 +517,7 @@ const AnimatedSelectImpl = React.forwardRef<
                   const active = it.value === value;
                   const disabledItem = !!it.disabled || it.loading;
                   return (
-                    <li key={String(it.value)}>
+                    <li key={String(it.value)} role="presentation">
                       <button
                         type="button"
                         role="option"


### PR DESCRIPTION
## Summary
- add presentation role to the list items that wrap select options to keep semantics correct

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8a035c02c832c899aab218ef03903