### PR TITLE
feat: centralize field id hook

### DIFF
--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -6,8 +6,8 @@ import { createPortal } from "react-dom";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { Check, ChevronDown, ChevronRight } from "lucide-react";
 import FieldShell from "./primitives/FieldShell";
-import { resolveFieldIds } from "@/lib/fieldIds";
 import useMounted from "@/lib/useMounted";
+import { useFieldIds } from "@/lib/useFieldIds";
 import { cn } from "@/lib/utils";
 
 /** Option item */
@@ -74,11 +74,14 @@ const NativeSelect = React.forwardRef<HTMLSelectElement, NativeSelectProps>(
     },
     ref,
   ) {
-    const { id: finalId, name: finalName } = resolveFieldIds({
+    const { id: finalId, name: finalName, isInvalid } = useFieldIds(
+      props["aria-label"] as string | undefined,
       id,
-      name: props.name,
-      ariaLabel: props["aria-label"] as string | undefined,
-    });
+      props.name,
+      {
+        ariaInvalid: errorText ? "true" : props["aria-invalid"],
+      },
+    );
     const successId = `${finalId}-success`;
     const errorId = errorText ? `${finalId}-error` : undefined;
     const helperId = helperText ? `${finalId}-helper` : undefined;
@@ -96,7 +99,7 @@ const NativeSelect = React.forwardRef<HTMLSelectElement, NativeSelectProps>(
               "cursor-not-allowed focus-within:ring-0 focus-within:shadow-none",
             className,
           )}
-          error={!!errorText}
+          error={isInvalid}
           disabled={disabled}
         >
           <select

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -3,7 +3,7 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
-import { resolveFieldIds } from "@/lib/fieldIds";
+import { useFieldIds } from "@/lib/useFieldIds";
 import FieldShell from "./FieldShell";
 
 export type InputSize = "sm" | "md" | "lg";
@@ -51,15 +51,15 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
   },
   ref,
 ) {
-  const { id: finalId, name: finalName } = resolveFieldIds({
+  const { id: finalId, name: finalName, isInvalid } = useFieldIds(
+    ariaLabel as string | undefined,
     id,
     name,
-    ariaLabel: ariaLabel as string | undefined,
-    ariaLabelStrategy: "custom-id",
-  });
-
-  const error =
-    props["aria-invalid"] === true || props["aria-invalid"] === "true";
+    {
+      ariaInvalid: props["aria-invalid"],
+      ariaLabelStrategy: "custom-id",
+    },
+  );
   const disabled = props.disabled;
   const readOnly = props.readOnly;
 
@@ -74,7 +74,7 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
 
   return (
     <FieldShell
-      error={error}
+      error={isInvalid}
       disabled={disabled}
       readOnly={readOnly}
       className={className}

--- a/src/components/ui/primitives/Textarea.tsx
+++ b/src/components/ui/primitives/Textarea.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
-import { resolveFieldIds } from "@/lib/fieldIds";
+import { useFieldIds } from "@/lib/useFieldIds";
 import FieldShell from "./FieldShell";
 
 /**
@@ -38,19 +38,19 @@ export default React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     },
     ref,
   ) {
-    const { id: finalId, name: finalName } = resolveFieldIds({
+    const { id: finalId, name: finalName, isInvalid } = useFieldIds(
+      ariaLabel as string | undefined,
       id,
       name,
-      ariaLabel: ariaLabel as string | undefined,
-      slugifyFallback: true,
-    });
-
-    const error =
-      props["aria-invalid"] === true || props["aria-invalid"] === "true";
+      {
+        ariaInvalid: props["aria-invalid"],
+        slugifyFallback: true,
+      },
+    );
 
     return (
       <FieldShell
-        error={error}
+        error={isInvalid}
         disabled={props.disabled}
         readOnly={props.readOnly}
         className={className}

--- a/src/lib/useFieldIds.ts
+++ b/src/lib/useFieldIds.ts
@@ -1,0 +1,55 @@
+// src/lib/useFieldIds.ts
+import { type AriaAttributes } from "react";
+
+import useFieldNaming, {
+  type FieldNamingOptions,
+} from "./useFieldNaming";
+
+export type UseFieldIdsOptions = Pick<
+  FieldNamingOptions,
+  "ariaLabelStrategy" | "slugifyFallback"
+> & {
+  ariaInvalid?: AriaAttributes["aria-invalid"];
+};
+
+export type UseFieldIdsResult = {
+  id: string;
+  name: string;
+  isInvalid: boolean;
+};
+
+export function useFieldIds(
+  ariaLabel?: string,
+  idProp?: string,
+  nameProp?: string,
+): UseFieldIdsResult;
+export function useFieldIds(
+  ariaLabel?: string,
+  idProp?: string,
+  nameProp?: string,
+  options?: UseFieldIdsOptions,
+): UseFieldIdsResult;
+export function useFieldIds(
+  ariaLabel?: string,
+  idProp?: string,
+  nameProp?: string,
+  options: UseFieldIdsOptions = {},
+): UseFieldIdsResult {
+  const { ariaInvalid, ariaLabelStrategy, slugifyFallback } = options;
+
+  const namingOptions: FieldNamingOptions = {
+    id: idProp,
+    name: nameProp,
+    ariaLabel,
+    ariaLabelStrategy,
+    slugifyFallback,
+  };
+
+  const { id, name } = useFieldNaming(namingOptions);
+
+  const isInvalid = ariaInvalid === true || ariaInvalid === "true";
+
+  return { id, name, isInvalid };
+}
+
+export default useFieldIds;


### PR DESCRIPTION
## Summary
- add a shared `useFieldIds` hook that wraps `useFieldNaming` and normalizes invalid state
- refactor the input, textarea, and native select primitives to consume the new hook

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8a78faf48832cbf3ce7b0f9892fb9