### PR TITLE
Cache review search blobs for reviews filtering

### DIFF
--- a/src/components/reviews/ReviewPage.tsx
+++ b/src/components/reviews/ReviewPage.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Review } from "@/lib/types";
 import { usePersistentState, uid } from "@/lib/db";
 import ReviewsPage from "./ReviewsPage";
+import { primeReviewSearch } from "./reviewSearch";
 
 /**
  * ReviewPage — container with local-first persistence.
@@ -44,6 +45,7 @@ export default function ReviewPage() {
       notes: "",
       createdAt: now,
     };
+    primeReviewSearch(fresh);
     setReviews(prev => [fresh, ...prev]);
     setSelectedId(fresh.id);
   }, [setReviews]);
@@ -51,7 +53,9 @@ export default function ReviewPage() {
   const onSelect = useCallback((id: string) => setSelectedId(id), []);
 
   const patchById = useCallback((id: string, patch: Partial<Review>) => {
-    setReviews(prev => prev.map(r => (r.id === id ? { ...r, ...patch } : r)));
+    setReviews(prev =>
+      prev.map(r => (r.id === id ? primeReviewSearch({ ...r, ...patch }) : r)),
+    );
   }, [setReviews]);
 
   const onRename = useCallback((id: string, nextTitle: string) => {

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -8,6 +8,7 @@ import ReviewList from "./ReviewList";
 import ReviewEditor from "./ReviewEditor";
 import ReviewSummary from "./ReviewSummary";
 import ReviewPanel from "./ReviewPanel";
+import { getSearchBlob } from "./reviewSearch";
 import { BookOpen, Ghost, Plus } from "lucide-react";
 
 import { Button, Select, PageHeader, PageShell } from "@/components/ui";
@@ -51,23 +52,7 @@ export default function ReviewsPage({
     const list =
       needle.length === 0
         ? [...base]
-        : base.filter((r) => {
-            const blob = [
-              r?.title,
-              Array.isArray(r?.tags) ? r.tags.join(" ") : "",
-              r?.opponent,
-              r?.lane,
-              r?.side,
-              r?.result,
-              r?.patch,
-              r?.duration,
-              r?.notes,
-            ]
-              .filter(Boolean)
-              .join(" ")
-              .toLowerCase();
-            return blob.includes(needle);
-          });
+        : base.filter((r) => getSearchBlob(r).includes(needle));
 
     if (sort === "newest")
       list.sort((a, b) => ts(b?.createdAt) - ts(a?.createdAt));

--- a/src/components/reviews/reviewSearch.ts
+++ b/src/components/reviews/reviewSearch.ts
@@ -1,0 +1,55 @@
+import type { Review } from "@/lib/types";
+
+const SEARCH_CACHE_KEY = Symbol.for("planner.reviews.searchCache");
+
+type SearchCache = {
+  raw: string;
+  blob: string;
+};
+
+type SearchableReview = Review & {
+  [SEARCH_CACHE_KEY]?: SearchCache;
+};
+
+function collectSearchParts(review: Review): string[] {
+  const parts: string[] = [];
+  if (review.title) parts.push(review.title);
+  if (Array.isArray(review.tags) && review.tags.length)
+    parts.push(review.tags.join(" "));
+  if (review.opponent) parts.push(review.opponent);
+  if (review.lane) parts.push(review.lane);
+  if (review.side) parts.push(review.side);
+  if (review.result) parts.push(review.result);
+  if (review.patch) parts.push(review.patch);
+  if (review.duration) parts.push(review.duration);
+  if (review.notes) parts.push(review.notes);
+  return parts;
+}
+
+function buildSearchSource(review: Review): string {
+  return collectSearchParts(review).join(" ");
+}
+
+function setCache(review: SearchableReview, cache: SearchCache) {
+  Object.defineProperty(review, SEARCH_CACHE_KEY, {
+    value: cache,
+    configurable: true,
+    enumerable: false,
+    writable: true,
+  });
+}
+
+export function getSearchBlob(review: Review): string {
+  const searchable = review as SearchableReview;
+  const raw = buildSearchSource(review);
+  const cached = searchable[SEARCH_CACHE_KEY];
+  if (cached && cached.raw === raw) return cached.blob;
+  const blob = raw.toLowerCase();
+  setCache(searchable, { raw, blob });
+  return blob;
+}
+
+export function primeReviewSearch(review: Review): Review {
+  getSearchBlob(review);
+  return review;
+}

--- a/src/components/reviews/useReviewFilter.ts
+++ b/src/components/reviews/useReviewFilter.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import type { Review } from "@/lib/types";
 import { ts } from "@/lib/date";
+import { getSearchBlob } from "./reviewSearch";
 
 export type SortKey = "newest" | "oldest" | "title";
 
@@ -14,23 +15,7 @@ export function useReviewFilter(
     const list =
       needle.length === 0
         ? [...base]
-        : base.filter((r) => {
-            const blob = [
-              r?.title,
-              Array.isArray(r?.tags) ? r.tags.join(" ") : "",
-              r?.opponent,
-              r?.lane,
-              r?.side,
-              r?.result,
-              r?.patch,
-              r?.duration,
-              r?.notes,
-            ]
-              .filter(Boolean)
-              .join(" ")
-              .toLowerCase();
-            return blob.includes(needle);
-          });
+        : base.filter((r) => getSearchBlob(r).includes(needle));
 
     if (sort === "newest")
       list.sort((a, b) => ts(b?.createdAt) - ts(a?.createdAt));


### PR DESCRIPTION
## Summary
- add a reviewSearch helper that caches each review's searchable text
- update the list filtering hooks/components to query the cached blob
- refresh cached text when reviews are created or patched so search stays accurate

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8a3fe0f3c832c8a15eb512181b3fe