### PR TITLE
Align typography utility usage

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1333,7 +1333,7 @@ textarea:-webkit-autofill {
     @apply text-label font-medium tracking-[0.02em] text-muted-foreground;
   }
   .title-ghost {
-    @apply text-2xl font-semibold opacity-60;
+    @apply text-title-lg font-semibold opacity-60;
     filter: blur(1px);
   }
   .title-glow {

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -35,7 +35,7 @@ export default function NotFound() {
             </Link>
           ),
           children: (
-            <p className="text-sm text-muted-foreground">
+            <p className="text-ui text-muted-foreground">
               The page you are looking for does not exist.
             </p>
           ),

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -157,7 +157,7 @@ function ChampListEditorDemo() {
   return (
     <div className="space-y-3" data-scope="team">
       <div className="flex items-center justify-between">
-        <span className="text-sm font-semibold tracking-[0.02em] text-muted-foreground">
+        <span className="text-label font-semibold tracking-[0.02em] text-muted-foreground">
           Champions
         </span>
         <Button size="sm" onClick={() => setEditing((prev) => !prev)}>


### PR DESCRIPTION
## Summary
- update not-found messaging to use the text-ui typography token
- align the prompts champ list label with the text-label utility
- switch the title-ghost helper to the text-title-lg token

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8c37ca8e0832c940af432a50b1d04