### PR TITLE
Replace TaskRow attachment img with Next Image

### DIFF
--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import Image from "next/image";
 import Input from "@/components/ui/primitives/Input";
 import IconButton from "@/components/ui/primitives/IconButton";
 import CheckCircle from "@/components/ui/toggles/CheckCircle";
@@ -8,6 +9,9 @@ import { Pencil, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import useAutoFocus from "@/lib/useAutoFocus";
 import type { DayTask } from "./plannerStore";
+import tokens from "../../../tokens/tokens.js";
+
+const TASK_IMAGE_SIZE = Number.parseInt(tokens.spacing7, 10);
 
 type Props = {
   task: DayTask;
@@ -195,10 +199,12 @@ export default function TaskRow({
         <ul className="mt-2 space-y-2">
           {task.images.map((url) => (
             <li key={url} className="flex items-center gap-2">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
+              <Image
                 src={url}
                 alt={`Image for ${task.title}`}
+                width={TASK_IMAGE_SIZE}
+                height={TASK_IMAGE_SIZE}
+                unoptimized
                 className="rounded-card r-card-md object-cover"
                 style={{
                   maxHeight: "var(--space-7)",

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -48,6 +48,46 @@ vi.mock("react", async () => {
   } satisfies ReactModule & { default: ReactModule };
 });
 
+vi.mock("next/image", async () => {
+  const React = (await vi.importActual<ReactModule>("react")) as ReactModule;
+  const MockNextImage = React.forwardRef<HTMLImageElement, any>((props, ref) => {
+    const {
+      src,
+      alt,
+      width,
+      height,
+      style,
+      className,
+      priority: _priority,
+      fill: _fill,
+      loader: _loader,
+      quality: _quality,
+      onLoadingComplete: _onLoadingComplete,
+      placeholder: _placeholder,
+      blurDataURL: _blurDataURL,
+      unoptimized: _unoptimized,
+      ...rest
+    } = props ?? {};
+
+    return React.createElement("img", {
+      ...rest,
+      src: typeof src === "string" ? src : "",
+      alt,
+      width,
+      height,
+      style,
+      className,
+      ref,
+    });
+  });
+
+  MockNextImage.displayName = "MockNextImage";
+
+  return {
+    default: MockNextImage,
+  };
+});
+
 const originalConsoleError = console.error;
 vi.spyOn(console, "error").mockImplementation((...args) => {
   const [format, value, attr, ...rest] = args;


### PR DESCRIPTION
## Summary
- switch the planner TaskRow attachment preview to use Next.js Image with spacing token dimensions and descriptive alt text
- load spacing token values for width and height while leaving token-based styling intact for consistent sizing
- mock next/image in the test setup so Vitest renders plain img elements and existing accessibility queries keep working

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8d8163a24832cb78bdefddd1d7442