### PR TITLE
refactor: share planner day header formatting

### DIFF
--- a/src/components/planner/DayCardHeader.tsx
+++ b/src/components/planner/DayCardHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { formatIsoLabel } from "@/lib/date";
 import { cn } from "@/lib/utils";
 import type { ISODate } from "./plannerStore";
 
@@ -17,32 +18,7 @@ export default function DayCardHeader({
   doneTasks,
   totalTasks,
 }: Props) {
-  const date = React.useMemo(() => new Date(`${iso}T00:00:00`), [iso]);
-  const WD = [
-    "SUNDAY",
-    "MONDAY",
-    "TUESDAY",
-    "WEDNESDAY",
-    "THURSDAY",
-    "FRIDAY",
-    "SATURDAY",
-  ] as const;
-  const MM = [
-    "JAN",
-    "FEB",
-    "MAR",
-    "APR",
-    "MAY",
-    "JUN",
-    "JUL",
-    "AUG",
-    "SEP",
-    "OCT",
-    "NOV",
-    "DEC",
-  ] as const;
-  const dd = (d: Date) => String(d.getDate()).padStart(2, "0");
-  const headerText = `// ${WD[date.getDay()]}_${MM[date.getMonth()]} :: ${dd(date)}`;
+  const headerText = React.useMemo(() => `// ${formatIsoLabel(iso)}`, [iso]);
   const pctNum =
     totalTasks === 0 ? 0 : Math.round((doneTasks / totalTasks) * 100);
 

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -14,6 +14,18 @@ const weekDayFormatter = new Intl.DateTimeFormat(LOCALE, {
   month: "short",
 });
 
+const isoLabelWeekdayFormatter = new Intl.DateTimeFormat(LOCALE, {
+  weekday: "long",
+});
+
+const isoLabelMonthFormatter = new Intl.DateTimeFormat(LOCALE, {
+  month: "short",
+});
+
+const isoLabelDayFormatter = new Intl.DateTimeFormat(LOCALE, {
+  day: "2-digit",
+});
+
 /** Predicate for "YYYY-MM-DD" */
 export function isISODate(v: string): boolean {
   return /^\d{4}-\d{2}-\d{2}$/.test(v);
@@ -34,6 +46,19 @@ export function formatWeekDay(iso: string): string {
   const dt = fromISODate(iso);
   if (!dt) return iso;
   return weekDayFormatter.format(dt);
+}
+
+export function formatIsoLabel(iso: string): string {
+  const dt = fromISODate(iso);
+  if (!dt) return iso;
+  const weekday = isoLabelWeekdayFormatter
+    .format(dt)
+    .toLocaleUpperCase(LOCALE);
+  const month = isoLabelMonthFormatter
+    .format(dt)
+    .toLocaleUpperCase(LOCALE);
+  const day = isoLabelDayFormatter.format(dt);
+  return `${weekday}_${month} :: ${day}`;
 }
 
 /** Normalize various inputs to a valid Date (fallback = now). */


### PR DESCRIPTION
## Summary
- add an Intl.DateTimeFormat-based ISO label formatter to `src/lib/date.ts`
- update `DayCardHeader` to use the shared formatter instead of inline arrays

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ab489788832cbf1bd02f387c3f26