### PR TITLE
Memoize theme query params parsing

### DIFF
--- a/src/lib/theme-hooks.ts
+++ b/src/lib/theme-hooks.ts
@@ -15,11 +15,14 @@ export function useThemeQuerySync() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const paramsKey = searchParams.toString();
+  const params = React.useMemo(
+    () => new URLSearchParams(paramsKey),
+    [paramsKey],
+  );
   const [theme, setTheme] = useTheme();
 
   React.useEffect(() => {
     if (typeof window === "undefined") return;
-    const params = new URLSearchParams(paramsKey);
     const themeParam = params.get("theme");
     const bgParam = params.get("bg");
     setTheme((prev) => {
@@ -38,17 +41,17 @@ export function useThemeQuerySync() {
       }
       return next;
     });
-  }, [paramsKey, setTheme]);
+  }, [params, setTheme]);
 
   React.useEffect(() => {
-    const params = new URLSearchParams(paramsKey);
     const currentTheme = params.get("theme");
     const currentBg = params.get("bg");
     if (currentTheme === theme.variant && currentBg === String(theme.bg)) {
       return;
     }
-    params.set("theme", theme.variant);
-    params.set("bg", String(theme.bg));
-    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
-  }, [theme, router, pathname, paramsKey]);
+    const nextParams = new URLSearchParams(params);
+    nextParams.set("theme", theme.variant);
+    nextParams.set("bg", String(theme.bg));
+    router.replace(`${pathname}?${nextParams.toString()}`, { scroll: false });
+  }, [theme, router, pathname, params]);
 }


### PR DESCRIPTION
## Summary
- memoize URLSearchParams parsing in useThemeQuerySync and reuse it in effects
- avoid mutating the memoized params by cloning when updating the query

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8a96214ec832c93702ff6e90d09e5