### PR TITLE
Refactor primary button shadow tokens

### DIFF
--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -133,7 +133,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const isDisabled = disabled || loading;
     const s = buttonSizes[size];
     const base = cn(
-      "relative inline-flex items-center justify-center rounded-[var(--radius-2xl)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)]",
+      "group relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)]",
       s.height,
       s.padding,
       s.text,
@@ -163,7 +163,6 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             : variant === "primary"
               ? {
                   scale: 1.03,
-                  boxShadow: `${neuRaised(16)},0 0 8px hsl(var(${colorVar[tone]})/.3)`,
                 }
               : whileHover
         }
@@ -173,7 +172,8 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {variant === "primary" ? (
           <span
             className={cn(
-              "absolute inset-0 pointer-events-none rounded-[var(--radius-2xl)]",
+              "absolute inset-0 pointer-events-none rounded-[var(--control-radius)] shadow-none transition-[box-shadow] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none",
+              "group-hover:shadow-glow-current group-focus-visible:shadow-glow-current group-active:shadow-inset-hairline group-data-[loading=true]:shadow-none group-[&[disabled]]:shadow-none",
               `bg-[linear-gradient(90deg,hsl(var(${colorVar[tone]})/.18),hsl(var(${colorVar[tone]})/.18))]`,
             )}
           />

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -827,12 +827,12 @@ exports[`ReviewsPage > renders default state 1`] = `
                             </div>
                           </div>
                           <button
-                            class="relative inline-flex items-center justify-center rounded-[var(--radius-2xl)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 gap-2 [&_svg]:size-5 px-4 whitespace-nowrap bg-[hsl(var(--accent)/0.12)] border-[hsl(var(--accent)/0.35)] hover:bg-[hsl(var(--accent)/0.14)] hover:shadow-btn-primary-hover active:translate-y-px active:shadow-btn-primary-active text-foreground"
+                            class="group relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 gap-2 [&_svg]:size-5 px-4 whitespace-nowrap bg-[hsl(var(--accent)/0.12)] border-[hsl(var(--accent)/0.35)] hover:bg-[hsl(var(--accent)/0.14)] hover:shadow-btn-primary-hover active:translate-y-px active:shadow-btn-primary-active text-foreground"
                             tabindex="0"
                             type="button"
                           >
                             <span
-                              class="absolute inset-0 pointer-events-none rounded-[var(--radius-2xl)] bg-[linear-gradient(90deg,hsl(var(--foreground)/.18),hsl(var(--foreground)/.18))]"
+                              class="absolute inset-0 pointer-events-none rounded-[var(--control-radius)] shadow-none transition-[box-shadow] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none group-hover:shadow-glow-current group-focus-visible:shadow-glow-current group-active:shadow-inset-hairline group-data-[loading=true]:shadow-none group-[&[disabled]]:shadow-none bg-[linear-gradient(90deg,hsl(var(--foreground)/.18),hsl(var(--foreground)/.18))]"
                             />
                             <span
                               class="relative z-10 inline-flex items-center gap-2"


### PR DESCRIPTION
## Summary
- switch the button base to the control radius token and add a group wrapper so stateful overlay classes can coordinate hover and focus styles
- replace the primary button’s manual hover glow with token-based shadow utilities and refresh the ReviewsPage snapshot to match the new markup

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8a11a98e4832c8eaca9a1a9906dd2