### PR TITLE
Refactor field naming helper for form primitives

### DIFF
--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -6,8 +6,9 @@ import { createPortal } from "react-dom";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { Check, ChevronDown, ChevronRight } from "lucide-react";
 import FieldShell from "./primitives/FieldShell";
+import { resolveFieldIds } from "@/lib/fieldIds";
 import useMounted from "@/lib/useMounted";
-import { cn, slugify } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 
 /** Option item */
 export type SelectItem = {
@@ -73,10 +74,11 @@ const NativeSelect = React.forwardRef<HTMLSelectElement, NativeSelectProps>(
     },
     ref,
   ) {
-    const auto = React.useId();
-    const fromAria = slugify(props["aria-label"] as string | undefined);
-    const finalId = id || auto;
-    const finalName = props.name || fromAria || finalId;
+    const { id: finalId, name: finalName } = resolveFieldIds({
+      id,
+      name: props.name,
+      ariaLabel: props["aria-label"] as string | undefined,
+    });
     const successId = `${finalId}-success`;
     const errorId = errorText ? `${finalId}-error` : undefined;
     const helperId = helperText ? `${finalId}-helper` : undefined;

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -3,7 +3,7 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
-import useFieldNaming from "@/lib/useFieldNaming";
+import { resolveFieldIds } from "@/lib/fieldIds";
 import FieldShell from "./FieldShell";
 
 export type InputSize = "sm" | "md" | "lg";
@@ -51,7 +51,7 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
   },
   ref,
 ) {
-  const { id: finalId, name: finalName } = useFieldNaming({
+  const { id: finalId, name: finalName } = resolveFieldIds({
     id,
     name,
     ariaLabel: ariaLabel as string | undefined,

--- a/src/components/ui/primitives/Textarea.tsx
+++ b/src/components/ui/primitives/Textarea.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
-import useFieldNaming from "@/lib/useFieldNaming";
+import { resolveFieldIds } from "@/lib/fieldIds";
 import FieldShell from "./FieldShell";
 
 /**
@@ -38,7 +38,7 @@ export default React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     },
     ref,
   ) {
-    const { id: finalId, name: finalName } = useFieldNaming({
+    const { id: finalId, name: finalName } = resolveFieldIds({
       id,
       name,
       ariaLabel: ariaLabel as string | undefined,

--- a/src/lib/fieldIds.ts
+++ b/src/lib/fieldIds.ts
@@ -1,0 +1,20 @@
+// src/lib/fieldIds.ts
+import useFieldNaming, {
+  type FieldNamingOptions,
+  type FieldNamingResult,
+} from "./useFieldNaming";
+
+type ResolveFieldIdsOptions = Pick<
+  FieldNamingOptions,
+  "id" | "name" | "ariaLabel" | "ariaLabelStrategy" | "slugifyFallback"
+>;
+
+export function useResolveFieldIds(
+  options: ResolveFieldIdsOptions = {},
+): FieldNamingResult {
+  return useFieldNaming(options);
+}
+
+export const resolveFieldIds = useResolveFieldIds;
+
+export type { ResolveFieldIdsOptions };

--- a/tests/primitives/input.test.tsx
+++ b/tests/primitives/input.test.tsx
@@ -87,4 +87,28 @@ describe("Input", () => {
       "data-[loading=true]:opacity-[var(--loading)]",
     );
   });
+
+  it("defaults name to the generated id when no overrides are provided", () => {
+    const { getByRole } = render(<Input aria-label="Generated" />);
+    const input = getByRole("textbox") as HTMLInputElement;
+    expect(input.id).toBeTruthy();
+    expect(input.name).toBe(input.id);
+  });
+
+  it("derives name from aria-label when a custom id is supplied", () => {
+    const { getByRole } = render(
+      <Input id="email" aria-label="Email Address" />,
+    );
+    const input = getByRole("textbox") as HTMLInputElement;
+    expect(input.id).toBe("email");
+    expect(input.name).toBe("email-address");
+  });
+
+  it("prefers an explicit name prop", () => {
+    const { getByRole } = render(
+      <Input aria-label="Custom" name="custom-name" />,
+    );
+    const input = getByRole("textbox") as HTMLInputElement;
+    expect(input.name).toBe("custom-name");
+  });
 });

--- a/tests/primitives/select-native.test.tsx
+++ b/tests/primitives/select-native.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import Select from "../../src/components/ui/Select";
+
+const items = [
+  { label: "Apple", value: "apple" },
+  { label: "Banana", value: "banana" },
+];
+
+afterEach(cleanup);
+
+describe("NativeSelect", () => {
+  it("derives name from aria-label when no id is provided", () => {
+    const { getByRole } = render(
+      <Select variant="native" aria-label="Fruit" items={items} />,
+    );
+    const select = getByRole("combobox") as HTMLSelectElement;
+    expect(select.id).toBeTruthy();
+    expect(select.name).toBe("fruit");
+  });
+
+  it("uses the provided id and slugifies the aria-label for the name", () => {
+    const { getByRole } = render(
+      <Select
+        variant="native"
+        id="fruit-select"
+        aria-label="Favorite Fruit"
+        items={items}
+      />,
+    );
+    const select = getByRole("combobox") as HTMLSelectElement;
+    expect(select.id).toBe("fruit-select");
+    expect(select.name).toBe("favorite-fruit");
+  });
+
+  it("prefers an explicit name prop", () => {
+    const { getByRole } = render(
+      <Select
+        variant="native"
+        aria-label="Custom Fruit"
+        name="fruit-choice"
+        items={items}
+      />,
+    );
+    const select = getByRole("combobox") as HTMLSelectElement;
+    expect(select.name).toBe("fruit-choice");
+  });
+});

--- a/tests/primitives/textarea.test.tsx
+++ b/tests/primitives/textarea.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import Textarea from "../../src/components/ui/primitives/Textarea";
+import { slugify } from "../../src/lib/utils";
+
+afterEach(cleanup);
+
+describe("Textarea", () => {
+  it("derives the name from the aria-label by default", () => {
+    const { getByRole } = render(<Textarea aria-label="Notes" />);
+    const textarea = getByRole("textbox") as HTMLTextAreaElement;
+    expect(textarea.id).toBeTruthy();
+    expect(textarea.name).toBe("notes");
+  });
+
+  it("slugifies the generated id when no aria-label is provided", () => {
+    const { getByRole } = render(<Textarea />);
+    const textarea = getByRole("textbox") as HTMLTextAreaElement;
+    expect(textarea.id).toBeTruthy();
+    expect(textarea.name).toBe(slugify(textarea.id));
+  });
+
+  it("derives the name from aria-label when an id is provided", () => {
+    const { getByRole } = render(
+      <Textarea id="notes" aria-label="Detailed Notes" />,
+    );
+    const textarea = getByRole("textbox") as HTMLTextAreaElement;
+    expect(textarea.id).toBe("notes");
+    expect(textarea.name).toBe("detailed-notes");
+  });
+
+  it("prefers an explicit name prop", () => {
+    const { getByRole } = render(
+      <Textarea aria-label="Custom" name="custom-textarea" />,
+    );
+    const textarea = getByRole("textbox") as HTMLTextAreaElement;
+    expect(textarea.name).toBe("custom-textarea");
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared `resolveFieldIds` helper that wraps `useFieldNaming`
- refactor the Input, Textarea, and native Select primitives to use the helper
- expand primitive tests to cover id/name behaviour across the inputs

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8a3efff0c832c9c174c99995df49a