### PR TITLE
Update select helper text live region

### DIFF
--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -142,6 +142,8 @@ const NativeSelect = React.forwardRef<HTMLSelectElement, NativeSelectProps>(
               "text-label mt-1 line-clamp-2",
               errorText ? "text-danger" : "text-muted-foreground",
             )}
+            role="alert"
+            aria-live={errorText ? "assertive" : "polite"}
           >
             {errorText || helperText}
           </p>

--- a/tests/ui/__snapshots__/select.test.tsx.snap
+++ b/tests/ui/__snapshots__/select.test.tsx.snap
@@ -123,8 +123,10 @@ exports[`Select > renders error state 1`] = `
     </svg>
   </div>
   <p
+    aria-live="assertive"
     class="text-label mt-1 line-clamp-2 text-danger"
     id=":r2:-error"
+    role="alert"
   >
     Error
   </p>


### PR DESCRIPTION
## Summary
- announce NativeSelect helper and error messaging with `role="alert"` and appropriate `aria-live`
- refresh select component snapshot to capture the accessibility attributes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8d125a1a4832caad46b5ff686a3c2