### PR TITLE
Replace Tailwind font size utilities with tokens

### DIFF
--- a/src/components/chrome/Banner.tsx
+++ b/src/components/chrome/Banner.tsx
@@ -35,7 +35,7 @@ export default function Banner({
       <div className="mx-auto max-w-6xl px-2 md:px-4 py-2">
         {title || actions ? (
           <div className="flex items-center justify-between gap-4">
-            <div className="font-mono text-sm text-muted-foreground">
+            <div className="font-mono text-ui text-muted-foreground">
               {title}
             </div>
             <div className="flex items-center gap-2">{actions}</div>

--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -33,7 +33,7 @@ export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
                 href={href}
                 aria-current={active ? "page" : undefined}
                 className={cn(
-                  "relative inline-flex items-center rounded-[var(--radius-2xl)] border px-4 py-2 font-mono text-sm transition motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  "relative inline-flex items-center rounded-[var(--radius-2xl)] border px-4 py-2 font-mono text-ui transition motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                   "bg-[hsl(var(--card)/0.85)]",
                   "supports-[background:color-mix(in_oklab,hsl(var(--card))_85%,transparent)]:bg-[color:color-mix(in_oklab,hsl(var(--card))_85%,transparent)]",
                   active

--- a/src/components/chrome/PageTabs.tsx
+++ b/src/components/chrome/PageTabs.tsx
@@ -95,7 +95,7 @@ export default function PageTabs({
               const active = t.id === value;
               const controls = t.controls ?? `${t.id}-panel`;
               const className = [
-                "rounded-[var(--control-radius)] px-4 py-2 font-mono text-sm border relative",
+                "rounded-[var(--control-radius)] px-4 py-2 font-mono text-ui border relative",
                 active ? "btn-glitch" : "",
               ]
                 .filter(Boolean)

--- a/src/components/home/BottomNav.tsx
+++ b/src/components/home/BottomNav.tsx
@@ -28,7 +28,7 @@ export default function BottomNav() {
                 aria-current={active ? "page" : undefined}
                 data-active={active}
                 className={cn(
-                  "group flex flex-col items-center gap-1 rounded-xl px-3 py-2 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none",
+                  "group flex flex-col items-center gap-1 rounded-xl px-3 py-2 text-label font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none",
                   active
                     ? "text-accent ring-2 ring-[--theme-ring]"
                     : "text-muted-foreground hover:text-foreground"

--- a/src/components/home/DashboardCard.tsx
+++ b/src/components/home/DashboardCard.tsx
@@ -20,7 +20,7 @@ export default function DashboardCard({
   return (
     <NeoCard className="p-4 md:p-6 space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-base font-semibold tracking-[-0.01em]">{title}</h2>
+        <h2 className="text-body font-semibold tracking-[-0.01em]">{title}</h2>
         {actions}
       </div>
       {children && (
@@ -31,7 +31,7 @@ export default function DashboardCard({
       {cta && (
         <Link
           href={cta.href}
-          className="text-sm font-medium text-accent underline"
+          className="text-ui font-medium text-accent underline"
         >
           {cta.label}
         </Link>

--- a/src/components/home/GoalsCard.tsx
+++ b/src/components/home/GoalsCard.tsx
@@ -23,19 +23,19 @@ export default function GoalsCard() {
       <ul className="divide-y divide-[hsl(var(--border))]">
         {activeGoals.map((g) => (
           <li key={g.id} className="py-2">
-            <p className="text-sm">{g.title}</p>
+            <p className="text-ui">{g.title}</p>
             <div className="mt-2">
               <Progress value={0} />
             </div>
           </li>
         ))}
         {activeGoals.length === 0 && (
-          <li className="flex justify-between py-2 text-sm text-muted-foreground">
+          <li className="flex justify-between py-2 text-ui text-muted-foreground">
             <span className="flex items-center gap-2">
               <CircleSlash className="size-3" />
               No active goals
             </span>
-            <Link href="/goals" className="text-xs underline">
+            <Link href="/goals" className="text-label underline">
               Create
             </Link>
           </li>

--- a/src/components/home/ReviewsCard.tsx
+++ b/src/components/home/ReviewsCard.tsx
@@ -22,20 +22,20 @@ export default function ReviewsCard() {
     >
       <ul className="divide-y divide-[hsl(var(--border))]">
         {recentReviews.map((r) => (
-          <li key={r.id} className="flex justify-between py-2 text-sm">
+          <li key={r.id} className="flex justify-between py-2 text-ui">
             <span>{r.title || "Untitled"}</span>
-            <span className="text-xs text-muted-foreground">
+            <span className="text-label text-muted-foreground">
               {new Date(r.createdAt).toLocaleDateString(LOCALE)}
             </span>
           </li>
         ))}
         {recentReviews.length === 0 && (
-          <li className="flex justify-between py-2 text-sm text-muted-foreground">
+          <li className="flex justify-between py-2 text-ui text-muted-foreground">
             <span className="flex items-center gap-2">
               <CircleSlash className="size-3" />
               No reviews yet
             </span>
-            <Link href="/reviews" className="text-xs underline">
+            <Link href="/reviews" className="text-label underline">
               Create
             </Link>
           </li>

--- a/src/components/home/TeamPromptsCard.tsx
+++ b/src/components/home/TeamPromptsCard.tsx
@@ -12,19 +12,19 @@ export default function TeamPromptsCard() {
           <div className="grid grid-cols-12 gap-4">
             <Link
               href="/team"
-              className="col-span-6 rounded-card r-card-md border border-border px-3 py-1 text-xs hover:bg-[--hover] active:bg-[--active] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0"
+              className="col-span-6 rounded-card r-card-md border border-border px-3 py-1 text-label hover:bg-[--hover] active:bg-[--active] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0"
             >
               Archetypes
             </Link>
             <Link
               href="/team"
-              className="col-span-6 rounded-card r-card-md border border-border px-3 py-1 text-xs hover:bg-[--hover] active:bg-[--active] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0"
+              className="col-span-6 rounded-card r-card-md border border-border px-3 py-1 text-label hover:bg-[--hover] active:bg-[--active] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0"
             >
               Team Builder
             </Link>
             <Link
               href="/team"
-              className="col-span-6 rounded-card r-card-md border border-border px-3 py-1 text-xs hover:bg-[--hover] active:bg-[--active] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0"
+              className="col-span-6 rounded-card r-card-md border border-border px-3 py-1 text-label hover:bg-[--hover] active:bg-[--active] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0"
             >
               Jungle Clears
             </Link>
@@ -36,7 +36,7 @@ export default function TeamPromptsCard() {
           title="Prompts peek"
           cta={{ label: "Explore Prompts", href: "/prompts" }}
         >
-          <div className="rounded-card r-card-md bg-seg-active-grad p-4 text-center text-sm text-neon-soft">
+          <div className="rounded-card r-card-md bg-seg-active-grad p-4 text-center text-ui text-neon-soft">
             Get inspired with curated prompts
           </div>
         </DashboardCard>

--- a/src/components/home/TodayCard.tsx
+++ b/src/components/home/TodayCard.tsx
@@ -23,18 +23,18 @@ export default function TodayCard() {
     <DashboardCard title="Today" cta={{ label: "Planner", href: "/planner" }}>
       <ul className="divide-y divide-[hsl(var(--border))]">
         {topTasks.map((t) => (
-          <li key={t.id} className="flex justify-between py-2 text-sm">
+          <li key={t.id} className="flex justify-between py-2 text-ui">
             <span>{t.title}</span>
-            <span className="text-xs text-muted-foreground">Today</span>
+            <span className="text-label text-muted-foreground">Today</span>
           </li>
         ))}
         {topTasks.length === 0 && (
-          <li className="flex justify-between py-2 text-sm text-muted-foreground">
+          <li className="flex justify-between py-2 text-ui text-muted-foreground">
             <span className="flex items-center gap-2">
               <CircleSlash className="size-3" />
               No tasks
             </span>
-            <Link href="/planner" className="text-xs underline">
+            <Link href="/planner" className="text-label underline">
               Create
             </Link>
           </li>

--- a/src/components/planner/DayCardHeader.tsx
+++ b/src/components/planner/DayCardHeader.tsx
@@ -25,7 +25,7 @@ export default function DayCardHeader({
   return (
     <div className="col-span-1 lg:col-span-3 flex items-center gap-3 min-w-0">
       <span
-        className="glitch glitch-label text-sm font-semibold tracking-wide shrink-0"
+        className="glitch glitch-label text-ui font-semibold tracking-wide shrink-0"
         data-text={headerText}
       >
         {headerText}
@@ -47,7 +47,7 @@ export default function DayCardHeader({
         </div>
       </div>
 
-      <div className="shrink-0 flex items-baseline gap-3 text-xs text-muted-foreground">
+      <div className="shrink-0 flex items-baseline gap-3 text-label text-muted-foreground">
         <span className="tabular-nums font-medium text-foreground">
           {pctNum}%
         </span>

--- a/src/components/planner/EmptyRow.tsx
+++ b/src/components/planner/EmptyRow.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
 
 export default function EmptyRow({ text }: { text: string }) {
-  return <div className="tasks-placeholder text-xs">{text}</div>;
+  return <div className="tasks-placeholder text-label">{text}</div>;
 }

--- a/src/components/planner/FocusPanel.tsx
+++ b/src/components/planner/FocusPanel.tsx
@@ -55,7 +55,7 @@ export default function FocusPanel({ iso }: Props) {
         </form>
 
         {/* Subtle status text without yelling at the user */}
-        <div className="mt-2 text-xs text-muted-foreground" aria-live="polite">
+        <div className="mt-2 text-label text-muted-foreground" aria-live="polite">
           {saving
             ? "Saving changes…"
             : isDirty

--- a/src/components/planner/WeekNotes.tsx
+++ b/src/components/planner/WeekNotes.tsx
@@ -32,7 +32,7 @@ export default function WeekNotes({ iso }: Props) {
           textareaClassName="min-h-[calc(var(--space-8)*3_-_var(--space-3))] leading-relaxed"
           onBlur={commit}
         />
-        <div className="mt-2 text-xs text-muted-foreground" aria-live="polite">
+        <div className="mt-2 text-label text-muted-foreground" aria-live="polite">
           {saving
             ? "Saving changes…"
             : isDirty

--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -190,7 +190,7 @@ export default function WeekPicker() {
         <div className="flex items-center justify-between gap-3">
           <span
             className={cn(
-              "inline-flex items-center gap-2 rounded-card r-card-lg px-3 py-2 text-sm",
+              "inline-flex items-center gap-2 rounded-card r-card-lg px-3 py-2 text-ui",
               "bg-card/72 ring-1 ring-border/55 backdrop-blur",
             )}
             aria-label={`Week range ${rangeLabel}`}
@@ -199,7 +199,7 @@ export default function WeekPicker() {
             <span className="opacity-90">{rangeLabel}</span>
           </span>
 
-          <span className="text-sm text-muted-foreground">
+          <span className="text-ui text-muted-foreground">
             <span className="opacity-70">Total tasks: </span>
             <span className="font-medium tabular-nums text-foreground">
               {weekDone} / {weekTotal}

--- a/src/components/prompts/ColorGallery.tsx
+++ b/src/components/prompts/ColorGallery.tsx
@@ -44,14 +44,14 @@ export default function ColorGallery() {
         >
           {p.key === "aurora" && (
             <div className="flex flex-col items-center gap-2 sm:col-span-2 md:col-span-3">
-              <span className="text-sm font-medium">Aurora Palette</span>
+              <span className="text-ui font-medium">Aurora Palette</span>
               <div className="flex gap-2">
                 <div className="w-10 h-10 rounded-md bg-aurora-g" />
                 <div className="w-10 h-10 rounded-md bg-aurora-g-light" />
                 <div className="w-10 h-10 rounded-md bg-aurora-p" />
                 <div className="w-10 h-10 rounded-md bg-aurora-p-light" />
               </div>
-              <p className="mt-2 text-center text-xs text-muted-foreground">
+              <p className="mt-2 text-center text-label text-muted-foreground">
                 Use <code>aurora-g</code>, <code>aurora-g-light</code>,{" "}
                 <code>aurora-p</code>, and <code>aurora-p-light</code> Tailwind
                 classes for aurora effects.
@@ -60,7 +60,7 @@ export default function ColorGallery() {
           )}
           {COLOR_PALETTES[p.key].map((c) => (
             <div key={c} className="flex flex-col items-center gap-2">
-              <span className="text-xs uppercase tracking-wide text-accent">
+              <span className="text-label uppercase tracking-wide text-accent">
                 {c}
               </span>
               <div

--- a/src/components/prompts/ColorsView.tsx
+++ b/src/components/prompts/ColorsView.tsx
@@ -10,7 +10,7 @@ type SectionCardProps = {
 function SectionCard({ title, children }: SectionCardProps) {
   return (
     <section className="space-y-4">
-      <h2 className="text-xl font-semibold tracking-[-0.01em]">{title}</h2>
+      <h2 className="text-title font-semibold tracking-[-0.01em]">{title}</h2>
       {children}
     </section>
   );
@@ -25,7 +25,7 @@ function Swatch({ token }: SwatchProps) {
         className="h-16 w-full rounded-card r-card-md border border-[var(--card-hairline)]"
         style={{ backgroundColor: `hsl(var(--${token}))` }}
       />
-      <span className="text-xs font-medium">{token}</span>
+      <span className="text-label font-medium">{token}</span>
     </li>
   );
 }
@@ -34,7 +34,7 @@ function GradientSwatch() {
   return (
     <li className="col-span-12 md:col-span-6 flex flex-col items-center gap-3">
       <div className="h-16 w-full rounded-card r-card-md bg-gradient-to-r from-primary via-accent to-transparent" />
-      <span className="text-xs font-medium">
+      <span className="text-label font-medium">
         from-primary via-accent to-transparent
       </span>
     </li>

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -625,7 +625,7 @@ export default function ComponentGallery() {
             <div className="text-label font-semibold tracking-[0.02em] text-muted-foreground">
               PageShell
             </div>
-            <p className="text-sm text-muted-foreground">
+            <p className="text-ui text-muted-foreground">
               Constrains page content to the shell width.
             </p>
             <div className="flex flex-wrap gap-2">

--- a/src/components/prompts/ComponentsView.tsx
+++ b/src/components/prompts/ComponentsView.tsx
@@ -13,28 +13,28 @@ function SpecCard({ name, description, element, props, code }: Spec) {
   return (
     <div className="flex flex-col gap-4 rounded-card r-card-lg border border-[var(--card-hairline)] bg-card p-6 shadow-[0_0_0_1px_var(--neon-soft)]">
       <header className="flex items-center justify-between">
-        <h3 className="text-base font-semibold tracking-[-0.01em]">{name}</h3>
+        <h3 className="text-body font-semibold tracking-[-0.01em]">{name}</h3>
         {code && (
           <button
             type="button"
             onClick={() => setShowCode((s) => !s)}
-            className="text-xs underline underline-offset-2"
+            className="text-label underline underline-offset-2"
           >
             {showCode ? "Hide code" : "Show code"}
           </button>
         )}
       </header>
       {description ? (
-        <p className="text-sm font-medium text-muted-foreground">{description}</p>
+        <p className="text-ui font-medium text-muted-foreground">{description}</p>
       ) : null}
       <div className="rounded-card r-card-md bg-background p-4">{element}</div>
       {showCode && code ? (
-        <pre className="rounded-card r-card-md bg-muted p-4 text-xs overflow-x-auto">
+        <pre className="rounded-card r-card-md bg-muted p-4 text-label overflow-x-auto">
           <code>{code}</code>
         </pre>
       ) : null}
       {props ? (
-        <ul className="flex flex-wrap gap-3 text-xs">
+        <ul className="flex flex-wrap gap-3 text-label">
           {props.map((p) => (
             <li key={p.label} className="flex gap-1">
               <span className="font-medium tracking-[0.02em]">{p.label}</span>

--- a/src/components/prompts/GalleryItem.tsx
+++ b/src/components/prompts/GalleryItem.tsx
@@ -16,7 +16,7 @@ export default function GalleryItem({
 }: GalleryItemProps) {
   return (
     <div className={cn("flex flex-col items-center space-y-2", className)}>
-      <span className="text-sm font-medium">{label}</span>
+      <span className="text-ui font-medium">{label}</span>
       {children}
     </div>
   );

--- a/src/components/prompts/NeomorphicHeroFrameDemo.tsx
+++ b/src/components/prompts/NeomorphicHeroFrameDemo.tsx
@@ -46,7 +46,7 @@ export default function NeomorphicHeroFrameDemo() {
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="px-2 text-xs font-semibold uppercase tracking-[0.08em]"
+                  className="px-2 text-label font-semibold uppercase tracking-[0.08em]"
                 >
                   View all
                 </Button>
@@ -85,18 +85,18 @@ export default function NeomorphicHeroFrameDemo() {
             <h3 className="text-title font-semibold tracking-[-0.01em] text-foreground">
               Default neomorphic frame
             </h3>
-            <p className="text-sm text-muted-foreground">
+            <p className="text-ui text-muted-foreground">
               The default variant applies the <code>r-card-lg</code> radius, border tint
               from <code>border-border/40</code>, and responsive padding tokens
               (<code>px-6</code>, <code>md:px-7</code>, <code>lg:px-8</code>) to stay aligned with the 12-column grid.
             </p>
-            <p className="text-sm text-muted-foreground">
+            <p className="text-ui text-muted-foreground">
               Tabs, search, and button actions all inherit hover, focus, active,
               disabled, and loading states from the design system tokens—interact with
               each control to preview the full range of feedback.
             </p>
           </div>
-          <dl className="md:col-span-5 grid gap-2 text-xs uppercase tracking-[0.08em] text-muted-foreground">
+          <dl className="md:col-span-5 grid gap-2 text-label uppercase tracking-[0.08em] text-muted-foreground">
             <div className="flex items-center justify-between rounded-card r-card-md border border-border/30 bg-card/60 px-3 py-2">
               <dt className="font-semibold text-foreground">Layer tokens</dt>
               <dd className="text-label">bg-card/70 · ring-border/55</dd>
@@ -154,17 +154,17 @@ export default function NeomorphicHeroFrameDemo() {
             <h3 className="text-ui font-semibold uppercase tracking-[0.08em] text-muted-foreground">
               Compact layout
             </h3>
-            <p className="text-sm text-muted-foreground">
+            <p className="text-ui text-muted-foreground">
               Compact frames tighten the padding to <code>px-4</code>/<code>md:px-5</code>/<code>lg:px-6</code>
               with the <code>r-card-md</code> radius, ideal for utility nav or filter rails.
             </p>
-            <p className="text-sm text-muted-foreground">
+            <p className="text-ui text-muted-foreground">
               The action row mirrors the grid: tabs span <code>md:col-span-7</code>, search spans
               <code>md:col-span-3</code>, and button actions anchor on <code>md:col-span-2</code> for
               consistent alignment.
             </p>
           </div>
-          <div className="md:col-span-6 space-y-2 text-xs text-muted-foreground">
+          <div className="md:col-span-6 space-y-2 text-label text-muted-foreground">
             <p className="font-semibold text-foreground">Interaction checklist</p>
             <ul className="grid grid-cols-2 gap-2">
               <li className="rounded-card r-card-md border border-border/25 bg-card/60 px-3 py-2">

--- a/src/components/prompts/OnboardingTabs.tsx
+++ b/src/components/prompts/OnboardingTabs.tsx
@@ -45,7 +45,7 @@ export default function OnboardingTabs() {
         onValueChange={setRole}
         ariaLabel="Onboarding roles"
       />
-      <p className="text-sm text-muted-foreground">
+      <p className="text-ui text-muted-foreground">
         Last updated {new Date(updatedAt).toLocaleTimeString()}
       </p>
       <div

--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -76,7 +76,7 @@ export default function PageHeaderDemo() {
                 onClick={() => setActivePrimaryNav(item.key)}
                 data-state={isActive ? "active" : "inactive"}
                 aria-pressed={isActive}
-                className="inline-flex items-center rounded-full border border-transparent px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.08em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=inactive]:hover:bg-[--hover] data-[state=inactive]:hover:text-foreground data-[state=active]:bg-[hsl(var(--card)/0.85)] data-[state=active]:text-foreground data-[state=active]:shadow-[0_0_0_1px_hsl(var(--ring)/0.35)]"
+                className="inline-flex items-center rounded-full border border-transparent px-3 py-1.5 text-label font-semibold uppercase tracking-[0.08em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=inactive]:hover:bg-[--hover] data-[state=inactive]:hover:text-foreground data-[state=active]:bg-[hsl(var(--card)/0.85)] data-[state=active]:text-foreground data-[state=active]:shadow-[0_0_0_1px_hsl(var(--ring)/0.35)]"
               >
                 {item.label}
               </button>
@@ -112,7 +112,7 @@ export default function PageHeaderDemo() {
           }
         }}
         data-state={profileOpen ? "open" : "inactive"}
-        className="inline-flex items-center gap-2 rounded-full border border-transparent bg-[hsl(var(--card)/0.55)] px-3 py-1.5 text-sm font-medium transition-colors hover:bg-[--hover] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=open]:bg-[hsl(var(--card)/0.85)]"
+        className="inline-flex items-center gap-2 rounded-full border border-transparent bg-[hsl(var(--card)/0.55)] px-3 py-1.5 text-ui font-medium transition-colors hover:bg-[--hover] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=open]:bg-[hsl(var(--card)/0.85)]"
       >
         <CircleUser className="h-4 w-4" />
         <span className="hidden sm:inline">Profile</span>
@@ -141,7 +141,7 @@ export default function PageHeaderDemo() {
           </Button>
         }
       >
-        <p className="text-sm text-muted-foreground">
+        <p className="text-ui text-muted-foreground">
           {compactNavCopy[activePrimaryNav]}
         </p>
       </Header>
@@ -163,7 +163,7 @@ export default function PageHeaderDemo() {
         }}
       >
         <div className="flex flex-wrap items-center gap-3">
-          <p className="text-sm text-muted-foreground">{tabCopy[activeTab]}</p>
+          <p className="text-ui text-muted-foreground">{tabCopy[activeTab]}</p>
           <div className="flex items-center gap-2">
             <Button size="sm" variant="secondary">
               Invite teammate
@@ -209,7 +209,7 @@ export default function PageHeaderDemo() {
           </div>
         }
       >
-        <p className="text-sm text-muted-foreground">
+        <p className="text-ui text-muted-foreground">
           {heroFilterCopy[activeFilter]}
         </p>
       </Hero>
@@ -254,7 +254,7 @@ export default function PageHeaderDemo() {
           heading: "Your day at a glance",
           subtitle: "Stay synced with the squad",
           children: (
-            <p className="text-sm text-muted-foreground">
+            <p className="text-ui text-muted-foreground">
               {heroFilterCopy[activeFilter]}
             </p>
           ),

--- a/src/components/prompts/PromptList.tsx
+++ b/src/components/prompts/PromptList.tsx
@@ -20,13 +20,13 @@ export default function PromptList({ prompts, query }: PromptListProps) {
               <h3 className="font-semibold">{p.title}</h3>
               <time
                 dateTime={new Date(p.createdAt).toISOString()}
-                className="text-xs text-muted-foreground"
+                className="text-label text-muted-foreground"
               >
                 {new Date(p.createdAt).toLocaleString(LOCALE)}
               </time>
             </header>
             {p.text ? (
-              <p className="mt-1 whitespace-pre-wrap text-sm">{p.text}</p>
+              <p className="mt-1 whitespace-pre-wrap text-ui">{p.text}</p>
             ) : null}
           </Card>
         </li>

--- a/src/components/prompts/PromptsComposePanel.tsx
+++ b/src/components/prompts/PromptsComposePanel.tsx
@@ -37,7 +37,7 @@ export default function PromptsComposePanel({
         </Input>
         <p
           id={`${titleId}-help`}
-          className="mt-1 text-xs text-muted-foreground"
+          className="mt-1 text-label text-muted-foreground"
         >
           Add a short title
         </p>

--- a/src/components/prompts/PromptsDemos.tsx
+++ b/src/components/prompts/PromptsDemos.tsx
@@ -43,11 +43,11 @@ export default function PromptsDemos() {
     <>
       <OutlineGlowDemo />
       <SectionLabel>Section Label</SectionLabel>
-      <p className="text-sm text-muted-foreground">Divider used in reviews</p>
+      <p className="text-ui text-muted-foreground">Divider used in reviews</p>
 
       <Card className="mt-8 space-y-4">
         <h3 className="type-title">Input</h3>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-ui text-muted-foreground">
           Customize focus rings with the <code>--theme-ring</code> variable.
         </p>
         <div className="space-y-3">
@@ -125,7 +125,7 @@ export default function PromptsDemos() {
           <code>textareaClassName</code> to target the inner element.
         </p>
         <FieldShell>
-          <div className="px-4 py-2 text-sm text-muted-foreground">
+          <div className="px-4 py-2 text-ui text-muted-foreground">
             Custom content
           </div>
         </FieldShell>

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -172,7 +172,7 @@ function CardDemo() {
         <CardDescription>Description</CardDescription>
       </CardHeader>
       <CardContent>
-        <p className="text-sm">Body</p>
+        <p className="text-ui">Body</p>
       </CardContent>
       <CardFooter>
         <Button size="sm">Action</Button>
@@ -189,7 +189,7 @@ function NeoCardDemo() {
         <div className="pointer-events-none absolute inset-0 rounded-[inherit] bg-[var(--accent-overlay)] mix-blend-overlay opacity-20" />
       }
     >
-      <p className="text-sm">Body</p>
+      <p className="text-ui">Body</p>
     </NeoCard>
   );
 }
@@ -207,7 +207,7 @@ function SheetDemo() {
             <CardTitle>Sheet</CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-sm">Content</p>
+            <p className="text-ui">Content</p>
           </CardContent>
         </Card>
       </Sheet>
@@ -228,7 +228,7 @@ function ModalDemo() {
             <CardTitle>Modal</CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-sm">Content</p>
+            <p className="text-ui">Content</p>
           </CardContent>
           <CardFooter>
             <Button size="sm" onClick={() => setOpen(false)}>
@@ -249,7 +249,7 @@ function ToastDemo() {
         Show
       </Button>
       <Toast open={open} onOpenChange={setOpen}>
-        <p className="text-sm">Toast message</p>
+        <p className="text-ui">Toast message</p>
       </Toast>
     </>
   );
@@ -490,14 +490,14 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       description: "Frame for custom field content",
       element: (
         <FieldShell className="w-56">
-          <div className="px-4 py-2 text-sm text-muted-foreground">
+          <div className="px-4 py-2 text-ui text-muted-foreground">
             Custom content
           </div>
         </FieldShell>
       ),
       tags: ["field", "shell"],
       code: `<FieldShell className="w-56">
-  <div className="px-4 py-2 text-sm text-muted-foreground">
+  <div className="px-4 py-2 text-ui text-muted-foreground">
     Custom content
   </div>
 </FieldShell>`,
@@ -630,7 +630,7 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
     <CardDescription>Description</CardDescription>
   </CardHeader>
   <CardContent>
-    <p className="text-sm">Body</p>
+    <p className="text-ui">Body</p>
   </CardContent>
   <CardFooter>
     <Button size="sm">Action</Button>
@@ -646,7 +646,7 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
   className="p-4"
   overlay={<div className="pointer-events-none absolute inset-0 rounded-[inherit] bg-[var(--accent-overlay)] mix-blend-overlay opacity-20" />}
 >
-  <p className="text-sm">Body</p>
+  <p className="text-ui">Body</p>
 </NeoCard>`,
     },
     {
@@ -739,7 +739,7 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
 >
   <div className="grid gap-4 md:grid-cols-12">
     <div className="md:col-span-7 space-y-3">
-      <p className="text-sm text-muted-foreground">
+      <p className="text-ui text-muted-foreground">
         Default variant uses r-card-lg radius with px-6/md:px-7/lg:px-8 tokens and aligns content to the 12-column grid.
       </p>
     </div>
@@ -749,7 +749,7 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
 <NeomorphicHeroFrame as="nav" variant="compact" actionArea={{ align: "between" }}>
   <div className="grid gap-3 md:grid-cols-12">
     <div className="md:col-span-6">
-      <p className="text-sm text-muted-foreground">
+      <p className="text-ui text-muted-foreground">
         Compact variant swaps to r-card-md radius with px-4/md:px-5/lg:px-6 spacing.
       </p>
     </div>
@@ -778,7 +778,7 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
           search={{ value: "", onValueChange: () => {}, round: true }}
           actions={<Button size="sm">Action</Button>}
         >
-          <div className="text-sm text-muted-foreground">Body content</div>
+          <div className="text-ui text-muted-foreground">Body content</div>
         </Hero>
       ),
       tags: ["hero", "layout"],
@@ -790,7 +790,7 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
   search={{ value: "", onValueChange: () => {}, round: true }}
   actions={<Button size="sm">Action</Button>}
 >
-  <div className="text-sm text-muted-foreground">Body content</div>
+  <div className="text-ui text-muted-foreground">Body content</div>
 </Hero>`,
     },
     {
@@ -825,7 +825,7 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       <CardTitle>Sheet</CardTitle>
     </CardHeader>
     <CardContent>
-      <p className="text-sm">Content</p>
+      <p className="text-ui">Content</p>
     </CardContent>
   </Card>
 </Sheet>`,
@@ -842,7 +842,7 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       <CardTitle>Modal</CardTitle>
     </CardHeader>
     <CardContent>
-      <p className="text-sm">Content</p>
+      <p className="text-ui">Content</p>
     </CardContent>
     <CardFooter>
       <Button size="sm">Close</Button>
@@ -856,7 +856,7 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       element: <ToastDemo />,
       tags: ["toast", "feedback"],
       code: `<Button size="sm">Show</Button>
-<Toast open><p className="text-sm">Toast message</p></Toast>`,
+<Toast open><p className="text-ui">Toast message</p></Toast>`,
     },
     {
       id: "split",

--- a/src/components/reviews/ResultScoreSection.tsx
+++ b/src/components/reviews/ResultScoreSection.tsx
@@ -94,7 +94,7 @@ function ResultScoreSection(
               boxShadow: "0 10px 30px hsl(var(--shadow-color) / .25)",
             }}
           />
-          <div className="relative z-10 grid w-full grid-cols-2 text-sm font-mono">
+          <div className="relative z-10 grid w-full grid-cols-2 text-ui font-mono">
             <div
               className={cn(
                 "py-2 text-center",
@@ -152,8 +152,8 @@ function ResultScoreSection(
             </div>
           </div>
         </div>
-        <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
-          <span className="pill h-6 px-2 text-xs">{score}/10</span>
+        <div className="mt-1 flex items-center gap-2 text-ui text-muted-foreground">
+          <span className="pill h-6 px-2 text-label">{score}/10</span>
           <ScoreIcon className={cn("h-4 w-4", scoreIconCls)} />
           <span>{msg}</span>
         </div>

--- a/src/components/reviews/ReviewCard.tsx
+++ b/src/components/reviews/ReviewCard.tsx
@@ -47,7 +47,7 @@ export default function ReviewCard({
             </IconButton>
           </div>
 
-          <div className="mt-1 text-xs text-muted-foreground grid grid-cols-2 gap-2">
+          <div className="mt-1 text-label text-muted-foreground grid grid-cols-2 gap-2">
             <span>Opponent: {review.opponent || "—"}</span>
             <span>Lane: {review.lane || "—"}</span>
             <span>Side: {review.side || "—"}</span>

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -286,8 +286,8 @@ export default function ReviewEditor({
                   </div>
                 </div>
               </div>
-              <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
-                <span className="pill h-6 px-2 text-xs">{focus}/10</span>
+              <div className="mt-1 flex items-center gap-2 text-ui text-muted-foreground">
+                <span className="pill h-6 px-2 text-label">{focus}/10</span>
                 <span>{focusMsg}</span>
               </div>
             </>
@@ -344,7 +344,7 @@ export default function ReviewEditor({
           </div>
 
           {tags.length === 0 ? (
-            <div className="mt-2 text-sm text-muted-foreground/80">
+            <div className="mt-2 text-ui text-muted-foreground/80">
               No tags yet.
             </div>
           ) : (
@@ -353,7 +353,7 @@ export default function ReviewEditor({
                 <button
                   key={t}
                   type="button"
-                  className="chip h-9 px-4 text-sm group inline-flex items-center gap-1"
+                  className="chip h-9 px-4 text-ui group inline-flex items-center gap-1"
                   title="Remove tag"
                   onClick={() => removeTag(t)}
                 >

--- a/src/components/reviews/ReviewList.tsx
+++ b/src/components/reviews/ReviewList.tsx
@@ -31,7 +31,7 @@ export default function ReviewList({
   if (count === 0) {
     return (
       <Card className={containerClass}>
-        <div className="flex flex-col items-center justify-center gap-3 p-6 text-sm text-muted-foreground">
+        <div className="flex flex-col items-center justify-center gap-3 p-6 text-ui text-muted-foreground">
           <Tv className="h-6 w-6 opacity-60" />
           <p>No reviews yet</p>
           <Button variant="primary" onClick={onCreate}>

--- a/src/components/reviews/ReviewListItem.tsx
+++ b/src/components/reviews/ReviewListItem.tsx
@@ -28,7 +28,7 @@ const itemLoading = cn(
 );
 const loadingLine = "h-3 rounded-md bg-muted";
 const scoreBadge = cn(
-  "px-2 py-1 rounded-full text-xs leading-none font-medium",
+  "px-2 py-1 rounded-full text-label leading-none font-medium",
   "text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2",
   "hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground",
   "focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground",
@@ -79,7 +79,7 @@ export default function ReviewListItem({
         <div className="flex items-start justify-between gap-2">
           <div
             className={cn(
-              "truncate font-medium text-base",
+              "truncate font-medium text-body",
               untitled && "text-muted-foreground/70",
             )}
             aria-label={untitled ? "Untitled Review" : undefined}
@@ -87,7 +87,7 @@ export default function ReviewListItem({
             {title}
           </div>
           {matchup ? (
-            <div className="truncate text-sm text-muted-foreground">
+            <div className="truncate text-ui text-muted-foreground">
               {matchup}
             </div>
           ) : null}

--- a/src/components/reviews/ReviewSummaryNotes.tsx
+++ b/src/components/reviews/ReviewSummaryNotes.tsx
@@ -9,7 +9,7 @@ export default function ReviewSummaryNotes({ notes }: ReviewSummaryNotesProps) {
   return (
     <div>
       <SectionLabel>Notes</SectionLabel>
-      <div className="rounded-card r-card-lg border border-border bg-card p-3 text-sm leading-6 text-foreground/70">
+      <div className="rounded-card r-card-lg border border-border bg-card p-3 text-ui leading-6 text-foreground/70">
         {notes}
       </div>
     </div>

--- a/src/components/reviews/ReviewSummaryPillars.tsx
+++ b/src/components/reviews/ReviewSummaryPillars.tsx
@@ -38,7 +38,7 @@ export default function ReviewSummaryPillars({
           ))}
         </div>
       ) : (
-        <div className="text-sm text-muted-foreground">
+        <div className="text-ui text-muted-foreground">
           No pillars selected.
         </div>
       )}

--- a/src/components/reviews/ReviewSummaryScore.tsx
+++ b/src/components/reviews/ReviewSummaryScore.tsx
@@ -36,8 +36,8 @@ export default function ReviewSummaryScore({
           </div>
         </div>
       </div>
-      <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
-        <span className="pill h-6 px-2 text-xs">{score}/10</span>
+      <div className="mt-1 flex items-center gap-2 text-ui text-muted-foreground">
+        <span className="pill h-6 px-2 text-label">{score}/10</span>
         <ScoreIcon className={cn("h-4 w-4", scoreIconCls)} />
         <span>{msg}</span>
       </div>
@@ -62,8 +62,8 @@ export default function ReviewSummaryScore({
               </div>
             </div>
           </div>
-          <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
-            <span className="pill h-6 px-2 text-xs">{focus}/10</span>
+          <div className="mt-1 flex items-center gap-2 text-ui text-muted-foreground">
+            <span className="pill h-6 px-2 text-label">{focus}/10</span>
             <span>{focusMsg}</span>
           </div>
         </div>

--- a/src/components/reviews/ReviewSummaryTimestamps.tsx
+++ b/src/components/reviews/ReviewSummaryTimestamps.tsx
@@ -22,7 +22,7 @@ export default function ReviewSummaryTimestamps({
         <div className="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
       </div>
       {!markers.length ? (
-        <div className="text-sm text-muted-foreground">No timestamps yet.</div>
+        <div className="text-ui text-muted-foreground">No timestamps yet.</div>
       ) : (
         <ul className="space-y-2">
           {[...markers]
@@ -41,11 +41,11 @@ export default function ReviewSummaryTimestamps({
                     <FileText size={14} className="opacity-80" />
                   </span>
                 ) : (
-                  <span className="pill h-7 px-3 text-xs font-mono tabular-nums leading-none">
+                  <span className="pill h-7 px-3 text-label font-mono tabular-nums leading-none">
                     {m.time ?? "00:00"}
                   </span>
                 )}
-                <span className="truncate text-sm">{m.note || "—"}</span>
+                <span className="truncate text-ui">{m.note || "—"}</span>
               </li>
             ))}
         </ul>

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -101,7 +101,7 @@ export default function ReviewsPage({
           },
           actions: (
             <div className="flex items-center gap-3">
-              <div className="hidden sm:flex items-center gap-2 text-xs text-muted-foreground">
+              <div className="hidden sm:flex items-center gap-2 text-label text-muted-foreground">
                 <span>Sort</span>
                 <Select
                   variant="animated"
@@ -139,7 +139,7 @@ export default function ReviewsPage({
         <nav aria-label="Review list" className="md:col-span-4">
           <div className="card-neo-soft rounded-card r-card-lg overflow-hidden bg-card/50 shadow-neo-strong">
             <div className="section-b">
-              <div className="mb-2 text-sm text-muted-foreground">
+              <div className="mb-2 text-ui text-muted-foreground">
                 {filtered.length} shown
               </div>
               <ReviewList
@@ -160,7 +160,7 @@ export default function ReviewsPage({
             <ReviewPanel
               className={cn(
                 panelClass,
-                "flex flex-col items-center justify-center gap-2 py-7 text-sm text-muted-foreground",
+                "flex flex-col items-center justify-center gap-2 py-7 text-ui text-muted-foreground",
               )}
             >
               <Ghost className="h-6 w-6 opacity-60" />

--- a/src/components/reviews/SectionLabel.tsx
+++ b/src/components/reviews/SectionLabel.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 export default function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
     <div className="mb-2 flex items-center gap-2">
-      <div className="text-xs tracking-wide text-foreground/20">{children}</div>
+      <div className="text-label tracking-wide text-foreground/20">{children}</div>
       <div className="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
     </div>
   );

--- a/src/components/reviews/TimestampMarkers.tsx
+++ b/src/components/reviews/TimestampMarkers.tsx
@@ -237,13 +237,13 @@ function TimestampMarkers(
           </IconButton>
         </div>
         {timeError && (
-          <p id="tTime-error" className="mt-1 text-xs text-danger">
+          <p id="tTime-error" className="mt-1 text-label text-danger">
             Enter time as mm:ss
           </p>
         )}
 
         {sortedMarkers.length === 0 ? (
-          <div className="mt-2 text-sm text-muted-foreground">No timestamps yet.</div>
+          <div className="mt-2 text-ui text-muted-foreground">No timestamps yet.</div>
         ) : (
           <ul className="mt-3 space-y-2">
             {sortedMarkers.map((m) => (
@@ -256,10 +256,10 @@ function TimestampMarkers(
                     <FileText size={14} className="opacity-80" />
                   </span>
                 ) : (
-                  <span className="pill h-7 w-16 px-3 text-xs font-mono tabular-nums text-center">{m.time}</span>
+                  <span className="pill h-7 w-16 px-3 text-label font-mono tabular-nums text-center">{m.time}</span>
                 )}
 
-                <span className="truncate text-sm">{m.note}</span>
+                <span className="truncate text-ui">{m.note}</span>
                 <IconButton
                   aria-label="Delete timestamp"
                   title="Delete timestamp"

--- a/src/components/team/JungleClears.tsx
+++ b/src/components/team/JungleClears.tsx
@@ -181,7 +181,7 @@ export default React.forwardRef<
                     <Timer className="opacity-80" />
                     {/* Glitch title + glow */}
                     <span
-                      className="glitch-title glitch-flicker title-glow text-xl sm:text-2xl md:text-3xl font-semibold"
+                      className="glitch-title glitch-flicker title-glow text-title sm:text-title-lg md:text-title-lg font-semibold"
                       data-text={bucket}
                     >
                       {bucket}
@@ -191,7 +191,7 @@ export default React.forwardRef<
                 actions={
                   // Big timer: same glitch treatment + glow
                   <span
-                    className="glitch-title glitch-flicker title-glow font-mono leading-none text-2xl sm:text-3xl md:text-4xl"
+                    className="glitch-title glitch-flicker title-glow font-mono leading-none text-title-lg sm:text-title-lg md:text-title-lg"
                     data-text={SPEED_TIME[bucket]}
                     aria-label="Expected first-clear timing"
                     title="Expected first-clear timing"
@@ -202,23 +202,23 @@ export default React.forwardRef<
               />
               <SectionCard.Body>
                 <div className="mb-2 flex flex-wrap items-center gap-2">
-                  <span className="rounded-full border border-border bg-card px-2 py-1 text-xs tracking-wide uppercase">
+                  <span className="rounded-full border border-border bg-card px-2 py-1 text-label tracking-wide uppercase">
                     {SPEED_PERSONA[bucket].tag}
                   </span>
-                  <span className="text-sm text-muted-foreground">
+                  <span className="text-ui text-muted-foreground">
                     {SPEED_HINT[bucket]}
                   </span>
                 </div>
 
                 {/* Example row (canonical pills) */}
                 <div className="mb-3 flex flex-wrap items-center gap-2">
-                  <span className="text-muted-foreground text-sm">
+                  <span className="text-muted-foreground text-ui">
                     Example:
                   </span>
-                  <span className="pill pill-compact text-xs">
+                  <span className="pill pill-compact text-label">
                     {exampleByBucket[bucket]}
                   </span>
-                  <span className="text-xs text-muted-foreground">
+                  <span className="text-label text-muted-foreground">
                     ({rowsAll.length} total)
                   </span>
                 </div>
@@ -238,7 +238,7 @@ export default React.forwardRef<
                 )}
 
                 <div className="overflow-x-auto">
-                  <table className="w-full text-sm">
+                  <table className="w-full text-ui">
                     <caption className="sr-only">
                       {bucket} junglers with types and notes
                     </caption>
@@ -338,7 +338,7 @@ export default React.forwardRef<
                                 {(r.type ?? []).map((t) => (
                                   <span
                                     key={t}
-                                    className="pill pill-compact text-xs"
+                                    className="pill pill-compact text-label"
                                   >
                                     {t}
                                   </span>

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -275,7 +275,7 @@ export default function TeamCompPage() {
           round: true,
           debounceMs: 80,
           right: (
-            <span className="text-xs opacity-80">{clearsCount} shown</span>
+            <span className="text-label opacity-80">{clearsCount} shown</span>
           ),
         }}
         actions={
@@ -299,7 +299,7 @@ export default function TeamCompPage() {
           </div>
         }
       >
-        <p className="text-sm text-muted-foreground">
+        <p className="text-ui text-muted-foreground">
           If you’re on a <em>Medium</em> champ, don’t race farm vs <em>Very Fast</em>.
           Path for fights, ganks, or cross-map trades.
         </p>

--- a/src/components/team/style.css
+++ b/src/components/team/style.css
@@ -5,7 +5,7 @@
   @apply flex flex-wrap gap-2;
 }
 .champ-badge {
-  @apply inline-flex items-center h-6 px-2 rounded-full border text-xs leading-none whitespace-nowrap;
+  @apply inline-flex items-center h-6 px-2 rounded-full border text-label leading-none whitespace-nowrap;
   transition:
     background 0.15s var(--ease-out),
     border-color 0.15s var(--ease-out),

--- a/src/components/ui/AnimationToggle.tsx
+++ b/src/components/ui/AnimationToggle.tsx
@@ -67,7 +67,7 @@ export default function AnimationToggle({
         )}
       </button>
       {showNotice && (
-        <span className="text-xs text-muted-foreground">
+        <span className="text-label text-muted-foreground">
           Animations disabled per OS preference
         </span>
       )}

--- a/src/components/ui/Label.tsx
+++ b/src/components/ui/Label.tsx
@@ -14,7 +14,7 @@ const Label = React.forwardRef<HTMLLabelElement, LabelProps>(function Label(
     <label
       ref={ref}
       className={cn(
-        "text-xs font-medium text-muted-foreground mb-2",
+        "text-label font-medium text-muted-foreground mb-2",
         className
       )}
       {...props}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -112,7 +112,7 @@ const NativeSelect = React.forwardRef<HTMLSelectElement, NativeSelectProps>(
             aria-invalid={errorText ? "true" : props["aria-invalid"]}
             aria-describedby={describedBy}
             className={cn(
-              "flex-1 h-[var(--control-h)] px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-foreground placeholder:text-muted-foreground/70 caret-accent appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none",
+              "flex-1 h-[var(--control-h)] px-[var(--space-14)] pr-[var(--space-36)] text-ui bg-transparent text-foreground placeholder:text-muted-foreground/70 caret-accent appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none",
               selectClassName,
             )}
             {...props}
@@ -139,7 +139,7 @@ const NativeSelect = React.forwardRef<HTMLSelectElement, NativeSelectProps>(
           <p
             id={errorId || helperId}
             className={cn(
-              "text-xs mt-1 line-clamp-2",
+              "text-label mt-1 line-clamp-2",
               errorText ? "text-danger" : "text-muted-foreground",
             )}
           >
@@ -411,7 +411,7 @@ const AnimatedSelectImpl = React.forwardRef<
         <div
           id={labelId}
           className={
-            hideLabel ? "sr-only" : "mb-1 text-xs text-muted-foreground"
+            hideLabel ? "sr-only" : "mb-1 text-label text-muted-foreground"
           }
         >
           {label}
@@ -546,7 +546,7 @@ const AnimatedSelectImpl = React.forwardRef<
                         data-loading={it.loading}
                       >
                         <div className="flex items-center justify-between gap-3">
-                          <span className="text-sm leading-none glitch-text">
+                          <span className="text-ui leading-none glitch-text">
                             {it.label}
                           </span>
                           <Check

--- a/src/components/ui/feedback/Snackbar.tsx
+++ b/src/components/ui/feedback/Snackbar.tsx
@@ -21,7 +21,7 @@ export default function Snackbar({
       role="status"
       aria-live="polite"
       className={cn(
-        "mx-auto w-fit rounded-card r-card-lg border border-border bg-surface-2 px-4 py-2 text-sm shadow-sm",
+        "mx-auto w-fit rounded-card r-card-lg border border-border bg-surface-2 px-4 py-2 text-ui shadow-sm",
         className,
       )}
       {...props}

--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -195,7 +195,7 @@ export default function Header<Key extends string = string>({
           {hasNav ? (
             <div
               className={cx(
-                "flex min-w-0 flex-1 items-center gap-1 overflow-x-auto whitespace-nowrap text-xs font-medium text-muted-foreground sm:text-sm sm:overflow-visible",
+                "flex min-w-0 flex-1 items-center gap-1 overflow-x-auto whitespace-nowrap text-label font-medium text-muted-foreground sm:text-ui sm:overflow-visible",
                 "[&_[data-state=active]]:text-foreground [&_[data-state=active]]:opacity-100",
                 "[&_[data-state=inactive]]:text-muted-foreground [&_[data-state=inactive]:hover]:text-foreground [&_[data-state=inactive]:focus-visible]:text-foreground",
               )}

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -177,20 +177,20 @@ function Hero<Key extends string = string>({
 
           <div className="min-w-0">
             {eyebrow ? (
-              <div className="text-xs font-semibold tracking-[0.02em] uppercase text-muted-foreground">
+              <div className="text-label font-semibold tracking-[0.02em] uppercase text-muted-foreground">
                 {eyebrow}
               </div>
             ) : null}
 
             <div className="flex items-baseline gap-2">
               <h2
-                className="hero2-title title-glow text-2xl md:text-3xl font-semibold tracking-[-0.005em] truncate"
+                className="hero2-title title-glow text-title-lg md:text-title-lg font-semibold tracking-[-0.005em] truncate"
                 data-text={headingStr}
               >
                 {heading}
               </h2>
               {subtitle ? (
-                <span className="text-sm md:text-base font-medium text-[hsl(var(--muted-foreground))] truncate">
+                <span className="text-ui md:text-body font-medium text-[hsl(var(--muted-foreground))] truncate">
                   {subtitle}
                 </span>
               ) : null}

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -43,9 +43,9 @@ export type TabBarProps<K extends string = string> = {
 };
 
 const sizeMap: Record<Size, { h: string; px: string; text: string }> = {
-  sm: { h: "h-8", px: "px-3", text: "text-sm" },
-  md: { h: "h-10", px: "px-4", text: "text-sm" },
-  lg: { h: "h-11", px: "px-8", text: "text-base" },
+  sm: { h: "h-8", px: "px-3", text: "text-ui" },
+  md: { h: "h-10", px: "px-4", text: "text-ui" },
+  lg: { h: "h-11", px: "px-8", text: "text-body" },
 };
 
 export default function TabBar<K extends string = string>({
@@ -181,7 +181,7 @@ export default function TabBar<K extends string = string>({
                 )}
                 <span className="truncate">{item.label}</span>
                 {item.badge != null && (
-                  <span className="ml-2 inline-flex items-center justify-center rounded-full px-2 py-1 text-xs leading-none bg-primary-soft text-foreground">
+                  <span className="ml-2 inline-flex items-center justify-center rounded-full px-2 py-1 text-label leading-none bg-primary-soft text-foreground">
                     {item.badge}
                   </span>
                 )}

--- a/src/components/ui/league/SideSelector.tsx
+++ b/src/components/ui/league/SideSelector.tsx
@@ -105,7 +105,7 @@ export default function SideSelector({
       />
 
       {/* Labels */}
-      <div className="relative z-10 grid w-full grid-cols-2 text-sm font-mono">
+      <div className="relative z-10 grid w-full grid-cols-2 text-ui font-mono">
         <div
           className={cn(
             "py-2 text-center transition-colors",

--- a/src/components/ui/league/pillars/PillarBadge.tsx
+++ b/src/components/ui/league/pillars/PillarBadge.tsx
@@ -50,10 +50,10 @@ export default function PillarBadge({
 
   const sizeCls =
     size === "lg"
-      ? "h-10 px-4 text-base gap-2"
+      ? "h-10 px-4 text-body gap-2"
       : size === "sm"
-      ? "h-8 px-3 text-xs gap-2"
-      : "h-9 px-4 text-sm gap-2";
+      ? "h-8 px-3 text-label gap-2"
+      : "h-9 px-4 text-ui gap-2";
 
   // Default element: "button" if interactive, else "span".
   const Tag: AsTag = as ?? (interactive ? "button" : "span");

--- a/src/components/ui/primitives/Badge.tsx
+++ b/src/components/ui/primitives/Badge.tsx
@@ -28,8 +28,8 @@ export type BadgeProps<T extends React.ElementType = "span"> =
     Omit<React.ComponentPropsWithoutRef<T>, keyof BadgeOwnProps<T>>;
 
 const sizeMap: Record<Size, string> = {
-  xs: "px-[var(--space-2)] py-[var(--space-1)] text-xs leading-none",
-  sm: "px-[var(--space-3)] py-[var(--space-2)] text-xs leading-none",
+  xs: "px-[var(--space-2)] py-[var(--space-1)] text-label leading-none",
+  sm: "px-[var(--space-3)] py-[var(--space-2)] text-label leading-none",
 };
 
 const toneBorder: Record<Tone, string> = {

--- a/src/components/ui/primitives/GlitchSegmented.tsx
+++ b/src/components/ui/primitives/GlitchSegmented.tsx
@@ -108,7 +108,7 @@ export const GlitchSegmentedButton = React.forwardRef<
       onClick={onSelect}
       className={cn(
         styles.glitchScanlines,
-        "flex-1 h-9 px-3 inline-flex items-center justify-center gap-2 text-sm font-medium select-none",
+        "flex-1 h-9 px-3 inline-flex items-center justify-center gap-2 text-ui font-medium select-none",
         "rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
         "bg-[var(--btn-bg)] text-[var(--btn-fg)]",
         "hover:-translate-y-px hover:shadow-neon-soft",

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -85,7 +85,7 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
         id={finalId}
         name={finalName}
         className={cn(
-          "w-full rounded-[inherit] bg-transparent px-3 text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]",
+          "w-full rounded-[inherit] bg-transparent px-3 text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]",
           indent && "pl-7",
           showEndSlot && "pr-7",
           inputClassName,

--- a/src/components/ui/primitives/Textarea.tsx
+++ b/src/components/ui/primitives/Textarea.tsx
@@ -21,7 +21,7 @@ export type TextareaProps =
   };
 
 const INNER =
-  "block w-full max-w-full min-h-7 px-3 py-3 text-base bg-transparent " +
+  "block w-full max-w-full min-h-7 px-3 py-3 text-body bg-transparent " +
   "text-foreground placeholder:text-muted-foreground/70 " +
   "focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default";
 

--- a/src/components/ui/theme/BackgroundPicker.tsx
+++ b/src/components/ui/theme/BackgroundPicker.tsx
@@ -49,7 +49,7 @@ export default function BackgroundPicker({
       items={items}
       value={String(bg)}
       onChange={(v) => onBgChange(Number(v) as Background)}
-      buttonClassName="!h-9 !px-3 !rounded-full !text-sm !shadow-neo-inset hover:ring-2 hover:ring-[--edge-iris] focus-visible:ring-2 focus-visible:ring-[--edge-iris]"
+      buttonClassName="!h-9 !px-3 !rounded-full !text-ui !shadow-neo-inset hover:ring-2 hover:ring-[--edge-iris] focus-visible:ring-2 focus-visible:ring-[--edge-iris]"
       matchTriggerWidth={false}
       className={className}
     />

--- a/src/components/ui/theme/ThemePicker.tsx
+++ b/src/components/ui/theme/ThemePicker.tsx
@@ -20,7 +20,7 @@ export default function ThemePicker({ variant, onVariantChange, className = "" }
       items={items}
       value={variant}
       onChange={v => onVariantChange(v as Variant)}
-      buttonClassName="!h-9 !px-3 !rounded-full !text-sm !shadow-neo-inset hover:ring-2 hover:ring-[--edge-iris] focus-visible:ring-2 focus-visible:ring-[--edge-iris]"
+      buttonClassName="!h-9 !px-3 !rounded-full !text-ui !shadow-neo-inset hover:ring-2 hover:ring-[--edge-iris] focus-visible:ring-2 focus-visible:ring-[--edge-iris]"
       matchTriggerWidth={false}
       className={className}
     />

--- a/src/components/ui/theme/ThemeToggle.tsx
+++ b/src/components/ui/theme/ThemeToggle.tsx
@@ -94,7 +94,7 @@ export default function ThemeToggle({
         items={items}
         value={variant}
         onChange={(v) => setVariantPersist(v as Variant)}
-        buttonClassName="!h-9 !px-3 !rounded-full !text-sm !w-auto"
+        buttonClassName="!h-9 !px-3 !rounded-full !text-ui !w-auto"
         matchTriggerWidth={false}
         align="right"
         className="shrink-0"

--- a/src/components/ui/toggles/toggle.tsx
+++ b/src/components/ui/toggles/toggle.tsx
@@ -79,7 +79,7 @@ export default function Toggle({
       <span
         id={leftId}
         className={cn(
-          "relative z-10 flex-1 text-center font-mono text-sm transition-colors",
+          "relative z-10 flex-1 text-center font-mono text-ui transition-colors",
           !isRight ? "text-foreground/70" : "text-muted-foreground",
         )}
         style={{
@@ -93,7 +93,7 @@ export default function Toggle({
       <span
         id={rightId}
         className={cn(
-          "relative z-10 flex-1 text-center font-mono text-sm transition-colors",
+          "relative z-10 flex-1 text-center font-mono text-ui transition-colors",
           isRight ? "text-foreground/70" : "text-muted-foreground",
         )}
         style={{

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,7 +2,15 @@
 // Tiny helpers. Keep dependencies minimal and SSR-safe.
 
 import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+
+const twMerge = extendTailwindMerge({
+  extend: {
+    theme: {
+      text: ["label", "ui", "body", "title", "title-lg"],
+    },
+  },
+});
 
 // Default locale for consistent date/time formatting.
 export const LOCALE = "en-US";

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`ReviewEditor > renders default state 1`] = `
               class="mb-2 flex items-center gap-2"
             >
               <div
-                class="text-xs tracking-wide text-foreground/20"
+                class="text-label tracking-wide text-foreground/20"
               >
                 Lane
               </div>
@@ -52,7 +52,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 <button
                   aria-controls="TOP-panel"
                   aria-selected="false"
-                  class="_glitchScanlines_ff763a flex-1 h-9 px-3 inline-flex items-center justify-center gap-2 text-sm font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:-translate-y-px hover:shadow-neon-soft active:shadow-neon-soft active:scale-95 data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[--neon-soft] disabled:opacity-50 disabled:pointer-events-none"
+                  class="_glitchScanlines_ff763a flex-1 h-9 px-3 inline-flex items-center justify-center gap-2 text-ui font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:-translate-y-px hover:shadow-neon-soft active:shadow-neon-soft active:scale-95 data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[--neon-soft] disabled:opacity-50 disabled:pointer-events-none"
                   id="TOP-tab"
                   role="tab"
                   tabindex="-1"
@@ -94,7 +94,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 <button
                   aria-controls="JUNGLE-panel"
                   aria-selected="false"
-                  class="_glitchScanlines_ff763a flex-1 h-9 px-3 inline-flex items-center justify-center gap-2 text-sm font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:-translate-y-px hover:shadow-neon-soft active:shadow-neon-soft active:scale-95 data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[--neon-soft] disabled:opacity-50 disabled:pointer-events-none"
+                  class="_glitchScanlines_ff763a flex-1 h-9 px-3 inline-flex items-center justify-center gap-2 text-ui font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:-translate-y-px hover:shadow-neon-soft active:shadow-neon-soft active:scale-95 data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[--neon-soft] disabled:opacity-50 disabled:pointer-events-none"
                   id="JUNGLE-tab"
                   role="tab"
                   tabindex="-1"
@@ -135,7 +135,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 <button
                   aria-controls="MID-panel"
                   aria-selected="true"
-                  class="_glitchScanlines_ff763a flex-1 h-9 px-3 inline-flex items-center justify-center gap-2 text-sm font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:-translate-y-px hover:shadow-neon-soft active:shadow-neon-soft active:scale-95 data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[--neon-soft] disabled:opacity-50 disabled:pointer-events-none"
+                  class="_glitchScanlines_ff763a flex-1 h-9 px-3 inline-flex items-center justify-center gap-2 text-ui font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:-translate-y-px hover:shadow-neon-soft active:shadow-neon-soft active:scale-95 data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[--neon-soft] disabled:opacity-50 disabled:pointer-events-none"
                   data-selected="true"
                   id="MID-tab"
                   role="tab"
@@ -184,7 +184,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 <button
                   aria-controls="BOT-panel"
                   aria-selected="false"
-                  class="_glitchScanlines_ff763a flex-1 h-9 px-3 inline-flex items-center justify-center gap-2 text-sm font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:-translate-y-px hover:shadow-neon-soft active:shadow-neon-soft active:scale-95 data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[--neon-soft] disabled:opacity-50 disabled:pointer-events-none"
+                  class="_glitchScanlines_ff763a flex-1 h-9 px-3 inline-flex items-center justify-center gap-2 text-ui font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:-translate-y-px hover:shadow-neon-soft active:shadow-neon-soft active:scale-95 data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[--neon-soft] disabled:opacity-50 disabled:pointer-events-none"
                   id="BOT-tab"
                   role="tab"
                   tabindex="-1"
@@ -246,7 +246,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 <button
                   aria-controls="SUPPORT-panel"
                   aria-selected="false"
-                  class="_glitchScanlines_ff763a flex-1 h-9 px-3 inline-flex items-center justify-center gap-2 text-sm font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:-translate-y-px hover:shadow-neon-soft active:shadow-neon-soft active:scale-95 data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[--neon-soft] disabled:opacity-50 disabled:pointer-events-none"
+                  class="_glitchScanlines_ff763a flex-1 h-9 px-3 inline-flex items-center justify-center gap-2 text-ui font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:-translate-y-px hover:shadow-neon-soft active:shadow-neon-soft active:scale-95 data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[--neon-soft] disabled:opacity-50 disabled:pointer-events-none"
                   id="SUPPORT-tab"
                   role="tab"
                   tabindex="-1"
@@ -324,7 +324,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                   style="--control-h: var(--control-h-md);"
                 >
                   <input
-                    class="w-full rounded-[inherit] bg-transparent px-3 text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
+                    class="w-full rounded-[inherit] bg-transparent px-3 text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
                     id=":r1:"
                     name="lane"
                     placeholder="Ashe/Lulu"
@@ -338,7 +338,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 class="mb-2 flex items-center gap-2"
               >
                 <div
-                  class="text-xs tracking-wide text-foreground/20"
+                  class="text-label tracking-wide text-foreground/20"
                 >
                   <span
                     id=":r0:"
@@ -375,7 +375,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 >
                   <input
                     aria-labelledby=":r0:"
-                    class="w-full rounded-[inherit] bg-transparent px-3 text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
+                    class="w-full rounded-[inherit] bg-transparent px-3 text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
                     id=":r2:"
                     name="opponent"
                     placeholder="Draven/Thresh"
@@ -399,7 +399,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           class="mb-2 flex items-center gap-2"
         >
           <div
-            class="text-xs tracking-wide text-foreground/20"
+            class="text-label tracking-wide text-foreground/20"
           >
             Result
           </div>
@@ -420,7 +420,7 @@ exports[`ReviewEditor > renders default state 1`] = `
             style="width: calc(50% - 4px); transform: translate3d(0,0,0); transition-timing-function: cubic-bezier(.22,1,.36,1); background: linear-gradient(90deg, hsl(var(--success)/0.32), hsl(var(--accent)/0.28)); box-shadow: 0 10px 30px hsl(var(--shadow-color) / .25);"
           />
           <div
-            class="relative z-10 grid w-full grid-cols-2 text-sm font-mono"
+            class="relative z-10 grid w-full grid-cols-2 text-ui font-mono"
           >
             <div
               class="py-2 text-center text-foreground/70"
@@ -440,7 +440,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           class="mb-2 flex items-center gap-2"
         >
           <div
-            class="text-xs tracking-wide text-foreground/20"
+            class="text-label tracking-wide text-foreground/20"
           >
             Score
           </div>
@@ -478,10 +478,10 @@ exports[`ReviewEditor > renders default state 1`] = `
           </div>
         </div>
         <div
-          class="mt-1 flex items-center gap-2 text-sm text-muted-foreground"
+          class="mt-1 flex items-center gap-2 text-ui text-muted-foreground"
         >
           <span
-            class="pill h-6 px-2 text-xs"
+            class="pill h-6 px-2 text-label"
           >
             5
             /10
@@ -731,7 +731,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           class="mb-2 flex items-center gap-2"
         >
           <div
-            class="text-xs tracking-wide text-foreground/20"
+            class="text-label tracking-wide text-foreground/20"
           >
             Pillars
           </div>
@@ -762,7 +762,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(2px); transition: opacity 220ms var(--ease-out);"
               />
               <span
-                class="lg-pillar-badge rounded-full h-9 px-4 text-sm gap-2"
+                class="lg-pillar-badge rounded-full h-9 px-4 text-ui gap-2"
                 style="--g1: hsla(257, 90%, 70%, 1); --g2: hsla(198, 90%, 62%, 1); --shadow: hsla(258, 90%, 38%, 0.35);"
                 title="Wave"
               >
@@ -889,7 +889,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(2px); transition: opacity 220ms var(--ease-out);"
               />
               <span
-                class="lg-pillar-badge rounded-full h-9 px-4 text-sm gap-2"
+                class="lg-pillar-badge rounded-full h-9 px-4 text-ui gap-2"
                 style="--g1: hsla(292, 85%, 72%, 1); --g2: hsla(6, 85%, 66%, 1); --shadow: hsla(292, 85%, 38%, 0.35);"
                 title="Trading"
               >
@@ -1026,7 +1026,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(2px); transition: opacity 220ms var(--ease-out);"
               />
               <span
-                class="lg-pillar-badge rounded-full h-9 px-4 text-sm gap-2"
+                class="lg-pillar-badge rounded-full h-9 px-4 text-ui gap-2"
                 style="--g1: hsla(157, 70%, 55%, 1); --g2: hsla(192, 75%, 60%, 1); --shadow: hsla(170, 70%, 30%, 0.35);"
                 title="Vision"
               >
@@ -1152,7 +1152,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(2px); transition: opacity 220ms var(--ease-out);"
               />
               <span
-                class="lg-pillar-badge rounded-full h-9 px-4 text-sm gap-2"
+                class="lg-pillar-badge rounded-full h-9 px-4 text-ui gap-2"
                 style="--g1: hsla(260, 85%, 70%, 1); --g2: hsla(280, 85%, 65%, 1); --shadow: hsla(270, 80%, 35%, 0.35);"
                 title="Tempo"
               >
@@ -1287,7 +1287,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(2px); transition: opacity 220ms var(--ease-out);"
               />
               <span
-                class="lg-pillar-badge rounded-full h-9 px-4 text-sm gap-2"
+                class="lg-pillar-badge rounded-full h-9 px-4 text-ui gap-2"
                 style="--g1: hsla(190, 90%, 66%, 1); --g2: hsla(220, 90%, 66%, 1); --shadow: hsla(205, 85%, 35%, 0.35);"
                 title="Positioning"
               >
@@ -1434,7 +1434,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(2px); transition: opacity 220ms var(--ease-out);"
               />
               <span
-                class="lg-pillar-badge rounded-full h-9 px-4 text-sm gap-2"
+                class="lg-pillar-badge rounded-full h-9 px-4 text-ui gap-2"
                 style="--g1: hsla(40, 95%, 62%, 1); --g2: hsla(18, 90%, 60%, 1); --shadow: hsla(28, 90%, 35%, 0.35);"
                 title="Comms"
               >
@@ -1545,7 +1545,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           class="mb-2 flex items-center gap-2"
         >
           <div
-            class="text-xs tracking-wide text-foreground/20"
+            class="text-label tracking-wide text-foreground/20"
           >
             Timestamps
           </div>
@@ -1865,7 +1865,7 @@ exports[`ReviewEditor > renders default state 1`] = `
               <input
                 aria-describedby="tTime-error"
                 aria-invalid="true"
-                class="w-full rounded-[inherit] bg-transparent px-3 text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
+                class="w-full rounded-[inherit] bg-transparent px-3 text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
                 id=":r3:"
                 inputmode="numeric"
                 name="timestamp-time"
@@ -1879,7 +1879,7 @@ exports[`ReviewEditor > renders default state 1`] = `
               style="--control-h: var(--control-h-md);"
             >
               <input
-                class="w-full rounded-[inherit] bg-transparent px-3 text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
+                class="w-full rounded-[inherit] bg-transparent px-3 text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
                 id=":r4:"
                 name="timestamp-note"
                 placeholder="Quick note"
@@ -1916,13 +1916,13 @@ exports[`ReviewEditor > renders default state 1`] = `
             </button>
           </div>
           <p
-            class="mt-1 text-xs text-danger"
+            class="mt-1 text-label text-danger"
             id="tTime-error"
           >
             Enter time as mm:ss
           </p>
           <div
-            class="mt-2 text-sm text-muted-foreground"
+            class="mt-2 text-ui text-muted-foreground"
           >
             No timestamps yet.
           </div>
@@ -1933,7 +1933,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           class="mb-2 flex items-center gap-2"
         >
           <div
-            class="text-xs tracking-wide text-foreground/20"
+            class="text-label tracking-wide text-foreground/20"
           >
             Tags
           </div>
@@ -1974,7 +1974,7 @@ exports[`ReviewEditor > renders default state 1`] = `
               style="--control-h: var(--control-h-md);"
             >
               <input
-                class="w-full rounded-[inherit] bg-transparent px-3 text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
+                class="w-full rounded-[inherit] bg-transparent px-3 text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
                 id=":r5:"
                 name="tag-input"
                 placeholder="Add tag and press Enter"
@@ -2011,7 +2011,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           </button>
         </div>
         <div
-          class="mt-2 text-sm text-muted-foreground/80"
+          class="mt-2 text-ui text-muted-foreground/80"
         >
           No tags yet.
         </div>
@@ -2021,7 +2021,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           class="mb-2 flex items-center gap-2"
         >
           <div
-            class="text-xs tracking-wide text-foreground/20"
+            class="text-label tracking-wide text-foreground/20"
           >
             Notes
           </div>
@@ -2033,7 +2033,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           class="relative inline-flex w-full items-center overflow-hidden border border-card-hairline bg-card/60 backdrop-blur-[2px] shadow-control transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-control-hover focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),url('/noise.svg')] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] focus-within:after:opacity-100 rounded-[var(--radius-2xl)]"
         >
           <textarea
-            class="block w-full max-w-full px-3 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground/70 focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default resize-y min-h-[calc(var(--space-8)*3_-_var(--space-3))] leading-relaxed"
+            class="block w-full max-w-full px-3 py-3 text-body bg-transparent text-foreground placeholder:text-muted-foreground/70 focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default resize-y min-h-[calc(var(--space-8)*3_-_var(--space-3))] leading-relaxed"
             id=":r6:"
             name="r6"
             placeholder="Key moments, mistakes to fix, drills to run…"

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -15,12 +15,12 @@ exports[`ReviewListItem > renders default state 1`] = `
         class="flex items-start justify-between gap-2"
       >
         <div
-          class="truncate font-medium text-base"
+          class="truncate font-medium text-body"
         >
           Sample Review
         </div>
         <div
-          class="truncate text-sm text-muted-foreground"
+          class="truncate text-ui text-muted-foreground"
         >
           Lux vs Ahri
         </div>
@@ -36,14 +36,14 @@ exports[`ReviewListItem > renders default state 1`] = `
             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
+            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-label leading-none border-card-hairline px-1 py-0"
           >
             MID
           </span>
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
+          class="px-2 py-1 rounded-full text-label leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
         >
           9
           /10
@@ -70,12 +70,12 @@ exports[`ReviewListItem > renders disabled state 1`] = `
         class="flex items-start justify-between gap-2"
       >
         <div
-          class="truncate font-medium text-base"
+          class="truncate font-medium text-body"
         >
           Sample Review
         </div>
         <div
-          class="truncate text-sm text-muted-foreground"
+          class="truncate text-ui text-muted-foreground"
         >
           Lux vs Ahri
         </div>
@@ -91,14 +91,14 @@ exports[`ReviewListItem > renders disabled state 1`] = `
             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
+            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-label leading-none border-card-hairline px-1 py-0"
           >
             MID
           </span>
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
+          class="px-2 py-1 rounded-full text-label leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
         >
           9
           /10
@@ -141,12 +141,12 @@ exports[`ReviewListItem > renders selected state 1`] = `
         class="flex items-start justify-between gap-2"
       >
         <div
-          class="truncate font-medium text-base"
+          class="truncate font-medium text-body"
         >
           Sample Review
         </div>
         <div
-          class="truncate text-sm text-muted-foreground"
+          class="truncate text-ui text-muted-foreground"
         >
           Lux vs Ahri
         </div>
@@ -162,14 +162,14 @@ exports[`ReviewListItem > renders selected state 1`] = `
             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
+            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-label leading-none border-card-hairline px-1 py-0"
           >
             MID
           </span>
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
+          class="px-2 py-1 rounded-full text-label leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
         >
           9
           /10
@@ -196,12 +196,12 @@ exports[`ReviewListItem > renders untitled state 1`] = `
       >
         <div
           aria-label="Untitled Review"
-          class="truncate font-medium text-base text-muted-foreground/70"
+          class="truncate font-medium text-body text-muted-foreground/70"
         >
           Untitled Review
         </div>
         <div
-          class="truncate text-sm text-muted-foreground"
+          class="truncate text-ui text-muted-foreground"
         >
           Lux vs Ahri
         </div>
@@ -217,14 +217,14 @@ exports[`ReviewListItem > renders untitled state 1`] = `
             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
+            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-label leading-none border-card-hairline px-1 py-0"
           >
             MID
           </span>
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-2 py-1 rounded-full text-xs leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
+          class="px-2 py-1 rounded-full text-label leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
         >
           9
           /10

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -449,13 +449,13 @@ exports[`ReviewsPage > renders default state 1`] = `
                       class="flex items-baseline gap-2"
                     >
                       <h2
-                        class="hero2-title title-glow text-2xl md:text-3xl font-semibold tracking-[-0.005em] truncate"
+                        class="hero2-title title-glow text-title-lg md:text-title-lg font-semibold tracking-[-0.005em] truncate"
                         data-text="Browse Reviews"
                       >
                         Browse Reviews
                       </h2>
                       <span
-                        class="text-sm md:text-base font-medium text-[hsl(var(--muted-foreground))] truncate"
+                        class="text-ui md:text-body font-medium text-[hsl(var(--muted-foreground))] truncate"
                       >
                         <span
                           class="pill"
@@ -522,7 +522,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                               autocapitalize="none"
                               autocomplete="off"
                               autocorrect="off"
-                              class="w-full rounded-[inherit] bg-transparent px-3 text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)] pl-7"
+                              class="w-full rounded-[inherit] bg-transparent px-3 text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)] pl-7"
                               id=":r0:"
                               name=":r0:"
                               placeholder="Search title, tags, opponent, patch…"
@@ -540,7 +540,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                           class="flex items-center gap-3"
                         >
                           <div
-                            class="hidden sm:flex items-center gap-2 text-xs text-muted-foreground"
+                            class="hidden sm:flex items-center gap-2 text-label text-muted-foreground"
                           >
                             <span>
                               Sort
@@ -838,7 +838,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                             </div>
                           </div>
                           <button
-                            class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 gap-2 [&_svg]:size-5 px-4 whitespace-nowrap shadow-glow-sm bg-[hsl(var(--accent)/0.12)] border-[hsl(var(--accent)/0.35)] hover:bg-[hsl(var(--accent)/0.14)] hover:shadow-glow-md active:translate-y-px active:shadow-btn-primary-active text-foreground"
+                            class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 text-ui gap-2 [&_svg]:size-5 px-4 whitespace-nowrap shadow-glow-sm bg-[hsl(var(--accent)/0.12)] border-[hsl(var(--accent)/0.35)] hover:bg-[hsl(var(--accent)/0.14)] hover:shadow-glow-md active:translate-y-px active:shadow-btn-primary-active text-foreground"
                             style="--glow-active: hsl(var(--foreground) / 0.35);"
                             tabindex="0"
                             type="button"
@@ -902,7 +902,7 @@ exports[`ReviewsPage > renders default state 1`] = `
             class="section-b"
           >
             <div
-              class="mb-2 text-sm text-muted-foreground"
+              class="mb-2 text-ui text-muted-foreground"
             >
               3
                shown
@@ -927,12 +927,12 @@ exports[`ReviewsPage > renders default state 1`] = `
                         class="flex items-start justify-between gap-2"
                       >
                         <div
-                          class="truncate font-medium text-base"
+                          class="truncate font-medium text-body"
                         >
                           Alpha
                         </div>
                         <div
-                          class="truncate text-sm text-muted-foreground"
+                          class="truncate text-ui text-muted-foreground"
                         >
                           Lux vs Ahri
                         </div>
@@ -948,7 +948,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
                           />
                           <span
-                            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
+                            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-label leading-none border-card-hairline px-1 py-0"
                           >
                             MID
                           </span>
@@ -971,12 +971,12 @@ exports[`ReviewsPage > renders default state 1`] = `
                         class="flex items-start justify-between gap-2"
                       >
                         <div
-                          class="truncate font-medium text-base"
+                          class="truncate font-medium text-body"
                         >
                           Gamma
                         </div>
                         <div
-                          class="truncate text-sm text-muted-foreground"
+                          class="truncate text-ui text-muted-foreground"
                         >
                           Ashe vs Cait
                         </div>
@@ -992,7 +992,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
                           />
                           <span
-                            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
+                            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-label leading-none border-card-hairline px-1 py-0"
                           >
                             BOT
                           </span>
@@ -1015,12 +1015,12 @@ exports[`ReviewsPage > renders default state 1`] = `
                         class="flex items-start justify-between gap-2"
                       >
                         <div
-                          class="truncate font-medium text-base"
+                          class="truncate font-medium text-body"
                         >
                           Beta
                         </div>
                         <div
-                          class="truncate text-sm text-muted-foreground"
+                          class="truncate text-ui text-muted-foreground"
                         >
                           Garen vs Darius
                         </div>
@@ -1036,7 +1036,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                             class="h-2 w-2 rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
                           />
                           <span
-                            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-xs leading-none border-card-hairline px-1 py-0"
+                            class="inline-flex max-w-full items-center gap-2 whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out text-label leading-none border-card-hairline px-1 py-0"
                           >
                             TOP
                           </span>
@@ -1056,7 +1056,7 @@ exports[`ReviewsPage > renders default state 1`] = `
       >
         <div
           aria-live="polite"
-          class="rounded-card r-card-lg p-4 border border-border/25 bg-card/60 shadow-outline-subtle w-full container mx-auto flex flex-col items-center justify-center gap-2 py-7 text-sm text-muted-foreground"
+          class="rounded-card r-card-lg p-4 border border-border/25 bg-card/60 shadow-outline-subtle w-full container mx-auto flex flex-col items-center justify-center gap-2 py-7 text-ui text-muted-foreground"
         >
           <svg
             class="lucide lucide-ghost h-6 w-6 opacity-60"

--- a/tests/ui/__snapshots__/input.test.tsx.snap
+++ b/tests/ui/__snapshots__/input.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Input > renders default state 1`] = `
   style="--control-h: var(--control-h-md);"
 >
   <input
-    class="w-full rounded-[inherit] bg-transparent px-3 text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
+    class="w-full rounded-[inherit] bg-transparent px-3 text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
     id=":r0:"
     name=":r0:"
   />
@@ -19,7 +19,7 @@ exports[`Input > renders disabled state 1`] = `
   style="--control-h: var(--control-h-md);"
 >
   <input
-    class="w-full rounded-[inherit] bg-transparent px-3 text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
+    class="w-full rounded-[inherit] bg-transparent px-3 text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
     disabled=""
     id=":r4:"
     name=":r4:"
@@ -34,7 +34,7 @@ exports[`Input > renders error state 1`] = `
 >
   <input
     aria-invalid="true"
-    class="w-full rounded-[inherit] bg-transparent px-3 text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
+    class="w-full rounded-[inherit] bg-transparent px-3 text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
     id=":r2:"
     name=":r2:"
   />
@@ -47,7 +47,7 @@ exports[`Input > renders focus state 1`] = `
   style="--control-h: var(--control-h-md);"
 >
   <input
-    class="w-full rounded-[inherit] bg-transparent px-3 text-sm text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
+    class="w-full rounded-[inherit] bg-transparent px-3 text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)]"
     id=":r1:"
     name=":r1:"
   />

--- a/tests/ui/__snapshots__/select.test.tsx.snap
+++ b/tests/ui/__snapshots__/select.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Select > renders default state 1`] = `
   >
     <select
       aria-label="test"
-      class="flex-1 h-[var(--control-h)] px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-foreground placeholder:text-muted-foreground/70 caret-accent appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
+      class="flex-1 h-[var(--control-h)] px-[var(--space-14)] pr-[var(--space-36)] text-ui bg-transparent text-foreground placeholder:text-muted-foreground/70 caret-accent appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
       id=":r0:"
       name="test"
     >
@@ -53,7 +53,7 @@ exports[`Select > renders disabled state 1`] = `
   >
     <select
       aria-label="test"
-      class="flex-1 h-[var(--control-h)] px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-foreground placeholder:text-muted-foreground/70 caret-accent appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
+      class="flex-1 h-[var(--control-h)] px-[var(--space-14)] pr-[var(--space-36)] text-ui bg-transparent text-foreground placeholder:text-muted-foreground/70 caret-accent appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
       disabled=""
       id=":r4:"
       name="test"
@@ -95,7 +95,7 @@ exports[`Select > renders error state 1`] = `
       aria-describedby=":r2:-error"
       aria-invalid="true"
       aria-label="test"
-      class="flex-1 h-[var(--control-h)] px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-foreground placeholder:text-muted-foreground/70 caret-accent appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
+      class="flex-1 h-[var(--control-h)] px-[var(--space-14)] pr-[var(--space-36)] text-ui bg-transparent text-foreground placeholder:text-muted-foreground/70 caret-accent appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
       id=":r2:"
       name="test"
     >
@@ -123,7 +123,7 @@ exports[`Select > renders error state 1`] = `
     </svg>
   </div>
   <p
-    class="text-xs mt-1 line-clamp-2 text-danger"
+    class="text-label mt-1 line-clamp-2 text-danger"
     id=":r2:-error"
   >
     Error
@@ -140,7 +140,7 @@ exports[`Select > renders focus state 1`] = `
   >
     <select
       aria-label="test"
-      class="flex-1 h-[var(--control-h)] px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-foreground placeholder:text-muted-foreground/70 caret-accent appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
+      class="flex-1 h-[var(--control-h)] px-[var(--space-14)] pr-[var(--space-36)] text-ui bg-transparent text-foreground placeholder:text-muted-foreground/70 caret-accent appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
       id=":r1:"
       name="test"
     >
@@ -185,7 +185,7 @@ exports[`Select > renders success state 1`] = `
     <select
       aria-describedby=":r3:-success"
       aria-label="test"
-      class="flex-1 h-[var(--control-h)] px-[var(--space-14)] pr-[var(--space-36)] text-sm bg-transparent text-foreground placeholder:text-muted-foreground/70 caret-accent appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
+      class="flex-1 h-[var(--control-h)] px-[var(--space-14)] pr-[var(--space-36)] text-ui bg-transparent text-foreground placeholder:text-muted-foreground/70 caret-accent appearance-none disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none"
       id=":r3:"
       name="test"
     >

--- a/tests/ui/__snapshots__/textarea.test.tsx.snap
+++ b/tests/ui/__snapshots__/textarea.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Textarea > renders default state 1`] = `
   class="relative inline-flex w-full items-center rounded-[var(--control-radius)] overflow-hidden border border-card-hairline bg-card/60 backdrop-blur-[2px] shadow-control transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-control-hover focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),url('/noise.svg')] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] focus-within:after:opacity-100"
 >
   <textarea
-    class="block w-full max-w-full min-h-7 px-3 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground/70 focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default"
+    class="block w-full max-w-full min-h-7 px-3 py-3 text-body bg-transparent text-foreground placeholder:text-muted-foreground/70 focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default"
     id=":r0:"
     name="test"
   />
@@ -17,7 +17,7 @@ exports[`Textarea > renders disabled state 1`] = `
   class="relative inline-flex w-full items-center rounded-[var(--control-radius)] overflow-hidden border border-card-hairline bg-card/60 backdrop-blur-[2px] shadow-control transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-control-hover focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),url('/noise.svg')] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] focus-within:after:opacity-100 opacity-[var(--disabled)] pointer-events-none"
 >
   <textarea
-    class="block w-full max-w-full min-h-7 px-3 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground/70 focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default"
+    class="block w-full max-w-full min-h-7 px-3 py-3 text-body bg-transparent text-foreground placeholder:text-muted-foreground/70 focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default"
     disabled=""
     id=":r2:"
     name="test"
@@ -31,7 +31,7 @@ exports[`Textarea > renders error state 1`] = `
 >
   <textarea
     aria-invalid="true"
-    class="block w-full max-w-full min-h-7 px-3 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground/70 focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default"
+    class="block w-full max-w-full min-h-7 px-3 py-3 text-body bg-transparent text-foreground placeholder:text-muted-foreground/70 focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default"
     id=":r3:"
     name="test"
   />
@@ -43,7 +43,7 @@ exports[`Textarea > renders focus state 1`] = `
   class="relative inline-flex w-full items-center rounded-[var(--control-radius)] overflow-hidden border border-card-hairline bg-card/60 backdrop-blur-[2px] shadow-control transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-control-hover focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),url('/noise.svg')] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] focus-within:after:opacity-100"
 >
   <textarea
-    class="block w-full max-w-full min-h-7 px-3 py-3 text-base bg-transparent text-foreground placeholder:text-muted-foreground/70 focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default"
+    class="block w-full max-w-full min-h-7 px-3 py-3 text-body bg-transparent text-foreground placeholder:text-muted-foreground/70 focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default"
     id=":r1:"
     name="test"
   />

--- a/tests/ui/badge.test.tsx
+++ b/tests/ui/badge.test.tsx
@@ -26,7 +26,7 @@ describe('Badge', () => {
     const badge = getByText('Small');
     expect(badge).toHaveClass('px-[var(--space-2)]');
     expect(badge).toHaveClass('py-[var(--space-1)]');
-    expect(badge).toHaveClass('text-xs');
+    expect(badge).toHaveClass('text-label');
   });
 });
 


### PR DESCRIPTION
## Summary
- replace direct Tailwind font size utilities in components with the typography tokens (text-label/ui/body/title/title-lg)
- extend our `cn` helper to keep the custom font-size tokens when merging class names
- update tests and snapshots to reflect the new typography classes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b115d0bc832c8b4e2e9a25046906