### PR TITLE
Add Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- add Dependabot configuration to keep GitHub Actions up to date on a weekly schedule

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b68c207c832cb4a0ccfa55717911