### PR TITLE
Add state styling for planner task tiles

### DIFF
--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -114,10 +114,28 @@
   text-shadow: 0 0 calc(var(--space-3) - var(--space-1) / 2)
     hsl(var(--accent) / 0.18);
 }
+.task-tile__text:active {
+  color: hsl(var(--accent));
+  cursor: pointer;
+  text-shadow: 0 0 calc(var(--space-3) - var(--space-1) / 2)
+    hsl(var(--accent) / 0.28);
+}
 .task-tile__text:focus-visible {
   outline: calc(var(--hairline-w) * 2) solid hsl(var(--ring));
   outline-offset: calc(var(--hairline-w) * 2);
   border-radius: var(--radius-md);
+}
+.task-tile__text[aria-disabled="true"] {
+  color: hsl(var(--muted-foreground));
+  cursor: not-allowed;
+  text-shadow: none;
+  pointer-events: none;
+}
+.task-tile__text[data-loading="true"] {
+  color: hsl(var(--muted-foreground) / 0.85);
+  cursor: progress;
+  text-shadow: 0 0 calc(var(--space-2)) hsl(var(--accent) / 0.16);
+  pointer-events: none;
 }
 
 /* Soft, readable strike-through for completed tasks */


### PR DESCRIPTION
## Summary
- add semantic token-driven active styling for planner task tile text
- add disabled and loading attribute states with cursor and text-shadow updates

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8c6c643b8832cafdf53fe37828ec2