### PR TITLE
chore: switch to namespace React imports

### DIFF
--- a/src/components/reviews/ReviewList.tsx
+++ b/src/components/reviews/ReviewList.tsx
@@ -1,7 +1,7 @@
 // src/components/reviews/ReviewList.tsx
 "use client";
 
-import React from "react";
+import * as React from "react";
 import type { Review } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import ReviewListItem from "./ReviewListItem";

--- a/src/components/reviews/ReviewListItem.tsx
+++ b/src/components/reviews/ReviewListItem.tsx
@@ -1,7 +1,7 @@
 // src/components/reviews/ReviewListItem.tsx
 "use client";
 
-import React from "react";
+import * as React from "react";
 import { cn } from "@/lib/utils";
 import type { Review } from "@/lib/types";
 import Badge from "@/components/ui/primitives/Badge";

--- a/src/components/reviews/ReviewPanel.tsx
+++ b/src/components/reviews/ReviewPanel.tsx
@@ -1,4 +1,5 @@
-import React, { type HTMLAttributes } from "react";
+import * as React from "react";
+import { type HTMLAttributes } from "react";
 import { cn } from "@/lib/utils";
 import { Card } from "@/components/ui";
 

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
+import * as React from "react";
+import { useMemo, useState } from "react";
 import { ts } from "@/lib/date";
 import type { Review } from "@/lib/types";
 import { cn } from "@/lib/utils";

--- a/src/components/team/JungleClears.tsx
+++ b/src/components/team/JungleClears.tsx
@@ -11,7 +11,8 @@ import "./style.css";
  * - Titles and timers now use glitch-title + glitch-flicker + title-glow.
  */
 
-import React, { useMemo, useState, useEffect } from "react";
+import * as React from "react";
+import { useMemo, useState, useEffect } from "react";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import IconButton from "@/components/ui/primitives/IconButton";
 import Input from "@/components/ui/primitives/Input";

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -11,7 +11,8 @@
  */
 import "./style.css";
 
