### PR TITLE
Add IconButton active styling tokens and pressed demos

### DIFF
--- a/src/components/prompts/IconButtonShowcase.tsx
+++ b/src/components/prompts/IconButtonShowcase.tsx
@@ -2,6 +2,14 @@ import * as React from "react";
 import { IconButton, type IconButtonProps } from "@/components/ui";
 import { Plus } from "lucide-react";
 
+type ShowcaseButtonProps = Pick<
+  IconButtonProps,
+  "size" | "variant" | "className" | "aria-pressed"
+> & {
+  "aria-label": string;
+  title: string;
+};
+
 const ICON_BUTTONS = [
   {
     size: "xs",
@@ -39,21 +47,44 @@ const ICON_BUTTONS = [
     "aria-label": "Add item glow",
     title: "Add item glow",
   },
-] satisfies Array<
-  Pick<IconButtonProps, "size" | "variant"> & {
-    "aria-label": string;
-    title: string;
-  }
->;
+] satisfies ShowcaseButtonProps[];
+
+const PRESSED_ICON_BUTTONS = [
+  {
+    variant: "ring",
+    size: "md",
+    className: "bg-[--active]",
+    "aria-pressed": true,
+    "aria-label": "Add item ring pressed",
+    title: "Add item ring pressed",
+  },
+  {
+    variant: "glow",
+    size: "md",
+    className: "bg-[--active]",
+    "aria-pressed": true,
+    "aria-label": "Add item glow pressed",
+    title: "Add item glow pressed",
+  },
+] satisfies ShowcaseButtonProps[];
 
 export default function IconButtonShowcase() {
   return (
-    <div className="mb-8 flex gap-2">
-      {ICON_BUTTONS.map((props) => (
-        <IconButton key={props.title} {...props}>
-          <Plus aria-hidden />
-        </IconButton>
-      ))}
+    <div className="mb-8 flex flex-col gap-4">
+      <div className="flex gap-2">
+        {ICON_BUTTONS.map((props) => (
+          <IconButton key={props.title} {...props}>
+            <Plus aria-hidden />
+          </IconButton>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        {PRESSED_ICON_BUTTONS.map((props) => (
+          <IconButton key={props.title} {...props}>
+            <Plus aria-hidden />
+          </IconButton>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -72,9 +72,9 @@ const getSizeClass = (s: IconButtonSize) => {
 };
 
 const variantBase: Record<Variant, string> = {
-  ring: "border bg-card/35 hover:bg-[--hover] [--hover:hsl(var(--panel)/0.45)]",
+  ring: "border bg-card/35 hover:bg-[--hover] [--hover:hsl(var(--panel)/0.45)] [--active:hsl(var(--panel)/0.55)]",
   solid: "border",
-  glow: "border bg-card/35 hover:bg-[--hover] [--hover:hsl(var(--panel)/0.45)] shadow-glow-current",
+  glow: "border bg-card/35 hover:bg-[--hover] [--hover:hsl(var(--panel)/0.45)] [--active:hsl(var(--panel)/0.55)] shadow-glow-current",
 };
 
 const toneClasses: Record<Variant, Record<Tone, string>> = {


### PR DESCRIPTION
## Summary
- extend the ring and glow IconButton variants with the `--active` token so `active:bg-[--active]` resolves correctly
- update the IconButton showcase to add pressed state examples for ring and glow variants

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ab75524c832c88103fb8cbef319a