### PR TITLE
Adjust focus outline for forced colors

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -98,6 +98,14 @@ html.no-animations *::after {
   box-shadow: 0 0 6px hsl(var(--glow) / 0.6);
 }
 
+@media (forced-colors: active) {
+  *:focus-visible {
+    outline: 2px solid CanvasText;
+    outline-offset: 2px;
+    box-shadow: none;
+  }
+}
+
 ::selection {
   background: hsl(var(--accent));
   color: hsl(var(--accent-foreground));


### PR DESCRIPTION
## Summary
- add a forced-colors override for global focus-visible styling to ensure system high-contrast support

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8d977414c832ca678f9c36a2fb243