### PR TITLE
Use spacing tokens for primary button shadows

### DIFF
--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -14,8 +14,10 @@
     0 0 var(--space-1) hsl(var(--neon) / 0.55),
     0 0 calc(var(--space-3) - var(--space-1) / 2) hsl(var(--neon) / 0.35),
     0 0 calc(var(--space-4) + var(--space-1) / 2) hsl(var(--neon) / 0.2);
-  --btn-primary-hover-shadow: 0 2px 6px -1px hsl(var(--accent) / 0.25);
-  --btn-primary-active-shadow: inset 0 0 0 1px hsl(var(--accent) / 0.6);
+  --btn-primary-hover-shadow: 0 calc(var(--space-1) / 2) calc(var(--space-3) / 2)
+    calc(-1 * var(--space-1) / 4) hsl(var(--accent) / 0.25);
+  --btn-primary-active-shadow: inset 0 0 0 calc(var(--space-1) / 4)
+    hsl(var(--accent) / 0.6);
 }
 
 /* Upgrade tokens when color-mix(oklab) is supported */


### PR DESCRIPTION
## Summary
- replace the primary button hover and active shadows to express all offsets with spacing tokens instead of hard-coded pixel values

## Testing
- npm run check
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68c8bb9fce40832cb27181761f7fdb9b