### PR TITLE
Add tasksByProject coverage to planner store tests

### DIFF
--- a/tests/planner/usePlannerStore.test.tsx
+++ b/tests/planner/usePlannerStore.test.tsx
@@ -34,15 +34,31 @@ describe("usePlannerStore", () => {
     });
     expect(result.current.day.projects).toHaveLength(1);
     expect(result.current.day.projects[0].name).toBe("Proj A");
+    expect(
+      result.current.planner.day.tasksByProject[projectId],
+    ).toBeUndefined();
 
     act(() => result.current.planner.renameProject(projectId, "Proj B"));
     expect(result.current.day.projects[0].name).toBe("Proj B");
 
     let taskId = "";
+    let secondTaskId = "";
     act(() => {
       taskId = result.current.planner.addTask("Task 1", projectId);
     });
     expect(result.current.day.tasks).toHaveLength(1);
+    expect(result.current.planner.day.tasksByProject[projectId]).toEqual([
+      taskId,
+    ]);
+
+    act(() => {
+      secondTaskId = result.current.planner.addTask("Task 2", projectId);
+    });
+    expect(result.current.day.tasks).toHaveLength(2);
+    expect(result.current.planner.day.tasksByProject[projectId]).toEqual([
+      taskId,
+      secondTaskId,
+    ]);
 
     act(() => {
       result.current.planner.addTaskImage(
@@ -72,10 +88,20 @@ describe("usePlannerStore", () => {
     expect(result.current.day.tasks[0].done).toBe(true);
 
     act(() => result.current.planner.removeTask(taskId));
-    expect(result.current.day.tasks).toHaveLength(0);
+    expect(result.current.day.tasks).toHaveLength(1);
+    expect(result.current.planner.day.tasksByProject[projectId]).toEqual([
+      secondTaskId,
+    ]);
+    expect(
+      result.current.planner.day.tasksByProject[projectId],
+    ).not.toContain(taskId);
 
     act(() => result.current.planner.removeProject(projectId));
     expect(result.current.day.projects).toHaveLength(0);
+    expect(result.current.day.tasks).toHaveLength(0);
+    expect(
+      result.current.planner.day.tasksByProject[projectId],
+    ).toBeUndefined();
   });
 
   it("provides day-scoped utilities via useDay", () => {


### PR DESCRIPTION
## Summary
- extend the planner store CRUD test to assert `tasksByProject` updates when tasks are created, removed, or the owning project is deleted
- exercise scenarios with multiple tasks to confirm orphaned IDs are sanitized from the mapping

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8cfadd2c0832c8ee9c846524be240