### PR TITLE
Add memoized task lookup map to planner store

### DIFF
--- a/src/components/planner/plannerStore.ts
+++ b/src/components/planner/plannerStore.ts
@@ -92,9 +92,12 @@ function sanitizeDaysMap(map: Record<ISODate, DayRecord>) {
   }
   return mutated ? next : map;
 }
+type TaskIdMap = Record<ISODate, Record<string, DayTask>>;
+
 type DaysState = {
   days: Record<ISODate, DayRecord>;
   setDays: React.Dispatch<React.SetStateAction<Record<ISODate, DayRecord>>>;
+  tasksById: TaskIdMap;
 };
 
 type FocusState = { focus: ISODate; setFocus: (iso: ISODate) => void };
@@ -126,6 +129,22 @@ export function PlannerProvider({ children }: { children: React.ReactNode }) {
     [rawDays],
   );
 
+  const tasksById = React.useMemo<TaskIdMap>(() => {
+    const map: TaskIdMap = {};
+    for (const [iso, record] of Object.entries(days)) {
+      if (!record.tasks.length) {
+        map[iso] = {};
+        continue;
+      }
+      const taskMap: Record<string, DayTask> = {};
+      for (const task of record.tasks) {
+        taskMap[task.id] = task;
+      }
+      map[iso] = taskMap;
+    }
+    return map;
+  }, [days]);
+
   React.useEffect(() => {
     if (!Object.is(rawDays, days)) {
       setRawDays(days);
@@ -151,8 +170,8 @@ export function PlannerProvider({ children }: { children: React.ReactNode }) {
   );
 
   const daysValue = React.useMemo(
-    () => ({ days, setDays }),
-    [days, setDays],
+    () => ({ days, setDays, tasksById }),
+    [days, setDays, tasksById],
   );
   const focusValue = React.useMemo(
     () => ({ focus, setFocus }),

--- a/src/components/planner/useSelection.ts
+++ b/src/components/planner/useSelection.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { ensureDay, useSelection, useDays, type ISODate } from "./plannerStore";
+import { useSelection, useDays, type ISODate } from "./plannerStore";
 
 /**
  * Manages the selected project for a given day.
@@ -32,7 +32,7 @@ export function useSelectedProject(iso: ISODate) {
  */
 export function useSelectedTask(iso: ISODate) {
   const { selected, setSelected } = useSelection();
-  const { days } = useDays();
+  const { tasksById } = useDays();
   const current = selected[iso]?.taskId ?? "";
 
   const set = React.useCallback(
@@ -41,14 +41,13 @@ export function useSelectedTask(iso: ISODate) {
         setSelected((prev) => ({ ...prev, [iso]: {} }));
         return;
       }
-      const rec = ensureDay(days, iso);
-      const projectId = rec.tasks.find((t) => t.id === taskId)?.projectId;
+      const projectId = tasksById[iso]?.[taskId]?.projectId;
       setSelected((prev) => ({
         ...prev,
         [iso]: { taskId, projectId },
       }));
     },
-    [iso, setSelected, days],
+    [iso, setSelected, tasksById],
   );
 
   return [current, set] as const;


### PR DESCRIPTION
## Summary
- memoize a per-day task lookup map inside the planner store context
- expose the memoized task map through useDays for consumers that need quick task lookup
- switch useSelectedTask to resolve project ownership through the shared map instead of scanning day tasks

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8df9fa3e8832c8234498bb0ab3fcc