### PR TITLE
Remove redundant legacy migration flag update

### DIFF
--- a/src/components/planner/usePlannerStore.ts
+++ b/src/components/planner/usePlannerStore.ts
@@ -81,7 +81,6 @@ export function usePlannerStore() {
       }
 
       applyDaysUpdate((prev) => migrateLegacy(prev, focus));
-      legacyMigrated = true;
     }
   }, [applyDaysUpdate, focus]);
 


### PR DESCRIPTION
## Summary
- remove the extra legacy migration flag update now handled within migrateLegacy

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8e4abac74832cb463b0024e939c04