### PR TITLE
Add skeleton loading component

### DIFF
--- a/src/app/prompts/PromptsPage.tsx
+++ b/src/app/prompts/PromptsPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { PageHeader, PageShell, Button, IconButton } from "@/components/ui";
+import { PageHeader, PageShell, Button, IconButton, Skeleton } from "@/components/ui";
 import { Sparkles, Plus } from "lucide-react";
 import ComponentsView from "@/components/prompts/ComponentsView";
 import ColorsView from "@/components/prompts/ColorsView";
@@ -18,9 +18,49 @@ import { useRouter, useSearchParams } from "next/navigation";
 
 export default function Page() {
   return (
-    <React.Suspense fallback={<p className="p-4 text-sm">Loading...</p>}>
+    <React.Suspense fallback={<PromptsPageFallback />}>
       <PageContent />
     </React.Suspense>
+  );
+}
+
+function PromptsPageFallback() {
+  return (
+    <PageShell
+      as="main"
+      className="space-y-6 py-6"
+      aria-labelledby="prompts-loading-title"
+      aria-busy="true"
+    >
+      <div role="status" aria-live="polite" className="space-y-6">
+        <span id="prompts-loading-title" className="sr-only">
+          Loading Prompts Playground
+        </span>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-2/5 sm:w-1/3" radius="card" />
+            <Skeleton className="w-3/5 sm:w-1/2" />
+          </div>
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <Skeleton className="h-10 w-full md:w-96" radius="card" />
+            <div className="flex gap-3 md:flex-none">
+              <Skeleton className="h-10 w-24" radius="card" />
+              <Skeleton className="h-10 w-10" radius="full" />
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Skeleton className="h-9 w-28 flex-1" radius="full" />
+            <Skeleton className="h-9 w-28 flex-1" radius="full" />
+            <Skeleton className="h-9 w-28 flex-1" radius="full" />
+          </div>
+        </div>
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <Skeleton className="h-64" radius="card" />
+          <Skeleton className="h-64" radius="card" />
+          <Skeleton className="h-64 lg:col-span-2" radius="card" />
+        </div>
+      </div>
+    </PageShell>
   );
 }
 

--- a/src/components/prompts/SkeletonShowcase.tsx
+++ b/src/components/prompts/SkeletonShowcase.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "@/components/ui";
+
+export default function SkeletonShowcase() {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Skeleton className="h-6 w-2/5 sm:w-1/3" radius="card" />
+        <Skeleton className="w-full" />
+        <Skeleton className="w-5/6" />
+      </div>
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-12 w-12 flex-none" radius="full" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="w-3/4" />
+          <Skeleton className="w-2/3" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -43,6 +43,7 @@ import PromptList from "./PromptList";
 import SelectShowcase from "./SelectShowcase";
 import SpinnerShowcase from "./SpinnerShowcase";
 import SnackbarShowcase from "./SnackbarShowcase";
+import SkeletonShowcase from "./SkeletonShowcase";
 import ToggleShowcase from "./ToggleShowcase";
 import PageHeaderDemo from "./PageHeaderDemo";
 import NeomorphicHeroFrameDemo from "./NeomorphicHeroFrameDemo";
@@ -959,6 +960,18 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       element: <SnackbarShowcase />,
       tags: ["snackbar", "feedback"],
       code: `<Snackbar message="Saved" actionLabel="Undo" onAction={() => {}} />`,
+    },
+    {
+      id: "skeleton",
+      name: "Skeleton",
+      description: "Shimmer placeholder for loading layouts.",
+      element: <SkeletonShowcase />,
+      tags: ["skeleton", "loading", "feedback"],
+      code: `<div className="space-y-2">
+  <Skeleton />
+  <Skeleton className="w-3/4" />
+  <Skeleton radius="full" className="h-10 w-10" />
+</div>`,
     },
     {
       id: "spinner",

--- a/src/components/ui/feedback/Skeleton.tsx
+++ b/src/components/ui/feedback/Skeleton.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const radiusClasses = {
+  sm: "rounded-md",
+  md: "rounded-lg",
+  lg: "rounded-xl",
+  card: "rounded-card",
+  full: "rounded-full",
+} as const;
+
+export type SkeletonRadius = keyof typeof radiusClasses;
+
+export interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
+  radius?: SkeletonRadius;
+}
+
+const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(
+  ({ className, radius = "md", ...props }, ref) => (
+    <div
+      ref={ref}
+      aria-hidden="true"
+      className={cn("skeleton h-4 w-full", radiusClasses[radius], className)}
+      {...props}
+    />
+  ),
+);
+
+Skeleton.displayName = "Skeleton";
+
+export default Skeleton;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -13,6 +13,8 @@ export * from "./Sheet";
 export { default as Toast } from "./Toast";
 export * from "./Toast";
 export { default as Progress } from "./feedback/Progress";
+export { default as Skeleton } from "./feedback/Skeleton";
+export * from "./feedback/Skeleton";
 export { default as Snackbar } from "./feedback/Snackbar";
 export { default as Spinner } from "./feedback/Spinner";
 export * from "./hooks/useDialogTrap";


### PR DESCRIPTION
## Summary
- add a reusable Skeleton feedback component and export it through the UI index
- replace the prompts page suspense fallback with a structured skeleton layout
- document the skeleton in the prompts component gallery via a dedicated showcase

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8b8da0cdc832cabbe251b2e424005