### PR TITLE
Add shared weekday formatter and update week summary

### DIFF
--- a/src/components/planner/WeekSummary.tsx
+++ b/src/components/planner/WeekSummary.tsx
@@ -7,7 +7,8 @@ import SectionCard from "@/components/ui/layout/SectionCard";
 import { useWeek } from "./useFocusDate";
 import { usePlannerStore } from "./usePlannerStore";
 import type { ISODate } from "./plannerStore";
-import { cn, LOCALE } from "@/lib/utils";
+import { cn } from "@/lib/utils";
+import { formatWeekDay } from "@/lib/date";
 
 /**
  * WeekSummary
@@ -57,7 +58,7 @@ export default function WeekSummary({
 
   const rangeLabel =
     weekDays.length === 7
-      ? `${fmtDay(weekDays[0])} — ${fmtDay(weekDays[6])}`
+      ? `${formatWeekDay(weekDays[0])} — ${formatWeekDay(weekDays[6])}`
       : "";
 
   const grid =
@@ -152,13 +153,3 @@ export default function WeekSummary({
   );
 }
 
-/* ───────────── utils ──────────── */
-function fmtDay(iso: string) {
-  try {
-    const [y, m, d] = iso.split("-").map(Number);
-    const dt = new Date(Date.UTC(y, m - 1, d));
-    return dt.toLocaleDateString(LOCALE, { day: "2-digit", month: "short" });
-  } catch {
-    return iso;
-  }
-}

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -9,6 +9,11 @@ export const shortDate = new Intl.DateTimeFormat(LOCALE, {
   year: "numeric",
 });
 
+const weekDayFormatter = new Intl.DateTimeFormat(LOCALE, {
+  day: "2-digit",
+  month: "short",
+});
+
 /** Predicate for "YYYY-MM-DD" */
 export function isISODate(v: string): boolean {
   return /^\d{4}-\d{2}-\d{2}$/.test(v);
@@ -23,6 +28,12 @@ export function fromISODate(iso: string): Date | null {
   return dt.getFullYear() === y && dt.getMonth() === m - 1 && dt.getDate() === d
     ? dt
     : null;
+}
+
+export function formatWeekDay(iso: string): string {
+  const dt = fromISODate(iso);
+  if (!dt) return iso;
+  return weekDayFormatter.format(dt);
 }
 
 /** Normalize various inputs to a valid Date (fallback = now). */

--- a/tests/lib/date.test.ts
+++ b/tests/lib/date.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeDate,
   weekRangeFromISO,
   ts,
+  formatWeekDay,
 } from '../../src/lib/date';
 
 describe('fromISODate', () => {
@@ -104,5 +105,16 @@ describe('weekRangeFromISO', () => {
     const { start, end } = weekRangeFromISO('2024-06-15');
     expect(toISODate(start)).toBe('2024-06-10');
     expect(toISODate(end)).toBe('2024-06-16');
+  });
+});
+
+describe('formatWeekDay', () => {
+  it('formats ISO dates for week range display', () => {
+    expect(formatWeekDay('2024-02-29')).toBe('Feb 29');
+    expect(formatWeekDay('2024-02-01')).toBe('Feb 01');
+  });
+
+  it('falls back to the original input when invalid', () => {
+    expect(formatWeekDay('not-a-date')).toBe('not-a-date');
   });
 });


### PR DESCRIPTION
## Summary
- add a shared `formatWeekDay` helper in `src/lib/date.ts` for consistent week range labels
- update `WeekSummary` to use the new formatter instead of a local implementation
- extend the date helper tests to cover the new formatting and invalid-input fallback

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8a90988e0832caf0ed6a038d03b6e