### PR TITLE
Extract prompts accent badge styles

### DIFF
--- a/src/app/prompts/PromptsPage.module.css
+++ b/src/app/prompts/PromptsPage.module.css
@@ -1,0 +1,13 @@
+.accentBadge {
+  --prompts-accent-badge-bg: hsl(var(--accent-3) / 0.18);
+  --prompts-accent-badge-border: hsl(var(--accent-3));
+  --prompts-accent-badge-foreground: hsl(var(--accent-foreground));
+
+  background-color: var(--prompts-accent-badge-bg);
+  border-color: var(--prompts-accent-badge-border);
+  color: var(--prompts-accent-badge-foreground);
+}
+
+.accentBadgeIndicator {
+  background-color: var(--prompts-accent-badge-border);
+}

--- a/src/app/prompts/PromptsPage.tsx
+++ b/src/app/prompts/PromptsPage.tsx
@@ -14,7 +14,9 @@ import {
 } from "@/components/prompts/constants";
 import { usePromptsRouter } from "@/components/prompts/usePromptsRouter";
 import { usePersistentState } from "@/lib/db";
+import { cn } from "@/lib/utils";
 import { useRouter, useSearchParams } from "next/navigation";
+import styles from "./PromptsPage.module.css";
 
 export default function Page() {
   return (
@@ -147,17 +149,17 @@ function PageContent() {
           actions: (
             <div className="flex items-center gap-2">
               <div
-                className="hidden sm:flex items-center gap-2 rounded-full border px-3 py-1 text-label font-medium tracking-[-0.01em]"
-                style={{
-                  backgroundColor: "hsl(var(--accent-3) / 0.18)",
-                  borderColor: "hsl(var(--accent-3))",
-                  color: "hsl(var(--accent-foreground))",
-                }}
+                className={cn(
+                  "hidden sm:flex items-center gap-2 rounded-full border px-3 py-1 text-label font-medium tracking-[-0.01em]",
+                  styles.accentBadge,
+                )}
               >
                 <span
                   aria-hidden
-                  className="h-2 w-2 rounded-full"
-                  style={{ backgroundColor: "hsl(var(--accent-3))" }}
+                  className={cn(
+                    "h-2 w-2 rounded-full",
+                    styles.accentBadgeIndicator,
+                  )}
                 />
                 Accent 3
               </div>


### PR DESCRIPTION
## Summary
- move the prompts hero accent badge styling out of inline styles and into a CSS module that uses design tokens
- apply the new accent badge utility classes to the badge and indicator span via `className`

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8c1fc0b24832c80f89d8af2d26176