### PR TITLE
Tokenize badge radius and spacing

### DIFF
--- a/src/components/ui/primitives/Badge.tsx
+++ b/src/components/ui/primitives/Badge.tsx
@@ -28,8 +28,8 @@ export type BadgeProps<T extends React.ElementType = "span"> =
     Omit<React.ComponentPropsWithoutRef<T>, keyof BadgeOwnProps<T>>;
 
 const sizeMap: Record<Size, string> = {
-  xs: "px-2 py-1 text-xs leading-none",
-  sm: "px-3 py-2 text-xs leading-none",
+  xs: "px-[var(--space-2)] py-[var(--space-1)] text-xs leading-none",
+  sm: "px-[var(--space-3)] py-[var(--space-2)] text-xs leading-none",
 };
 
 const toneBorder: Record<Tone, string> = {
@@ -60,7 +60,7 @@ export default function Badge<T extends React.ElementType = "span">({
     <Comp
       data-selected={selected ? "true" : undefined}
       className={cn(
-        "inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-full font-medium tracking-[-0.01em]",
+        "inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em]",
         "border bg-muted/18",
         "shadow-badge",
         "transition-[background,box-shadow,transform] duration-140 ease-out",

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`ReviewListItem > renders default state 1`] = `
             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-full font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
+            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
           >
             MID
           </span>
@@ -91,7 +91,7 @@ exports[`ReviewListItem > renders disabled state 1`] = `
             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-full font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
+            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
           >
             MID
           </span>
@@ -162,7 +162,7 @@ exports[`ReviewListItem > renders selected state 1`] = `
             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-full font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
+            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
           >
             MID
           </span>
@@ -217,7 +217,7 @@ exports[`ReviewListItem > renders untitled state 1`] = `
             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-full font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
+            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
           >
             MID
           </span>

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -936,7 +936,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
                           />
                           <span
-                            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-full font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
+                            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
                           >
                             MID
                           </span>
@@ -980,7 +980,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
                           />
                           <span
-                            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-full font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
+                            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
                           >
                             BOT
                           </span>
@@ -1024,7 +1024,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
                           />
                           <span
-                            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-full font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
+                            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
                           >
                             TOP
                           </span>

--- a/tests/ui/badge.test.tsx
+++ b/tests/ui/badge.test.tsx
@@ -24,8 +24,8 @@ describe('Badge', () => {
   it('supports the xs size', () => {
     const { getByText } = render(<Badge size="xs">Small</Badge>);
     const badge = getByText('Small');
-    expect(badge).toHaveClass('px-2');
-    expect(badge).toHaveClass('py-1');
+    expect(badge).toHaveClass('px-[var(--space-2)]');
+    expect(badge).toHaveClass('py-[var(--space-1)]');
     expect(badge).toHaveClass('text-xs');
   });
 });


### PR DESCRIPTION
## Summary
- replace the badge pill radius with the semantic `rounded-card` + `r-card-lg` utilities and swap size paddings to `--space-*` tokens
- update the badge unit test and review snapshots so generated markup reflects the tokenized styles

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8a1185b4c832c8660d7bd9e928e46