### PR TITLE
Add aria-hidden to decorative reminder dot

### DIFF
--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -714,7 +714,10 @@ function RemTile({
 
             <div className="mt-1 flex items-center justify-between text-ui font-medium">
               <div className="flex items-center gap-2">
-                <span className="inline-block h-2 w-2 rounded-full bg-[hsl(var(--accent-overlay))]" />
+                <span
+                  aria-hidden="true"
+                  className="inline-block h-2 w-2 rounded-full bg-[hsl(var(--accent-overlay))]"
+                />
                 <span className="text-label font-medium tracking-[0.02em]">{fmtDate(value.createdAt)}</span>
               </div>
 


### PR DESCRIPTION
## Summary
- add aria-hidden to the decorative status dot in the reminders tab so screen readers ignore it

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8c399d998832c84bcb8e1ed86184c