### PR TITLE
Fix sanitizeText escape map typing

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -61,13 +61,13 @@ export function slugify(s?: string): string {
 }
 
 /** Escape mappings for sanitizeText */
-const HTML_ESCAPE_MAP: Record<string, string> = {
+const HTML_ESCAPE_MAP = {
   "&": "&amp;",
   "<": "&lt;",
   ">": "&gt;",
   "\u0022": "&quot;",
   "'": "&#39;",
-};
+} as const;
 
 /**
  * Clone data using structuredClone with JSON fallback.
@@ -92,5 +92,8 @@ export function safeClone<T>(value: T): T {
  * Minimal on purpose; more heavy sanitizers can be added if needed.
  */
 export function sanitizeText(input: string): string {
-  return input.replace(/[&<>"']/g, (c) => HTML_ESCAPE_MAP[c]);
+  return input.replace(
+    /[&<>"']/g,
+    (c) => HTML_ESCAPE_MAP[c as keyof typeof HTML_ESCAPE_MAP] ?? c,
+  );
 }

--- a/tests/lib/utils.test.ts
+++ b/tests/lib/utils.test.ts
@@ -58,4 +58,18 @@ describe("sanitizeText", () => {
       "&lt;div&gt;&amp;&quot;&#39;&lt;/div&gt;",
     );
   });
+
+  it("maps individual escapable characters", () => {
+    const cases: Array<[string, string]> = [
+      ["&", "&amp;"],
+      ["<", "&lt;"],
+      [">", "&gt;"],
+      ["\"", "&quot;"],
+      ["'", "&#39;"],
+    ];
+
+    for (const [input, expected] of cases) {
+      expect(sanitizeText(input)).toBe(expected);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- type the HTML escape map as a const record and fallback to the original character when a mapping is missing
- add unit coverage to verify each HTML escape maps to the expected entity

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8d569472c832ca8f758049486c635