### PR TITLE
Avoid double cloning in local storage writes

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -123,11 +123,7 @@ export function readLocal<T>(key: string): T | null {
 export function writeLocal(key: string, value: unknown) {
   if (!isBrowser) return;
   try {
-    const persistedValue =
-      value !== null && (typeof value === "object" || typeof value === "function")
-        ? safeClone(value)
-        : value;
-    scheduleWrite(createStorageKey(key), persistedValue);
+    scheduleWrite(createStorageKey(key), value);
   } catch {
     // ignore quota/privacy errors
   }


### PR DESCRIPTION
## Summary
- remove the redundant `safeClone` call in `writeLocal` so values are only cloned once
- rely on `scheduleWrite` to perform cloning before persisting to storage

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8abdd3fa8832cb4589001e44b0d2f