### PR TITLE
Align PageTabs wrapper with page shell

### DIFF
--- a/src/components/chrome/PageTabs.tsx
+++ b/src/components/chrome/PageTabs.tsx
@@ -84,7 +84,7 @@ export default function PageTabs({
         .join(" ")}
       style={sticky ? { top: topOffset } : undefined}
     >
-      <div className="mx-auto max-w-6xl px-4">
+      <div className="page-shell">
         <div
           role="tablist"
           aria-label={ariaLabel}


### PR DESCRIPTION
## Summary
- replace the PageTabs inner container with the shared `page-shell` wrapper so the tabs respect the grid spacing tokens

## Testing
- npm run regen-ui
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b6c97098832c8b7de9b588554d42