### PR TITLE
Suppress styled-jsx warnings in tests

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,6 +1,20 @@
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
 
+const originalConsoleError = console.error;
+vi.spyOn(console, "error").mockImplementation((...args) => {
+  const [format, value, attr, ...rest] = args;
+  const isStyledJsxWarning =
+    typeof format === "string" &&
+    format.includes("Received `%s` for a non-boolean attribute `%s`.") &&
+    value === "true" &&
+    (attr === "jsx" || attr === "global");
+  if (isStyledJsxWarning) {
+    return;
+  }
+  originalConsoleError(...args);
+});
+
 Object.defineProperty(window, "matchMedia", {
   writable: true,
   value: vi.fn().mockReturnValue({


### PR DESCRIPTION
## Summary
- silence styled-jsx boolean attribute warnings during Vitest runs by filtering known console messages in the shared setup

## Testing
- npm test -- --run
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68c8a41345b0832cba7d6da116d69f51