### PR TITLE
feat: add optional label to SearchBar

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -116,6 +116,7 @@ Following these guidelines keeps the interface consistent and lets theme updates
 - Wraps its input in a `<form role="search">` for accessibility.
 - Submitting the form calls `onValueChange` immediately and optionally `onSubmit` with the current query.
 - Disables `autoComplete`, `autoCorrect`, `spellCheck`, and `autoCapitalize` by default for consistent text entry.
+- Accepts an optional `label` prop that renders the shared `<Label>` component and wires up `htmlFor`/`id` automatically. When you omit `label`, supply your own `aria-labelledby` or `aria-label` as needed.
 
 ```tsx
 import { SearchBar } from "@/components/ui";
@@ -126,6 +127,7 @@ export function Demo() {
       value=""
       onValueChange={() => {}}
       onSubmit={(q) => console.log(q)}
+      label="Search tasks"
     />
   );
 }

--- a/tests/primitives/search-bar.test.tsx
+++ b/tests/primitives/search-bar.test.tsx
@@ -65,4 +65,29 @@ describe('SearchBar', () => {
     const input = getByRole('searchbox');
     expect(input).toBeDisabled();
   });
+
+  it('renders an associated label when provided', () => {
+    const { getByLabelText } = render(
+      <SearchBar value="" onValueChange={() => {}} label="Search tasks" />
+    );
+
+    expect(getByLabelText('Search tasks')).toBeInTheDocument();
+  });
+
+  it('allows external labelling via aria-labelledby', () => {
+    const { getByRole } = render(
+      <>
+        <span id="search-title">Lookup</span>
+        <SearchBar
+          value=""
+          onValueChange={() => {}}
+          aria-labelledby="search-title"
+        />
+      </>
+    );
+
+    const input = getByRole('searchbox');
+    expect(input).toHaveAttribute('aria-labelledby', 'search-title');
+    expect(input).not.toHaveAttribute('aria-label');
+  });
 });


### PR DESCRIPTION
## Summary
- add an optional `label` prop to the SearchBar primitive and wire it to the shared Label component
- avoid forcing aria-labels when an external label or aria-labelledby is provided and keep markup backwards compatible
- document label usage in the design system guide and extend SearchBar tests for label and aria-labelledby scenarios

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8a02932e4832ca674d5eaf2cdbc85