### PR TITLE
Prefix GitHub Pages flag for deploy build

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "postinstall": "tsx scripts/regen-if-needed.ts",
     "prepare": "husky",
     "launch": "ts-node --esm scripts/launcher.ts",
-    "deploy": "npm run build && npx -y gh-pages -d out -b gh-pages"
+    "deploy": "GITHUB_PAGES=1 npm run build && npx -y gh-pages -d out -b gh-pages"
   },
   "dependencies": {
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- prefix `GITHUB_PAGES=1` when running the deploy build so the export picks up the GitHub Pages base path
- verified that the flag triggers the `/Planner` base path by rebuilding with the environment variable set

## Testing
- CI=1 npm run check
- CI=1 GITHUB_PAGES=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8bb581404832ca870f9f53f76adff