### PR TITLE
Remove redundant planner focus sync effect

### DIFF
--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -29,9 +29,6 @@ import { addDays, toISODate } from "@/lib/date";
 
 function Inner() {
   const { iso, today, setIso } = useFocusDate();
-  React.useEffect(() => {
-    setIso(iso);
-  }, [iso, setIso]);
   const { start, days } = useWeek(iso);
 
   // Derive once per week change; keeps list stable during edits elsewhere


### PR DESCRIPTION
## Summary
- remove the redundant focus synchronization effect from `PlannerPage`
- rely on the existing `PlannerProvider` persistence for the current focus date

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ba2befbc832c971d331534744dd1