### PR TITLE
Refactor team components to share roles constant

### DIFF
--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -16,10 +16,11 @@ import Textarea from "@/components/ui/primitives/Textarea";
 import { Pencil, Check } from "lucide-react";
 import { sanitizeText } from "@/lib/utils";
 import { sanitizeList } from "@/lib/sanitizeList";
+import { ROLES } from "./constants";
+import type { Role } from "./constants";
 
 /* ───────────── types ───────────── */
 
-type Role = "Top" | "Jungle" | "Mid" | "Bot" | "Support";
 type LaneExamples = Partial<Record<Role, string[]>>;
 
 export type Archetype = {
@@ -555,7 +556,7 @@ export default function CheatSheet({
               <div>
                 <Label>Examples</Label>
                 <div className="mt-2 space-y-2">
-                  {(["Top", "Jungle", "Mid", "Bot", "Support"] as Role[]).map(
+                  {ROLES.map(
                     (role) => {
                       const champs = a.examples[role];
                       const setChamps = (list: string[]) =>

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -29,10 +29,10 @@ import {
   Plus,
 } from "lucide-react";
 import { sanitizeList } from "@/lib/sanitizeList";
+import { ROLES } from "./constants";
+import type { Role } from "./constants";
 
 /* ───────────── Types ───────────── */
-
-type Role = "Top" | "Jungle" | "Mid" | "Bot" | "Support";
 
 export type TeamComp = {
   id: string;
@@ -78,8 +78,6 @@ const SEEDS: TeamComp[] = [
 ];
 
 /* ───────────── Utils ───────────── */
-
-const ROLES: Role[] = ["Top", "Jungle", "Mid", "Bot", "Support"];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;

--- a/src/components/team/constants.ts
+++ b/src/components/team/constants.ts
@@ -1,0 +1,6 @@
+// src/components/team/constants.ts
+// Shared constants for team planner roles.
+
+export type Role = "Top" | "Jungle" | "Mid" | "Bot" | "Support";
+
+export const ROLES: Role[] = ["Top", "Jungle", "Mid", "Bot", "Support"];


### PR DESCRIPTION
## Summary
- add a shared team constants module exporting the Role union and ROLES array
- update MyComps and CheatSheet to import the shared roles list instead of declaring inline arrays

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8a82a30c4832caa6ad92e3c08e3ba