### PR TITLE
Focus planner header after jumping to top

### DIFF
--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -86,6 +86,7 @@ function Inner() {
         <div className="space-y-2">
           <Header
             id="planner-header"
+            tabIndex={-1}
             eyebrow="Planner"
             heading="Planner for Today"
             subtitle="Plan your week"

--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -165,6 +165,14 @@ export default function WeekPicker() {
     if (typeof window !== "undefined") {
       const behavior: ScrollBehavior = reduceMotion ? "auto" : "smooth";
       window.scrollTo({ top: 0, behavior });
+      const focusTarget =
+        document.getElementById("planner-header") ??
+        document.getElementById("main-content");
+      if (focusTarget instanceof HTMLElement) {
+        window.requestAnimationFrame(() => {
+          focusTarget.focus({ preventScroll: true });
+        });
+      }
       // The scroll listener will auto-hide the button when we reach the top
     }
   };


### PR DESCRIPTION
## Summary
- focus the planner header (or main content fallback) after triggering jump to top so keyboard users land in a landmark
- allow the planner header to receive programmatic focus without affecting tab order

## Testing
- npm run check


------
https://chatgpt.com/codex/tasks/task_e_68c8c543a678832c981474e8f09eeef7