### PR TITLE
Add skip link for main content

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,10 +42,18 @@ export default function RootLayout({
         />
       </head>
       <body className="min-h-screen bg-background text-foreground glitch-root">
+        <a
+          className="fixed left-[var(--space-4)] top-[var(--space-4)] z-50 inline-flex items-center rounded-[var(--radius-lg)] bg-background px-[var(--space-4)] py-[var(--space-2)] text-ui font-medium text-foreground shadow-outline-subtle outline-none transition-all duration-[var(--dur-quick)] ease-[var(--ease-out)] opacity-0 -translate-y-full pointer-events-none focus-visible:translate-y-0 focus-visible:opacity-100 focus-visible:pointer-events-auto focus-visible:shadow-ring focus-visible:no-underline focus-visible:outline-none hover:shadow-ring focus-visible:active:translate-y-[var(--space-1)]"
+          href="#main-content"
+        >
+          Skip to main content
+        </a>
         <ThemeProvider>
           <SiteChrome />
           <CatCompanion />
-          <div className="relative z-10">{children}</div>
+          <div id="main-content" tabIndex={-1} className="relative z-10">
+            {children}
+          </div>
         </ThemeProvider>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- add a skip navigation link that becomes visible on focus using design tokens
- mark the primary content wrapper with the main-content anchor target

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b5f043c8832c9aef42c14892fee8