### PR TITLE
Add shared field naming hook

### DIFF
--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -2,7 +2,8 @@
 "use client";
 
 import * as React from "react";
-import { cn, slugify } from "@/lib/utils";
+import { cn } from "@/lib/utils";
+import useFieldNaming from "@/lib/useFieldNaming";
 import FieldShell from "./FieldShell";
 
 export type InputSize = "sm" | "md" | "lg";
@@ -50,10 +51,12 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
   },
   ref,
 ) {
-  const auto = React.useId();
-  const fromAria = slugify(ariaLabel as string | undefined);
-  const finalId = id || auto;
-  const finalName = name || (id ? fromAria : undefined) || finalId;
+  const { id: finalId, name: finalName } = useFieldNaming({
+    id,
+    name,
+    ariaLabel: ariaLabel as string | undefined,
+    ariaLabelStrategy: "custom-id",
+  });
 
   const error =
     props["aria-invalid"] === true || props["aria-invalid"] === "true";

--- a/src/components/ui/primitives/Textarea.tsx
+++ b/src/components/ui/primitives/Textarea.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { cn, slugify } from "@/lib/utils";
+import { cn } from "@/lib/utils";
+import useFieldNaming from "@/lib/useFieldNaming";
 import FieldShell from "./FieldShell";
 
 /**
@@ -37,12 +38,12 @@ export default React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     },
     ref,
   ) {
-    const auto = React.useId();
-    const fromAria = slugify(ariaLabel as string | undefined);
-    // Use React-generated id by default so multiple fields sharing an aria-label
-    // do not end up with duplicate ids.
-    const finalId = id || auto;
-    const finalName = name || fromAria || slugify(finalId);
+    const { id: finalId, name: finalName } = useFieldNaming({
+      id,
+      name,
+      ariaLabel: ariaLabel as string | undefined,
+      slugifyFallback: true,
+    });
 
     const error =
       props["aria-invalid"] === true || props["aria-invalid"] === "true";

--- a/src/lib/useFieldNaming.ts
+++ b/src/lib/useFieldNaming.ts
@@ -1,0 +1,58 @@
+import * as React from "react";
+
+import { slugify } from "./utils";
+
+export type FieldNamingOptions = {
+  /** Optional id override */
+  id?: string;
+  /** Optional name override */
+  name?: string;
+  /** Optional aria-label used to derive the name */
+  ariaLabel?: string;
+  /**
+   * Controls when the aria-label should be used to derive the field name.
+   * - "always": always attempt to use the aria-label slug.
+   * - "custom-id": only use the aria-label when an explicit id is provided.
+   * - "never": never use the aria-label slug.
+   */
+  ariaLabelStrategy?: "always" | "custom-id" | "never";
+  /** When true, slugify the fallback name derived from the id. */
+  slugifyFallback?: boolean;
+};
+
+export type FieldNamingResult = {
+  id: string;
+  name: string;
+};
+
+export default function useFieldNaming(
+  options: FieldNamingOptions = {},
+): FieldNamingResult {
+  const {
+    id,
+    name,
+    ariaLabel,
+    ariaLabelStrategy = "always",
+    slugifyFallback = false,
+  } = options;
+
+  const generatedId = React.useId();
+  const finalId = id ?? generatedId;
+
+  const fromAria = slugify(ariaLabel);
+  const shouldUseAria =
+    ariaLabelStrategy === "always"
+      ? true
+      : ariaLabelStrategy === "custom-id"
+        ? Boolean(id)
+        : false;
+
+  const fallbackName = slugifyFallback ? slugify(finalId) : finalId;
+
+  const finalName =
+    name ||
+    (shouldUseAria ? fromAria || undefined : undefined) ||
+    fallbackName;
+
+  return { id: finalId, name: finalName };
+}

--- a/tests/lib/useFieldNaming.test.tsx
+++ b/tests/lib/useFieldNaming.test.tsx
@@ -1,0 +1,62 @@
+import { renderHook, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import useFieldNaming from "../../src/lib/useFieldNaming";
+import { slugify } from "../../src/lib/utils";
+
+afterEach(cleanup);
+
+describe("useFieldNaming", () => {
+  it("returns slugified aria-label by default", () => {
+    const { result } = renderHook(() =>
+      useFieldNaming({ ariaLabel: "Project Name" }),
+    );
+
+    expect(result.current.name).toBe("project-name");
+    expect(typeof result.current.id).toBe("string");
+    expect(result.current.id.length).toBeGreaterThan(0);
+  });
+
+  it("respects provided overrides", () => {
+    const { result } = renderHook(() =>
+      useFieldNaming({
+        id: "custom-id",
+        name: "custom-name",
+        ariaLabel: "ignored",
+      }),
+    );
+
+    expect(result.current.id).toBe("custom-id");
+    expect(result.current.name).toBe("custom-name");
+  });
+
+  it("only uses aria-label slug with explicit id when strategy is custom-id", () => {
+    const withExplicitId = renderHook(() =>
+      useFieldNaming({
+        id: "field-id",
+        ariaLabel: "Display Name",
+        ariaLabelStrategy: "custom-id",
+      }),
+    );
+
+    expect(withExplicitId.result.current.id).toBe("field-id");
+    expect(withExplicitId.result.current.name).toBe("display-name");
+
+    const withoutExplicitId = renderHook(() =>
+      useFieldNaming({
+        ariaLabel: "Display Name",
+        ariaLabelStrategy: "custom-id",
+      }),
+    );
+
+    expect(withoutExplicitId.result.current.name).toBe(
+      withoutExplicitId.result.current.id,
+    );
+  });
+
+  it("slugifies the fallback id when requested", () => {
+    const { result } = renderHook(() => useFieldNaming({ slugifyFallback: true }));
+
+    expect(result.current.name).toBe(slugify(result.current.id));
+  });
+});

--- a/tests/primitives/search-bar.test.tsx
+++ b/tests/primitives/search-bar.test.tsx
@@ -24,6 +24,7 @@ describe('SearchBar', () => {
     fireEvent.submit(getByRole('search'));
     expect(handleChange).toHaveBeenCalledWith('hello');
     expect(handleSubmit).toHaveBeenCalledWith('hello');
+    vi.runAllTimers();
     vi.useRealTimers();
   });
 


### PR DESCRIPTION
## Summary
- add a `useFieldNaming` helper for shared id/name derivation with configurability for aria label fallbacks
- update Input and Textarea primitives to consume the new helper
- add coverage for the hook and ensure SearchBar timers finish during tests

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c89f285168832c8e8335a9ab61c3ec