### PR TITLE
Add shared debounce hook and use it in search components

### DIFF
--- a/src/components/prompts/PromptsHeader.tsx
+++ b/src/components/prompts/PromptsHeader.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { Button, SearchBar } from "@/components/ui";
 import Badge from "@/components/ui/primitives/Badge";
+import useDebouncedCallback from "@/lib/useDebouncedCallback";
 
 interface PromptsHeaderProps {
   count: number;
@@ -20,25 +21,18 @@ export default function PromptsHeader({
   disabled,
 }: PromptsHeaderProps) {
   const [localQuery, setLocalQuery] = React.useState(query);
-  const debounceRef = React.useRef<number>();
+  const [emitQueryChange] = useDebouncedCallback(onQueryChange, 300);
 
   React.useEffect(() => {
     setLocalQuery(query);
   }, [query]);
 
-  React.useEffect(() => {
-    return () => {
-      window.clearTimeout(debounceRef.current);
-    };
-  }, []);
-
   const handleChange = React.useCallback(
     (val: string) => {
       setLocalQuery(val);
-      window.clearTimeout(debounceRef.current);
-      debounceRef.current = window.setTimeout(() => onQueryChange(val), 300);
+      emitQueryChange(val);
     },
-    [onQueryChange],
+    [emitQueryChange],
   );
 
   const handleChip = (chip: string) => {

--- a/src/lib/useDebouncedCallback.ts
+++ b/src/lib/useDebouncedCallback.ts
@@ -1,0 +1,47 @@
+import * as React from "react";
+
+type AnyArgs = readonly unknown[];
+
+export default function useDebouncedCallback<TArgs extends AnyArgs>(
+  callback: (...args: TArgs) => void | Promise<void>,
+  delay: number,
+): readonly [(...args: TArgs) => void, () => void] {
+  const latestCallback = React.useRef(callback);
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  React.useEffect(() => {
+    latestCallback.current = callback;
+  }, [callback]);
+
+  const cancel = React.useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  React.useEffect(() => cancel, [cancel]);
+
+  React.useEffect(() => {
+    cancel();
+  }, [delay, cancel]);
+
+  const debounced = React.useCallback(
+    (...args: TArgs) => {
+      cancel();
+
+      if (delay <= 0) {
+        void latestCallback.current(...args);
+        return;
+      }
+
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        void latestCallback.current(...args);
+      }, delay);
+    },
+    [cancel, delay],
+  );
+
+  return React.useMemo(() => [debounced, cancel] as const, [debounced, cancel]);
+}


### PR DESCRIPTION
## Summary
- add a reusable `useDebouncedCallback` hook that manages timeout cleanup
- refactor `SearchBar` and `PromptsHeader` to use the shared debounce helper

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b831eedc832ca60757facdb7cf2e