### PR TITLE
Enable concurrency cancellation for Next.js workflow

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -22,7 +22,7 @@ permissions:
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # Build job


### PR DESCRIPTION
## Summary
- enable cancellation of in-progress runs for the Next.js deployment workflow to avoid redundant queued jobs

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b7d6f2c0832ca9ccdccede3b6bcc