### PR TITLE
Refactor quick action button styles

### DIFF
--- a/src/components/home/QuickActions.tsx
+++ b/src/components/home/QuickActions.tsx
@@ -4,22 +4,25 @@ import * as React from "react";
 import Button from "@/components/ui/primitives/Button";
 import Link from "next/link";
 
+const quickActionButtonClassName =
+  "rounded-[var(--radius-2xl)] [--focus:var(--theme-ring)] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none";
+
 export default function QuickActions() {
   return (
     <section aria-label="Quick actions" className="grid gap-4">
       <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <Link href="/planner">
-          <Button className="rounded-full focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none">
+          <Button className={quickActionButtonClassName}>
             Planner Today
           </Button>
         </Link>
         <Link href="/goals">
-          <Button className="rounded-full focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none" tone="accent">
+          <Button className={quickActionButtonClassName} tone="accent">
             New Goal
           </Button>
         </Link>
         <Link href="/reviews">
-          <Button className="rounded-full focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none" tone="accent">
+          <Button className={quickActionButtonClassName} tone="accent">
             New Review
           </Button>
         </Link>


### PR DESCRIPTION
## Summary
- extract a reusable class configuration for quick action buttons
- switch quick actions to use the radius token and shared focus styles instead of repeating utility classes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8d93a62e0832ca65fdd78d63b10b9