### PR TITLE
Relax Node version enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-> **Prerequisite:** Install [Node.js](https://nodejs.org) version 22 or higher.
+> **Prerequisite:** Install [Node.js](https://nodejs.org) 22 or newer for full support. Older LTS releases may still run, but expect reduced support and additional warnings.
 
 This project automatically regenerates its UI component export index. The `npm run dev` and `npm run build` commands run `npm run regen-ui` to keep exports in sync, and the `postinstall` script does the same after dependency installs. You can run `npm run regen-ui` manually whenever components are added or removed.
 

--- a/scripts/check-node-version.js
+++ b/scripts/check-node-version.js
@@ -1,5 +1,10 @@
 const major = parseInt(process.versions.node.split(".")[0], 10);
-if (major < 22) {
-  console.error(`Node 22+ is required. Detected ${process.versions.node}.`);
-  process.exit(1);
+if (Number.isNaN(major)) {
+  console.warn(
+    `Unable to detect Node.js version. Continuing, but please ensure you're using Node 22 or newer.`,
+  );
+} else if (major < 22) {
+  console.warn(
+    `Node 22+ is recommended for full support. Detected ${process.versions.node}. Continuing with reduced support.`,
+  );
 }


### PR DESCRIPTION
## Summary
- update the Node version check script to emit a warning and continue execution when using versions below 22
- document Node 22+ as the recommended runtime while clarifying reduced support for lower versions

## Testing
- npm run format
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8c8c0e2dc832c9c74a8d8e94df747