### PR TITLE
Refactor TeamCompPage to use PageHeader

### DIFF
--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -22,8 +22,8 @@ import {
   Clipboard,
   Plus,
 } from "lucide-react";
-import Header, { type HeaderTab } from "@/components/ui/layout/Header";
-import Hero from "@/components/ui/layout/Hero";
+import { type HeaderTab } from "@/components/ui/layout/Header";
+import type { HeroProps } from "@/components/ui/layout/Hero";
 import Builder, { type BuilderHandle } from "./Builder";
 import JungleClears, { type JungleClearsHandle } from "./JungleClears";
 import CheatSheet from "./CheatSheet";
@@ -31,7 +31,7 @@ import MyComps from "./MyComps";
 import { usePersistentState } from "@/lib/db";
 import IconButton from "@/components/ui/primitives/IconButton";
 import Button from "@/components/ui/primitives/Button";
-import { NeomorphicHeroFrame, PageShell } from "@/components/ui";
+import { PageHeader, PageShell } from "@/components/ui";
 
 type Tab = "cheat" | "builder" | "clears";
 type SubTab = "sheet" | "comps";
@@ -91,7 +91,7 @@ export default function TeamCompPage() {
   React.useEffect(() => {
     subPanelRefs.current[subTab]?.focus();
   }, [subTab]);
-  const subTabs = React.useMemo(
+  const subTabs = React.useMemo<HeaderTab<SubTab>[]>(
     () => [
       { key: "sheet", label: "Cheat Sheet", icon: <BookOpen /> },
       { key: "comps", label: "My Comps", icon: <Users2 /> },
@@ -181,130 +181,127 @@ export default function TeamCompPage() {
     TABS.find((t) => t.key === tab)?.ref.current?.focus();
   }, [tab, TABS]);
 
-  const hero = React.useMemo(() => {
+  const hero = React.useMemo<HeroProps<SubTab>>(() => {
     if (tab === "cheat") {
       const editingKey: keyof typeof editing =
         subTab === "sheet" ? "cheatSheet" : "myComps";
-      return (
-        <Hero
-          frame={false}
-          topClassName="top-[var(--header-stack)]"
-          eyebrow={active?.label}
-          heading="Comps"
-          subtitle={
-            subTab === "sheet"
-              ? "Archetypes & tips"
-              : "Your saved compositions"
-          }
-          subTabs={{
-            items: subTabs,
-            value: subTab,
-            onChange: (k: string) => setSubTab(k as SubTab),
-            showBaseline: true,
-          }}
-          search={{
-            value: query,
-            onValueChange: setQuery,
-            placeholder: "Search…",
-            round: true,
-          }}
-          actions={
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={() => toggleEditing(editingKey)}
-            >
-              {editing[editingKey] ? "Done" : "Edit"}
-            </Button>
-          }
-        />
-      );
+      return {
+        as: "section",
+        frame: false,
+        topClassName: "top-[var(--header-stack)]",
+        eyebrow: active?.label,
+        heading: "Comps",
+        subtitle:
+          subTab === "sheet"
+            ? "Archetypes & tips"
+            : "Your saved compositions",
+        subTabs: {
+          items: subTabs,
+          value: subTab,
+          onChange: (next: SubTab) => setSubTab(next),
+          showBaseline: true,
+        },
+        search: {
+          value: query,
+          onValueChange: setQuery,
+          placeholder: "Search…",
+          round: true,
+        },
+        actions: (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => toggleEditing(editingKey)}
+          >
+            {editing[editingKey] ? "Done" : "Edit"}
+          </Button>
+        ),
+      };
     }
     if (tab === "builder") {
-      return (
-        <Hero
-          frame={false}
-          topClassName="top-[var(--header-stack)]"
-          eyebrow="Comps"
-          heading="Builder"
-          subtitle="Fill allies vs enemies. Swap in one click."
-          actions={
-            <div className="flex items-center gap-2">
-              <IconButton
-                title="Swap Allies ↔ Enemies"
-                aria-label="Swap Allies and Enemies"
-                onClick={() => builderApi.current?.swapSides()}
-                size="sm"
-                iconSize="sm"
-              >
-                <Shuffle />
-              </IconButton>
-              <IconButton
-                title="Copy both sides"
-                aria-label="Copy both sides"
-                onClick={() => builderApi.current?.copyAll()}
-                size="sm"
-                iconSize="sm"
-              >
-                <Clipboard />
-              </IconButton>
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => toggleEditing("builder")}
-              >
-                {editing.builder ? "Done" : "Edit"}
-              </Button>
-            </div>
-          }
-        />
-      );
-    }
-    return (
-      <Hero
-        frame={false}
-        sticky={false}
-        topClassName="top-[var(--header-stack)]"
-        rail
-        heading="Clear Speed Buckets"
-        dividerTint="primary"
-        search={{
-          value: clearsQuery,
-          onValueChange: setClearsQuery,
-          placeholder: "Filter by champion, type, or note...",
-          round: true,
-          debounceMs: 80,
-          right: (
-            <span className="text-label opacity-80">{clearsCount} shown</span>
-          ),
-        }}
-        actions={
+      return {
+        as: "section",
+        frame: false,
+        topClassName: "top-[var(--header-stack)]",
+        eyebrow: "Comps",
+        heading: "Builder",
+        subtitle: "Fill allies vs enemies. Swap in one click.",
+        actions: (
           <div className="flex items-center gap-2">
-            <Button
-              variant="primary"
+            <IconButton
+              title="Swap Allies ↔ Enemies"
+              aria-label="Swap Allies and Enemies"
+              onClick={() => builderApi.current?.swapSides()}
               size="sm"
-              className="px-4 whitespace-nowrap"
-              onClick={() => clearsApi.current?.addRow("Medium")}
+              iconSize="sm"
             >
-              <Plus />
-              <span>New Row</span>
-            </Button>
+              <Shuffle />
+            </IconButton>
+            <IconButton
+              title="Copy both sides"
+              aria-label="Copy both sides"
+              onClick={() => builderApi.current?.copyAll()}
+              size="sm"
+              iconSize="sm"
+            >
+              <Clipboard />
+            </IconButton>
             <Button
               size="sm"
               variant="ghost"
-              onClick={() => toggleEditing("clears")}
+              onClick={() => toggleEditing("builder")}
             >
-              {editing.clears ? "Done" : "Edit"}
+              {editing.builder ? "Done" : "Edit"}
             </Button>
           </div>
-        }
-      >
+        ),
+      };
+    }
+    return {
+      as: "section",
+      frame: false,
+      sticky: false,
+      topClassName: "top-[var(--header-stack)]",
+      rail: true,
+      heading: "Clear Speed Buckets",
+      dividerTint: "primary",
+      search: {
+        value: clearsQuery,
+        onValueChange: setClearsQuery,
+        placeholder: "Filter by champion, type, or note...",
+        round: true,
+        debounceMs: 80,
+        right: (
+          <span className="text-label opacity-80">{clearsCount} shown</span>
+        ),
+      },
+      actions: (
+        <div className="flex items-center gap-2">
+          <Button
+            variant="primary"
+            size="sm"
+            className="px-4 whitespace-nowrap"
+            onClick={() => clearsApi.current?.addRow("Medium")}
+          >
+            <Plus />
+            <span>New Row</span>
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => toggleEditing("clears")}
+          >
+            {editing.clears ? "Done" : "Edit"}
+          </Button>
+        </div>
+      ),
+      children: (
         <p className="text-ui text-muted-foreground">
           If you’re on a <em>Medium</em> champ, don’t race farm vs <em>Very Fast</em>.
           Path for fights, ganks, or cross-map trades.
         </p>
-      </Hero>
-    );
+      ),
+    };
   }, [
     tab,
     active,
@@ -325,22 +322,21 @@ export default function TeamCompPage() {
       className="py-6 space-y-6 md:grid md:grid-cols-12 md:gap-4"
       aria-labelledby="teamcomp-header"
     >
-      <NeomorphicHeroFrame
-        variant="unstyled"
+      <PageHeader
         className="sticky top-0 rounded-card r-card-lg px-4 py-4 md:col-span-12"
-      >
-        <div className="relative z-[2] space-y-2">
-          <Header
-            id="teamcomp-header"
-            eyebrow="Comps"
-            heading="Team Comps Today"
-            subtitle="Readable. Fast. On brand."
-            icon={<Users2 className="opacity-80" />}
-            tabs={{ items: TABS, value: tab, onChange: (k: Tab) => setTab(k) }}
-          />
-          {hero}
-        </div>
-      </NeomorphicHeroFrame>
+        contentClassName="space-y-2"
+        frameProps={{ variant: "unstyled" }}
+        header={{
+          id: "teamcomp-header",
+          eyebrow: "Comps",
+          heading: "Team Comps Today",
+          subtitle: "Readable. Fast. On brand.",
+          icon: <Users2 className="opacity-80" />,
+          tabs: { items: TABS, value: tab, onChange: (next: Tab) => setTab(next) },
+          underline: true,
+        }}
+        hero={hero}
+      />
 
       <section className="grid gap-4 md:col-span-12 md:grid-cols-12">
         {TABS.map((t) => (


### PR DESCRIPTION
## Summary
- replace the custom header and hero composition in TeamCompPage with the shared PageHeader primitive
- refactor the hero configuration to return HeroProps so PageHeader can render the appropriate hero variants for each tab

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8cb512df8832cad8895275c24461d