### PR TITLE
Use token radius for review loading skeleton

### DIFF
--- a/src/components/reviews/ReviewListItem.tsx
+++ b/src/components/reviews/ReviewListItem.tsx
@@ -26,7 +26,7 @@ const itemLoading = cn(
   shellBase,
   "motion-safe:animate-pulse motion-reduce:animate-none",
 );
-const loadingLine = "h-3 rounded-md bg-muted";
+const loadingLine = "h-3 rounded-card bg-muted";
 const scoreBadge = cn(
   "px-2 py-1 rounded-full text-label leading-none font-medium",
   "text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2",

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -116,10 +116,10 @@ exports[`ReviewListItem > renders loading state 1`] = `
     data-scope="reviews"
   >
     <div
-      class="h-3 rounded-md bg-muted w-3/5 mb-3"
+      class="h-3 rounded-card bg-muted w-3/5 mb-3"
     />
     <div
-      class="h-3 rounded-md bg-muted w-2/5"
+      class="h-3 rounded-card bg-muted w-2/5"
     />
   </div>
 </div>


### PR DESCRIPTION
## Summary
- align the ReviewListItem loading skeleton with the rounded-card radius token
- update the loading state snapshot to match the new radius styling

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8c385a438832c8b19fae129c12208