### PR TITLE
Split Next.js workflow into checks and build jobs

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -25,9 +25,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Checks job
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+      - name: Restore cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+        with:
+          path: |
+            .next/cache
+          # Generate a new cache whenever packages or source files change.
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('**/*.js', '**/*.ts', '**/*.jsx', '**/*.tsx') }}
+          # If source files changed but packages didn't, rebuild from a prior cache.
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('**/*.js', '**/*.ts', '**/*.jsx', '**/*.tsx') }}-
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
+      - name: Install dependencies
+        run: npm ci
+      - name: Run checks
+        run: npm run check
+
   # Build job
   build:
     runs-on: ubuntu-latest
+    needs: checks
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -57,8 +85,6 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
       - name: Install dependencies
         run: npm ci
-      - name: Run checks
-        run: npm run check
       - name: Build with Next.js
         run: |
           npm run build


### PR DESCRIPTION
## Summary
- add a dedicated checks job to run npm run check with shared setup and cache steps
- update the build job to depend on checks and focus on building and uploading the Next.js artifact
- keep the deploy job dependent solely on the build job

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8de425640832c81f1d66b5220897e