### PR TITLE
refactor: align page header spacing tokens

### DIFF
--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -117,7 +117,8 @@ const PageHeaderInner = <
         <div
           className={cn(
             "relative z-[2]",
-            contentClassName ?? "space-y-5 md:space-y-6",
+            contentClassName ??
+              "space-y-[var(--space-5)] md:space-y-[var(--space-6)]",
           )}
         >
           <Header {...header} underline={header.underline ?? false} />


### PR DESCRIPTION
## Summary
- replace the PageHeader default content spacing with token-based values to avoid hard-coded gaps

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8e622d180832c96f1e951f92851a2