### PR TITLE
Fix npm check command in Next.js workflow

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -84,7 +84,7 @@ jobs:
           if [ "${{ steps.detect-package-manager.outputs.manager }}" = "yarn" ]; then
             ${{ steps.detect-package-manager.outputs.runner }} check
           else
-            ${{ steps.detect-package-manager.outputs.runner }} npm run check
+            npm run check
           fi
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build


### PR DESCRIPTION
## Summary
- call `npm run check` directly in the workflow when npm is the package manager to avoid relying on `npx --no-install`

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b1bcf994832cb81ee3f6f430d196