### PR TITLE
chore(ci): avoid duplicate test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,3 @@ jobs:
       - name: Run checks
         run: npm run check
 
-      - name: Run tests
-        run: npm test


### PR DESCRIPTION
## Summary
- remove the standalone `npm test` step from the CI workflow so tests only run through `npm run check`

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b67fdc98832c92cce6718a15e426