### PR TITLE
refactor(prompts): stabilize palette tabs

### DIFF
--- a/src/components/prompts/ColorGallery.tsx
+++ b/src/components/prompts/ColorGallery.tsx
@@ -4,12 +4,13 @@ import * as React from "react";
 import { TabBar, type TabItem } from "@/components/ui";
 import { COLOR_PALETTES, type ColorPalette } from "@/lib/theme";
 
+const paletteTabs: TabItem<ColorPalette>[] = [
+  { key: "aurora", label: "Aurora" },
+  { key: "neutrals", label: "Neutrals" },
+  { key: "accents", label: "Accents" },
+];
+
 export default function ColorGallery() {
-  const paletteTabs: TabItem<ColorPalette>[] = [
-    { key: "aurora", label: "Aurora" },
-    { key: "neutrals", label: "Neutrals" },
-    { key: "accents", label: "Accents" },
-  ];
   const [palette, setPalette] = React.useState<ColorPalette>("aurora");
   const panelRefs = React.useRef<Record<ColorPalette, HTMLDivElement | null>>({
     aurora: null,


### PR DESCRIPTION
## Summary
- hoist the ColorGallery palette tab definitions so the data is reused between renders
- keep the TabBar items prop stable to avoid unnecessary rerenders when the palette changes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8d42254a4832caee3adc9e84dc3d9