### PR TITLE
Use spacing tokens in review UI widths

### DIFF
--- a/src/components/reviews/ResultScoreSection.tsx
+++ b/src/components/reviews/ResultScoreSection.tsx
@@ -84,8 +84,8 @@ function ResultScoreSection(
             aria-hidden
             className="absolute top-1 bottom-1 left-1 rounded-xl transition-transform duration-300"
             style={{
-              width: "calc(50% - 4px)",
-              transform: `translate3d(${result === "Win" ? "0" : "calc(100% + 2px)"},0,0)`,
+              width: "calc(50% - var(--space-1))",
+              transform: `translate3d(${result === "Win" ? "0" : "calc(100% + var(--space-1) / 2)"},0,0)`,
               transitionTimingFunction: "cubic-bezier(.22,1,.36,1)",
               background:
                 result === "Win"

--- a/src/components/reviews/TimestampMarkers.tsx
+++ b/src/components/reviews/TimestampMarkers.tsx
@@ -183,7 +183,9 @@ function TimestampMarkers(
               pattern="^[0-9]?\d:[0-5]\d$"
               aria-invalid={timeError ? "true" : undefined}
               aria-describedby={timeError ? "tTime-error" : undefined}
-              style={{ width: "calc(5ch + 1.7rem)" }}
+              style={{
+                width: "calc(5ch + var(--space-5) + (var(--space-1) * 4 / 5))",
+              }}
               onKeyDown={(e) => {
                 if (e.key === "Enter" && canAddMarker) {
                   e.preventDefault();

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -417,7 +417,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           <span
             aria-hidden="true"
             class="absolute top-1 bottom-1 left-1 rounded-xl transition-transform duration-300"
-            style="width: calc(50% - 4px); transform: translate3d(0,0,0); transition-timing-function: cubic-bezier(.22,1,.36,1); background: linear-gradient(90deg, hsl(var(--success)/0.32), hsl(var(--accent)/0.28)); box-shadow: 0 10px 30px hsl(var(--shadow-color) / .25);"
+            style="width: calc(50% - var(--space-1)); transform: translate3d(0,0,0); transition-timing-function: cubic-bezier(.22,1,.36,1); background: linear-gradient(90deg, hsl(var(--success)/0.32), hsl(var(--accent)/0.28)); box-shadow: 0 10px 30px hsl(var(--shadow-color) / .25);"
           />
           <div
             class="relative z-10 grid w-full grid-cols-2 text-ui font-mono"
@@ -1860,7 +1860,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           >
             <div
               class="relative inline-flex w-full items-center rounded-[var(--control-radius)] overflow-hidden border border-card-hairline bg-card/60 backdrop-blur-[2px] shadow-control transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-control-hover focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),var(--asset-noise-url,none)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] ring-2 ring-danger/35 ring-offset-0 text-center font-mono tabular-nums"
-              style="--control-h: var(--control-h-md); width: calc(5ch + 1.7rem);"
+              style="--control-h: var(--control-h-md); width: calc(5ch + var(--space-5) + (var(--space-1) * 4 / 5));"
             >
               <input
                 aria-describedby="tTime-error"


### PR DESCRIPTION
## Summary
- replace the timestamp input width with spacing token math so the field uses design tokens
- update the result toggle offsets to rely on spacing tokens instead of raw pixel values
- refresh the review editor snapshot to reflect the tokenized styles

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8c18feff0832c9ee082c604b85fa9