### PR TITLE
Add disabled styling for champ badges

### DIFF
--- a/src/components/team/ChampListEditor.tsx
+++ b/src/components/team/ChampListEditor.tsx
@@ -76,7 +76,10 @@ export default function ChampListEditor({
       if (emptyLabel === undefined) return null;
       return (
         <div className={cn(VIEW_CONTAINER, viewClassName)}>
-          <span className={cn(PILL_BASE, pillClassName)}>
+          <span
+            className={cn(PILL_BASE, pillClassName)}
+            aria-disabled
+          >
             <i className="dot" />
             {emptyLabel}
           </span>

--- a/src/components/team/style.css
+++ b/src/components/team/style.css
@@ -21,6 +21,10 @@
 .champ-badge:active {
   @apply bg-[--active];
 }
+.champ-badge:disabled,
+.champ-badge[aria-disabled="true"] {
+  @apply opacity-[var(--disabled)] pointer-events-none;
+}
 .champ-badge--dense {
   @apply h-5 px-2;
 }


### PR DESCRIPTION
## Summary
- add a disabled selector for champ badges so opacity drops and pointer events are cleared
- mark empty champ list placeholders as aria-disabled to pick up the new styling

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8d43a98ec832c87b81618c2a2e40f