### PR TITLE
Remove unused theme persistence helpers

### DIFF
--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,4 +1,4 @@
-import { readLocal, writeLocal, localBootstrapScript } from "./local-bootstrap";
+import { localBootstrapScript } from "./local-bootstrap";
 
 const STORAGE_PREFIX = "noxis-planner:";
 function createStorageKey(key: string): string {
@@ -106,15 +106,6 @@ export const VARIANT_LABELS: Record<Variant, string> = VARIANTS.reduce(
 
 export function defaultTheme(): ThemeState {
   return { variant: "lg", bg: 0 };
-}
-
-export function readTheme(): ThemeState {
-  const data = readLocal<ThemeState>(createStorageKey(THEME_STORAGE_KEY));
-  return data ? { variant: data.variant, bg: data.bg } : defaultTheme();
-}
-
-export function writeTheme(state: ThemeState) {
-  writeLocal(createStorageKey(THEME_STORAGE_KEY), state);
 }
 
 export function applyTheme({ variant, bg }: ThemeState) {


### PR DESCRIPTION
## Summary
- remove the unused `readTheme` and `writeTheme` helpers from the theme module
- clean up the redundant local storage imports now that ThemeProvider owns persistence

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ad21497c832c9dc07baeb245c7be