### PR TITLE
Update lint script to use eslint cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "generate-tokens": "ts-node --esm scripts/generate-tokens.ts",
     "build": "ts-node --esm scripts/regen-if-needed.ts && npm run generate-themes && npm run generate-tokens && next build",
     "start": "next start -p 3000",
-    "lint": "node -r ./scripts/setup-eslint-flat.cjs ./node_modules/eslint/bin/eslint.js src",
+    "lint": "node -r ./scripts/setup-eslint-flat.cjs ./node_modules/eslint/bin/eslint.js --cache --cache-location .eslintcache src",
     "typecheck": "ts-node --esm scripts/typecheck.ts",
     "test": "vitest",
     "check": "concurrently \"npm test -- --run\" \"npm run lint\" \"npm run typecheck\"",


### PR DESCRIPTION
## Summary
- update the lint npm script to enable ESLint caching with the shared `.eslintcache` file

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8dfc0223c832cbdfef48f6920d33b