### PR TITLE
Sanitize planner days and streamline week aggregates

### DIFF
--- a/src/components/planner/useWeekData.ts
+++ b/src/components/planner/useWeekData.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { ensureDay, type ISODate } from "./plannerStore";
+import { type ISODate } from "./plannerStore";
 import { usePlannerStore } from "./usePlannerStore";
 
 export function useWeekData(days: ISODate[]) {
@@ -11,17 +11,15 @@ export function useWeekData(days: ISODate[]) {
     let weekDone = 0;
     let weekTotal = 0;
     const per = days.map((iso) => {
-      const rec = ensureDay(map, iso);
-      let done = 0;
-      let total = 0;
-      for (const p of rec.projects) {
-        total++;
-        if (p?.done) done++;
-      }
-      for (const t of rec.tasks) {
-        total++;
-        if (t?.done) done++;
-      }
+      const rec = map[iso];
+      const { done, total } = (rec ? [...rec.projects, ...rec.tasks] : []).reduce(
+        (counts, item) => {
+          counts.total += 1;
+          if (item.done) counts.done += 1;
+          return counts;
+        },
+        { done: 0, total: 0 },
+      );
       weekDone += done;
       weekTotal += total;
       return { iso, done, total };


### PR DESCRIPTION
## Summary
- sanitize persisted planner day records on load and before writes so tasks always include normalized fields
- expose sanitized days through the planner provider while wrapping updates to maintain normalized storage
- simplify weekly aggregation by relying on normalized data and a single reduce over projects and tasks

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8a7be5f58832cab628c0c1433f87f