### PR TITLE
Expose shared radius scale for globals

### DIFF
--- a/scripts/generate-tokens.ts
+++ b/scripts/generate-tokens.ts
@@ -7,7 +7,7 @@ import type {
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { spacingTokens, radiusTokens } from "../src/lib/tokens.ts";
+import { spacingTokens, radiusScale } from "../src/lib/tokens.ts";
 import { createTaskBar, stopBars } from "../src/utils/progress.ts";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -22,20 +22,6 @@ StyleDictionary.registerFormat({
     return ["| Token | Value |", "| --- | --- |", ...lines].join("\n");
   },
 });
-
-async function loadRadiusValues(): Promise<Record<string, string>> {
-  const globalsPath = path.resolve(__dirname, "../src/app/globals.css");
-  const css = await fs.readFile(globalsPath, "utf8");
-  const values: Record<string, string> = {};
-  for (const token of radiusTokens) {
-    const regex = new RegExp(`${token}:\\s*([^;]+);`);
-    const match = css.match(regex);
-    if (match) {
-      values[token] = match[1].trim();
-    }
-  }
-  return values;
-}
 
 async function loadBaseColors(): Promise<Record<string, { value: string }>> {
   const tokensPath = path.resolve(__dirname, "../tokens/tokens.css");
@@ -52,7 +38,6 @@ async function loadBaseColors(): Promise<Record<string, { value: string }>> {
 }
 
 async function buildTokens(): Promise<void> {
-  const radiusValues = await loadRadiusValues();
   const spacing = spacingTokens.reduce<Record<string, { value: string }>>(
     (acc, val, idx) => {
       acc[idx + 1] = { value: `${val}px` };
@@ -60,11 +45,10 @@ async function buildTokens(): Promise<void> {
     },
     {},
   );
-  const radius = Object.entries(radiusValues).reduce<
+  const radius = Object.entries(radiusScale).reduce<
     Record<string, { value: string }>
   >((acc, [name, value]) => {
-    const key = name.replace("--radius-", "");
-    acc[key] = { value };
+    acc[name] = { value: `${value}px` };
     return acc;
   }, {});
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1309,11 +1309,11 @@ textarea:-webkit-autofill {
   --glow-soft: var(--accent) / 0.25;
 
   /* Radius tokens */
-  --radius-md: 8px;
-  --radius-lg: 12px;
-  --radius-xl: 16px;
-  --radius-2xl: 24px;
-  --radius-full: 9999px;
+  --radius-md: theme("borderRadius.md");
+  --radius-lg: theme("borderRadius.lg");
+  --radius-xl: theme("borderRadius.xl");
+  --radius-2xl: theme("borderRadius.2xl");
+  --radius-full: theme("borderRadius.full");
 }
 
 @layer components {

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -31,9 +31,34 @@ export const colorTokens = [
 
 export const spacingTokens = [4, 8, 12, 16, 24, 32, 48, 64];
 
-export const radiusTokens = [
-  "--radius-md",
-  "--radius-lg",
-  "--radius-xl",
-  "--radius-2xl",
-];
+const radiusEntries = [
+  ["md", 8],
+  ["lg", 12],
+  ["xl", 16],
+  ["2xl", 24],
+  ["full", 9999],
+] as const;
+
+type RadiusKey = (typeof radiusEntries)[number][0];
+type RadiusVar = `--radius-${RadiusKey}`;
+
+export const radiusScale: Record<RadiusKey, number> = radiusEntries.reduce(
+  (acc, [token, value]) => {
+    acc[token] = value;
+    return acc;
+  },
+  {} as Record<RadiusKey, number>,
+);
+
+export const radiusTokens = radiusEntries.map(
+  ([token]) => `--radius-${token}` as RadiusVar,
+);
+
+export const radiusValues: Record<RadiusVar, string> = radiusEntries.reduce(
+  (acc, [token, value]) => {
+    const variable = `--radius-${token}` as RadiusVar;
+    acc[variable] = `${value}px`;
+    return acc;
+  },
+  {} as Record<RadiusVar, string>,
+);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,15 @@
 // - TypeScript config; works with Tailwind 3.4+
 // - Dark mode by class; colors map to CSS variables in globals.css
 import type { Config } from "tailwindcss";
-import { spacingTokens, radiusTokens } from "./src/lib/tokens";
+import { spacingTokens, radiusScale } from "./src/lib/tokens";
+
+const borderRadiusTokens = Object.entries(radiusScale).reduce(
+  (acc, [token, value]) => {
+    acc[token] = `${value}px`;
+    return acc;
+  },
+  {} as Record<string, string>,
+);
 
 const config: Config = {
   darkMode: ["class"],
@@ -56,12 +64,7 @@ const config: Config = {
         "surface-vhs": "hsl(var(--surface-vhs))",
         "surface-streak": "hsl(var(--surface-streak))",
       },
-      borderRadius: {
-        md: `var(${radiusTokens[0]})`,
-        lg: `var(${radiusTokens[1]})`,
-        xl: `var(${radiusTokens[2]})`,
-        "2xl": `var(${radiusTokens[3]})`,
-      },
+      borderRadius: borderRadiusTokens,
       boxShadow: {
         "neo-sm":
           "4px 4px 8px hsl(var(--panel)/0.72), -4px -4px 8px hsl(var(--foreground)/0.06)",

--- a/tests/prompts/demo-tokens.test.ts
+++ b/tests/prompts/demo-tokens.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest";
 import type { Config } from "tailwindcss";
 import config from "../../tailwind.config";
-import { colorTokens, spacingTokens, radiusTokens } from "../../src/lib/tokens";
+import {
+  colorTokens,
+  spacingTokens,
+  radiusTokens,
+  radiusScale,
+} from "../../src/lib/tokens";
 
 describe("demo tokens", () => {
   const tw = config as Config;
@@ -17,11 +22,18 @@ describe("demo tokens", () => {
   it("match tailwind radius config", () => {
     const radius =
       (tw.theme?.extend?.borderRadius as Record<string, string>) ?? {};
-    const radiusFromConfig = Object.values(radius).map((v) => {
-      const match = String(v).match(/var\(([^)]+)\)/);
-      return match ? match[1] : v;
-    });
-    expect(radiusTokens).toEqual(radiusFromConfig);
+    const expectedRadius = Object.entries(radiusScale).reduce<
+      Record<string, string>
+    >((acc, [name, value]) => {
+      acc[name] = `${value}px`;
+      return acc;
+    }, {});
+    expect(radius).toEqual(expectedRadius);
+
+    const configRadiusTokens = Object.keys(radius).map(
+      (name) => `--radius-${name}`,
+    );
+    expect(radiusTokens).toEqual(configRadiusTokens);
   });
 
   it("use colors defined in tailwind config", () => {


### PR DESCRIPTION
## Summary
- add an explicit radius scale to the shared tokens module so the codebase can consume both variable names and px values
- update Tailwind config, global CSS, token generation, and the demo test suite to pull from the shared radius data instead of hardcoding values

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c8cb962a3c832cadd522f110d040c6