### PR TITLE
Tokenize iris cyan color

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -1,98 +1,98 @@
-| Token                | Value                                                  |
-| -------------------- | ------------------------------------------------------ |
-| background           | 246 35% 7%                                             |
-| foreground           | 260 20% 96%                                            |
-| text                 | var(--foreground)                                      |
-| card                 | 248 30% 10%                                            |
-| panel                | var(--card)                                            |
-| border               | 252 20% 22%                                            |
-| line                 | var(--border)                                          |
-| input                | 250 22% 12%                                            |
-| ring                 | 262 83% 58%                                            |
-| theme-ring           | hsl(var(--ring))                                       |
-| primary              | 262 83% 58%                                            |
-| primary-foreground   | 0 0% 100%                                              |
-| primary-soft         | 262 83% 18%                                            |
-| accent               | 292 90% 35%                                            |
-| accent-2             | 192 100% 25%                                           |
-| accent-foreground    | 0 0% 100%                                              |
-| accent-soft          | 292 90% 15%                                            |
-| glow                 | 292 90% 35%                                            |
-| ring-muted           | 248 20% 22%                                            |
-| danger               | 0 84% 60%                                              |
-| warning              | 43 96% 56%                                             |
-| muted                | 248 26% 14%                                            |
-| muted-foreground     | 250 15% 70%                                            |
-| surface              | 248 24% 12%                                            |
-| surface-2            | 248 24% 16%                                            |
-| surface-vhs          | 210 27% 6%                                             |
-| surface-streak       | 240 16% 12%                                            |
-| shadow-color         | 262 83% 58%                                            |
-| lav-deep             | 320 85% 60%                                            |
-| team-blue            | 200 100% 60%                                           |
-| team-red             | 0 85% 60%                                              |
-| noir-background      | 350 70% 4%                                             |
-| noir-foreground      | 0 0% 92%                                               |
-| noir-border          | 350 40% 22%                                            |
-| hardstuck-background | 165 60% 3%                                             |
-| hardstuck-foreground | 160 12% 95%                                            |
-| hardstuck-border     | 165 40% 22%                                            |
-| success              | 316 92% 70%                                            |
-| success-glow         | 316 92% 52% / 0.6                                      |
-| tone-top             | 38 92% 60%                                             |
-| tone-jg              | 152 52% 44%                                            |
-| tone-mid             | 265 72% 62%                                            |
-| tone-bot             | 195 75% 56%                                            |
-| tone-sup             | 320 72% 60%                                            |
-| aurora-g             | var(--accent-2)                                        |
-| aurora-g-light       | color-mix(in oklab, hsl(var(--accent-2)) 37.5%, white) |
-| aurora-p             | var(--accent)                                          |
-| aurora-p-light       | color-mix(in oklab, hsl(var(--accent)) 37.5%, white)   |
-| icon-fg              | 247 100% 77%                                           |
-| accent-overlay       | hsl(var(--accent))                                     |
-| ring-contrast        | hsl(var(--ring))                                       |
-| glow-active          | hsl(var(--glow))                                       |
-| text-on-accent       | hsl(var(--foreground))                                 |
-| neon                 | var(--glow)                                            |
-| neon-soft            | hsl(var(--neon))                                       |
-| btn-bg               | transparent                                            |
-| btn-fg               | hsl(var(--foreground))                                 |
-| hover                | hsl(var(--foreground) / 0.08)                          |
-| focus                | hsl(var(--ring))                                       |
-| active               | hsl(var(--foreground) / 0.12)                          |
-| disabled             | 0.5                                                    |
-| loading              | 0.6                                                    |
-| card-hairline        | hsl(var(--border))                                     |
-| hairline-w           | 1px                                                    |
-| ease-out             | cubic-bezier(0.16, 1, 0.3, 1)                          |
-| ease-snap            | cubic-bezier(0.2, 0.8, 0.2, 1)                         |
-| dur-quick            | 140ms                                                  |
-| dur-chill            | 220ms                                                  |
-| dur-slow             | 420ms                                                  |
-| control-h-sm         | 36px                                                   |
-| control-h-md         | 40px                                                   |
-| control-h-lg         | 44px                                                   |
-| control-h            | var(--control-h-md)                                    |
-| control-radius       | var(--radius-xl)                                       |
-| control-fs           | 0.9rem                                                 |
-| control-px           | var(--spacing-3)                                       |
-| header-stack         | calc(var(--spacing-8) + var(--spacing-4))              |
-| edge-iris            | conic-gradient(                                        |
-
+| Token | Value |
+| --- | --- |
+| background | 246 35% 7% |
+| foreground | 260 20% 96% |
+| text | var(--foreground) |
+| card | 248 30% 10% |
+| panel | var(--card) |
+| border | 252 20% 22% |
+| line | var(--border) |
+| input | 250 22% 12% |
+| ring | 262 83% 58% |
+| theme-ring | hsl(var(--ring)) |
+| primary | 262 83% 58% |
+| primary-foreground | 0 0% 100% |
+| primary-soft | 262 83% 18% |
+| accent | 292 90% 35% |
+| accent-2 | 192 100% 25% |
+| iris-cyan | 192 90% 50% |
+| accent-foreground | 0 0% 100% |
+| accent-soft | 292 90% 15% |
+| highlight | 0 0% 100% |
+| glow | 292 90% 35% |
+| ring-muted | 248 20% 22% |
+| danger | 0 84% 60% |
+| warning | 43 96% 56% |
+| muted | 248 26% 14% |
+| muted-foreground | 250 15% 70% |
+| surface | 248 24% 12% |
+| surface-2 | 248 24% 16% |
+| surface-vhs | 210 27% 6% |
+| surface-streak | 240 16% 12% |
+| shadow-color | 262 83% 58% |
+| lav-deep | 320 85% 60% |
+| team-blue | 200 100% 60% |
+| team-red | 0 85% 60% |
+| noir-background | 350 70% 4% |
+| noir-foreground | 0 0% 92% |
+| noir-border | 350 40% 22% |
+| hardstuck-background | 165 60% 3% |
+| hardstuck-foreground | 160 12% 95% |
+| hardstuck-border | 165 40% 22% |
+| success | 316 92% 70% |
+| success-glow | 316 92% 52% / 0.6 |
+| tone-top | 38 92% 60% |
+| tone-jg | 152 52% 44% |
+| tone-mid | 265 72% 62% |
+| tone-bot | 195 75% 56% |
+| tone-sup | 320 72% 60% |
+| aurora-g | var(--accent-2) |
+| aurora-g-light | color-mix(in oklab, hsl(var(--accent-2)) 37.5%, white) |
+| aurora-p | var(--accent) |
+| aurora-p-light | color-mix(in oklab, hsl(var(--accent)) 37.5%, white) |
+| icon-fg | 247 100% 77% |
+| accent-overlay | hsl(var(--accent)) |
+| ring-contrast | hsl(var(--ring)) |
+| glow-active | hsl(var(--glow)) |
+| text-on-accent | hsl(var(--foreground)) |
+| neon | var(--glow) |
+| neon-soft | hsl(var(--neon)) |
+| btn-bg | transparent |
+| btn-fg | hsl(var(--foreground)) |
+| hover | hsl(var(--foreground) / 0.08) |
+| focus | hsl(var(--ring)) |
+| active | hsl(var(--foreground) / 0.12) |
+| disabled | 0.5 |
+| loading | 0.6 |
+| card-hairline | hsl(var(--border)) |
+| hairline-w | 1px |
+| ease-out | cubic-bezier(0.16, 1, 0.3, 1) |
+| ease-snap | cubic-bezier(0.2, 0.8, 0.2, 1) |
+| dur-quick | 140ms |
+| dur-chill | 220ms |
+| dur-slow | 420ms |
+| control-h-sm | 36px |
+| control-h-md | 40px |
+| control-h-lg | 44px |
+| control-h | var(--control-h-md) |
+| control-radius | var(--radius-xl) |
+| control-fs | 0.9rem |
+| control-px | var(--spacing-3) |
+| header-stack | calc(var(--spacing-8) + var(--spacing-4)) |
+| edge-iris | conic-gradient(
     from 180deg,
     hsl(262 83% 58% / 0),
     hsl(262 83% 58% / 0.7),
-    hsl(192 90% 50% / 0.7),
+    hsl(var(--iris-cyan) / 0.7),
     hsl(320 85% 60% / 0.7),
     hsl(262 83% 58% / 0)
-
-) |
+  ) |
 | seg-active-grad | linear-gradient(
-90deg,
-hsl(262 83% 58% / 0.95),
-hsl(292 80% 60% / 0.95),
-hsl(192 90% 50% / 0.95)
-) |
+    90deg,
+    hsl(262 83% 58% / 0.95),
+    hsl(292 80% 60% / 0.95),
+    hsl(var(--iris-cyan) / 0.95)
+  ) |
 | shadow | 0 10px 30px hsl(250 30% 2% / 0.35) |
 | lg-violet | var(--ring) |
 | lg-cyan | var(--accent-2) |
