### PR TITLE
Ensure PageTabs hash restore effect runs only once

### DIFF
--- a/src/components/chrome/PageTabs.tsx
+++ b/src/components/chrome/PageTabs.tsx
@@ -56,7 +56,8 @@ export default function PageTabs({
     if (hash && tabs.some(t => t.id === hash)) {
       onChange?.(hash);
     }
-  }, [tabs, onChange]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Sync active tab to URL hash
   React.useEffect(() => {


### PR DESCRIPTION
## Summary
- run the restore-from-hash logic exactly once on mount by using an empty dependency array
- suppress the exhaustive-deps lint warning for the intentional once-only effect

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8da2ea1d0832caa2afc0584828d9f