### PR TITLE
Use semantic token classes for team champ badges

### DIFF
--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -185,7 +185,10 @@ function ChampPillsView({ champs }: { champs?: string[] }) {
   return (
     <div className="champ-badges mt-1">
       {champs.map((c) => (
-        <span key={c} className="champ-badge glitch-pill text-label font-medium tracking-[0.02em]">
+        <span
+          key={c}
+          className="champ-badge glitch-pill border-border bg-card text-foreground text-label font-medium tracking-[0.02em]"
+        >
           <i className="dot" />
           {c}
         </span>
@@ -380,7 +383,10 @@ function ChampPillsEdit({
   return (
     <div className="champ-badges mt-1 flex flex-wrap gap-2">
       {(list.length ? list : [""]).map((c, i) => (
-        <span key={i} className="champ-badge text-label font-medium tracking-[0.02em]">
+        <span
+          key={i}
+          className="champ-badge border-border bg-card text-foreground text-label font-medium tracking-[0.02em]"
+        >
           <i className="dot" />
           <input
             type="text"

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -161,7 +161,10 @@ function ChampChips({
     return (
       <div className="champ-badges mt-1 flex flex-wrap gap-2">
         {(champs.length ? champs : ["-"]).map((c, i) => (
-          <span key={i} className="champ-badge glitch-pill text-label font-medium tracking-[0.02em]">
+          <span
+            key={i}
+            className="champ-badge glitch-pill border-border bg-card text-foreground text-label font-medium tracking-[0.02em]"
+          >
             <i className="dot" />
             {c}
           </span>
@@ -190,7 +193,10 @@ function ChampChips({
   return (
     <div className="champ-badges mt-1 flex flex-wrap gap-2">
       {(champs.length ? champs : [""]).map((c, i) => (
-        <span key={i} className="champ-badge glitch-pill text-label font-medium tracking-[0.02em]">
+        <span
+          key={i}
+          className="champ-badge glitch-pill border-border bg-card text-foreground text-label font-medium tracking-[0.02em]"
+        >
           <i className="dot" />
           <input
             type="text"

--- a/src/components/team/style.css
+++ b/src/components/team/style.css
@@ -6,9 +6,6 @@
 }
 .champ-badge {
   @apply inline-flex items-center h-6 px-2 rounded-full border text-xs leading-none whitespace-nowrap;
-  border-color: hsl(var(--border));
-  background: hsl(var(--card));
-  color: hsl(var(--foreground));
   transition:
     background 0.15s var(--ease-out),
     border-color 0.15s var(--ease-out),
@@ -16,8 +13,7 @@
     box-shadow 0.15s var(--ease-out);
 }
 .champ-badge:hover {
-  @apply bg-[--hover];
-  border-color: hsl(var(--ring));
+  @apply bg-[--hover] border-ring;
 }
 .champ-badge:focus-visible {
   @apply outline-none ring-2 ring-[--theme-ring] ring-offset-0;


### PR DESCRIPTION
## Summary
- apply semantic border, background, and text classes to champ badges in the team views
- drop redundant CSS color declarations and keep hover tokens via Tailwind utilities

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8aa489160832cba944ab2e88d64e9