### PR TITLE
Gate legacy migration effect

### DIFF
--- a/src/components/planner/usePlannerStore.ts
+++ b/src/components/planner/usePlannerStore.ts
@@ -69,7 +69,20 @@ export function usePlannerStore() {
   );
 
   React.useEffect(() => {
-    applyDaysUpdate((prev) => migrateLegacy(prev, focus));
+    if (!legacyMigrated) {
+      if (typeof window === "undefined") return;
+
+      const rawProjects = window.localStorage.getItem("planner:projects");
+      const rawTasks = window.localStorage.getItem("planner:tasks");
+
+      if (!rawProjects && !rawTasks) {
+        legacyMigrated = true;
+        return;
+      }
+
+      applyDaysUpdate((prev) => migrateLegacy(prev, focus));
+      legacyMigrated = true;
+    }
   }, [applyDaysUpdate, focus]);
 
   const upsertDay = React.useCallback(


### PR DESCRIPTION
## Summary
- ensure the legacy planner migration effect runs only once on the client
- skip invoking the migration when no legacy storage data exists and mark it complete

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8dfdb9288832c9e185fa784a0de87