### PR TITLE
Add loading indicator and aria-busy to Toggle

### DIFF
--- a/src/components/ui/toggles/Toggle.tsx
+++ b/src/components/ui/toggles/Toggle.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
+import Spinner from "../feedback/Spinner";
 
 type Side = "Left" | "Right";
 
@@ -48,6 +49,7 @@ export default function Toggle({
       role="switch"
       aria-checked={isRight}
       aria-labelledby={`${leftId} ${rightId}`}
+      aria-busy={loading || undefined}
       disabled={disabled}
       data-loading={loading || undefined}
       onClick={toggle}
@@ -65,6 +67,11 @@ export default function Toggle({
       )}
       data-side={value}
     >
+      {loading ? (
+        <span className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center">
+          <Spinner size={16} className="border-border border-t-transparent opacity-80" />
+        </span>
+      ) : null}
       {/* Sliding indicator */}
       <span
         aria-hidden

--- a/tests/ui/toggle.test.tsx
+++ b/tests/ui/toggle.test.tsx
@@ -20,4 +20,15 @@ describe('Toggle', () => {
     expect(button).toHaveAttribute('aria-labelledby', `${left.id} ${right.id}`);
     expect(button).not.toHaveAttribute('aria-label');
   });
+
+  it('reflects loading state via aria-busy', () => {
+    const { getByRole, rerender } = render(<Toggle loading />);
+    const button = getByRole('switch');
+
+    expect(button).toHaveAttribute('aria-busy', 'true');
+
+    rerender(<Toggle loading={false} />);
+
+    expect(button).not.toHaveAttribute('aria-busy');
+  });
 });


### PR DESCRIPTION
## Summary
- mark the toggle switch as busy while loading and show a centered spinner overlay
- cover the new aria-busy behavior in the toggle test suite

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8dc6f17a8832cae3b5f0f19080707