### PR TITLE
Add active styling for planner project cards

### DIFF
--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -62,6 +62,10 @@
   background: hsl(var(--card) / 0.7);
   border-color: hsl(var(--ring) / 0.45);
 }
+.proj-card:active {
+  --active: hsl(var(--panel) / 0.55);
+  background: hsl(var(--card) / 0.8);
+}
 .proj-card--active {
   border-color: hsl(var(--ring));
   box-shadow:


### PR DESCRIPTION
## Summary
- add an active state style for planner project cards that deepens the card background while exposing an --active token

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b3b29018832cb44825f6dbeded40