### PR TITLE
Require aria label for PageTabs

### DIFF
--- a/src/components/chrome/PageTabs.tsx
+++ b/src/components/chrome/PageTabs.tsx
@@ -22,7 +22,7 @@ export interface PageTabsProps {
   sticky?: boolean;
   /** CSS top offset when sticky (supports tokens) */
   topOffset?: string;
-  ariaLabel?: string;
+  ariaLabel: string;
 }
 
 /**

--- a/tests/chrome/PageTabs.test.tsx
+++ b/tests/chrome/PageTabs.test.tsx
@@ -29,15 +29,21 @@ describe("PageTabs", () => {
   });
 
   it("updates hash only when value changes", () => {
-    const { rerender } = render(<PageTabs tabs={tabs} value="one" />);
+    const { rerender } = render(
+      <PageTabs tabs={tabs} value="one" ariaLabel="Planner sections" />,
+    );
     expect(replace).toHaveBeenCalledWith("/path#one", { scroll: false });
 
     replace.mockClear();
     window.location.hash = "#one";
-    rerender(<PageTabs tabs={tabs} value="one" />);
+    rerender(
+      <PageTabs tabs={tabs} value="one" ariaLabel="Planner sections" />,
+    );
     expect(replace).not.toHaveBeenCalled();
 
-    rerender(<PageTabs tabs={tabs} value="two" />);
+    rerender(
+      <PageTabs tabs={tabs} value="two" ariaLabel="Planner sections" />,
+    );
     expect(replace).toHaveBeenCalledWith("/path#two", { scroll: false });
   });
 });


### PR DESCRIPTION
## Summary
- require the PageTabs component to receive an aria-label so tablists always expose a name
- update the PageTabs test helper usage to supply a descriptive "Planner sections" label

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b3bb0850832c9e36bf934a186496