### PR TITLE
Fix champ badge disabled handling

### DIFF
--- a/src/components/team/ChampListEditor.tsx
+++ b/src/components/team/ChampListEditor.tsx
@@ -78,7 +78,7 @@ export default function ChampListEditor({
         <div className={cn(VIEW_CONTAINER, viewClassName)}>
           <span
             className={cn(PILL_BASE, pillClassName)}
-            aria-disabled
+            aria-disabled="true"
           >
             <i className="dot" />
             {emptyLabel}

--- a/src/components/team/style.css
+++ b/src/components/team/style.css
@@ -23,7 +23,7 @@
 }
 .champ-badge:disabled,
 .champ-badge[aria-disabled="true"] {
-  @apply opacity-[var(--disabled)] pointer-events-none;
+  @apply pointer-events-none opacity-[var(--disabled)];
 }
 .champ-badge--dense {
   @apply h-5 px-2;


### PR DESCRIPTION
## Summary
- ensure the champ badge disabled rule removes pointer events while using the disabled opacity token
- set the champ list empty placeholder pill to expose `aria-disabled="true"` so the CSS selector applies

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8dafec2dc832c8fefc776f0d28cb6