### PR TITLE
Fix Next.js workflow branch and npm checks

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -7,7 +7,7 @@ name: Deploy Next.js site to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: [work]
+    branches: ["work"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -84,7 +84,7 @@ jobs:
           if [ "${{ steps.detect-package-manager.outputs.manager }}" = "yarn" ]; then
             ${{ steps.detect-package-manager.outputs.runner }} check
           else
-            ${{ steps.detect-package-manager.outputs.runner }} npm run check
+            npm run check
           fi
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build


### PR DESCRIPTION
## Summary
- ensure the Next.js Pages workflow triggers on the default work branch
- call `npm run check` directly when npm is the selected package manager

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b1f23068832c82800a89c787885d