### PR TITLE
feat(team): share champion list editor

### DIFF
--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -47,6 +47,7 @@ import ToggleShowcase from "./ToggleShowcase";
 import PageHeaderDemo from "./PageHeaderDemo";
 import NeomorphicHeroFrameDemo from "./NeomorphicHeroFrameDemo";
 import { DashboardCard, BottomNav, IsometricRoom } from "@/components/home";
+import ChampListEditor from "@/components/team/ChampListEditor";
 import {
   RoleSelector,
   ReviewListItem,
@@ -145,6 +146,31 @@ function BackgroundPickerDemo() {
       bg={t.bg}
       onBgChange={(b) => setT((prev) => ({ ...prev, bg: b }))}
     />
+  );
+}
+
+function ChampListEditorDemo() {
+  const [editing, setEditing] = React.useState(true);
+  const [list, setList] = React.useState<string[]>(["Ashe", "Lulu"]);
+
+  return (
+    <div className="space-y-3" data-scope="team">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-semibold tracking-[0.02em] text-muted-foreground">
+          Champions
+        </span>
+        <Button size="sm" onClick={() => setEditing((prev) => !prev)}>
+          {editing ? "Done" : "Edit"}
+        </Button>
+      </div>
+      <ChampListEditor
+        list={list}
+        onChange={setList}
+        editing={editing}
+        emptyLabel="-"
+        viewClassName="champ-badges mt-1 flex flex-wrap gap-2"
+      />
+    </div>
   );
 }
 
@@ -998,6 +1024,20 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       tags: ["side", "selector"],
       code: `<SideSelector />
 <SideSelector disabled />`,
