### PR TITLE
Fix Pages workflow branch configuration

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -7,7 +7,7 @@ name: Deploy Next.js site to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: [$default-branch]
+    branches: [work]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- update the Next.js Pages workflow to trigger on the repository's default `work` branch

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ae2bc73c832cae1f7ceafcf072ef