### PR TITLE
Add GlitchProgress primitive and reuse it in planner views

### DIFF
--- a/src/components/planner/DayCardHeader.tsx
+++ b/src/components/planner/DayCardHeader.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { formatIsoLabel } from "@/lib/date";
-import { cn } from "@/lib/utils";
+import GlitchProgress from "@/components/ui/primitives/GlitchProgress";
 import type { ISODate } from "./plannerStore";
 
 type Props = {
@@ -32,19 +32,7 @@ export default function DayCardHeader({
       </span>
 
       <div className="flex-1 min-w-0">
-        <div
-          className={cn("glitch-track", pctNum === 100 && "is-complete")}
-          role="progressbar"
-          aria-valuemin={0}
-          aria-valuemax={100}
-          aria-valuenow={pctNum}
-        >
-          <div
-            className="glitch-fill transition-[width] duration-500 ease-out"
-            style={{ width: `${pctNum}%` }}
-          />
-          <div className="glitch-scan" />
-        </div>
+        <GlitchProgress current={doneTasks} total={totalTasks} />
       </div>
 
       <div className="shrink-0 flex items-baseline gap-3 text-xs text-muted-foreground">

--- a/src/components/planner/TodayHero.tsx
+++ b/src/components/planner/TodayHero.tsx
@@ -16,6 +16,7 @@ import { useDay } from "./useDay";
 import CheckCircle from "@/components/ui/toggles/CheckCircle";
 import Input from "@/components/ui/primitives/Input";
 import IconButton from "@/components/ui/primitives/IconButton";
+import GlitchProgress from "@/components/ui/primitives/GlitchProgress";
 import { Pencil, Trash2, Calendar } from "lucide-react";
 import type React from "react";
 
@@ -81,8 +82,6 @@ export default function TodayHero({ iso }: Props) {
       ),
     [scopedTasks],
   );
-  const pct = total === 0 ? 0 : Math.round((done / total) * 100);
-
   // Date picker
   const dateRef = useRef<HTMLInputElement>(null);
   const openPicker = () => {
@@ -127,27 +126,14 @@ export default function TodayHero({ iso }: Props) {
       </div>
 
       {/* Animated Progress of selected project */}
-      <div className="mb-4 flex items-center gap-3">
-        <div
-          className={cn("glitch-track w-full", pct === 100 && "is-complete")}
-          role="progressbar"
-          aria-valuemin={0}
-          aria-valuemax={100}
-          aria-valuenow={pct}
-        >
-          <div
-            className="glitch-fill transition-[width] duration-500 ease-out"
-            style={{ width: `${pct}%` }}
-          />
-          <div className="glitch-scan" />
-        </div>
-        <span
-          className="glitch-percent w-12 text-right text-ui font-medium"
-          aria-live="polite"
-        >
-          {pct}%
-        </span>
-      </div>
+      <GlitchProgress
+        current={done}
+        total={total}
+        showPercentage
+        className="mb-4 flex items-center gap-3"
+        trackClassName="w-full"
+        percentageClassName="glitch-percent w-12 text-right text-ui font-medium"
+      />
 
       {/* Projects */}
       <div className="mt-4 space-y-4">

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -10,6 +10,7 @@ import {
   GlitchSegmentedButton,
   TabBar,
   Progress,
+  GlitchProgress,
   Spinner,
   ThemeToggle,
   AnimationToggle,
@@ -592,6 +593,19 @@ export default function ComponentGallery() {
           <div className="w-56">
             <Progress value={50} />
           </div>
+        ),
+      },
+      {
+        label: "GlitchProgress",
+        element: (
+          <GlitchProgress
+            current={3}
+            total={5}
+            showPercentage
+            className="w-56 flex items-center gap-3"
+            trackClassName="flex-1"
+            percentageClassName="w-12 text-right"
+          />
         ),
       },
       {

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -45,6 +45,8 @@ export { default as Card } from "./primitives/Card";
 export * from "./primitives/Card";
 export { default as FieldShell } from "./primitives/FieldShell";
 export * from "./primitives/FieldShell";
+export { default as GlitchProgress } from "./primitives/GlitchProgress";
+export * from "./primitives/GlitchProgress";
 export * from "./primitives/GlitchSegmented";
 export { default as IconButton } from "./primitives/IconButton";
 export * from "./primitives/IconButton";

--- a/src/components/ui/primitives/GlitchProgress.tsx
+++ b/src/components/ui/primitives/GlitchProgress.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type GlitchProgressProps = React.HTMLAttributes<HTMLDivElement> & {
+  current: number;
+  total: number;
+  showPercentage?: boolean;
+  trackClassName?: string;
+  trackProps?: React.ComponentPropsWithoutRef<"div">;
+  percentageClassName?: string;
+  percentageProps?: React.ComponentPropsWithoutRef<"span">;
+  formatPercentage?: (value: number) => React.ReactNode;
+};
+
+const getSafeNumber = (value: number) => (Number.isFinite(value) ? value : 0);
+
+const GlitchProgress = React.forwardRef<HTMLDivElement, GlitchProgressProps>(
+  (
+    {
+      current,
+      total,
+      className,
+      trackClassName,
+      showPercentage = false,
+      trackProps,
+      percentageClassName,
+      percentageProps,
+      formatPercentage,
+      ...rest
+    },
+    ref,
+  ) => {
+    const parsedTotal = Math.max(0, getSafeNumber(total));
+    const parsedCurrent = getSafeNumber(current);
+    const normalizedCurrent =
+      parsedTotal === 0
+        ? 0
+        : Math.min(Math.max(parsedCurrent, 0), parsedTotal);
+    const ratio = parsedTotal === 0 ? 0 : normalizedCurrent / parsedTotal;
+    const percent = Math.round(ratio * 100);
+    const formattedPercentage =
+      formatPercentage?.(percent) ?? `${percent}%`;
+
+    const { className: trackClassNameFromProps, ...restTrackProps } =
+      trackProps ?? {};
+    const {
+      className: percentageClassNameFromProps,
+      "aria-live": ariaLive,
+      ...restPercentageProps
+    } = percentageProps ?? {};
+
+    const progressTrack = (
+      <div
+        {...restTrackProps}
+        {...(!showPercentage ? rest : {})}
+        className={cn(
+          "glitch-track",
+          trackClassNameFromProps,
+          trackClassName,
+          !showPercentage && className,
+          percent >= 100 && "is-complete",
+        )}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={percent}
+        ref={showPercentage ? undefined : ref}
+      >
+        <div
+          className="glitch-fill transition-[width] duration-500 ease-out"
+          style={{ width: `${percent}%` }}
+        />
+        <div className="glitch-scan" />
+      </div>
+    );
+
+    if (!showPercentage) {
+      return progressTrack;
+    }
+
+    return (
+      <div
+        {...rest}
+        ref={ref}
+        className={cn("flex items-center gap-3", className)}
+      >
+        {progressTrack}
+        <span
+          {...restPercentageProps}
+          className={cn(
+            "glitch-percent text-ui font-medium",
+            percentageClassNameFromProps,
+            percentageClassName,
+          )}
+          aria-live={ariaLive ?? "polite"}
+        >
+          {formattedPercentage}
+        </span>
+      </div>
+    );
+  },
+);
+
+GlitchProgress.displayName = "GlitchProgress";
+
+export default GlitchProgress;


### PR DESCRIPTION
## Summary
- add a GlitchProgress primitive that renders the glitch progress track with optional percentage label
- reuse the primitive in DayCardHeader and TodayHero to remove duplicated markup
- document the primitive in the component gallery and regenerate the UI index

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b1562d3c832c933b15003eca268b