### PR TITLE
Expose base path env for GitHub Pages

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,6 +16,9 @@ const nextConfig = {
   output: "export",
   basePath: isGitHubPages ? normalizedBasePath : undefined,
   assetPrefix: isGitHubPages ? normalizedBasePath : undefined,
+  env: {
+    NEXT_PUBLIC_BASE_PATH: isGitHubPages ? normalizedBasePath ?? "" : "",
+  },
   webpack: (config) => {
     config.resolve.alias["@"] = path.resolve(__dirname, "src");
     return config;


### PR DESCRIPTION
## Summary
- expose the GitHub Pages base path via `NEXT_PUBLIC_BASE_PATH` in `next.config.mjs`

## Testing
- npm run format
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8cbd13640832c969fc9f0c5ab05ff