### PR TITLE
Add aria labeling props to modal and sheet

### DIFF
--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -222,15 +222,20 @@ function NeoCardDemo() {
 
 function SheetDemo() {
   const [open, setOpen] = React.useState(false);
+  const titleId = React.useId();
   return (
     <>
       <Button size="sm" onClick={() => setOpen(true)}>
         Open
       </Button>
-      <Sheet open={open} onClose={() => setOpen(false)}>
+      <Sheet
+        open={open}
+        onClose={() => setOpen(false)}
+        ariaLabelledBy={titleId}
+      >
         <Card>
           <CardHeader>
-            <CardTitle>Sheet</CardTitle>
+            <CardTitle id={titleId}>Sheet</CardTitle>
           </CardHeader>
           <CardContent>
             <p className="text-ui">Content</p>
@@ -243,15 +248,20 @@ function SheetDemo() {
 
 function ModalDemo() {
   const [open, setOpen] = React.useState(false);
+  const titleId = React.useId();
   return (
     <>
       <Button size="sm" onClick={() => setOpen(true)}>
         Open
       </Button>
-      <Modal open={open} onClose={() => setOpen(false)}>
+      <Modal
+        open={open}
+        onClose={() => setOpen(false)}
+        ariaLabelledBy={titleId}
+      >
         <Card>
           <CardHeader>
-            <CardTitle>Modal</CardTitle>
+            <CardTitle id={titleId}>Modal</CardTitle>
           </CardHeader>
           <CardContent>
             <p className="text-ui">Content</p>
@@ -845,10 +855,10 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       element: <SheetDemo />,
       tags: ["sheet", "overlay"],
       code: `<Button size="sm">Open</Button>
-<Sheet open>
+<Sheet open ariaLabelledBy="sheet-title">
   <Card>
     <CardHeader>
-      <CardTitle>Sheet</CardTitle>
+      <CardTitle id="sheet-title">Sheet</CardTitle>
     </CardHeader>
     <CardContent>
       <p className="text-ui">Content</p>
@@ -862,10 +872,10 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       element: <ModalDemo />,
       tags: ["modal", "overlay"],
       code: `<Button size="sm">Open</Button>
-<Modal open>
+<Modal open ariaLabelledBy="modal-title">
   <Card>
     <CardHeader>
-      <CardTitle>Modal</CardTitle>
+      <CardTitle id="modal-title">Modal</CardTitle>
     </CardHeader>
     <CardContent>
       <p className="text-ui">Content</p>

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -10,6 +10,8 @@ import { cn } from "@/lib/utils";
 export interface ModalProps extends React.ComponentProps<typeof Card> {
   open: boolean;
   onClose: () => void;
+  ariaLabel?: string;
+  ariaLabelledBy?: string;
 }
 
 export default function Modal({
@@ -17,6 +19,8 @@ export default function Modal({
   onClose,
   className,
   children,
+  ariaLabel,
+  ariaLabelledBy,
   ...props
 }: ModalProps) {
   const mounted = useMounted();
@@ -36,6 +40,8 @@ export default function Modal({
         ref={dialogRef}
         role="dialog"
         aria-modal="true"
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
         className={cn("relative w-full max-w-sm", className)}
         {...props}
       >

--- a/src/components/ui/Sheet.tsx
+++ b/src/components/ui/Sheet.tsx
@@ -12,6 +12,8 @@ export interface SheetProps extends React.ComponentProps<typeof Card> {
   open: boolean;
   onClose: () => void;
   side?: "left" | "right";
+  ariaLabel?: string;
+  ariaLabelledBy?: string;
 }
 
 export default function Sheet({
@@ -20,6 +22,8 @@ export default function Sheet({
   side = "right",
   className,
   children,
+  ariaLabel,
+  ariaLabelledBy,
   ...props
 }: SheetProps) {
   const mounted = useMounted();
@@ -48,6 +52,8 @@ export default function Sheet({
           ref={dialogRef}
           role="dialog"
           aria-modal="true"
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledBy}
           className={cn(
             "fixed top-0 h-full w-80 overflow-y-auto",
             side === "right" ? "right-0" : "left-0",


### PR DESCRIPTION
## Summary
- extend the Modal and Sheet primitives with optional aria labeling props and forward them to the dialog card
- label the prompt gallery modal and sheet demos and update the example code snippets

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b5fdf410832cb29d016c2ab7d306