### PR TITLE
Throttle WeekPicker scroll handler

### DIFF
--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -119,13 +119,27 @@ export default function WeekPicker() {
   // Show "Jump to top" button after a double-click jump; hide when back at top
   const [showTop, setShowTop] = React.useState(false);
   React.useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+
+    let frameId: number | null = null;
+
     const onScroll = () => {
-      if (typeof window === "undefined") return;
-      const atTop = window.scrollY <= 4;
-      setShowTop((prev) => (atTop ? false : prev));
+      if (frameId !== null) return;
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        const atTop = window.scrollY <= 4;
+        setShowTop((prev) => (atTop ? false : prev));
+      });
     };
+
     window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
+
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+      }
+    };
   }, []);
 
   // Select (single-click) vs jump (double-click)


### PR DESCRIPTION
## Summary
- throttle the WeekPicker scroll listener with requestAnimationFrame to minimize handler churn
- cancel any pending animation frame during cleanup to avoid stray updates

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8c0e1530c832ca46b31031ed88604