### PR TITLE
refactor: centralize storage key helpers

### DIFF
--- a/src/lib/storage-key.ts
+++ b/src/lib/storage-key.ts
@@ -1,0 +1,35 @@
+const STORAGE_PREFIX = "noxis-planner:";
+const OLD_STORAGE_PREFIX = "13lr:";
+
+const isBrowser = typeof window !== "undefined";
+
+let migrated = false;
+
+function ensureMigration() {
+  if (!isBrowser || migrated) return;
+  try {
+    const legacyKeys: string[] = [];
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i);
+      if (key?.startsWith(OLD_STORAGE_PREFIX)) legacyKeys.push(key);
+    }
+    for (const oldKey of legacyKeys) {
+      const newKey = `${STORAGE_PREFIX}${oldKey.slice(OLD_STORAGE_PREFIX.length)}`;
+      if (window.localStorage.getItem(newKey) === null) {
+        const value = window.localStorage.getItem(oldKey);
+        if (value !== null) window.localStorage.setItem(newKey, value);
+      }
+      window.localStorage.removeItem(oldKey);
+    }
+  } catch {
+    // ignore
+  }
+  migrated = true;
+}
+
+export function createStorageKey(key: string): string {
+  ensureMigration();
+  return `${STORAGE_PREFIX}${key}`;
+}
+
+export { STORAGE_PREFIX, OLD_STORAGE_PREFIX };

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,9 +1,5 @@
 import { localBootstrapScript } from "./local-bootstrap";
-
-const STORAGE_PREFIX = "noxis-planner:";
-function createStorageKey(key: string): string {
-  return `${STORAGE_PREFIX}${key}`;
-}
+import { createStorageKey } from "./storage-key";
 
 export type Variant =
   | "lg"


### PR DESCRIPTION
## Summary
- add a shared storage-key helper that migrates legacy keys and exposes the planner prefix
- update db utilities to consume the shared helper while retaining legacy reads
- reuse the shared storage key builder in the theme bootstrap script

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b15b64f4832cae8e689599aeaae8