### PR TITLE
Normalize styled-jsx attributes in tests

### DIFF
--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -683,7 +683,9 @@ exports[`ReviewEditor > renders default state 1`] = `
                 class="pointer-events-none absolute inset-0 rounded-full"
                 style="background: radial-gradient(120% 120% at 50% 50%, hsl(var(--foreground)/0.16), transparent 60%); mix-blend-mode: screen; opacity: 0;"
               />
-              <style>
+              <style
+                jsx="true"
+              >
                 
         .ni-root { width: var(--ni-size); height: var(--ni-size); }
 
@@ -792,7 +794,9 @@ exports[`ReviewEditor > renders default state 1`] = `
                 >
                   Wave
                 </span>
-                <style>
+                <style
+                  jsx="true"
+                >
                   
         .lg-pillar-badge {
           position: relative;
@@ -927,7 +931,9 @@ exports[`ReviewEditor > renders default state 1`] = `
                 >
                   Trading
                 </span>
-                <style>
+                <style
+                  jsx="true"
+                >
                   
         .lg-pillar-badge {
           position: relative;
@@ -1051,7 +1057,9 @@ exports[`ReviewEditor > renders default state 1`] = `
                 >
                   Vision
                 </span>
-                <style>
+                <style
+                  jsx="true"
+                >
                   
         .lg-pillar-badge {
           position: relative;
@@ -1184,7 +1192,9 @@ exports[`ReviewEditor > renders default state 1`] = `
                 >
                   Tempo
                 </span>
-                <style>
+                <style
+                  jsx="true"
+                >
                   
         .lg-pillar-badge {
           position: relative;
@@ -1329,7 +1339,9 @@ exports[`ReviewEditor > renders default state 1`] = `
                 >
                   Positioning
                 </span>
-                <style>
+                <style
+                  jsx="true"
+                >
                   
         .lg-pillar-badge {
           position: relative;
@@ -1451,7 +1463,9 @@ exports[`ReviewEditor > renders default state 1`] = `
                 >
                   Comms
                 </span>
-                <style>
+                <style
+                  jsx="true"
+                >
                   
         .lg-pillar-badge {
           position: relative;
@@ -1638,7 +1652,9 @@ exports[`ReviewEditor > renders default state 1`] = `
                 class="pointer-events-none absolute inset-0 rounded-full"
                 style="background: radial-gradient(120% 120% at 50% 50%, hsl(var(--foreground)/0.16), transparent 60%); mix-blend-mode: screen; opacity: 0;"
               />
-              <style>
+              <style
+                jsx="true"
+              >
                 
         .ni-root { width: var(--ni-size); height: var(--ni-size); }
 
@@ -1794,7 +1810,9 @@ exports[`ReviewEditor > renders default state 1`] = `
                 class="pointer-events-none absolute inset-0 rounded-full"
                 style="background: radial-gradient(120% 120% at 50% 50%, hsl(var(--foreground)/0.16), transparent 60%); mix-blend-mode: screen; opacity: 0;"
               />
-              <style>
+              <style
+                jsx="true"
+              >
                 
         .ni-root { width: var(--ni-size); height: var(--ni-size); }
 

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -7,7 +7,10 @@ exports[`ReviewsPage > renders default state 1`] = `
     class="page-shell py-6 space-y-6"
   >
     <header>
-      <style>
+      <style
+        global="true"
+        jsx="true"
+      >
         
       .hero2-beams {
         position: absolute;
@@ -206,7 +209,10 @@ exports[`ReviewsPage > renders default state 1`] = `
               </div>
             </header>
             <header>
-              <style>
+              <style
+                global="true"
+                jsx="true"
+              >
                 
       /* === Glitch title ================================================== */
       .hero2-title {
@@ -303,7 +309,10 @@ exports[`ReviewsPage > renders default state 1`] = `
       }
     
               </style>
-              <style>
+              <style
+                global="true"
+                jsx="true"
+              >
                 
       .hero2-beams {
         position: absolute;
@@ -592,7 +601,9 @@ exports[`ReviewsPage > renders default state 1`] = `
                                   />
                                 </button>
                               </div>
-                              <style>
+                              <style
+                                jsx="true"
+                              >
                                 
       /* caret jitter */
       .caret {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,5 +1,52 @@
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
+import type { ElementType, ReactNode } from "react";
+
+type ReactModule = typeof import("react");
+
+type StyleElementProps = {
+  jsx?: string | boolean;
+  global?: string | boolean;
+  [key: string]: unknown;
+};
+
+vi.mock("react", async () => {
+  const actual = (await vi.importActual<ReactModule>("react")) as ReactModule;
+
+  const createElement: ReactModule["createElement"] = ((
+    type: ElementType,
+    props: StyleElementProps | null,
+    ...children: ReactNode[]
+  ) => {
+    if (typeof type === "string" && type === "style" && props) {
+      if (props.jsx === true || props.global === true) {
+        const coercedProps: StyleElementProps = { ...props };
+
+        if (coercedProps.jsx === true) {
+          coercedProps.jsx = "true";
+        }
+
+        if (coercedProps.global === true) {
+          coercedProps.global = "true";
+        }
+
+        return actual.createElement(type, coercedProps, ...children);
+      }
+    }
+
+    return actual.createElement(type as ElementType, props as any, ...children);
+  }) as ReactModule["createElement"];
+
+  const patched = {
+    ...actual,
+    createElement,
+  } as ReactModule & { default: ReactModule };
+
+  return {
+    ...patched,
+    default: patched,
+  } satisfies ReactModule & { default: ReactModule };
+});
 
 Object.defineProperty(window, "matchMedia", {
   writable: true,


### PR DESCRIPTION
## Summary
- mock React in the Vitest setup to coerce styled-jsx `jsx` and `global` flags to string values so test renders match production markup without warnings
- refresh review-related snapshots to expect the normalized `jsx="true"` attributes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8a41903dc832c8d511f7966fad8d9