@@ -111,13 +111,15 @@ hsl(192 90% 50% / 0.95)
 | font-size-md | 20px |
 | font-weight-bold | 800 |
 | shadow-neon | 0 0 var(--space-1) hsl(var(--neon) / 0.55),
-0 0 calc(var(--space-3) - var(--space-1) / 2) hsl(var(--neon) / 0.35),
-0 0 calc(var(--space-4) + var(--space-1) / 2) hsl(var(--neon) / 0.2) |
+    0 0 calc(var(--space-3) - var(--space-1) / 2) hsl(var(--neon) / 0.35),
+    0 0 calc(var(--space-4) + var(--space-1) / 2) hsl(var(--neon) / 0.2) |
 | font-label | 12px |
 | font-ui | 14px |
 | font-body | 16px |
 | font-title | 20px |
 | font-title-lg | 24px |
+| btn-primary-hover-shadow | 0 2px 6px -1px hsl(var(--accent) / 0.25) |
+| btn-primary-active-shadow | inset 0 0 0 1px hsl(var(--accent) / 0.6) |
 | spacing-1 | 4px |
 | spacing-2 | 8px |
 | spacing-3 | 12px |

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,7 +4,6 @@
 @layer base {
   :root {
     --shell-max: 1120px;
-    --iris-cyan: 192 90% 50%;
   }
 
   .page-shell {

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -18,6 +18,7 @@
   --primary-soft: 262 83% 18%;
   --accent: 292 90% 35%;
   --accent-2: 192 100% 25%;
+  --iris-cyan: 192 90% 50%;
   --accent-foreground: 0 0% 100%;
   --accent-soft: 292 90% 15%;
   --highlight: 0 0% 100%;
@@ -85,7 +86,7 @@
     from 180deg,
     hsl(262 83% 58% / 0),
     hsl(262 83% 58% / 0.7),
-    hsl(192 90% 50% / 0.7),
+    hsl(var(--iris-cyan) / 0.7),
     hsl(320 85% 60% / 0.7),
     hsl(262 83% 58% / 0)
   );
@@ -93,7 +94,7 @@
     90deg,
     hsl(262 83% 58% / 0.95),
     hsl(292 80% 60% / 0.95),
-    hsl(192 90% 50% / 0.95)
+    hsl(var(--iris-cyan) / 0.95)
   );
   --shadow: 0 10px 30px hsl(250 30% 2% / 0.35);
   --lg-violet: var(--ring);
