### PR TITLE
Replace interactive reminder headings with dedicated buttons

### DIFF
--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -14,6 +14,7 @@
 
 import * as React from "react";
 import SectionCard from "@/components/ui/layout/SectionCard";
+import Button from "@/components/ui/primitives/Button";
 import Input from "@/components/ui/primitives/Input";
 import Textarea from "@/components/ui/primitives/Textarea";
 import Badge from "@/components/ui/primitives/Badge";
@@ -309,16 +310,21 @@ function ReminderCard({
             className="font-semibold"
           />
         ) : (
-          <h3
-            className="font-semibold title-glow cursor-text"
-            onClick={() => setEditing(true)}
-            role="button"
-            tabIndex={0}
-            onKeyDown={(e) => e.key === "Enter" && setEditing(true)}
-            title="Click to edit"
-          >
-            {value.title}
-          </h3>
+          <div className="flex items-center gap-2 min-w-0">
+            <h3 className="font-semibold title-glow truncate" title={value.title}>
+              {value.title}
+            </h3>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => setEditing(true)}
+              aria-label={value.title ? `Edit reminder ${value.title}` : "Edit reminder"}
+              className="shrink-0"
+            >
+              <Pencil aria-hidden="true" />
+              Edit
+            </Button>
+          </div>
         )}
 
         <div className="card-neo flex items-center gap-1">
@@ -363,15 +369,6 @@ function ReminderCard({
             </>
           ) : (
             <>
-              <IconButton
-                title="Edit"
-                aria-label="Edit"
-                onClick={() => setEditing(true)}
-                size="sm"
-                iconSize="sm"
-              >
-                <Pencil />
-              </IconButton>
               <IconButton
                 title="Delete"
                 aria-label="Delete"

--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -557,35 +557,30 @@ function RemTile({
               className="font-semibold uppercase tracking-wide"
             />
           ) : (
-            <h4
-              className="font-semibold uppercase tracking-wide pr-2 title-glow glitch cursor-text leading-6 truncate"
-              onClick={() => {
-                setEditing(true);
-              }}
-              role="button"
-              tabIndex={0}
-              onKeyDown={(e) => e.key === "Enter" && setEditing(true)}
-              title="Click to edit"
-            >
-              {value.title}
-            </h4>
+            <div className="flex items-center gap-2 min-w-0">
+              <h4
+                className="font-semibold uppercase tracking-wide pr-2 title-glow glitch leading-6 truncate"
+                title={value.title}
+              >
+                {value.title}
+              </h4>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setEditing(true);
+                }}
+                aria-label={value.title ? `Edit reminder ${value.title}` : "Edit reminder"}
+                className="shrink-0"
+              >
+                <Pencil aria-hidden="true" />
+                Edit
+              </Button>
+            </div>
           )}
         </div>
 
         <div className="flex items-center gap-1">
-          <IconButton
-            title="Edit"
-            aria-label="Edit"
-            onClick={() => {
-              setEditing(true);
-            }}
-            size="sm"
-            iconSize="sm"
-            className="opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity"
-          >
-            <Pencil />
-          </IconButton>
-
           <IconButton
             title="Delete"
             aria-label="Delete"


### PR DESCRIPTION
## Summary
- stop using clickable headings in reminder cards and render the title inside a semantic heading
- add an adjacent ghost button with the pencil icon to enter edit mode while preserving design token states
- remove the redundant edit icon button now that a dedicated action sits next to the heading

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8a40b02bc832c837655160ee7b2af