### PR TITLE
Add aria-hidden to bottom nav icons

### DIFF
--- a/src/components/home/BottomNav.tsx
+++ b/src/components/home/BottomNav.tsx
@@ -34,7 +34,7 @@ export default function BottomNav() {
                     : "text-muted-foreground hover:text-foreground"
                 )}
               >
-                <Icon className="size-5" />
+                <Icon aria-hidden="true" className="size-5" />
                 <span>{label}</span>
               </Link>
             </li>


### PR DESCRIPTION
## Summary
- mark the bottom navigation icons as aria-hidden so only the link text is announced by screen readers

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b1715170832cb3a81d58eceee291