### PR TITLE
Run PageTabs hash restore effect once on mount

### DIFF
--- a/src/components/chrome/PageTabs.tsx
+++ b/src/components/chrome/PageTabs.tsx
@@ -49,7 +49,7 @@ export default function PageTabs({
     if (hash && tabs.some(t => t.id === hash)) {
       onChange?.(hash);
     }
-  }, [tabs, onChange]);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Sync active tab to URL hash
   React.useEffect(() => {


### PR DESCRIPTION
## Summary
- run the PageTabs hash restoration effect only on mount and silence the exhaustive deps warning

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8d42b4380832c827ba8a81b6f3fb5