### PR TITLE
Use muted foreground token in hero subtitle

### DIFF
--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -190,7 +190,7 @@ function Hero<Key extends string = string>({
                 {heading}
               </h2>
               {subtitle ? (
-                <span className="text-ui md:text-body font-medium text-[hsl(var(--muted-foreground))] truncate">
+                <span className="text-ui md:text-body font-medium text-muted-foreground truncate">
                   {subtitle}
                 </span>
               ) : null}

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -455,7 +455,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                         Browse Reviews
                       </h2>
                       <span
-                        class="text-ui md:text-body font-medium text-[hsl(var(--muted-foreground))] truncate"
+                        class="text-ui md:text-body font-medium text-muted-foreground truncate"
                       >
                         <span
                           class="pill"


### PR DESCRIPTION
## Summary
- replace the Hero subtitle class with the semantic `text-muted-foreground` token for consistent theming
- update the ReviewsPage snapshot to match the semantic text color change

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ce203e88832caaede3c06bb5edf7