### PR TITLE
feat: add useFieldIds hook for field id/name handling

### DIFF
--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -7,7 +7,8 @@ import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { Check, ChevronDown, ChevronRight } from "lucide-react";
 import FieldShell from "./primitives/FieldShell";
 import useMounted from "@/lib/useMounted";
-import { cn, slugify } from "@/lib/utils";
+import { useFieldIds } from "@/lib/useFieldIds";
+import { cn } from "@/lib/utils";
 
 /** Option item */
 export type SelectItem = {
@@ -65,7 +66,8 @@ const NativeSelect = React.forwardRef<HTMLSelectElement, NativeSelectProps>(
       errorText,
       success,
       disabled,
-      id,
+      id: idProp,
+      name: nameProp,
       items,
       value,
       onChange,
@@ -73,13 +75,18 @@ const NativeSelect = React.forwardRef<HTMLSelectElement, NativeSelectProps>(
     },
     ref,
   ) {
-    const auto = React.useId();
-    const fromAria = slugify(props["aria-label"] as string | undefined);
-    const finalId = id || auto;
-    const finalName = props.name || fromAria || finalId;
-    const successId = `${finalId}-success`;
-    const errorId = errorText ? `${finalId}-error` : undefined;
-    const helperId = helperText ? `${finalId}-helper` : undefined;
+    const ariaLabel = props["aria-label"] as string | undefined;
+    const { id, name: generatedName, isInvalid } = useFieldIds(
+      ariaLabel,
+      idProp,
+      nameProp,
+    );
+    const name = nameProp ?? (ariaLabel ? generatedName : id);
+    const ariaInvalid = errorText ? "true" : props["aria-invalid"];
+    const invalid = isInvalid(ariaInvalid);
+    const successId = `${id}-success`;
+    const errorId = errorText ? `${id}-error` : undefined;
+    const helperId = helperText ? `${id}-helper` : undefined;
     const describedBy =
       [errorId, helperId, success ? successId : undefined]
         .filter(Boolean)
@@ -94,17 +101,17 @@ const NativeSelect = React.forwardRef<HTMLSelectElement, NativeSelectProps>(
               "cursor-not-allowed focus-within:ring-0 focus-within:shadow-none",
             className,
           )}
-          error={!!errorText}
+          error={invalid || !!errorText}
           disabled={disabled}
         >
           <select
             ref={ref}
-            id={finalId}
-            name={finalName}
+            id={id}
+            name={name}
             disabled={disabled}
             value={value}
             onChange={(e) => onChange?.(e.target.value)}
-            aria-invalid={errorText ? "true" : props["aria-invalid"]}
+            aria-invalid={ariaInvalid}
             aria-describedby={describedBy}
             className={cn(
               "flex-1 h-[var(--control-h)] px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-foreground placeholder:text-muted-foreground/70 caret-accent appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none",

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -2,7 +2,8 @@
 "use client";
 
 import * as React from "react";
-import { cn, slugify } from "@/lib/utils";
+import { useFieldIds } from "@/lib/useFieldIds";
+import { cn } from "@/lib/utils";
 import FieldShell from "./FieldShell";
 
 export type InputSize = "sm" | "md" | "lg";
@@ -30,17 +31,15 @@ const HEIGHT: Record<InputSize, string> = {
 /**
  * Input — Matte field with optional trailing slot.
  * - Accepts className overrides and passes all standard <input> props
- * - Auto-generates a stable `id`; if no `name` is supplied, the generated id is
- *   reused to ensure uniqueness. The `aria-label` is only slugified when a
- *   custom `id` guarantees uniqueness.
+ * - Auto-generates a stable `id`/`name` pair via `useFieldIds`.
  */
 export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
   {
     className,
     inputClassName,
     style,
-    id,
-    name,
+    id: idProp,
+    name: nameProp,
     "aria-label": ariaLabel,
     height = "md",
     indent = false,
@@ -50,13 +49,15 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
   },
   ref,
 ) {
-  const auto = React.useId();
-  const fromAria = slugify(ariaLabel as string | undefined);
-  const finalId = id || auto;
-  const finalName = name || (id ? fromAria : undefined) || finalId;
+  const { id, name: generatedName, isInvalid } = useFieldIds(
+    ariaLabel,
+    idProp,
+    nameProp,
+  );
 
-  const error =
-    props["aria-invalid"] === true || props["aria-invalid"] === "true";
+  const name = nameProp ?? (idProp ? generatedName : id);
+
+  const error = isInvalid(props["aria-invalid"]);
   const disabled = props.disabled;
   const readOnly = props.readOnly;
 
@@ -79,8 +80,8 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
     >
       <input
         ref={ref}
-        id={finalId}
-        name={finalName}
+        id={id}
+        name={name}
         className={cn(
           "w-full rounded-[inherit] bg-transparent px-3 text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]",
           indent && "pl-7",

--- a/src/components/ui/primitives/Textarea.tsx
+++ b/src/components/ui/primitives/Textarea.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { cn, slugify } from "@/lib/utils";
+import { useFieldIds } from "@/lib/useFieldIds";
+import { cn } from "@/lib/utils";
 import FieldShell from "./FieldShell";
 
 /**
@@ -30,22 +31,20 @@ export default React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       className,
       textareaClassName,
       resize,
-      id,
-      name,
+      id: idProp,
+      name: nameProp,
       "aria-label": ariaLabel,
       ...props
     },
     ref,
   ) {
-    const auto = React.useId();
-    const fromAria = slugify(ariaLabel as string | undefined);
-    // Use React-generated id by default so multiple fields sharing an aria-label
-    // do not end up with duplicate ids.
-    const finalId = id || auto;
-    const finalName = name || fromAria || slugify(finalId);
+    const { id, name, isInvalid } = useFieldIds(
+      ariaLabel,
+      idProp,
+      nameProp,
+    );
 
-    const error =
-      props["aria-invalid"] === true || props["aria-invalid"] === "true";
+    const error = isInvalid(props["aria-invalid"]);
 
     return (
       <FieldShell
@@ -56,8 +55,8 @@ export default React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       >
         <textarea
           ref={ref}
-          id={finalId}
-          name={finalName}
+          id={id}
+          name={name}
           className={cn(INNER, resize, textareaClassName)}
           {...props}
         />

--- a/src/lib/useFieldIds.ts
+++ b/src/lib/useFieldIds.ts
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { slugify } from "./utils";
+
+type AriaInvalidValue =
+  | boolean
+  | "true"
+  | "false"
+  | "grammar"
+  | "spelling"
+  | undefined;
+
+export function useFieldIds(
+  ariaLabel?: string,
+  idProp?: string,
+  nameProp?: string,
+): {
+  id: string;
+  name: string;
+  isInvalid: (value: AriaInvalidValue) => boolean;
+} {
+  const autoId = React.useId();
+  const id = idProp ?? autoId;
+  const labelSlug = React.useMemo(() => slugify(ariaLabel), [ariaLabel]);
+
+  const name = React.useMemo(() => {
+    if (nameProp) return nameProp;
+    if (labelSlug) return labelSlug;
+    if (idProp) {
+      const slugged = slugify(idProp);
+      return slugged || id;
+    }
+    const slugged = slugify(id);
+    return slugged || id;
+  }, [nameProp, labelSlug, idProp, id]);
+
+  const isInvalid = React.useCallback(
+    (value: AriaInvalidValue) => value === true || value === "true",
+    [],
+  );
+
+  return React.useMemo(
+    () => ({ id, name, isInvalid }),
+    [id, name, isInvalid],
+  );
+}


### PR DESCRIPTION
## Summary
- add a shared `useFieldIds` hook to centralize field id/name generation and aria-invalid parsing
- refactor Input, Textarea, and Select primitives to use the hook and simplify error handling

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c89eef4234832c945f0a3b33c8c7c4