### PR TITLE
Refactor Select glitch styles into CSS module

### DIFF
--- a/src/components/ui/Select.module.css
+++ b/src/components/ui/Select.module.css
@@ -1,0 +1,245 @@
+/* Scoped glitch styles: chroma/iris ring, flicker, scanlines. */
+.caret {
+  transition:
+    transform var(--dur-quick) var(--ease-out),
+    filter var(--dur-quick) var(--ease-out);
+}
+
+.caretOpen {
+  transform: rotate(180deg);
+}
+
+.glitchTrigger:hover .caret {
+  animation: caret-jitter 0.9s steps(2, end) infinite;
+  filter: drop-shadow(0 0 4px hsl(var(--ring) / 0.55));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .caret {
+    transition: none;
+  }
+
+  .glitchTrigger:hover .caret {
+    animation: none;
+    filter: none;
+  }
+}
+
+@keyframes caret-jitter {
+  0%,
+  100% {
+    transform: translateX(0) rotate(var(--rot, 0deg));
+  }
+
+  50% {
+    transform: translateX(0.6px) rotate(var(--rot, 0deg));
+  }
+}
+
+.gbIris,
+.gbChroma,
+.gbFlicker,
+.gbScan {
+  position: absolute;
+  inset: -1px;
+  border-radius: var(--radius-2xl);
+  pointer-events: none;
+}
+
+.gbIris {
+  padding: 1px;
+  background: conic-gradient(
+    from 180deg,
+    hsl(var(--ring) / 0),
+    hsl(var(--ring) / 0.55),
+    hsl(var(--accent-2) / 0.55),
+    hsl(var(--lav-deep) / 0.55),
+    hsl(var(--ring) / 0)
+  );
+  -webkit-mask:
+    linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+    linear-gradient(hsl(var(--foreground)) 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  opacity: 0.32;
+  animation: iris-rotate 10s linear infinite;
+}
+
+@keyframes iris-rotate {
+  to {
+    filter: hue-rotate(360deg);
+  }
+}
+
+.gbChroma {
+  padding: 1px;
+  background: conic-gradient(
+    from 90deg,
+    hsl(var(--ring) / 0),
+    hsl(var(--ring) / 0.7),
+    hsl(var(--accent-2) / 0.65),
+    hsl(var(--accent) / 0.65),
+    hsl(var(--ring) / 0)
+  );
+  -webkit-mask:
+    linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+    linear-gradient(hsl(var(--foreground)) 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  mix-blend-mode: screen;
+  opacity: 0.28;
+  animation: chroma-jitter 2.1s steps(6, end) infinite;
+}
+
+@keyframes chroma-jitter {
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+
+  20% {
+    transform: translate(0.25px, -0.25px);
+  }
+
+  40% {
+    transform: translate(-0.25px, 0.25px);
+  }
+
+  60% {
+    transform: translate(0.15px, 0.15px);
+  }
+
+  80% {
+    transform: translate(-0.15px, -0.1px);
+  }
+}
+
+.gbFlicker {
+  inset: -2px;
+  border-radius: var(--radius-2xl);
+  background: radial-gradient(
+    120% 120% at 50% 50%,
+    hsl(var(--ring) / 0.18),
+    transparent 60%
+  );
+  filter: blur(7px) saturate(1.06);
+  mix-blend-mode: screen;
+  opacity: 0.18;
+  animation:
+    border-flicker 3.2s steps(24, end) infinite,
+    border-pulse 6s ease-in-out infinite alternate;
+}
+
+@keyframes border-flicker {
+  0%,
+  7%,
+  9%,
+  100% {
+    opacity: 0.16;
+  }
+
+  8% {
+    opacity: 0.46;
+  }
+
+  31% {
+    opacity: 0.22;
+  }
+
+  33% {
+    opacity: 0.4;
+  }
+
+  54% {
+    opacity: 0.2;
+  }
+
+  55% {
+    opacity: 0.46;
+  }
+
+  78% {
+    opacity: 0.24;
+  }
+}
+
+@keyframes border-pulse {
+  0%,
+  100% {
+    filter: blur(7px) saturate(1.02);
+  }
+
+  50% {
+    filter: blur(8px) saturate(1.18);
+  }
+}
+
+.gbScan {
+  padding: 1px;
+  -webkit-mask:
+    linear-gradient(hsl(var(--foreground)) 0 0) content-box,
+    linear-gradient(hsl(var(--foreground)) 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  background: repeating-linear-gradient(
+    0deg,
+    hsl(var(--foreground) / 0.1) 0 1px,
+    transparent 2px 4px
+  );
+  mix-blend-mode: soft-light;
+  opacity: 0.2;
+  animation: scan-move 5.2s linear infinite;
+}
+
+@keyframes scan-move {
+  0% {
+    transform: translateY(-10%);
+  }
+
+  100% {
+    transform: translateY(10%);
+  }
+}
+
+.glitchTrigger[data-lit="true"] .gbIris,
+.glitchTrigger[data-open="true"] .gbIris {
+  opacity: 0.45;
+}
+
+.glitchTrigger[data-lit="true"] .gbChroma,
+.glitchTrigger[data-open="true"] .gbChroma {
+  opacity: 0.48;
+}
+
+.glitchTrigger[data-lit="true"] .gbFlicker,
+.glitchTrigger[data-open="true"] .gbFlicker {
+  opacity: 0.28;
+}
+
+[data-open="true"] .gbIris {
+  opacity: 0.38;
+}
+
+[data-open="true"] .gbChroma {
+  opacity: 0.42;
+}
+
+[data-open="true"] .gbFlicker {
+  opacity: 0.26;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gbIris,
+  .gbChroma,
+  .gbFlicker,
+  .gbScan,
+  .glitchTrigger:hover .caret {
+    animation: none;
+  }
+}
+
+.glitchText:hover {
+  text-shadow:
+    0.6px 0 hsl(var(--accent-2) / 0.45),
+    -0.6px 0 hsl(var(--lav-deep) / 0.45);
+}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -6,6 +6,7 @@ import { createPortal } from "react-dom";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { Check, ChevronDown, ChevronRight } from "lucide-react";
 import FieldShell from "./primitives/FieldShell";
+import styles from "./Select.module.css";
 import useMounted from "@/lib/useMounted";
 import { cn, slugify } from "@/lib/utils";
 
@@ -390,15 +391,21 @@ const AnimatedSelectImpl = React.forwardRef<
         : "Select option");
 
   // ── Trigger (glitch chrome + stays lit on selection) ──
-  const triggerCls = [
-    "glitch-trigger relative flex items-center h-9 rounded-full px-3 overflow-hidden",
+  const triggerCls = cn(
+    styles.glitchTrigger,
+    "relative flex items-center h-9 rounded-full px-3 overflow-hidden",
     "bg-muted/12 hover:bg-muted/18",
     "focus:[outline:none] focus-visible:[outline:none]",
     "transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none",
     buttonClassName,
-  ].join(" ");
+  );
 
-  const caretCls = `caret ml-auto size-4 shrink-0 opacity-75 ${open ? "caret-open" : ""}`;
+  const caretCls = cn(
+    "caret",
+    "ml-auto size-4 shrink-0 opacity-75",
+    styles.caret,
+    open && styles.caretOpen,
+  );
 
   return (
     <div id={id} className={["glitch-wrap", className].join(" ")}>
@@ -440,11 +447,12 @@ const AnimatedSelectImpl = React.forwardRef<
           ) : null}
 
           <span
-            className={[
+            className={cn(
               "font-medium glitch-text",
+              styles.glitchText,
               lit ? "text-foreground" : "text-muted-foreground",
               "group-hover:text-foreground",
-            ].join(" ")}
+            )}
           >
             {current ? (
               current.label
@@ -456,10 +464,10 @@ const AnimatedSelectImpl = React.forwardRef<
           <ChevronDown className={caretCls} aria-hidden="true" />
 
           {/* ── glitch border stack (no whites) ── */}
-          <span aria-hidden className="gb-iris" />
-          <span aria-hidden className="gb-chroma" />
-          <span aria-hidden className="gb-flicker" />
-          <span aria-hidden className="gb-scan" />
+          <span aria-hidden className={cn("gb-iris", styles.gbIris)} />
+          <span aria-hidden className={cn("gb-chroma", styles.gbChroma)} />
+          <span aria-hidden className={cn("gb-flicker", styles.gbFlicker)} />
+          <span aria-hidden className={cn("gb-scan", styles.gbScan)} />
         </button>
       </div>
 
@@ -508,10 +516,10 @@ const AnimatedSelectImpl = React.forwardRef<
                 data-open="true"
               >
                 {/* same border stack for menu */}
-                <span aria-hidden className="gb-iris" />
-                <span aria-hidden className="gb-chroma" />
-                <span aria-hidden className="gb-flicker" />
-                <span aria-hidden className="gb-scan" />
+                <span aria-hidden className={cn("gb-iris", styles.gbIris)} />
+                <span aria-hidden className={cn("gb-chroma", styles.gbChroma)} />
+                <span aria-hidden className={cn("gb-flicker", styles.gbFlicker)} />
+                <span aria-hidden className={cn("gb-scan", styles.gbScan)} />
 
                 {items.map((it, idx) => {
                   const active = it.value === value;
@@ -541,7 +549,12 @@ const AnimatedSelectImpl = React.forwardRef<
                         data-loading={it.loading}
                       >
                         <div className="flex items-center justify-between gap-3">
-                          <span className="text-sm leading-none glitch-text">
+                          <span
+                            className={cn(
+                              "text-sm leading-none glitch-text",
+                              styles.glitchText,
+                            )}
+                          >
                             {it.label}
                           </span>
                           <Check
@@ -573,250 +586,9 @@ const AnimatedSelectImpl = React.forwardRef<
           document.body,
         )}
 
-      <GlitchStyles />
     </div>
   );
 });
-
-/* ─────────────────────────────────────────────────────────
-   Scoped glitch styles: chroma/iris ring, flicker, scanlines.
-   Boosted when [data-lit="true"] or [data-open="true"].
-   No white borders; all hues use theme tokens.
-   ───────────────────────────────────────────────────────── */
-function GlitchStyles() {
-  return (
-    <style jsx>{`
-      /* caret jitter */
-      .caret {
-        transition:
-          transform var(--dur-quick) var(--ease-out),
-          filter var(--dur-quick) var(--ease-out);
-      }
-      .caret-open {
-        transform: rotate(180deg);
-      }
-      .glitch-trigger:hover .caret {
-        animation: caret-jitter 0.9s steps(2, end) infinite;
-        filter: drop-shadow(0 0 4px hsl(var(--ring) / 0.55));
-      }
-
-      @media (prefers-reduced-motion: reduce) {
-        .caret {
-          transition: none;
-        }
-        .glitch-trigger:hover .caret {
-          animation: none;
-          filter: none;
-        }
-      }
-      @keyframes caret-jitter {
-        0%,
-        100% {
-          transform: translateX(0) rotate(var(--rot, 0deg));
-        }
-        50% {
-          transform: translateX(0.6px) rotate(var(--rot, 0deg));
-        }
-      }
-
-      /* ── border stack pieces (masked to border) ── */
-
-      .gb-iris,
-      .gb-chroma,
-      .gb-flicker,
-      .gb-scan {
-        position: absolute;
-        inset: -1px;
-        border-radius: var(--radius-2xl);
-        pointer-events: none;
-      }
-
-      /* Base iris sheen with subtle rotation */
-      .gb-iris {
-        padding: 1px;
-        background: conic-gradient(
-          from 180deg,
-          hsl(var(--ring) / 0),
-          hsl(var(--ring) / 0.55),
-          hsl(var(--accent-2) / 0.55),
-          hsl(var(--lav-deep) / 0.55),
-          hsl(var(--ring) / 0)
-        );
-        -webkit-mask:
-          linear-gradient(hsl(var(--foreground)) 0 0) content-box,
-          linear-gradient(hsl(var(--foreground)) 0 0);
-        -webkit-mask-composite: xor;
-        mask-composite: exclude;
-        opacity: 0.32;
-        animation: iris-rotate 10s linear infinite;
-      }
-      @keyframes iris-rotate {
-        to {
-          filter: hue-rotate(360deg);
-        }
-      }
-
-      /* Stronger chroma jitter (RGB split feel) */
-      .gb-chroma {
-        padding: 1px;
-        background: conic-gradient(
-          from 90deg,
-          hsl(var(--ring) / 0),
-          hsl(var(--ring) / 0.7),
-          hsl(var(--accent-2) / 0.65),
-          hsl(var(--accent) / 0.65),
-          hsl(var(--ring) / 0)
-        );
-        -webkit-mask:
-          linear-gradient(hsl(var(--foreground)) 0 0) content-box,
-          linear-gradient(hsl(var(--foreground)) 0 0);
-        -webkit-mask-composite: xor;
-        mask-composite: exclude;
-        mix-blend-mode: screen;
-        opacity: 0.28;
-        animation: chroma-jitter 2.1s steps(6, end) infinite;
-      }
-      @keyframes chroma-jitter {
-        0%,
-        100% {
-          transform: translate(0, 0);
-        }
-        20% {
-          transform: translate(0.25px, -0.25px);
-        }
-        40% {
-          transform: translate(-0.25px, 0.25px);
-        }
-        60% {
-          transform: translate(0.15px, 0.15px);
-        }
-        80% {
-          transform: translate(-0.15px, -0.1px);
-        }
-      }
-
-      /* Flickery aura hugging the border */
-      .gb-flicker {
-        inset: -2px;
-        border-radius: var(--radius-2xl);
-        background: radial-gradient(
-          120% 120% at 50% 50%,
-          hsl(var(--ring) / 0.18),
-          transparent 60%
-        );
-        filter: blur(7px) saturate(1.06);
-        mix-blend-mode: screen;
-        opacity: 0.18;
-        animation:
-          border-flicker 3.2s steps(24, end) infinite,
-          border-pulse 6s ease-in-out infinite alternate;
-      }
-      @keyframes border-flicker {
-        0%,
-        7%,
-        9%,
-        100% {
-          opacity: 0.16;
-        }
-        8% {
-          opacity: 0.46;
-        }
-        31% {
-          opacity: 0.22;
-        }
-        33% {
-          opacity: 0.4;
-        }
-        54% {
-          opacity: 0.2;
-        }
-        55% {
-          opacity: 0.46;
-        }
-        78% {
-          opacity: 0.24;
-        }
-      }
-      @keyframes border-pulse {
-        0%,
-        100% {
-          filter: blur(7px) saturate(1.02);
-        }
-        50% {
-          filter: blur(8px) saturate(1.18);
-        }
-      }
-
-      /* Thin scanlines constrained to the edge */
-      .gb-scan {
-        padding: 1px;
-        -webkit-mask:
-          linear-gradient(hsl(var(--foreground)) 0 0) content-box,
-          linear-gradient(hsl(var(--foreground)) 0 0);
-        -webkit-mask-composite: xor;
-        mask-composite: exclude;
-        background: repeating-linear-gradient(
-          0deg,
-          hsl(var(--foreground) / 0.1) 0 1px,
-          transparent 2px 4px
-        );
-        mix-blend-mode: soft-light;
-        opacity: 0.2;
-        animation: scan-move 5.2s linear infinite;
-      }
-      @keyframes scan-move {
-        0% {
-          transform: translateY(-10%);
-        }
-        100% {
-          transform: translateY(10%);
-        }
-      }
-
-      /* Light up when selected or open */
-      .glitch-trigger[data-lit="true"] .gb-iris,
-      .glitch-trigger[data-open="true"] .gb-iris {
-        opacity: 0.45;
-      }
-      .glitch-trigger[data-lit="true"] .gb-chroma,
-      .glitch-trigger[data-open="true"] .gb-chroma {
-        opacity: 0.48;
-      }
-      .glitch-trigger[data-lit="true"] .gb-flicker,
-      .glitch-trigger[data-open="true"] .gb-flicker {
-        opacity: 0.28;
-      }
-
-      /* Menu also glows a bit stronger */
-      [data-open="true"] .gb-iris {
-        opacity: 0.38;
-      }
-      [data-open="true"] .gb-chroma {
-        opacity: 0.42;
-      }
-      [data-open="true"] .gb-flicker {
-        opacity: 0.26;
-      }
-
-      @media (prefers-reduced-motion: reduce) {
-        .gb-iris,
-        .gb-chroma,
-        .gb-flicker,
-        .gb-scan,
-        .glitch-trigger:hover .caret {
-          animation: none;
-        }
-      }
-
-      /* subtle label RGB split on hover */
-      .glitch-text:hover {
-        text-shadow:
-          0.6px 0 hsl(var(--accent-2) / 0.45),
-          -0.6px 0 hsl(var(--lav-deep) / 0.45);
-      }
-    `}</style>
-  );
-}
 
 type SelectRef = HTMLSelectElement | HTMLButtonElement;
 

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -547,19 +547,19 @@ exports[`ReviewsPage > renders default state 1`] = `
                                   aria-expanded="false"
                                   aria-haspopup="listbox"
                                   aria-label="Select option"
-                                  class="glitch-trigger relative flex items-center h-9 rounded-full px-3 overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none h-10 px-4"
+                                  class="_glitchTrigger_85f92b relative flex items-center rounded-full overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none h-10 px-4"
                                   data-lit="true"
                                   data-open="false"
                                   type="button"
                                 >
                                   <span
-                                    class="font-medium glitch-text text-foreground group-hover:text-foreground"
+                                    class="font-medium glitch-text _glitchText_85f92b text-foreground group-hover:text-foreground"
                                   >
                                     Newest
                                   </span>
                                   <svg
                                     aria-hidden="true"
-                                    class="lucide lucide-chevron-down caret ml-auto size-4 shrink-0 opacity-75 "
+                                    class="lucide lucide-chevron-down caret ml-auto size-4 shrink-0 opacity-75 _caret_85f92b"
                                     fill="none"
                                     height="24"
                                     stroke="currentColor"
@@ -576,254 +576,22 @@ exports[`ReviewsPage > renders default state 1`] = `
                                   </svg>
                                   <span
                                     aria-hidden="true"
-                                    class="gb-iris"
+                                    class="gb-iris _gbIris_85f92b"
                                   />
                                   <span
                                     aria-hidden="true"
-                                    class="gb-chroma"
+                                    class="gb-chroma _gbChroma_85f92b"
                                   />
                                   <span
                                     aria-hidden="true"
-                                    class="gb-flicker"
+                                    class="gb-flicker _gbFlicker_85f92b"
                                   />
                                   <span
                                     aria-hidden="true"
-                                    class="gb-scan"
+                                    class="gb-scan _gbScan_85f92b"
                                   />
                                 </button>
                               </div>
-                              <style>
-                                
-      /* caret jitter */
-      .caret {
-        transition:
-          transform var(--dur-quick) var(--ease-out),
-          filter var(--dur-quick) var(--ease-out);
-      }
-      .caret-open {
-        transform: rotate(180deg);
-      }
-      .glitch-trigger:hover .caret {
-        animation: caret-jitter 0.9s steps(2, end) infinite;
-        filter: drop-shadow(0 0 4px hsl(var(--ring) / 0.55));
-      }
-
-      @media (prefers-reduced-motion: reduce) {
-        .caret {
-          transition: none;
-        }
-        .glitch-trigger:hover .caret {
-          animation: none;
-          filter: none;
-        }
-      }
-      @keyframes caret-jitter {
-        0%,
-        100% {
-          transform: translateX(0) rotate(var(--rot, 0deg));
-        }
-        50% {
-          transform: translateX(0.6px) rotate(var(--rot, 0deg));
-        }
-      }
-
-      /* ── border stack pieces (masked to border) ── */
-
-      .gb-iris,
-      .gb-chroma,
-      .gb-flicker,
-      .gb-scan {
-        position: absolute;
-        inset: -1px;
-        border-radius: var(--radius-2xl);
-        pointer-events: none;
-      }
-
-      /* Base iris sheen with subtle rotation */
-      .gb-iris {
-        padding: 1px;
-        background: conic-gradient(
-          from 180deg,
-          hsl(var(--ring) / 0),
-          hsl(var(--ring) / 0.55),
-          hsl(var(--accent-2) / 0.55),
-          hsl(var(--lav-deep) / 0.55),
-          hsl(var(--ring) / 0)
-        );
-        -webkit-mask:
-          linear-gradient(hsl(var(--foreground)) 0 0) content-box,
-          linear-gradient(hsl(var(--foreground)) 0 0);
-        -webkit-mask-composite: xor;
-        mask-composite: exclude;
-        opacity: 0.32;
-        animation: iris-rotate 10s linear infinite;
-      }
-      @keyframes iris-rotate {
-        to {
-          filter: hue-rotate(360deg);
-        }
-      }
-
-      /* Stronger chroma jitter (RGB split feel) */
-      .gb-chroma {
-        padding: 1px;
-        background: conic-gradient(
-          from 90deg,
-          hsl(var(--ring) / 0),
-          hsl(var(--ring) / 0.7),
-          hsl(var(--accent-2) / 0.65),
-          hsl(var(--accent) / 0.65),
-          hsl(var(--ring) / 0)
-        );
-        -webkit-mask:
-          linear-gradient(hsl(var(--foreground)) 0 0) content-box,
-          linear-gradient(hsl(var(--foreground)) 0 0);
-        -webkit-mask-composite: xor;
-        mask-composite: exclude;
-        mix-blend-mode: screen;
-        opacity: 0.28;
-        animation: chroma-jitter 2.1s steps(6, end) infinite;
-      }
-      @keyframes chroma-jitter {
-        0%,
-        100% {
-          transform: translate(0, 0);
-        }
-        20% {
-          transform: translate(0.25px, -0.25px);
-        }
-        40% {
-          transform: translate(-0.25px, 0.25px);
-        }
-        60% {
-          transform: translate(0.15px, 0.15px);
-        }
-        80% {
-          transform: translate(-0.15px, -0.1px);
-        }
-      }
-
-      /* Flickery aura hugging the border */
-      .gb-flicker {
-        inset: -2px;
-        border-radius: var(--radius-2xl);
-        background: radial-gradient(
-          120% 120% at 50% 50%,
-          hsl(var(--ring) / 0.18),
-          transparent 60%
-        );
-        filter: blur(7px) saturate(1.06);
-        mix-blend-mode: screen;
-        opacity: 0.18;
-        animation:
-          border-flicker 3.2s steps(24, end) infinite,
-          border-pulse 6s ease-in-out infinite alternate;
-      }
-      @keyframes border-flicker {
-        0%,
-        7%,
-        9%,
-        100% {
-          opacity: 0.16;
-        }
-        8% {
-          opacity: 0.46;
-        }
-        31% {
-          opacity: 0.22;
-        }
-        33% {
-          opacity: 0.4;
-        }
-        54% {
-          opacity: 0.2;
-        }
-        55% {
-          opacity: 0.46;
-        }
-        78% {
-          opacity: 0.24;
-        }
-      }
-      @keyframes border-pulse {
-        0%,
-        100% {
-          filter: blur(7px) saturate(1.02);
-        }
-        50% {
-          filter: blur(8px) saturate(1.18);
-        }
-      }
-
-      /* Thin scanlines constrained to the edge */
-      .gb-scan {
-        padding: 1px;
-        -webkit-mask:
-          linear-gradient(hsl(var(--foreground)) 0 0) content-box,
-          linear-gradient(hsl(var(--foreground)) 0 0);
-        -webkit-mask-composite: xor;
-        mask-composite: exclude;
-        background: repeating-linear-gradient(
-          0deg,
-          hsl(var(--foreground) / 0.1) 0 1px,
-          transparent 2px 4px
-        );
-        mix-blend-mode: soft-light;
-        opacity: 0.2;
-        animation: scan-move 5.2s linear infinite;
-      }
-      @keyframes scan-move {
-        0% {
-          transform: translateY(-10%);
-        }
-        100% {
-          transform: translateY(10%);
-        }
-      }
-
-      /* Light up when selected or open */
-      .glitch-trigger[data-lit="true"] .gb-iris,
-      .glitch-trigger[data-open="true"] .gb-iris {
-        opacity: 0.45;
-      }
-      .glitch-trigger[data-lit="true"] .gb-chroma,
-      .glitch-trigger[data-open="true"] .gb-chroma {
-        opacity: 0.48;
-      }
-      .glitch-trigger[data-lit="true"] .gb-flicker,
-      .glitch-trigger[data-open="true"] .gb-flicker {
-        opacity: 0.28;
-      }
-
-      /* Menu also glows a bit stronger */
-      [data-open="true"] .gb-iris {
-        opacity: 0.38;
-      }
-      [data-open="true"] .gb-chroma {
-        opacity: 0.42;
-      }
-      [data-open="true"] .gb-flicker {
-        opacity: 0.26;
-      }
-
-      @media (prefers-reduced-motion: reduce) {
-        .gb-iris,
-        .gb-chroma,
-        .gb-flicker,
-        .gb-scan,
-        .glitch-trigger:hover .caret {
-          animation: none;
-        }
-      }
-
-      /* subtle label RGB split on hover */
-      .glitch-text:hover {
-        text-shadow:
-          0.6px 0 hsl(var(--accent-2) / 0.45),
-          -0.6px 0 hsl(var(--lav-deep) / 0.45);
-      }
-    
-                              </style>
                             </div>
                           </div>
                           <button


### PR DESCRIPTION
## Summary
- move the Select glitch styling rules into a dedicated CSS module for better scoping
- update the Select component to import the module, replace dynamic style injection, and reuse the new classes
- refresh the Reviews page snapshot to capture the updated markup

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8a3f71d30832ca5491f4e93f71eca