### PR TITLE
Precompute planner day counts

### DIFF
--- a/src/components/planner/DayCard.tsx
+++ b/src/components/planner/DayCard.tsx
@@ -33,8 +33,8 @@ export default function DayCard({ iso, isToday }: Props) {
     deleteTask,
     addTaskImage,
     removeTaskImage,
-    doneTasks,
-    totalTasks,
+    doneCount,
+    totalCount,
   } = useDay(iso);
 
   const [selectedProjectId, setSelectedProjectId] = useSelectedProject(iso);
@@ -66,8 +66,8 @@ export default function DayCard({ iso, isToday }: Props) {
         <DayCardHeader
           iso={iso}
           projectCount={projects.length}
-          doneTasks={doneTasks}
-          totalTasks={totalTasks}
+          doneCount={doneCount}
+          totalCount={totalCount}
         />
       </div>
 

--- a/src/components/planner/DayCardHeader.tsx
+++ b/src/components/planner/DayCardHeader.tsx
@@ -8,19 +8,19 @@ import type { ISODate } from "./plannerStore";
 type Props = {
   iso: ISODate;
   projectCount: number;
-  doneTasks: number;
-  totalTasks: number;
+  doneCount: number;
+  totalCount: number;
 };
 
 export default function DayCardHeader({
   iso,
   projectCount,
-  doneTasks,
-  totalTasks,
+  doneCount,
+  totalCount,
 }: Props) {
   const headerText = React.useMemo(() => `// ${formatIsoLabel(iso)}`, [iso]);
   const pctNum =
-    totalTasks === 0 ? 0 : Math.round((doneTasks / totalTasks) * 100);
+    totalCount === 0 ? 0 : Math.round((doneCount / totalCount) * 100);
 
   return (
     <div className="col-span-1 lg:col-span-3 flex items-center gap-3 min-w-0">
@@ -32,7 +32,7 @@ export default function DayCardHeader({
       </span>
 
       <div className="flex-1 min-w-0">
-        <GlitchProgress current={doneTasks} total={totalTasks} />
+        <GlitchProgress current={doneCount} total={totalCount} />
       </div>
 
       <div className="shrink-0 flex items-baseline gap-3 text-label text-muted-foreground">
@@ -45,8 +45,8 @@ export default function DayCardHeader({
         </span>
         <span className="hidden sm:inline">·</span>
         <span className="whitespace-nowrap">
-          <span className="tabular-nums">{doneTasks}</span> /{" "}
-          <span className="tabular-nums">{totalTasks}</span> tasks
+          <span className="tabular-nums">{doneCount}</span> /{" "}
+          <span className="tabular-nums">{totalCount}</span> items
         </span>
       </div>
     </div>

--- a/src/components/planner/WeekSummary.tsx
+++ b/src/components/planner/WeekSummary.tsx
@@ -75,7 +75,7 @@ export default function WeekSummary({
           className="ml-auto badge badge--sm"
           role="status"
           aria-live="polite"
-          title="Completed / Total tasks this week"
+          title="Completed / Total items this week"
         >
           <span className="badge__icon">✅</span>
           <span className="tabular-nums">{doneAll}</span>/

--- a/src/components/planner/useDay.ts
+++ b/src/components/planner/useDay.ts
@@ -13,12 +13,8 @@ export function useDay(iso: ISODate) {
   const tasks = rec.tasks;
 
   const crud = React.useMemo(() => makeCrud(iso, upsertDay), [iso, upsertDay]);
-
-  const doneTasks = React.useMemo(
-    () => tasks.filter((t) => t.done).length,
-    [tasks],
-  );
-  const totalTasks = tasks.length;
+  const doneCount = rec.doneCount;
+  const totalCount = rec.totalCount;
 
   return {
     projects: rec.projects,
@@ -33,7 +29,9 @@ export function useDay(iso: ISODate) {
     toggleTask: crud.toggleTask,
     addTaskImage: crud.addTaskImage,
     removeTaskImage: crud.removeTaskImage,
-    doneTasks,
-    totalTasks,
+    doneCount,
+    totalCount,
+    doneTasks: doneCount,
+    totalTasks: totalCount,
   } as const;
 }

--- a/src/components/planner/useWeekData.ts
+++ b/src/components/planner/useWeekData.ts
@@ -12,14 +12,8 @@ export function useWeekData(days: ISODate[]) {
     let weekTotal = 0;
     const per = days.map((iso) => {
       const rec = map[iso];
-      const { done, total } = (rec ? [...rec.projects, ...rec.tasks] : []).reduce(
-        (counts, item) => {
-          counts.total += 1;
-          if (item.done) counts.done += 1;
-          return counts;
-        },
-        { done: 0, total: 0 },
-      );
+      const done = rec?.doneCount ?? 0;
+      const total = rec?.totalCount ?? 0;
       weekDone += done;
       weekTotal += total;
       return { iso, done, total };

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -460,8 +460,8 @@ export default function ComponentGallery() {
           <DayCardHeader
             iso="2024-01-01"
             projectCount={2}
-            doneTasks={1}
-            totalTasks={3}
+            doneCount={1}
+            totalCount={3}
           />
         ),
       },

--- a/tests/planner/usePlannerStore.test.tsx
+++ b/tests/planner/usePlannerStore.test.tsx
@@ -118,13 +118,17 @@ describe("usePlannerStore", () => {
       t1 = result.current.addTask("First");
       result.current.addTask("Second");
     });
+    expect(result.current.totalCount).toBe(2);
+    expect(result.current.doneCount).toBe(0);
     expect(result.current.totalTasks).toBe(2);
     expect(result.current.doneTasks).toBe(0);
 
     act(() => result.current.toggleTask(t1));
+    expect(result.current.doneCount).toBe(1);
     expect(result.current.doneTasks).toBe(1);
 
     act(() => result.current.deleteTask(t1));
+    expect(result.current.totalCount).toBe(1);
     expect(result.current.totalTasks).toBe(1);
   });
 


### PR DESCRIPTION
## Summary
- add `doneCount` and `totalCount` to day records with a shared counter helper
- update planner CRUD, hooks, and UI to reuse the precomputed counts
- adjust legacy migration, gallery demo, and tests to cover the new fields

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8e52e7880832cbbcd4734a81b12aa