-import React, { useState } from "react";
+import * as React from "react";
+import { useState } from "react";
 import {
   Users2,
   BookOpenText,
@@ -153,9 +154,7 @@ export default function TeamCompPage() {
         label: "Builder",
         hint: "Fill allies vs enemies",
         icon: <Hammer />,
-        render: () => (
-          <Builder ref={builderApi} editing={editing.builder} />
-        ),
+        render: () => <Builder ref={builderApi} editing={editing.builder} />,
         ref: builderRef,
       },
       {
@@ -192,9 +191,7 @@ export default function TeamCompPage() {
           eyebrow={active?.label}
           heading="Comps"
           subtitle={
-            subTab === "sheet"
-              ? "Archetypes & tips"
-              : "Your saved compositions"
+            subTab === "sheet" ? "Archetypes & tips" : "Your saved compositions"
           }
           subTabs={{
             items: subTabs,
@@ -300,8 +297,8 @@ export default function TeamCompPage() {
         }
       >
         <p className="text-ui text-muted-foreground">
-          If you’re on a <em>Medium</em> champ, don’t race farm vs <em>Very Fast</em>.
-          Path for fights, ganks, or cross-map trades.
+          If you’re on a <em>Medium</em> champ, don’t race farm vs{" "}
+          <em>Very Fast</em>. Path for fights, ganks, or cross-map trades.
         </p>
       </Hero>
     );

--- a/tests/goals/goals-page.test.tsx
+++ b/tests/goals/goals-page.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   render,
   screen,
@@ -32,7 +32,9 @@ describe("GoalsPage", () => {
     render(<GoalsPage />);
 
     const titleInput = screen.getByRole("textbox", { name: "Title" });
-    const metricInput = screen.getByRole("textbox", { name: "Metric (optional)" });
+    const metricInput = screen.getByRole("textbox", {
+      name: "Metric (optional)",
+    });
     const addButton = screen.getByRole("button", { name: /add goal/i });
 
     fireEvent.change(titleInput, { target: { value: "Initial" } });
@@ -42,7 +44,9 @@ describe("GoalsPage", () => {
     const goalTitle = await screen.findByText("Initial");
     const article = goalTitle.closest("article") as HTMLElement;
 
-    const editButton = within(article).getByRole("button", { name: "Edit goal" });
+    const editButton = within(article).getByRole("button", {
+      name: "Edit goal",
+    });
     fireEvent.click(editButton);
 
     const editTitle = await within(article).findByPlaceholderText("Title");
@@ -91,9 +95,7 @@ describe("GoalsPage", () => {
     render(<GoalsPage />);
     const timerTab = screen.getByRole("tab", { name: "Timer" });
     fireEvent.click(timerTab);
-    expect(
-      screen.getByRole("heading", { name: "Timer" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Timer" })).toBeInTheDocument();
     expect(
       screen.getByRole("tablist", { name: "Timer profiles" }),
     ).toBeInTheDocument();

--- a/tests/goals/timer-tab.test.tsx
+++ b/tests/goals/timer-tab.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import TimerTab from "@/components/goals/TimerTab";

--- a/tests/icons/TimerRingIcon.test.tsx
+++ b/tests/icons/TimerRingIcon.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, cleanup, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import TimerRingIcon from "@/icons/TimerRingIcon";

--- a/tests/primitives/button.test.tsx
+++ b/tests/primitives/button.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, cleanup, fireEvent } from "@testing-library/react";
 import { describe, it, expect, afterEach, vi } from "vitest";
 import {

--- a/tests/primitives/glitch-segmented.test.tsx
+++ b/tests/primitives/glitch-segmented.test.tsx
@@ -1,32 +1,39 @@
-import React from 'react';
-import { render, cleanup } from '@testing-library/react';
-import { describe, it, expect, afterEach } from 'vitest';
-import { GlitchSegmentedGroup, GlitchSegmentedButton } from '../../src/components/ui/primitives/GlitchSegmented';
+import * as React from "react";
+import { render, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  GlitchSegmentedGroup,
+  GlitchSegmentedButton,
+} from "../../src/components/ui/primitives/GlitchSegmented";
 
 afterEach(cleanup);
 
-describe('GlitchSegmented', () => {
-  it('renders buttons', () => {
+describe("GlitchSegmented", () => {
+  it("renders buttons", () => {
     const { getByRole } = render(
       <GlitchSegmentedGroup value="a" onChange={() => {}}>
         <GlitchSegmentedButton value="a">A</GlitchSegmentedButton>
         <GlitchSegmentedButton value="b">B</GlitchSegmentedButton>
-      </GlitchSegmentedGroup>
+      </GlitchSegmentedGroup>,
     );
-    expect(getByRole('tab', { name: 'A' })).toBeInTheDocument();
-    expect(getByRole('tab', { name: 'B' })).toBeInTheDocument();
+    expect(getByRole("tab", { name: "A" })).toBeInTheDocument();
+    expect(getByRole("tab", { name: "B" })).toBeInTheDocument();
   });
 
-  it('has no outline when focused', () => {
+  it("has no outline when focused", () => {
     const { getByRole } = render(
       <GlitchSegmentedGroup value="a" onChange={() => {}}>
         <GlitchSegmentedButton value="a">A</GlitchSegmentedButton>
-      </GlitchSegmentedGroup>
+      </GlitchSegmentedGroup>,
     );
-    const btn = getByRole('tab');
+    const btn = getByRole("tab");
     btn.focus();
     const style = getComputedStyle(btn);
-    expect(style.outlineStyle === 'none' || style.outlineStyle === '').toBe(true);
-    expect(style.outlineWidth === '0px' || style.outlineWidth === '').toBe(true);
+    expect(style.outlineStyle === "none" || style.outlineStyle === "").toBe(
+      true,
+    );
+    expect(style.outlineWidth === "0px" || style.outlineWidth === "").toBe(
+      true,
+    );
   });
 });

--- a/tests/primitives/icon-button.test.tsx
+++ b/tests/primitives/icon-button.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, cleanup, waitFor } from "@testing-library/react";
 import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import IconButton from "../../src/components/ui/primitives/IconButton";

--- a/tests/primitives/input.test.tsx
+++ b/tests/primitives/input.test.tsx
@@ -1,7 +1,9 @@
-import React from "react";
+import * as React from "react";
 import { render, cleanup } from "@testing-library/react";
 import { describe, it, expect, afterEach } from "vitest";
-import Input, { type InputSize } from "../../src/components/ui/primitives/Input";
+import Input, {
+  type InputSize,
+} from "../../src/components/ui/primitives/Input";
 
 afterEach(cleanup);
 
@@ -18,39 +20,29 @@ describe("Input", () => {
     ["md", "var(--control-h-md)"],
     ["lg", "var(--control-h-lg)"],
   ])("applies %s height", (size, value) => {
-    const { getByRole } = render(
-      <Input aria-label={size} height={size} />,
-    );
+    const { getByRole } = render(<Input aria-label={size} height={size} />);
     const wrapper = getByRole("textbox").parentElement as HTMLElement;
     expect(wrapper).toHaveStyle(`--control-h: ${value}`);
   });
 
   it("applies indent padding", () => {
-    const { getByRole } = render(
-      <Input aria-label="indent" indent />,
-    );
+    const { getByRole } = render(<Input aria-label="indent" indent />);
     expect(getByRole("textbox")).toHaveClass("pl-7");
   });
 
   it("reserves end slot padding when hasEndSlot is true", () => {
-    const { getByRole } = render(
-      <Input aria-label="slot" hasEndSlot />,
-    );
+    const { getByRole } = render(<Input aria-label="slot" hasEndSlot />);
     expect(getByRole("textbox")).toHaveClass("pr-7");
   });
 
   it("shows error state when aria-invalid is true", () => {
-    const { getByRole } = render(
-      <Input aria-label="error" aria-invalid />,
-    );
+    const { getByRole } = render(<Input aria-label="error" aria-invalid />);
     const wrapper = getByRole("textbox").parentElement as HTMLElement;
     expect(wrapper).toHaveClass("ring-2", "ring-danger/35", "ring-offset-0");
   });
 
   it("applies disabled state", () => {
-    const { getByRole } = render(
-      <Input aria-label="disabled" disabled />,
-    );
+    const { getByRole } = render(<Input aria-label="disabled" disabled />);
     const input = getByRole("textbox") as HTMLInputElement;
     expect(input).toBeDisabled();
     expect(input).toHaveClass(
@@ -65,16 +57,12 @@ describe("Input", () => {
   });
 
   it("applies readOnly state", () => {
-    const { getByRole } = render(
-      <Input aria-label="readonly" readOnly />,
-    );
+    const { getByRole } = render(<Input aria-label="readonly" readOnly />);
     const input = getByRole("textbox") as HTMLInputElement;
     expect(input).toHaveAttribute("readonly");
     expect(input).toHaveClass("read-only:cursor-default");
     const wrapper = input.parentElement as HTMLElement;
-    expect(wrapper).toHaveClass(
-      "focus-within:after:bg-[var(--ring-muted)]",
-    );
+    expect(wrapper).toHaveClass("focus-within:after:bg-[var(--ring-muted)]");
   });
 
   it("handles data-loading attribute", () => {
@@ -83,9 +71,7 @@ describe("Input", () => {
     );
     const input = getByRole("textbox");
     expect(input).toHaveAttribute("data-loading", "true");
-    expect(input).toHaveClass(
-      "data-[loading=true]:opacity-[var(--loading)]",
-    );
+    expect(input).toHaveClass("data-[loading=true]:opacity-[var(--loading)]");
   });
 
   it("defaults name to the generated id when no overrides are provided", () => {

--- a/tests/primitives/search-bar.test.tsx
+++ b/tests/primitives/search-bar.test.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
-import { render, cleanup, fireEvent } from '@testing-library/react';
-import { describe, it, expect, afterEach, vi } from 'vitest';
-import { SearchBar } from '@/components/ui';
+import * as React from "react";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { SearchBar } from "@/components/ui";
 
 afterEach(cleanup);
 
-describe('SearchBar', () => {
-  it('invokes callbacks on submit', () => {
+describe("SearchBar", () => {
+  it("invokes callbacks on submit", () => {
     vi.useFakeTimers();
     const handleChange = vi.fn();
     const handleSubmit = vi.fn();
@@ -16,30 +16,30 @@ describe('SearchBar', () => {
         onValueChange={handleChange}
         onSubmit={handleSubmit}
         debounceMs={1000}
-      />
+      />,
     );
-    const input = getByRole('searchbox');
-    fireEvent.change(input, { target: { value: 'hello' } });
+    const input = getByRole("searchbox");
+    fireEvent.change(input, { target: { value: "hello" } });
     expect(handleChange).not.toHaveBeenCalled();
-    fireEvent.submit(getByRole('search'));
-    expect(handleChange).toHaveBeenCalledWith('hello');
-    expect(handleSubmit).toHaveBeenCalledWith('hello');
+    fireEvent.submit(getByRole("search"));
+    expect(handleChange).toHaveBeenCalledWith("hello");
+    expect(handleSubmit).toHaveBeenCalledWith("hello");
     vi.runAllTimers();
     vi.useRealTimers();
   });
 
-  it('disables browser text help by default', () => {
+  it("disables browser text help by default", () => {
     const { getByRole } = render(
-      <SearchBar value="" onValueChange={() => {}} />
+      <SearchBar value="" onValueChange={() => {}} />,
     );
-    const input = getByRole('searchbox');
-    expect(input).toHaveAttribute('autocomplete', 'off');
-    expect(input).toHaveAttribute('autocorrect', 'off');
-    expect(input).toHaveAttribute('autocapitalize', 'none');
-    expect(input).toHaveAttribute('spellcheck', 'false');
+    const input = getByRole("searchbox");
+    expect(input).toHaveAttribute("autocomplete", "off");
+    expect(input).toHaveAttribute("autocorrect", "off");
+    expect(input).toHaveAttribute("autocapitalize", "none");
+    expect(input).toHaveAttribute("spellcheck", "false");
   });
 
-  it('allows overriding text helpers', () => {
+  it("allows overriding text helpers", () => {
     const { getByRole } = render(
       <SearchBar
         value=""
@@ -48,34 +48,34 @@ describe('SearchBar', () => {
         autoCorrect="on"
         spellCheck={true}
         autoCapitalize="words"
-      />
+      />,
     );
-    const input = getByRole('searchbox');
-    expect(input).toHaveAttribute('autocomplete', 'on');
-    expect(input).toHaveAttribute('autocorrect', 'on');
-    expect(input).toHaveAttribute('autocapitalize', 'words');
-    expect(input).toHaveAttribute('spellcheck', 'true');
+    const input = getByRole("searchbox");
+    expect(input).toHaveAttribute("autocomplete", "on");
+    expect(input).toHaveAttribute("autocorrect", "on");
+    expect(input).toHaveAttribute("autocapitalize", "words");
+    expect(input).toHaveAttribute("spellcheck", "true");
   });
 
-  it('applies loading state', () => {
+  it("applies loading state", () => {
     const { getByRole } = render(
-      <SearchBar value="" onValueChange={() => {}} loading />
+      <SearchBar value="" onValueChange={() => {}} loading />,
     );
-    const form = getByRole('search');
-    expect(form).toHaveAttribute('data-loading', 'true');
-    const input = getByRole('searchbox');
+    const form = getByRole("search");
+    expect(form).toHaveAttribute("data-loading", "true");
+    const input = getByRole("searchbox");
     expect(input).toBeDisabled();
   });
 
-  it('renders an associated label when provided', () => {
+  it("renders an associated label when provided", () => {
     const { getByLabelText } = render(
-      <SearchBar value="" onValueChange={() => {}} label="Search tasks" />
+      <SearchBar value="" onValueChange={() => {}} label="Search tasks" />,
     );
 
-    expect(getByLabelText('Search tasks')).toBeInTheDocument();
+    expect(getByLabelText("Search tasks")).toBeInTheDocument();
   });
 
-  it('allows external labelling via aria-labelledby', () => {
+  it("allows external labelling via aria-labelledby", () => {
     const { getByRole } = render(
       <>
         <span id="search-title">Lookup</span>
@@ -84,11 +84,11 @@ describe('SearchBar', () => {
           onValueChange={() => {}}
           aria-labelledby="search-title"
         />
-      </>
+      </>,
     );
 
-    const input = getByRole('searchbox');
-    expect(input).toHaveAttribute('aria-labelledby', 'search-title');
-    expect(input).not.toHaveAttribute('aria-label');
+    const input = getByRole("searchbox");
+    expect(input).toHaveAttribute("aria-labelledby", "search-title");
+    expect(input).not.toHaveAttribute("aria-label");
   });
 });

--- a/tests/primitives/select-native.test.tsx
+++ b/tests/primitives/select-native.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 

--- a/tests/primitives/textarea.test.tsx
+++ b/tests/primitives/textarea.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, cleanup } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 

--- a/tests/prompts/prompts-compose-panel.test.tsx
+++ b/tests/prompts/prompts-compose-panel.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { PromptsComposePanel } from "@/components/prompts";
@@ -27,7 +27,9 @@ describe("PromptsComposePanel", () => {
     expect(
       screen.queryByRole("button", { name: "Confirm" }),
     ).not.toBeInTheDocument();
-    expect(container.querySelector("svg[aria-hidden='true']")).toBeInTheDocument();
+    expect(
+      container.querySelector("svg[aria-hidden='true']"),
+    ).toBeInTheDocument();
 
     fireEvent.change(titleInput, { target: { value: "New" } });
     expect(handleTitle).toHaveBeenCalledWith("New");

--- a/tests/prompts/prompts-demos.test.tsx
+++ b/tests/prompts/prompts-demos.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, screen, cleanup } from "@testing-library/react";
 import { describe, it, expect, afterEach } from "vitest";
 import { PromptsDemos } from "@/components/prompts";

--- a/tests/prompts/prompts-header.test.tsx
+++ b/tests/prompts/prompts-header.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { PromptsHeader } from "@/components/prompts";

--- a/tests/prompts/prompts-page.test.tsx
+++ b/tests/prompts/prompts-page.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   render,
   screen,

--- a/tests/reviews/LaneOpponentForm.test.tsx
+++ b/tests/reviews/LaneOpponentForm.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   cleanup,
   fireEvent,
@@ -59,7 +59,9 @@ describe("LaneOpponentForm", () => {
       />,
     );
 
-    const laneInput = screen.getByPlaceholderText("Ashe/Lulu") as HTMLInputElement;
+    const laneInput = screen.getByPlaceholderText(
+      "Ashe/Lulu",
+    ) as HTMLInputElement;
     const opponentInput = screen.getByPlaceholderText(
       "Draven/Thresh",
     ) as HTMLInputElement;
@@ -106,7 +108,9 @@ describe("LaneOpponentForm", () => {
     const commitMeta = vi.fn();
     render(<LaneOpponentForm commitMeta={commitMeta} />);
 
-    const laneInput = screen.getByPlaceholderText("Ashe/Lulu") as HTMLInputElement;
+    const laneInput = screen.getByPlaceholderText(
+      "Ashe/Lulu",
+    ) as HTMLInputElement;
     const opponentInput = screen.getByPlaceholderText(
       "Draven/Thresh",
     ) as HTMLInputElement;

--- a/tests/reviews/ReviewEditor.test.tsx
+++ b/tests/reviews/ReviewEditor.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { ReviewEditor } from "@/components/reviews";

--- a/tests/reviews/ReviewListItem.test.tsx
+++ b/tests/reviews/ReviewListItem.test.tsx
@@ -1,55 +1,55 @@
-import React from 'react';
-import { render, cleanup } from '@testing-library/react';
-import { describe, it, expect, afterEach } from 'vitest';
-import ReviewListItem from '../../src/components/reviews/ReviewListItem';
-import type { Review } from '../../src/lib/types';
+import * as React from "react";
+import { render, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import ReviewListItem from "../../src/components/reviews/ReviewListItem";
+import type { Review } from "../../src/lib/types";
 
 afterEach(cleanup);
 
 const baseReview: Review = {
-  id: '1',
-  title: 'Sample Review',
-  notes: 'Quick note',
+  id: "1",
+  title: "Sample Review",
+  notes: "Quick note",
   createdAt: 1700000000000,
-  matchup: 'Lux vs Ahri',
-  role: 'MID',
+  matchup: "Lux vs Ahri",
+  role: "MID",
   score: 9,
-  result: 'Win',
+  result: "Win",
   tags: [],
   pillars: [],
 };
 
-describe('ReviewListItem', () => {
-  it('renders default state', () => {
+describe("ReviewListItem", () => {
+  it("renders default state", () => {
     const { container } = render(<ReviewListItem review={baseReview} />);
     expect(container).toMatchSnapshot();
   });
 
-  it('renders selected state', () => {
+  it("renders selected state", () => {
     const { container } = render(
-      <ReviewListItem review={baseReview} selected />
+      <ReviewListItem review={baseReview} selected />,
     );
     expect(container).toMatchSnapshot();
   });
 
-  it('renders loading state', () => {
+  it("renders loading state", () => {
     const { container } = render(<ReviewListItem loading />);
     expect(container).toMatchSnapshot();
   });
 
-  it('renders disabled state', () => {
+  it("renders disabled state", () => {
     const { container } = render(
       <ReviewListItem disabled review={baseReview} />,
     );
     expect(container.firstChild).toHaveClass(
-      'disabled:opacity-60',
-      'disabled:pointer-events-none',
+      "disabled:opacity-60",
+      "disabled:pointer-events-none",
     );
     expect(container).toMatchSnapshot();
   });
 
-  it('renders untitled state', () => {
-    const review = { ...baseReview, title: '' };
+  it("renders untitled state", () => {
+    const review = { ...baseReview, title: "" };
     const { container } = render(<ReviewListItem review={review} />);
     expect(container).toMatchSnapshot();
   });

--- a/tests/reviews/ReviewsPage.test.tsx
+++ b/tests/reviews/ReviewsPage.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   render,
   screen,
@@ -160,6 +160,8 @@ describe("ReviewsPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Edit review" }));
     expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Done" }));
-    expect(screen.getByRole("button", { name: "Edit review" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Edit review" }),
+    ).toBeInTheDocument();
   });
 });

--- a/tests/ui/animated-select.test.tsx
+++ b/tests/ui/animated-select.test.tsx
@@ -1,43 +1,47 @@
-import React from 'react';
-import { render, cleanup, fireEvent } from '@testing-library/react';
-import { describe, it, expect, afterEach } from 'vitest';
-import Select from '../../src/components/ui/Select';
+import * as React from "react";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import Select from "../../src/components/ui/Select";
 
 afterEach(cleanup);
 
-describe('Select animated variant', () => {
-  it('associates label and trigger via aria-labelledby', () => {
+describe("Select animated variant", () => {
+  it("associates label and trigger via aria-labelledby", () => {
     const items = [
-      { value: 'apple', label: 'Apple' },
-      { value: 'orange', label: 'Orange' },
+      { value: "apple", label: "Apple" },
+      { value: "orange", label: "Orange" },
     ];
     const { getByText, getByRole } = render(
-      <Select variant="animated" label="Fruit" items={items} />
+      <Select variant="animated" label="Fruit" items={items} />,
     );
 
-    const labelEl = getByText('Fruit');
-    const button = getByRole('button', { name: 'Fruit' });
+    const labelEl = getByText("Fruit");
+    const button = getByRole("button", { name: "Fruit" });
 
     expect(labelEl.id).toBeTruthy();
-    expect(button).toHaveAttribute('aria-labelledby', labelEl.id);
+    expect(button).toHaveAttribute("aria-labelledby", labelEl.id);
 
     fireEvent.click(button);
-    const listbox = getByRole('listbox');
-    expect(listbox).toHaveAttribute('aria-labelledby', labelEl.id);
+    const listbox = getByRole("listbox");
+    expect(listbox).toHaveAttribute("aria-labelledby", labelEl.id);
   });
 
-  it('has no outline on trigger when focused', () => {
+  it("has no outline on trigger when focused", () => {
     const items = [
-      { value: 'apple', label: 'Apple' },
-      { value: 'orange', label: 'Orange' },
+      { value: "apple", label: "Apple" },
+      { value: "orange", label: "Orange" },
     ];
     const { getByRole } = render(
-      <Select variant="animated" ariaLabel="Fruit" items={items} />
+      <Select variant="animated" ariaLabel="Fruit" items={items} />,
     );
-    const button = getByRole('button');
+    const button = getByRole("button");
     fireEvent.focus(button);
     const style = getComputedStyle(button as HTMLElement);
-    expect(style.outlineStyle === 'none' || style.outlineStyle === '').toBe(true);
-    expect(style.outlineWidth === '0px' || style.outlineWidth === '').toBe(true);
+    expect(style.outlineStyle === "none" || style.outlineStyle === "").toBe(
+      true,
+    );
+    expect(style.outlineWidth === "0px" || style.outlineWidth === "").toBe(
+      true,
+    );
   });
 });

--- a/tests/ui/animation-toggle.test.tsx
+++ b/tests/ui/animation-toggle.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, fireEvent, cleanup, waitFor } from "@testing-library/react";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { AnimationToggle } from "@/components/ui";

--- a/tests/ui/badge.test.tsx
+++ b/tests/ui/badge.test.tsx
@@ -1,32 +1,31 @@
-import React from 'react';
-import { render, cleanup } from '@testing-library/react';
-import { describe, it, expect, afterEach } from 'vitest';
-import { Badge } from '@/components/ui';
+import * as React from "react";
+import { render, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import { Badge } from "@/components/ui";
 
 afterEach(() => {
   cleanup();
 });
 
-describe('Badge', () => {
-  it('renders neutral tone by default', () => {
+describe("Badge", () => {
+  it("renders neutral tone by default", () => {
     const { getByText } = render(<Badge>Neutral</Badge>);
-    const badge = getByText('Neutral');
-    expect(badge).toHaveClass('border-card-hairline');
-    expect(badge).toHaveClass('bg-muted/18');
+    const badge = getByText("Neutral");
+    expect(badge).toHaveClass("border-card-hairline");
+    expect(badge).toHaveClass("bg-muted/18");
   });
 
-  it('applies accent tone styles', () => {
+  it("applies accent tone styles", () => {
     const { getByText } = render(<Badge tone="accent">Accent</Badge>);
-    const badge = getByText('Accent');
-    expect(badge).toHaveClass('border-[var(--accent-overlay)]');
+    const badge = getByText("Accent");
+    expect(badge).toHaveClass("border-[var(--accent-overlay)]");
   });
 
-  it('supports the xs size', () => {
+  it("supports the xs size", () => {
     const { getByText } = render(<Badge size="xs">Small</Badge>);
-    const badge = getByText('Small');
-    expect(badge).toHaveClass('px-[var(--space-2)]');
-    expect(badge).toHaveClass('py-[var(--space-1)]');
-    expect(badge).toHaveClass('text-label');
+    const badge = getByText("Small");
+    expect(badge).toHaveClass("px-[var(--space-2)]");
+    expect(badge).toHaveClass("py-[var(--space-1)]");
+    expect(badge).toHaveClass("text-label");
   });
 });
-

--- a/tests/ui/button.test.tsx
+++ b/tests/ui/button.test.tsx
@@ -1,11 +1,7 @@
-import React from "react";
+import * as React from "react";
 import { render, cleanup, fireEvent } from "@testing-library/react";
 import { describe, it, expect, afterEach, vi } from "vitest";
-import {
-  Button,
-  type ButtonProps,
-  type ButtonSize,
-} from "@/components/ui";
+import { Button, type ButtonProps, type ButtonSize } from "@/components/ui";
 
 afterEach(cleanup);
 
@@ -50,7 +46,7 @@ describe("Button", () => {
 
   for (const [size, sizeCls] of Object.entries(sizes) as [
     ButtonSize,
-    string
+    string,
   ][]) {
     for (const variant of Object.keys(variantToneClasses) as Array<
       NonNullable<ButtonProps["variant"]>
@@ -123,4 +119,3 @@ describe("Button", () => {
     );
   });
 });
-

--- a/tests/ui/input.test.tsx
+++ b/tests/ui/input.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, cleanup, fireEvent } from "@testing-library/react";
 import { describe, it, expect, afterEach } from "vitest";
 import { Input } from "@/components/ui";

--- a/tests/ui/label.test.tsx
+++ b/tests/ui/label.test.tsx
@@ -1,31 +1,30 @@
-import React from 'react';
-import { render, cleanup } from '@testing-library/react';
-import { describe, it, expect, afterEach } from 'vitest';
-import { Label } from '@/components/ui';
+import * as React from "react";
+import { render, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import { Label } from "@/components/ui";
 
 afterEach(() => {
   cleanup();
 });
 
-describe('Label', () => {
-  it('renders provided text', () => {
+describe("Label", () => {
+  it("renders provided text", () => {
     const { getByText } = render(<Label>Username</Label>);
-    expect(getByText('Username')).toBeInTheDocument();
+    expect(getByText("Username")).toBeInTheDocument();
   });
 
-  it('associates with input via htmlFor', () => {
+  it("associates with input via htmlFor", () => {
     const { getByLabelText } = render(
       <>
         <Label htmlFor="email">Email</Label>
         <input id="email" />
-      </>
+      </>,
     );
-    expect(getByLabelText('Email')).toBeInTheDocument();
+    expect(getByLabelText("Email")).toBeInTheDocument();
   });
 
-  it('merges custom class names', () => {
+  it("merges custom class names", () => {
     const { getByText } = render(<Label className="custom">Name</Label>);
-    expect(getByText('Name')).toHaveClass('custom');
+    expect(getByText("Name")).toHaveClass("custom");
   });
 });
-

--- a/tests/ui/select.test.tsx
+++ b/tests/ui/select.test.tsx
@@ -1,94 +1,98 @@
-import React from 'react';
-import { render, cleanup, fireEvent } from '@testing-library/react';
-import { describe, it, expect, afterEach } from 'vitest';
-import Select from '../../src/components/ui/Select';
+import * as React from "react";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import Select from "../../src/components/ui/Select";
 
 afterEach(cleanup);
 
-describe('Select', () => {
-  it('renders default state', () => {
+describe("Select", () => {
+  it("renders default state", () => {
     const { container } = render(
       <Select
         variant="native"
         aria-label="test"
         items={[
-          { value: '', label: 'Choose…' },
-          { value: 'a', label: 'A' },
+          { value: "", label: "Choose…" },
+          { value: "a", label: "A" },
         ]}
         value=""
-      />
+      />,
     );
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('renders focus state', () => {
+  it("renders focus state", () => {
     const { container, getByRole } = render(
       <Select
         variant="native"
         aria-label="test"
         items={[
-          { value: '', label: 'Choose…' },
-          { value: 'a', label: 'A' },
+          { value: "", label: "Choose…" },
+          { value: "a", label: "A" },
         ]}
         value=""
-      />
+      />,
     );
-    fireEvent.focus(getByRole('combobox'));
+    fireEvent.focus(getByRole("combobox"));
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('renders error state', () => {
+  it("renders error state", () => {
     const { container } = render(
       <Select
         variant="native"
         aria-label="test"
         errorText="Error"
-        items={[{ value: '', label: 'Choose…' }]}
+        items={[{ value: "", label: "Choose…" }]}
         value=""
-      />
+      />,
     );
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('renders success state', () => {
+  it("renders success state", () => {
     const { container } = render(
       <Select
         variant="native"
         aria-label="test"
         success
-        items={[{ value: '', label: 'Choose…' }]}
+        items={[{ value: "", label: "Choose…" }]}
         value=""
-      />
+      />,
     );
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('renders disabled state', () => {
+  it("renders disabled state", () => {
     const { container } = render(
       <Select
         variant="native"
         aria-label="test"
         disabled
-        items={[{ value: '', label: 'Choose…' }]}
+        items={[{ value: "", label: "Choose…" }]}
         value=""
-      />
+      />,
     );
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('has no outline when focused', () => {
+  it("has no outline when focused", () => {
     const { getByRole } = render(
       <Select
         variant="native"
         aria-label="outline"
-        items={[{ value: '', label: 'Choose…' }]}
+        items={[{ value: "", label: "Choose…" }]}
         value=""
-      />
+      />,
     );
-    const select = getByRole('combobox');
+    const select = getByRole("combobox");
     fireEvent.focus(select);
     const style = getComputedStyle(select);
-    expect(style.outlineStyle === 'none' || style.outlineStyle === '').toBe(true);
-    expect(style.outlineWidth === '0px' || style.outlineWidth === '').toBe(true);
+    expect(style.outlineStyle === "none" || style.outlineStyle === "").toBe(
+      true,
+    );
+    expect(style.outlineWidth === "0px" || style.outlineWidth === "").toBe(
+      true,
+    );
   });
 });

--- a/tests/ui/spinner.test.tsx
+++ b/tests/ui/spinner.test.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import Spinner from '@/components/ui/feedback/Spinner';
-import { describe, expect, it } from 'vitest';
+import * as React from "react";
+import { render } from "@testing-library/react";
+import Spinner from "@/components/ui/feedback/Spinner";
+import { describe, expect, it } from "vitest";
 
-describe('Spinner', () => {
-  it('renders with status role', () => {
+describe("Spinner", () => {
+  it("renders with status role", () => {
     const { getByRole } = render(<Spinner />);
-    expect(getByRole('status')).toBeInTheDocument();
+    expect(getByRole("status")).toBeInTheDocument();
   });
 });

--- a/tests/ui/tab-bar.test.tsx
+++ b/tests/ui/tab-bar.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { describe, it, expect, afterEach } from "vitest";
 import { Header, Hero } from "@/components/ui";

--- a/tests/ui/textarea.test.tsx
+++ b/tests/ui/textarea.test.tsx
@@ -1,72 +1,76 @@
-import React from 'react';
-import { render, cleanup, fireEvent } from '@testing-library/react';
-import { describe, it, expect, afterEach } from 'vitest';
-import Textarea from '../../src/components/ui/primitives/Textarea';
-import { slugify } from '../../src/lib/utils';
+import * as React from "react";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import Textarea from "../../src/components/ui/primitives/Textarea";
+import { slugify } from "../../src/lib/utils";
 
 afterEach(cleanup);
 
-describe('Textarea', () => {
-  it('renders default state', () => {
+describe("Textarea", () => {
+  it("renders default state", () => {
     const { container } = render(<Textarea aria-label="test" />);
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('renders focus state', () => {
+  it("renders focus state", () => {
     const { container, getByRole } = render(<Textarea aria-label="test" />);
-    fireEvent.focus(getByRole('textbox'));
+    fireEvent.focus(getByRole("textbox"));
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('renders disabled state', () => {
+  it("renders disabled state", () => {
     const { container } = render(<Textarea aria-label="test" disabled />);
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('renders error state', () => {
+  it("renders error state", () => {
     const { container } = render(
-      <Textarea aria-label="test" aria-invalid="true" />
+      <Textarea aria-label="test" aria-invalid="true" />,
     );
     expect(container.firstChild).toMatchSnapshot();
   });
 
   it('handles aria-invalid="false" as non-error', () => {
     const { container } = render(
-      <Textarea aria-label="test" aria-invalid="false" />
+      <Textarea aria-label="test" aria-invalid="false" />,
     );
     expect(container.firstChild).not.toHaveClass(
-      'border-[hsl(var(--danger)/0.6)]'
+      "border-[hsl(var(--danger)/0.6)]",
     );
   });
 
-  it('has no outline when focused', () => {
+  it("has no outline when focused", () => {
     const { getByRole } = render(<Textarea aria-label="outline" />);
-    const ta = getByRole('textbox');
+    const ta = getByRole("textbox");
     fireEvent.focus(ta);
     const style = getComputedStyle(ta);
-    expect(style.outlineStyle === 'none' || style.outlineStyle === '').toBe(true);
-    expect(style.outlineWidth === '0px' || style.outlineWidth === '').toBe(true);
-  });
-
-  it('applies resize prop', () => {
-    const { getByRole } = render(
-      <Textarea aria-label="resize" resize="resize-y" />
+    expect(style.outlineStyle === "none" || style.outlineStyle === "").toBe(
+      true,
     );
-    const ta = getByRole('textbox');
-    expect(ta).toHaveClass('resize-y');
-  });
-
-  it('applies textareaClassName to textarea', () => {
-    const { getByRole } = render(
-      <Textarea aria-label="custom" textareaClassName="custom" />
+    expect(style.outlineWidth === "0px" || style.outlineWidth === "").toBe(
+      true,
     );
-    const ta = getByRole('textbox');
-    expect(ta).toHaveClass('custom');
   });
 
-  it('slugifies generated id for default name', () => {
+  it("applies resize prop", () => {
+    const { getByRole } = render(
+      <Textarea aria-label="resize" resize="resize-y" />,
+    );
+    const ta = getByRole("textbox");
+    expect(ta).toHaveClass("resize-y");
+  });
+
+  it("applies textareaClassName to textarea", () => {
+    const { getByRole } = render(
+      <Textarea aria-label="custom" textareaClassName="custom" />,
+    );
+    const ta = getByRole("textbox");
+    expect(ta).toHaveClass("custom");
+  });
+
+  it("slugifies generated id for default name", () => {
     const { getByRole } = render(<Textarea />);
-    const ta = getByRole('textbox') as HTMLTextAreaElement;
+    const ta = getByRole("textbox") as HTMLTextAreaElement;
     expect(ta.name).toBe(slugify(ta.id));
   });
 });

--- a/tests/ui/toggle.test.tsx
+++ b/tests/ui/toggle.test.tsx
@@ -1,23 +1,23 @@
-import React from 'react';
-import { render, cleanup } from '@testing-library/react';
-import { describe, it, expect, afterEach } from 'vitest';
-import { Toggle } from '@/components/ui';
+import * as React from "react";
+import { render, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import { Toggle } from "@/components/ui";
 
 afterEach(() => {
   cleanup();
 });
 
-describe('Toggle', () => {
-  it('labels the switch via aria-labelledby', () => {
+describe("Toggle", () => {
+  it("labels the switch via aria-labelledby", () => {
     const { getByRole, getByText } = render(
-      <Toggle leftLabel="Left" rightLabel="Right" />
+      <Toggle leftLabel="Left" rightLabel="Right" />,
     );
-    const button = getByRole('switch');
-    const left = getByText('Left');
-    const right = getByText('Right');
+    const button = getByRole("switch");
+    const left = getByText("Left");
+    const right = getByText("Right");
     expect(left.id).toBeTruthy();
     expect(right.id).toBeTruthy();
-    expect(button).toHaveAttribute('aria-labelledby', `${left.id} ${right.id}`);
-    expect(button).not.toHaveAttribute('aria-label');
+    expect(button).toHaveAttribute("aria-labelledby", `${left.id} ${right.id}`);
+    expect(button).not.toHaveAttribute("aria-label");
   });
 });


### PR DESCRIPTION
## Summary
- replace default React imports in review and team components with namespace imports and preserved named hooks where needed
- update tests across goals, reviews, prompts, primitives, and ui suites to use the namespace React import and consistent quoting

## Testing
- npm run format
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8cdf17804832cadbda09540a1eb18