### PR TITLE
Remove redundant sr-only label from task selector

### DIFF
--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -89,7 +89,6 @@ export default function TaskRow({
           )}
           data-focus-within={hasFocusWithin ? "true" : undefined}
         >
-          <span className="sr-only">{`Select task ${task.title}`}</span>
         </button>
 
         <div


### PR DESCRIPTION
## Summary
- remove the redundant visually hidden span inside the task selection button because the button already exposes an aria-label

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8bbba2808832c90cc271e3cbcc834