### PR TITLE
Use group hover state for NavBar sheen overlay

### DIFF
--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -33,7 +33,7 @@ export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
                 href={href}
                 aria-current={active ? "page" : undefined}
                 className={cn(
-                  "relative inline-flex items-center rounded-[var(--radius-2xl)] border px-4 py-2 font-mono text-ui transition motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  "group relative inline-flex items-center rounded-[var(--radius-2xl)] border px-4 py-2 font-mono text-ui transition motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                   "bg-[hsl(var(--card)/0.85)]",
                   "supports-[background:color-mix(in_oklab,hsl(var(--card))_85%,transparent)]:bg-[color:color-mix(in_oklab,hsl(var(--card))_85%,transparent)]",
                   active
@@ -46,7 +46,7 @@ export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
                 {/* hover sheen */}
                 <span
                   aria-hidden
-                  className="pointer-events-none absolute inset-0 rounded-[var(--radius-2xl)] opacity-0 transition hover:opacity-100 nav-hover-sheen"
+                  className="pointer-events-none absolute inset-0 rounded-[var(--radius-2xl)] opacity-0 transition group-hover:opacity-100 nav-hover-sheen"
                 />
 
                 {/* faint scanlines */}


### PR DESCRIPTION
## Summary
- add the `group` utility to NavBar links so child overlays can read the hover state
- switch the hover sheen to use `group-hover:opacity-100`, keeping existing focus styling untouched

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8cf0ba0e0832ca6946ce5e09cea2d