### PR TITLE
Adjust hero heading tracking

### DIFF
--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -184,7 +184,7 @@ function Hero<Key extends string = string>({
 
             <div className="flex items-baseline gap-2">
               <h2
-                className="hero2-title title-glow text-title-lg md:text-title-lg font-semibold tracking-[-0.005em] truncate"
+                className="hero2-title title-glow text-title-lg md:text-title-lg font-semibold tracking-[-0.01em] truncate"
                 data-text={headingStr}
               >
                 {heading}

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -449,7 +449,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                       class="flex items-baseline gap-2"
                     >
                       <h2
-                        class="hero2-title title-glow text-title-lg md:text-title-lg font-semibold tracking-[-0.005em] truncate"
+                        class="hero2-title title-glow text-title-lg md:text-title-lg font-semibold tracking-[-0.01em] truncate"
                         data-text="Browse Reviews"
                       >
                         Browse Reviews


### PR DESCRIPTION
## Summary
- tighten the Hero heading letter spacing to align with desired tracking
- update the ReviewsPage snapshot to match the adjusted heading class

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ccb49978832ca979b770679e2321