### PR TITLE
Add pill shape support to Button quick actions

### DIFF
--- a/src/components/home/QuickActions.tsx
+++ b/src/components/home/QuickActions.tsx
@@ -13,24 +13,13 @@ export default function QuickActions() {
   return (
     <section aria-label="Quick actions" className="grid gap-4">
       <div className="flex flex-col gap-4">
-        <Button
-          className="rounded-full focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
-          onClick={goPlanner}
-        >
+        <Button shape="pill" onClick={goPlanner}>
           Planner Today
         </Button>
-        <Button
-          className="rounded-full focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
-          tone="accent"
-          onClick={goGoals}
-        >
+        <Button shape="pill" tone="accent" onClick={goGoals}>
           New Goal
         </Button>
-        <Button
-          className="rounded-full focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
-          tone="accent"
-          onClick={goReviews}
-        >
+        <Button shape="pill" tone="accent" onClick={goReviews}>
           New Review
         </Button>
       </div>

--- a/src/components/prompts/ButtonShowcase.tsx
+++ b/src/components/prompts/ButtonShowcase.tsx
@@ -15,6 +15,7 @@ export default function ButtonShowcase() {
           Danger primary
         </Button>
         <Button disabled>Disabled</Button>
+        <Button shape="pill">Pill action</Button>
       </div>
       <div className="flex flex-wrap items-center gap-2">
         <Button size="sm">

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -44,6 +44,7 @@ export type ButtonProps = React.ComponentProps<typeof motion.button> & {
   variant?: "primary" | "secondary" | "ghost";
   tone?: Tone;
   loading?: boolean;
+  shape?: "default" | "pill";
 };
 
 export const colorVar: Record<Tone, string> = {
@@ -126,6 +127,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       loading,
       disabled,
       style,
+      shape = "default",
       ...rest
     },
     ref,
@@ -134,7 +136,8 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const isDisabled = disabled || loading;
     const s = buttonSizes[size];
     const base = cn(
-      "relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)]",
+      "relative inline-flex items-center justify-center border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)]",
+      shape === "pill" ? "rounded-full" : "rounded-[var(--control-radius)]",
       s.height,
       s.padding,
       s.text,

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -838,7 +838,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                             </div>
                           </div>
                           <button
-                            class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-10 gap-2 [&_svg]:size-5 px-4 whitespace-nowrap shadow-glow-sm bg-[hsl(var(--accent)/0.12)] border-[hsl(var(--accent)/0.35)] hover:bg-[hsl(var(--accent)/0.14)] hover:shadow-glow-md active:translate-y-px active:shadow-btn-primary-active text-foreground"
+                            class="relative inline-flex items-center justify-center border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] rounded-[var(--control-radius)] h-10 gap-2 [&_svg]:size-5 px-4 whitespace-nowrap shadow-glow-sm bg-[hsl(var(--accent)/0.12)] border-[hsl(var(--accent)/0.35)] hover:bg-[hsl(var(--accent)/0.14)] hover:shadow-glow-md active:translate-y-px active:shadow-btn-primary-active text-foreground"
                             style="--glow-active: hsl(var(--foreground) / 0.35);"
                             tabindex="0"
                             type="button"


### PR DESCRIPTION
## Summary
- add a pill shape option to the Button primitive so rounded controls use shared token styling
- switch home quick actions to the new pill shape and remove repeated inline class overrides
- surface the pill button option in the gallery showcase for documentation

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b37653e8832cac09dc6a6241f803