### PR TITLE
Use Next Image for planner header logo

### DIFF
--- a/public/planner-logo.svg
+++ b/public/planner-logo.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <rect
+    x="10"
+    y="7"
+    width="28"
+    height="34"
+    rx="9"
+    stroke="currentColor"
+    stroke-width="2.5"
+  />
+  <path
+    d="M17 19h14"
+    stroke="currentColor"
+    stroke-width="2.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M17 27h9"
+    stroke="currentColor"
+    stroke-width="2.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <circle cx="31" cy="27" r="3" fill="currentColor" />
+  <path
+    d="M24 12v-3"
+    stroke="currentColor"
+    stroke-width="2.5"
+    stroke-linecap="round"
+  />
+</svg>

--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import Image from "next/image";
 import {
   PageHeader,
   Header,
@@ -236,9 +237,11 @@ export default function PageHeaderDemo() {
           ),
           subtitle: "Plan your day, track goals, and review games.",
           icon: (
-            <img
-              src="https://chatgpt.com/backend-api/estuary/content?id=file-PYBH1vD28Bzi3KruKxaiXa&ts=488268&p=fs&cid=1&sig=1e357c5433df95c196bb9530996ae68bb6ef1b29fde1a5dc741cdc1fce727ecb&v=0"
-              alt=""
+            <Image
+              src="/planner-logo.svg"
+              alt="Planner logo"
+              width={48}
+              height={48}
               className="h-12 w-auto object-contain"
             />
           ),


### PR DESCRIPTION
## Summary
- replace the PageHeaderDemo hero icon with Next.js Image so the component uses Next’s image optimization
- add a local planner logo SVG asset in `public/` for a stable source used by the header demo

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8a663b4c8832caca6c8fed8d791e0