### PR TITLE
Add close control and aria hooks to modal

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -3,6 +3,8 @@
 import * as React from "react";
 import { createPortal } from "react-dom";
 import Card from "./primitives/Card";
+import IconButton from "./primitives/IconButton";
+import { X } from "lucide-react";
 import { useDialogTrap } from "./hooks/useDialogTrap";
 import useMounted from "@/lib/useMounted";
 import { cn } from "@/lib/utils";
@@ -10,6 +12,8 @@ import { cn } from "@/lib/utils";
 export interface ModalProps extends React.ComponentProps<typeof Card> {
   open: boolean;
   onClose: () => void;
+  "aria-labelledby"?: string;
+  "aria-describedby"?: string;
 }
 
 export default function Modal({
@@ -17,6 +21,8 @@ export default function Modal({
   onClose,
   className,
   children,
+  "aria-labelledby": ariaLabelledby,
+  "aria-describedby": ariaDescribedby,
   ...props
 }: ModalProps) {
   const mounted = useMounted();
@@ -27,18 +33,29 @@ export default function Modal({
   if (!open || !mounted) return null;
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center">
-      <div
-        aria-hidden="true"
-        className="absolute inset-0 bg-background/80"
+      <button
+        type="button"
+        aria-label="Close modal"
+        className="absolute inset-0 bg-background/80 transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[hsl(var(--background)/0.86)] active:bg-[hsl(var(--background)/0.92)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--focus]"
         onClick={onClose}
       />
       <Card
         ref={dialogRef}
         role="dialog"
         aria-modal="true"
+        aria-labelledby={ariaLabelledby}
+        aria-describedby={ariaDescribedby}
         className={cn("relative w-full max-w-sm", className)}
         {...props}
       >
+        <IconButton
+          aria-label="Close"
+          size="sm"
+          className="absolute right-3 top-3"
+          onClick={onClose}
+        >
+          <X />
+        </IconButton>
         {children}
       </Card>
     </div>,


### PR DESCRIPTION
## Summary
- add a dedicated close icon button inside the modal card that calls `onClose`
- expose `aria-labelledby` and `aria-describedby` props on the modal and forward them to the dialog element
- update the modal overlay to a button with design-token driven hover, focus, and active states

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b48b1cf8832c8eb69aa491e4f9db