+    },
+    {
+      id: "champ-list-editor",
+      name: "ChampListEditor",
+      description: "Shared champion list editor with toggleable state.",
+      element: <ChampListEditorDemo />,
+      tags: ["champion", "editor"],
+      code: `<ChampListEditor
+  list={list}
+  onChange={setList}
+  editing={editing}
+  emptyLabel="-"
+  viewClassName="champ-badges mt-1 flex flex-wrap gap-2"
+/>`,
     },
     {
       id: "pillar-badge",

--- a/src/components/team/ChampListEditor.tsx
+++ b/src/components/team/ChampListEditor.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import "./style.css";
+
+import * as React from "react";
+import { sanitizeList } from "@/lib/sanitizeList";
+import { cn } from "@/lib/utils";
+
+export type ChampListEditorProps = {
+  list?: string[];
+  onChange: (next: string[]) => void;
+  editing: boolean;
+  /**
+   * When provided, renders a fallback pill when the list is empty in view mode.
+   * Use `undefined` (default) to hide the component when no champs are present.
+   */
+  emptyLabel?: React.ReactNode;
+  viewClassName?: string;
+  editClassName?: string;
+  pillClassName?: string;
+  editPillClassName?: string;
+  inputClassName?: string;
+};
+
+const VIEW_CONTAINER = "champ-badges mt-1";
+const EDIT_CONTAINER = "champ-badges mt-1 flex flex-wrap gap-2";
+const PILL_BASE =
+  "champ-badge glitch-pill border-border bg-card text-foreground text-label font-medium tracking-[0.02em]";
+const INPUT_BASE =
+  "bg-transparent border-none rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring w-24";
+
+export default function ChampListEditor({
+  list,
+  onChange,
+  editing,
+  emptyLabel,
+  viewClassName,
+  editClassName,
+  pillClassName,
+  editPillClassName,
+  inputClassName,
+}: ChampListEditorProps) {
+  const sanitized = React.useMemo(() => sanitizeList(list ?? []), [list]);
+  const workingList = sanitized.length ? sanitized : [""];
+
+  function commit(next: string[]) {
+    onChange(sanitizeList(next));
+  }
+
+  function commitWithoutBlanks(next: string[]) {
+    const cleaned = sanitizeList(next).filter((item) => item.trim().length);
+    onChange(cleaned);
+  }
+
+  function setAt(index: number, value: string) {
+    const next = [...workingList];
+    next[index] = value;
+    commitWithoutBlanks(next);
+  }
+
+  function insertAfter(index: number) {
+    const next = [...workingList];
+    next.splice(index + 1, 0, "");
+    const sanitizedNext = sanitizeList(next);
+    commit(sanitizedNext.length ? sanitizedNext : [""]);
+  }
+
+  function removeAt(index: number) {
+    const next = [...workingList];
+    next.splice(index, 1);
+    commit(sanitizeList(next));
+  }
+
+  if (!editing) {
+    if (sanitized.length === 0) {
+      if (emptyLabel === undefined) return null;
+      return (
+        <div className={cn(VIEW_CONTAINER, viewClassName)}>
+          <span className={cn(PILL_BASE, pillClassName)}>
+            <i className="dot" />
+            {emptyLabel}
+          </span>
+        </div>
+      );
+    }
+
+    return (
+      <div className={cn(VIEW_CONTAINER, viewClassName)}>
+        {sanitized.map((champ, index) => (
+          <span key={index} className={cn(PILL_BASE, pillClassName)}>
+            <i className="dot" />
+            {champ}
+          </span>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn(EDIT_CONTAINER, editClassName)}>
+      {workingList.map((champ, index) => (
+        <span
+          key={index}
+          className={cn(PILL_BASE, editPillClassName ?? pillClassName)}
+        >
+          <i className="dot" />
+          <input
+            type="text"
+            dir="ltr"
+            value={champ}
+            onChange={(event) => setAt(index, event.currentTarget.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === ",") {
+                event.preventDefault();
+                insertAfter(index);
+              }
+              if (event.key === "Backspace" && !event.currentTarget.value) {
+                event.preventDefault();
+                removeAt(index);
+              }
+            }}
+            aria-label="Champion name"
+            autoComplete="off"
+            className={cn(INPUT_BASE, inputClassName)}
+          />
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -18,6 +18,7 @@ import { sanitizeText } from "@/lib/utils";
 import { sanitizeList } from "@/lib/sanitizeList";
 import { ROLES } from "./constants";
 import type { Role } from "./constants";
+import ChampListEditor from "./ChampListEditor";
 
 /* ───────────── types ───────────── */
 
@@ -190,23 +191,6 @@ function Label({ children }: { children: React.ReactNode }) {
   );
 }
 
-function ChampPillsView({ champs }: { champs?: string[] }) {
-  if (!champs?.length) return null;
-  return (
-    <div className="champ-badges mt-1">
-      {champs.map((c) => (
-        <span
-          key={c}
-          className="champ-badge glitch-pill border-border bg-card text-foreground text-label font-medium tracking-[0.02em]"
-        >
-          <i className="dot" />
-          {c}
-        </span>
-      ))}
-    </div>
-  );
-}
-
 /* ───────────── editable primitives ───────────── */
 
 function TitleEdit({
@@ -359,68 +343,6 @@ function BulletListEdit({
         </li>
       ))}
     </ul>
-  );
-}
-
-function ChampPillsEdit({
-  champs,
-  onChange,
-  editing,
-}: {
-  champs?: string[];
-  onChange: (list: string[]) => void;
-  editing: boolean;
-}) {
-  const list = champs ?? [];
-
-  if (!editing) return <ChampPillsView champs={list} />;
-
-  function setAt(i: number, next: string) {
-    const arr = [...list];
-    arr[i] = sanitizeText(next);
-    onChange(arr.filter((s) => s.trim().length));
-  }
-  function insertAfter(i: number) {
-    const arr = [...list];
-    arr.splice(i + 1, 0, "");
-    onChange(arr.length ? arr : [""]);
-  }
-  function removeAt(i: number) {
-    const arr = [...list];
-    arr.splice(i, 1);
-    onChange(arr);
-  }
-
-  return (
-    <div className="champ-badges mt-1 flex flex-wrap gap-2">
-      {(list.length ? list : [""]).map((c, i) => (
-        <span
-          key={i}
-          className="champ-badge border-border bg-card text-foreground text-label font-medium tracking-[0.02em]"
-        >
-          <i className="dot" />
-          <input
-            type="text"
-            dir="ltr"
-            value={c}
-            onChange={(e) => setAt(i, e.currentTarget.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === ",") {
-                e.preventDefault();
-                insertAfter(i);
-              }
-              if (e.key === "Backspace" && !e.currentTarget.value) {
-                e.preventDefault();
-                removeAt(i);
-              }
-            }}
-            aria-label="Champion name"
-            autoComplete="off"
-            className="bg-transparent border-none rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring w-24"
-          />
-        </span>
-      ))}
-    </div>
   );
 }
 
@@ -594,10 +516,11 @@ export default function CheatSheet({
                           >
                             {role}
                           </div>
-                          <ChampPillsEdit
-                            champs={champs ?? []}
+                          <ChampListEditor
+                            list={champs}
                             onChange={setChamps}
                             editing={isEditing}
+                            editPillClassName="champ-badge border-border bg-card text-foreground text-label font-medium tracking-[0.02em]"
                           />
                         </div>
                       );

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -28,9 +28,9 @@ import {
   NotebookPen,
   Plus,
 } from "lucide-react";
-import { sanitizeList } from "@/lib/sanitizeList";
 import { ROLES } from "./constants";
 import type { Role } from "./constants";
+import ChampListEditor from "./ChampListEditor";
 
 /* ───────────── Types ───────────── */
 
@@ -142,85 +142,6 @@ function normalize(list: unknown[]): TeamComp[] {
       updatedAt: safeNumber(raw.updatedAt, Date.now()),
     };
   });
-}
-
-/* ───────────── Chips Editor ───────────── */
-
-function ChampChips({
-  list,
-  onChange,
-  editing,
-}: {
-  list: string[] | undefined;
-  onChange: (next: string[]) => void;
-  editing: boolean;
-}) {
-  const champs = list ?? [];
-
-  if (!editing) {
-    return (
-      <div className="champ-badges mt-1 flex flex-wrap gap-2">
-        {(champs.length ? champs : ["-"]).map((c, i) => (
-          <span
-            key={i}
-            className="champ-badge glitch-pill border-border bg-card text-foreground text-label font-medium tracking-[0.02em]"
-          >
-            <i className="dot" />
-            {c}
-          </span>
-        ))}
-      </div>
-    );
-  }
-
-  function setAt(i: number, next: string) {
-    const arr = [...champs];
-    arr[i] = next;
-    onChange(sanitizeList(arr).filter((s) => s.trim().length));
-  }
-  function insertAfter(i: number) {
-    const arr = [...champs];
-    arr.splice(i + 1, 0, "");
-    const nextArr = arr.length ? arr : [""];
-    onChange(sanitizeList(nextArr));
-  }
-  function removeAt(i: number) {
-    const arr = [...champs];
-    arr.splice(i, 1);
-    onChange(sanitizeList(arr));
-  }
-
-  return (
-    <div className="champ-badges mt-1 flex flex-wrap gap-2">
-      {(champs.length ? champs : [""]).map((c, i) => (
-        <span
-          key={i}
-          className="champ-badge glitch-pill border-border bg-card text-foreground text-label font-medium tracking-[0.02em]"
-        >
-          <i className="dot" />
-          <input
-            type="text"
-            dir="ltr"
-            value={c}
-            onChange={(e) => setAt(i, e.currentTarget.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === ",") {
-                e.preventDefault();
-                insertAfter(i);
-              }
-              if (e.key === "Backspace" && !e.currentTarget.value) {
-                e.preventDefault();
-                removeAt(i);
-              }
-            }}
-            aria-label="Champion name"
-            autoComplete="off"
-            className="bg-transparent border-none rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring w-24"
-          />
-        </span>
-      ))}
-    </div>
-  );
 }
 
 /* ───────────── Component ───────────── */
@@ -446,10 +367,12 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
                           </div>
 
                           {/* chips editor/view */}
-                          <ChampChips
+                          <ChampListEditor
                             list={list}
                             onChange={setList}
                             editing={editing}
+                            emptyLabel="-"
+                            viewClassName="champ-badges mt-1 flex flex-wrap gap-2"
                           />
                         </div>
                       );


### PR DESCRIPTION
## Summary
- add a reusable ChampListEditor component that centralizes sanitization and editing interactions for champion lists
- refactor the Team MyComps and CheatSheet views to consume the shared editor while preserving their existing layouts
- surface the new editor in the prompts gallery for documentation and discovery

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b14b8bf0832c9a37641494090aac