### PR TITLE
Use npm build script in Next.js deployment workflow

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run checks
         run: npm run check
       - name: Build with Next.js
-        run: npx next build
+        run: npm run build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b
         with:


### PR DESCRIPTION
## Summary
- switch the GitHub Actions build step to use `npm run build`
- keep the Pages artifact upload pointing at the generated `out` directory

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ba3c7624832cad5884dfc4d117da