### PR TITLE
Wrap quick action buttons with Next.js links

### DIFF
--- a/src/components/home/QuickActions.tsx
+++ b/src/components/home/QuickActions.tsx
@@ -2,37 +2,27 @@
 
 import * as React from "react";
 import Button from "@/components/ui/primitives/Button";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 export default function QuickActions() {
-  const router = useRouter();
-  const goPlanner = React.useCallback(() => router.push("/planner"), [router]);
-  const goGoals = React.useCallback(() => router.push("/goals"), [router]);
-  const goReviews = React.useCallback(() => router.push("/reviews"), [router]);
-
   return (
     <section aria-label="Quick actions" className="grid gap-4">
       <div className="flex flex-col gap-4">
-        <Button
-          className="rounded-full focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
-          onClick={goPlanner}
-        >
-          Planner Today
-        </Button>
-        <Button
-          className="rounded-full focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
-          tone="accent"
-          onClick={goGoals}
-        >
-          New Goal
-        </Button>
-        <Button
-          className="rounded-full focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
-          tone="accent"
-          onClick={goReviews}
-        >
-          New Review
-        </Button>
+        <Link href="/planner">
+          <Button className="rounded-full focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none">
+            Planner Today
+          </Button>
+        </Link>
+        <Link href="/goals">
+          <Button className="rounded-full focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none" tone="accent">
+            New Goal
+          </Button>
+        </Link>
+        <Link href="/reviews">
+          <Button className="rounded-full focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none" tone="accent">
+            New Review
+          </Button>
+        </Link>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- replace imperative router navigation in QuickActions with Next.js Link wrappers
- keep existing button styling so navigation and focus behavior remain intact

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ce55e328832c8832127499765e46