### PR TITLE
Use sanitizeList in MyComps setAt

### DIFF
--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -28,7 +28,6 @@ import {
   NotebookPen,
   Plus,
 } from "lucide-react";
-import { sanitizeText } from "@/lib/utils";
 import { sanitizeList } from "@/lib/sanitizeList";
 
 /* ───────────── Types ───────────── */
@@ -175,7 +174,7 @@ function ChampChips({
 
   function setAt(i: number, next: string) {
     const arr = [...champs];
-    arr[i] = sanitizeText(next);
+    arr[i] = next;
     onChange(sanitizeList(arr).filter((s) => s.trim().length));
   }
   function insertAfter(i: number) {


### PR DESCRIPTION
## Summary
- remove the redundant sanitizeText usage when updating champ chips
- rely on sanitizeList to sanitize entries and filter blank strings before persisting

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8a6170afc832caac94eb7a8993eda