### PR TITLE
Improve ReviewCard interactive states

### DIFF
--- a/src/components/reviews/ReviewCard.tsx
+++ b/src/components/reviews/ReviewCard.tsx
@@ -7,29 +7,51 @@ import { IconButton } from "@/components/ui";
 import Badge from "@/components/ui/primitives/Badge";
 import { Pencil } from "lucide-react";
 
+type ReviewCardState = "default" | "active" | "disabled" | "loading";
+
+type ReviewCardProps = {
+  review: Review;
+  active: boolean;
+  onRenameStart: () => void;
+  state?: ReviewCardState;
+};
+
 export default function ReviewCard({
   review,
   active,
   onRenameStart,
-}: {
-  review: Review;
-  active: boolean;
-  onRenameStart: () => void;
-}) {
+  state,
+}: ReviewCardProps) {
+  const cardState: ReviewCardState = state ?? (active ? "active" : "default");
+  const isDisabled = cardState === "disabled";
+  const isLoading = cardState === "loading";
   const created = review.createdAt ? new Date(review.createdAt) : null;
 
   return (
     <div
+      data-state={cardState}
+      aria-disabled={isDisabled ? true : undefined}
+      aria-busy={isLoading ? true : undefined}
       className={cn(
-        "p-3 rounded-card r-card-lg border border-border bg-card/85",
-        active && "shadow-lg",
+        "group rounded-card r-card-lg border border-border bg-card/85 p-3",
+        "transition-colors transition-shadow duration-200 focus-visible:outline-none",
+        "shadow-neoSoft",
+        "hover:border-ring/60 hover:bg-card hover:shadow-ring",
+        "focus-visible:border-ring focus-visible:bg-card focus-visible:ring-2 focus-visible:ring-ring focus-visible:shadow-ring",
+        "active:border-ring/70 active:bg-card/95 active:shadow-neo-strong active:ring-2 active:ring-ring/70",
+        "data-[state=active]:border-ring data-[state=active]:shadow-ring",
+        "data-[state=disabled]:pointer-events-none data-[state=disabled]:opacity-55 data-[state=disabled]:shadow-none data-[state=disabled]:ring-0 data-[state=disabled]:border-border/60 data-[state=disabled]:bg-muted/20 data-[state=disabled]:cursor-not-allowed",
+        "data-[state=loading]:pointer-events-none data-[state=loading]:opacity-80 data-[state=loading]:shadow-outline-faint data-[state=loading]:cursor-progress",
       )}
     >
       <div className="flex items-start gap-2">
         <div className="min-w-0 flex-1">
           <div className="flex items-center justify-between gap-2">
             <h3
-              className={cn("truncate font-semibold", active && "title-glow")}
+              className={cn(
+                "truncate font-semibold transition-colors",
+                cardState === "active" && "title-glow",
+              )}
             >
               {review.title || "Untitled Review"}
             </h3>


### PR DESCRIPTION
## Summary
- add a typed card state prop so ReviewCard can express active, disabled, and loading variants via data attributes
- replace the generic shadow with token-based shadows and add hover, focus-visible, and active feedback classes on the card shell

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8c2b79a20832ca88787c4fbb0e09c