### PR TITLE
Use IconButton for theme toggle

### DIFF
--- a/src/components/ui/theme/ThemeToggle.tsx
+++ b/src/components/ui/theme/ThemeToggle.tsx
@@ -4,6 +4,7 @@
 import * as React from "react";
 import { Image as ImageIcon } from "lucide-react";
 import { Select, type SelectItem } from "@/components/ui";
+import IconButton from "@/components/ui/primitives/IconButton";
 import useMounted from "@/lib/useMounted";
 import { useTheme } from "@/lib/theme-context";
 import {
@@ -63,16 +64,17 @@ export default function ThemeToggle({
   return (
     <div className={`flex items-center gap-2 whitespace-nowrap ${className}`}>
       {/* background cycle */}
-      <button
+      <IconButton
         id={id}
-        type="button"
         aria-label={`${aria}: cycle background`}
         onClick={cycleBg}
         title="Change background"
-        className="inline-flex h-9 w-9 items-center justify-center rounded-full shrink-0 border border-border bg-card opacity-70 hover:opacity-100 focus-visible:opacity-100 hover:shadow-[0_0_12px_hsl(var(--ring)/.35)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        size="sm"
+        iconSize="sm"
+        className="shrink-0"
       >
-        <ImageIcon className="h-4 w-4" />
-      </button>
+        <ImageIcon />
+      </IconButton>
 
       {/* dropdown — no visible title; uses aria label */}
       <Select


### PR DESCRIPTION
## Summary
- import the shared IconButton primitive into the theme toggle component
- replace the custom background cycle button with IconButton while preserving aria metadata and click handling

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c8ab6b57e0832c869bbba5ad355f61