@@ -112,8 +113,7 @@
   --space-8: var(--spacing-8);
   --font-size-md: 20px;
   --font-weight-bold: 800;
-  --shadow-neon:
-    0 0 var(--space-1) hsl(var(--neon) / 0.55),
+  --shadow-neon: 0 0 var(--space-1) hsl(var(--neon) / 0.55),
     0 0 calc(var(--space-3) - var(--space-1) / 2) hsl(var(--neon) / 0.35),
     0 0 calc(var(--space-4) + var(--space-1) / 2) hsl(var(--neon) / 0.2);
   --font-label: 12px;
@@ -121,6 +121,8 @@
   --font-body: 16px;
   --font-title: 20px;
   --font-title-lg: 24px;
+  --btn-primary-hover-shadow: 0 2px 6px -1px hsl(var(--accent) / 0.25);
+  --btn-primary-active-shadow: inset 0 0 0 1px hsl(var(--accent) / 0.6);
   --spacing-1: 4px;
   --spacing-2: 8px;
   --spacing-3: 12px;

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -18,6 +18,7 @@ export default {
   primarySoft: "262 83% 18%",
   accent: "292 90% 35%",
   accent2: "192 100% 25%",
+  irisCyan: "192 90% 50%",
   accentForeground: "0 0% 100%",
   accentSoft: "292 90% 15%",
   highlight: "0 0% 100%",
@@ -82,9 +83,9 @@ export default {
   controlPx: "var(--spacing-3)",
   headerStack: "calc(var(--spacing-8) + var(--spacing-4))",
   edgeIris:
-    "conic-gradient(\n    from 180deg,\n    hsl(262 83% 58% / 0),\n    hsl(262 83% 58% / 0.7),\n    hsl(192 90% 50% / 0.7),\n    hsl(320 85% 60% / 0.7),\n    hsl(262 83% 58% / 0)\n  )",
+    "conic-gradient(\n    from 180deg,\n    hsl(262 83% 58% / 0),\n    hsl(262 83% 58% / 0.7),\n    hsl(var(--iris-cyan) / 0.7),\n    hsl(320 85% 60% / 0.7),\n    hsl(262 83% 58% / 0)\n  )",
   segActiveGrad:
-    "linear-gradient(\n    90deg,\n    hsl(262 83% 58% / 0.95),\n    hsl(292 80% 60% / 0.95),\n    hsl(192 90% 50% / 0.95)\n  )",
+    "linear-gradient(\n    90deg,\n    hsl(262 83% 58% / 0.95),\n    hsl(292 80% 60% / 0.95),\n    hsl(var(--iris-cyan) / 0.95)\n  )",
   shadow: "0 10px 30px hsl(250 30% 2% / 0.35)",
   lgViolet: "var(--ring)",
   lgCyan: "var(--accent-2)",
@@ -109,6 +110,8 @@ export default {
   fontBody: "16px",
   fontTitle: "20px",
   fontTitleLg: "24px",
+  btnPrimaryHoverShadow: "0 2px 6px -1px hsl(var(--accent) / 0.25)",
+  btnPrimaryActiveShadow: "inset 0 0 0 1px hsl(var(--accent) / 0.6)",
   spacing1: "4px",
   spacing2: "8px",
   spacing3: "12px",


### PR DESCRIPTION
## Summary
- add the iris cyan hue to the generated design tokens (CSS/JS/docs)
- update gradients to consume the new token and drop the local globals override

## Testing
- npm run generate-tokens
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b8a96d34832c92ef2e0a34b114a8