### PR TITLE
Add tasksById indexing for planner tasks

### DIFF
--- a/src/components/planner/DayCard.tsx
+++ b/src/components/planner/DayCard.tsx
@@ -26,7 +26,8 @@ export default function DayCard({ iso, isToday }: Props) {
     renameProject,
     deleteProject,
     toggleProject,
-    tasks,
+    tasksById,
+    tasksByProject,
     addTask,
     renameTask,
     toggleTask,
@@ -92,7 +93,8 @@ export default function DayCard({ iso, isToday }: Props) {
 
           <div className="col-span-1 lg:col-span-8">
             <TaskList
-              tasks={tasks}
+              tasksById={tasksById}
+              tasksByProject={tasksByProject}
               selectedProjectId={selectedProjectId}
               addTask={addTask}
               renameTask={renameTask}

--- a/src/components/planner/TaskList.tsx
+++ b/src/components/planner/TaskList.tsx
@@ -7,7 +7,8 @@ import TaskRow from "./TaskRow";
 import type { DayTask } from "./plannerStore";
 
 type Props = {
-  tasks: DayTask[];
+  tasksById: Record<string, DayTask>;
+  tasksByProject: Record<string, string[]>;
   selectedProjectId: string;
   addTask: (title: string, projectId?: string) => string | undefined;
   renameTask: (id: string, title: string) => void;
@@ -19,7 +20,8 @@ type Props = {
 };
 
 export default function TaskList({
-  tasks,
+  tasksById,
+  tasksByProject,
   selectedProjectId,
   addTask,
   renameTask,
@@ -30,10 +32,13 @@ export default function TaskList({
   setSelectedTaskId,
 }: Props) {
   const [draftTask, setDraftTask] = React.useState("");
-  const tasksForSelected = React.useMemo(
-    () => tasks.filter((t) => t.projectId === selectedProjectId),
-    [tasks, selectedProjectId],
-  );
+  const tasksForSelected = React.useMemo<DayTask[]>(() => {
+    if (!selectedProjectId) return [];
+    const ids = tasksByProject[selectedProjectId] ?? [];
+    return ids
+      .map((taskId) => tasksById[taskId])
+      .filter((task): task is DayTask => Boolean(task));
+  }, [selectedProjectId, tasksByProject, tasksById]);
 
   const onSubmit = React.useCallback(
     (e: React.FormEvent<HTMLFormElement>) => {

--- a/src/components/planner/plannerCrud.ts
+++ b/src/components/planner/plannerCrud.ts
@@ -29,29 +29,11 @@ export function makeCrud(iso: ISODate, upsertDay: UpsertDay) {
     upsertDay(iso, (d) => dayToggleProject(d, id));
 
   const removeProject = (id: string) =>
-    upsertDay(iso, (d) => {
-      const next = dayRemoveProject(d, id);
-      const { [id]: _removed, ...rest } = next.tasksByProject;
-      void _removed;
-      return { ...next, tasksByProject: rest };
-    });
+    upsertDay(iso, (d) => dayRemoveProject(d, id));
 
   const addTask = (title: string, projectId?: string) => {
     const id = uid("task");
-    upsertDay(iso, (d) => {
-      const next = dayAddTask(d, id, title, projectId);
-      if (projectId) {
-        const ids = next.tasksByProject[projectId] ?? [];
-        return {
-          ...next,
-          tasksByProject: {
-            ...next.tasksByProject,
-            [projectId]: [...ids, id],
-          },
-        };
-      }
-      return next;
-    });
+    upsertDay(iso, (d) => dayAddTask(d, id, title, projectId));
     return id;
   };
 
@@ -62,20 +44,7 @@ export function makeCrud(iso: ISODate, upsertDay: UpsertDay) {
     upsertDay(iso, (d) => dayToggleTask(d, id));
 
   const removeTask = (id: string) =>
-    upsertDay(iso, (d) => {
-      const projectId = d.tasks.find((t) => t.id === id)?.projectId;
-      const next = dayRemoveTask(d, id);
-      if (projectId) {
-        const ids = (next.tasksByProject[projectId] ?? []).filter(
-          (tid) => tid !== id,
-        );
-        return {
-          ...next,
-          tasksByProject: { ...next.tasksByProject, [projectId]: ids },
-        };
-      }
-      return next;
-    });
+    upsertDay(iso, (d) => dayRemoveTask(d, id));
 
   const addTaskImage = (id: string, url: string) =>
     upsertDay(iso, (d) => dayAddTaskImage(d, id, url));

--- a/src/components/planner/useDay.ts
+++ b/src/components/planner/useDay.ts
@@ -11,6 +11,8 @@ export function useDay(iso: ISODate) {
   const rec = React.useMemo(() => ensureDay(days, iso), [days, iso]);
 
   const tasks = rec.tasks;
+  const tasksById = rec.tasksById;
+  const tasksByProject = rec.tasksByProject;
 
   const crud = React.useMemo(() => makeCrud(iso, upsertDay), [iso, upsertDay]);
 
@@ -33,6 +35,8 @@ export function useDay(iso: ISODate) {
     toggleTask: crud.toggleTask,
     addTaskImage: crud.addTaskImage,
     removeTaskImage: crud.removeTaskImage,
+    tasksById,
+    tasksByProject,
     doneTasks,
     totalTasks,
   } as const;

--- a/src/components/planner/usePlannerStore.ts
+++ b/src/components/planner/usePlannerStore.ts
@@ -33,12 +33,19 @@ function migrateLegacy(
   const cur = ensureDay(next, iso);
   if (projects) cur.projects = projects;
   if (tasks) {
-    cur.tasks = tasks;
-    const map: Record<string, string[]> = {};
-    for (const t of tasks) {
-      if (t.projectId) (map[t.projectId] ??= []).push(t.id);
+    const normalized = tasks.map((task) => ({
+      ...task,
+      images: Array.isArray(task.images) ? task.images : [],
+    }));
+    const byId: Record<string, DayTask> = {};
+    const byProject: Record<string, string[]> = {};
+    for (const t of normalized) {
+      byId[t.id] = t;
+      if (t.projectId) (byProject[t.projectId] ??= []).push(t.id);
     }
-    cur.tasksByProject = map;
+    cur.tasks = normalized;
+    cur.tasksById = byId;
+    cur.tasksByProject = byProject;
   }
   next[iso] = cur;
   try {

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -38,6 +38,7 @@ import PromptsHeader from "./PromptsHeader";
 import PromptsComposePanel from "./PromptsComposePanel";
 import PromptsDemos from "./PromptsDemos";
 import ReviewPanel from "@/components/reviews/ReviewPanel";
+import type { DayTask } from "@/components/planner";
 import ReviewListItem from "@/components/reviews/ReviewListItem";
 import Banner from "@/components/chrome/Banner";
 import NavBar from "@/components/chrome/NavBar";
@@ -92,7 +93,7 @@ const demoProjects = [
   { id: "p2", name: "Beta", done: true, createdAt: Date.now() },
 ];
 
-const demoTasks = [
+const demoTasks: DayTask[] = [
   {
     id: "t1",
     title: "Task A",
@@ -110,6 +111,21 @@ const demoTasks = [
     images: [],
   },
 ];
+
+const demoTasksById = demoTasks.reduce<
+  Record<string, (typeof demoTasks)[number]>
+>((acc, task) => {
+  acc[task.id] = task;
+  return acc;
+}, {});
+
+const demoTasksByProject = demoTasks.reduce<Record<string, string[]>>(
+  (acc, task) => {
+    if (task.projectId) (acc[task.projectId] ??= []).push(task.id);
+    return acc;
+  },
+  {},
+);
 
 export default function ComponentGallery() {
   const [goalFilter, setGoalFilter] = React.useState<FilterKey>("All");
@@ -508,7 +524,8 @@ export default function ComponentGallery() {
         label: "TaskList",
         element: (
           <TaskList
-            tasks={demoTasks}
+            tasksById={demoTasksById}
+            tasksByProject={demoTasksByProject}
             selectedProjectId="p1"
             addTask={() => ""}
             renameTask={() => {}}

--- a/tests/planner/usePlannerStore.test.tsx
+++ b/tests/planner/usePlannerStore.test.tsx
@@ -50,6 +50,9 @@ describe("usePlannerStore", () => {
     expect(result.current.planner.day.tasksByProject[projectId]).toEqual([
       taskId,
     ]);
+    expect(result.current.planner.day.tasksById[taskId]?.title).toBe(
+      "Task 1",
+    );
 
     act(() => {
       secondTaskId = result.current.planner.addTask("Task 2", projectId);
@@ -59,6 +62,9 @@ describe("usePlannerStore", () => {
       taskId,
       secondTaskId,
     ]);
+    expect(result.current.planner.day.tasksById[secondTaskId]?.title).toBe(
+      "Task 2",
+    );
 
     act(() => {
       result.current.planner.addTaskImage(
@@ -79,13 +85,18 @@ describe("usePlannerStore", () => {
 
     act(() => result.current.planner.renameTask(taskId, "Task renamed"));
     expect(result.current.day.tasks[0].title).toBe("Task renamed");
+    expect(result.current.planner.day.tasksById[taskId]?.title).toBe(
+      "Task renamed",
+    );
 
     act(() => result.current.planner.toggleTask(taskId));
     expect(result.current.day.tasks[0].done).toBe(true);
+    expect(result.current.planner.day.tasksById[taskId]?.done).toBe(true);
 
     act(() => result.current.planner.toggleProject(projectId));
     expect(result.current.day.projects[0].done).toBe(true);
     expect(result.current.day.tasks[0].done).toBe(true);
+    expect(result.current.planner.day.tasksById[taskId]?.done).toBe(true);
 
     act(() => result.current.planner.removeTask(taskId));
     expect(result.current.day.tasks).toHaveLength(1);
@@ -95,6 +106,7 @@ describe("usePlannerStore", () => {
     expect(
       result.current.planner.day.tasksByProject[projectId],
     ).not.toContain(taskId);
+    expect(result.current.planner.day.tasksById[taskId]).toBeUndefined();
 
     act(() => result.current.planner.removeProject(projectId));
     expect(result.current.day.projects).toHaveLength(0);
@@ -102,6 +114,7 @@ describe("usePlannerStore", () => {
     expect(
       result.current.planner.day.tasksByProject[projectId],
     ).toBeUndefined();
+    expect(Object.keys(result.current.planner.day.tasksById)).toHaveLength(0);
   });
 
   it("provides day-scoped utilities via useDay", () => {


### PR DESCRIPTION
## Summary
- extend the planner day record with a tasksById map that is kept in sync alongside tasksByProject
- update CRUD helpers, TaskList, and DayCard to consume the indexed task data
- migrate legacy planner data, refresh the component gallery demo, and expand tests to cover the new indexing

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8e5665e60832c87cefe1fd54477eb