### PR TITLE
Refactor base path normalization in utils

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,6 +12,12 @@ const twMerge = extendTailwindMerge({
   },
 });
 
+const RAW_BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+const NORMALIZED_BASE =
+  RAW_BASE_PATH && RAW_BASE_PATH !== "/"
+    ? `/${RAW_BASE_PATH.replace(/^\/+|\/+$|\s+/g, "")}`
+    : "";
+
 // Default locale for consistent date/time formatting.
 export const LOCALE = "en-US";
 
@@ -25,17 +31,13 @@ export function cn(...inputs: ClassValue[]): string {
  * Ensures consistent asset URLs for environments served from sub-paths.
  */
 export function withBasePath(path: string): string {
-  const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
 
-  if (!basePath || basePath === "/") {
+  if (!NORMALIZED_BASE) {
     return normalizedPath;
   }
 
-  const trimmedBase = basePath.replace(/^\/+|\/+$|\s+/g, "");
-  const normalizedBase = trimmedBase ? `/${trimmedBase}` : "";
-
-  return `${normalizedBase}${normalizedPath}`;
+  return `${NORMALIZED_BASE}${normalizedPath}`;
 }
 
 /** Capitalize first letter (not Unicode-smart on purpose). */


### PR DESCRIPTION
## Summary
- cache the normalized Next.js base path at module load
- update withBasePath to reuse the cached value while preserving existing URL behavior

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8e1e77b28832c9e5501210e921620