### PR TITLE
refactor: extract shared validators

### DIFF
--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -14,6 +14,7 @@ import "./style.css";
 
 import * as React from "react";
 import { usePersistentState, uid } from "@/lib/db";
+import { isRecord, isStringArray, safeNumber } from "@/lib/validators";
 import { copyText } from "@/lib/clipboard";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import IconButton from "@/components/ui/primitives/IconButton";
@@ -78,17 +79,6 @@ const SEEDS: TeamComp[] = [
 ];
 
 /* ───────────── Utils ───────────── */
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-function isStringArray(v: unknown): v is string[] {
-  return Array.isArray(v) && v.every((x) => typeof x === "string");
-}
-function safeNumber(v: unknown, fallback: number): number {
-  const n = typeof v === "number" ? v : Number.NaN;
-  return Number.isFinite(n) ? n : fallback;
-}
 
 function stringify(c: TeamComp) {
   const body = ROLES.map((r) => `${r}: ${c.roles[r]?.join(", ") || "-"}`).join(

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,0 +1,15 @@
+// src/lib/validators.ts
+// Shared runtime type guards and validators.
+
+export function isRecord<T = unknown>(value: unknown): value is Record<string, T> {
+  return typeof value === "object" && value !== null;
+}
+
+export function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+export function safeNumber(value: unknown, fallback: number): number {
+  const n = typeof value === "number" ? value : Number.NaN;
+  return Number.isFinite(n) ? n : fallback;
+}


### PR DESCRIPTION
## Summary
- add `src/lib/validators.ts` with shared runtime validators for records, string arrays, and numbers
- update `MyComps` to import the shared helpers instead of local copies

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8d717c630832ca355c82757fca88a