### PR TITLE
Guard background indices when applying theme

### DIFF
--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -109,7 +109,9 @@ export function applyTheme({ variant, bg }: ThemeState) {
   const cl = document.documentElement.classList;
   resetThemeClasses(cl);
   cl.add(`theme-${variant}`);
-  if (bg > 0) cl.add(BG_CLASSES[bg]);
+  const isValidBgIndex =
+    Number.isInteger(bg) && bg >= 0 && bg < BG_CLASSES.length;
+  if (isValidBgIndex && bg > 0) cl.add(BG_CLASSES[bg]);
   cl.add("dark");
 }
 
@@ -129,7 +131,11 @@ export function themeBootstrapScript(): string {
       const cl = document.documentElement.classList;
       resetThemeClasses(cl);
       cl.add("theme-" + data.variant);
-      if (data.bg > 0) cl.add(BG_CLASSES[data.bg]);
+      const isValidBgIndex =
+        Number.isInteger(data.bg) &&
+        data.bg >= 0 &&
+        data.bg < BG_CLASSES.length;
+      if (isValidBgIndex && data.bg > 0) cl.add(BG_CLASSES[data.bg]);
       cl.add("dark");
     } catch {}
   })())`;

--- a/tests/lib/theme.test.ts
+++ b/tests/lib/theme.test.ts
@@ -1,0 +1,65 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import {
+  applyTheme,
+  BG_CLASSES,
+  THEME_STORAGE_KEY,
+  themeBootstrapScript,
+} from "@/lib/theme";
+import { createStorageKey } from "@/lib/storage-key";
+import type { Background } from "@/lib/theme";
+import { resetLocalStorage } from "../setup";
+
+beforeEach(() => {
+  document.documentElement.className = "";
+  resetLocalStorage();
+});
+
+describe("applyTheme", () => {
+  it.each([-1, BG_CLASSES.length])(
+    "ignores invalid background index %s",
+    (invalidIndex) => {
+      applyTheme({
+        variant: "lg",
+        bg: invalidIndex as unknown as Background,
+      });
+
+      expect(Array.from(document.documentElement.classList)).toEqual([
+        "theme-lg",
+        "dark",
+      ]);
+      expect(
+        document.documentElement.classList.contains("undefined"),
+      ).toBe(false);
+    },
+  );
+});
+
+describe("themeBootstrapScript", () => {
+  it("ignores invalid background index from stored theme", () => {
+    const key = createStorageKey(THEME_STORAGE_KEY);
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({ variant: "lg", bg: BG_CLASSES.length }),
+    );
+
+    const script = themeBootstrapScript();
+    expect(() => {
+      // eslint-disable-next-line no-eval
+      eval(script);
+    }).not.toThrow();
+
+    const { classList } = document.documentElement;
+    expect(Array.from(classList)).toContain("theme-lg");
+    expect(Array.from(classList)).toContain("dark");
+    for (const bgClass of BG_CLASSES) {
+      if (!bgClass) continue;
+      expect(classList.contains(bgClass)).toBe(false);
+    }
+    expect(classList.contains("undefined")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- validate background indices before applying theme classes at runtime and during bootstrap
- add coverage ensuring invalid background values do not add unexpected document classes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8d40c47b0832c969892bd73f43da2