### PR TITLE
Streamline Next.js deploy workflow checks

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -82,9 +82,11 @@ jobs:
       - name: Run checks
         run: |
           if [ "${{ steps.detect-package-manager.outputs.manager }}" = "yarn" ]; then
-            ${{ steps.detect-package-manager.outputs.runner }} check
+            yarn lint
+            yarn typecheck
           else
-            npm run check
+            npm run lint
+            npm run typecheck
           fi
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build


### PR DESCRIPTION
## Summary
- limit the Pages workflow check step to lint and typecheck commands

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b84dabe8832cad835f3bd35a439d