### PR TITLE
Optimize TodayHero progress reduction

### DIFF
--- a/src/components/planner/TodayHero.tsx
+++ b/src/components/planner/TodayHero.tsx
@@ -69,19 +69,17 @@ export default function TodayHero({ iso }: Props) {
       selProjectId ? tasks.filter((t) => t.projectId === selProjectId) : [],
     [tasks, selProjectId],
   );
-  const { done, total } = useMemo(
+  const { done, total } = useMemo<{ done: number; total: number }>(
     () =>
-      tasks.reduce(
+      scopedTasks.reduce<{ done: number; total: number }>(
         (acc, t) => {
-          if (t.projectId === selProjectId) {
-            acc.total += 1;
-            if (t.done) acc.done += 1;
-          }
+          acc.total += 1;
+          if (t.done) acc.done += 1;
           return acc;
         },
         { done: 0, total: 0 },
       ),
-    [tasks, selProjectId],
+    [scopedTasks],
   );
   const pct = total === 0 ? 0 : Math.round((done / total) * 100);
 

--- a/src/components/planner/index.ts
+++ b/src/components/planner/index.ts
@@ -18,6 +18,7 @@ export * from "./dayCrud";
 export * from "./plannerCrud";
 export * from "./plannerStore";
 export * from "./useDay";
+export * from "./useDayNotes";
 export * from "./useFocusDate";
 export * from "./usePlannerStore";
 export * from "./useSelection";

--- a/src/components/prompts/index.ts
+++ b/src/components/prompts/index.ts
@@ -9,6 +9,7 @@ export { default as DemoHeader } from "./DemoHeader";
 export { default as GalleryItem } from "./GalleryItem";
 export { default as GoalListDemo } from "./GoalListDemo";
 export { default as IconButtonShowcase } from "./IconButtonShowcase";
+export { default as NeomorphicHeroFrameDemo } from "./NeomorphicHeroFrameDemo";
 export { default as OnboardingTabs } from "./OnboardingTabs";
 export { default as OutlineGlowDemo } from "./OutlineGlowDemo";
 export { default as PageHeaderDemo } from "./PageHeaderDemo";


### PR DESCRIPTION
## Summary
- compute TodayHero progress totals with a typed reduction over scoped tasks to avoid redundant filtering
- regenerate the auto-generated UI indexes after touching component code

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ac27d65c832c81c5266ced4a5207