### PR TITLE
Fix PageTabs hash restore effect dependencies

### DIFF
--- a/src/components/chrome/PageTabs.tsx
+++ b/src/components/chrome/PageTabs.tsx
@@ -43,13 +43,20 @@ export default function PageTabs({
   const router = useRouter();
   const pathname = usePathname();
 
+  const hasRestoredFromHash = React.useRef(false);
+
   // Restore tab from hash on load
   React.useEffect(() => {
+    if (hasRestoredFromHash.current) {
+      return;
+    }
+    hasRestoredFromHash.current = true;
+
     const hash = window.location.hash.replace("#", "");
     if (hash && tabs.some(t => t.id === hash)) {
       onChange?.(hash);
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [tabs, onChange]);
 
   // Sync active tab to URL hash
   React.useEffect(() => {


### PR DESCRIPTION
## Summary
- guard the PageTabs hash-restore effect with a ref to avoid lint suppression
- keep the effect dependency list accurate while still running once on mount

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8d6b81bc4832cafd20237a01bbddd