### PR TITLE
Add reduced motion helper and integrate in UI

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -25,6 +25,7 @@ import GoalList from "./GoalList";
 import { usePersistentState } from "@/lib/db";
 import type { Pillar } from "@/lib/types";
 import { useGoals, ACTIVE_CAP } from "./useGoals";
+import { usePrefersReducedMotion } from "@/lib/useReducedMotion";
 
 /* Tabs */
 import RemindersTab from "./RemindersTab";
@@ -106,14 +107,11 @@ export default function GoalsPage() {
     [setTab],
   );
 
+  const reduceMotion = usePrefersReducedMotion();
   const handleAddFirst = React.useCallback(() => {
-    const behavior: ScrollBehavior = window.matchMedia(
-      "(prefers-reduced-motion: reduce)",
-    ).matches
-      ? "auto"
-      : "smooth";
+    const behavior: ScrollBehavior = reduceMotion ? "auto" : "smooth";
     formRef.current?.scrollIntoView({ behavior });
-  }, []);
+  }, [reduceMotion]);
 
   const handleUndo = React.useCallback(() => {
     undoRemove();

--- a/src/components/planner/ScrollTopFloatingButton.tsx
+++ b/src/components/planner/ScrollTopFloatingButton.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import IconButton from "@/components/ui/primitives/IconButton";
 import { ArrowUp } from "lucide-react";
+import { usePrefersReducedMotion } from "@/lib/useReducedMotion";
 
 type ScrollTopFloatingButtonProps = {
   watchRef: React.RefObject<HTMLElement>;
@@ -14,6 +15,7 @@ export default function ScrollTopFloatingButton({
   forceVisible = false,
 }: ScrollTopFloatingButtonProps) {
   const [visible, setVisible] = React.useState(false);
+  const reduceMotion = usePrefersReducedMotion();
 
   React.useEffect(() => {
     const target = watchRef.current;
@@ -30,11 +32,7 @@ export default function ScrollTopFloatingButton({
 
   const scrollTop = () => {
     if (typeof window !== "undefined") {
-      const behavior: ScrollBehavior = window.matchMedia(
-        "(prefers-reduced-motion: reduce)",
-      ).matches
-        ? "auto"
-        : "smooth";
+      const behavior: ScrollBehavior = reduceMotion ? "auto" : "smooth";
       window.scrollTo({ top: 0, behavior });
     }
   };

--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -15,6 +15,7 @@ import { useFocusDate, useWeek } from "./useFocusDate";
 import type { ISODate } from "./plannerStore";
 import { useWeekData } from "./useWeekData";
 import { cn } from "@/lib/utils";
+import { usePrefersReducedMotion } from "@/lib/useReducedMotion";
 import { CalendarDays, ArrowUpToLine } from "lucide-react";
 import { toISODate } from "@/lib/date";
 
@@ -115,6 +116,7 @@ export default function WeekPicker() {
   const isoEnd = toISODate(end);
 
   const { per, weekDone, weekTotal } = useWeekData(days);
+  const reduceMotion = usePrefersReducedMotion();
 
   // Show "Jump to top" button after a double-click jump; hide when back at top
   const [showTop, setShowTop] = React.useState(false);
@@ -134,11 +136,7 @@ export default function WeekPicker() {
     setIso(d);
     const el = document.getElementById(`day-${d}`);
     if (el) {
-      const behavior: ScrollBehavior = window.matchMedia(
-        "(prefers-reduced-motion: reduce)",
-      ).matches
-        ? "auto"
-        : "smooth";
+      const behavior: ScrollBehavior = reduceMotion ? "auto" : "smooth";
       el.scrollIntoView({
         behavior,
         block: "start",
@@ -151,11 +149,7 @@ export default function WeekPicker() {
 
   const jumpToTop = () => {
     if (typeof window !== "undefined") {
-      const behavior: ScrollBehavior = window.matchMedia(
-        "(prefers-reduced-motion: reduce)",
-      ).matches
-        ? "auto"
-        : "smooth";
+      const behavior: ScrollBehavior = reduceMotion ? "auto" : "smooth";
       window.scrollTo({ top: 0, behavior });
       // The scroll listener will auto-hide the button when we reach the top
     }

--- a/src/components/ui/AnimationToggle.tsx
+++ b/src/components/ui/AnimationToggle.tsx
@@ -5,6 +5,7 @@ import { Zap, ZapOff } from "lucide-react";
 import Spinner from "./feedback/Spinner";
 import { usePersistentState, readLocal, writeLocal } from "@/lib/db";
 import { cn } from "@/lib/utils";
+import { usePrefersReducedMotion } from "@/lib/useReducedMotion";
 
 const KEY = "ui:animations";
 
@@ -15,17 +16,15 @@ export default function AnimationToggle({
 }) {
   const [enabled, setEnabled] = usePersistentState<boolean>(KEY, true);
   const [showNotice, setShowNotice] = React.useState(false);
+  const reduceMotion = usePrefersReducedMotion();
 
   React.useEffect(() => {
-    if (
-      readLocal<boolean>(KEY) === null &&
-      window.matchMedia("(prefers-reduced-motion: reduce)").matches
-    ) {
+    if (readLocal<boolean>(KEY) === null && reduceMotion) {
       setEnabled(false);
       writeLocal(KEY, false);
       setShowNotice(true);
     }
-  }, [setEnabled]);
+  }, [reduceMotion, setEnabled]);
 
   React.useEffect(() => {
     document.documentElement.classList.toggle("no-animations", !enabled);

--- a/src/components/ui/toggles/CheckCircle.tsx
+++ b/src/components/ui/toggles/CheckCircle.tsx
@@ -13,6 +13,7 @@
  */
 
 import { cn } from "@/lib/utils";
+import { usePrefersReducedMotion } from "@/lib/useReducedMotion";
 import { Check } from "lucide-react";
 import * as React from "react";
 
@@ -44,18 +45,7 @@ export default function CheckCircle({
   "aria-label"?: string;
 }) {
   const btnRef = React.useRef<HTMLButtonElement>(null);
-
-  const [reduceMotion, setReduceMotion] = React.useState(false);
-  React.useEffect(() => {
-    const mq =
-      typeof window.matchMedia === "function"
-        ? window.matchMedia("(prefers-reduced-motion: reduce)")
-        : null;
-    const onChange = () => setReduceMotion(mq?.matches ?? false);
-    onChange();
-    mq?.addEventListener("change", onChange);
-    return () => mq?.removeEventListener("change", onChange);
-  }, []);
+  const reduceMotion = usePrefersReducedMotion();
 
   // Hover/focus tracking
   const [hovered, setHovered] = React.useState(false);

--- a/src/lib/useReducedMotion.ts
+++ b/src/lib/useReducedMotion.ts
@@ -1,0 +1,58 @@
+import * as React from "react";
+
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+type MediaQuery = Pick<MediaQueryList, "matches"> & {
+  addEventListener?: MediaQueryList["addEventListener"];
+  removeEventListener?: MediaQueryList["removeEventListener"];
+  addListener?: MediaQueryList["addListener"];
+  removeListener?: MediaQueryList["removeListener"];
+};
+
+function getMediaQuery(): MediaQuery | null {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return null;
+  }
+
+  return window.matchMedia(QUERY);
+}
+
+export function prefersReducedMotion(): boolean {
+  return getMediaQuery()?.matches ?? false;
+}
+
+export function usePrefersReducedMotion(): boolean {
+  const [reduceMotion, setReduceMotion] = React.useState(prefersReducedMotion);
+
+  React.useEffect(() => {
+    const mediaQuery = getMediaQuery();
+    if (!mediaQuery) {
+      return;
+    }
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setReduceMotion(event.matches);
+    };
+    const handleLegacyChange = () => {
+      setReduceMotion(mediaQuery.matches);
+    };
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange);
+    } else if (typeof mediaQuery.addListener === "function") {
+      mediaQuery.addListener(handleLegacyChange);
+    }
+
+    setReduceMotion(mediaQuery.matches);
+
+    return () => {
+      if (typeof mediaQuery.removeEventListener === "function") {
+        mediaQuery.removeEventListener("change", handleChange);
+      } else if (typeof mediaQuery.removeListener === "function") {
+        mediaQuery.removeListener(handleLegacyChange);
+      }
+    };
+  }, []);
+
+  return reduceMotion;
+}


### PR DESCRIPTION
## Summary
- add a shared prefers-reduced-motion helper that listens for preference updates
- refactor scrolling and animation triggers to use the shared helper across planner and UI components
- ensure animation defaults respect the updated system preference before persisting settings

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8c0426a6c832cb5255deba7940a5d