### PR TITLE
Hoist chips constant in prompts header

### DIFF
--- a/src/components/prompts/PromptsHeader.tsx
+++ b/src/components/prompts/PromptsHeader.tsx
@@ -5,6 +5,8 @@ import { Button, SearchBar } from "@/components/ui";
 import Badge from "@/components/ui/primitives/Badge";
 import useDebouncedCallback from "@/lib/useDebouncedCallback";
 
+const chips = ["hover", "focus", "active", "disabled", "loading"];
+
 interface PromptsHeaderProps {
   count: number;
   query: string;
@@ -39,8 +41,6 @@ export default function PromptsHeader({
     setLocalQuery(chip);
     onQueryChange(chip);
   };
-
-  const chips = ["hover", "focus", "active", "disabled", "loading"];
 
   return (
     <div className="flex items-center justify-between w-full">


### PR DESCRIPTION
## Summary
- move the prompts header chips list to module scope so the component reuses the constant each render

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ba12af30832c8dc7cf01f47091b9