### PR TITLE
Refine PageHeader forward ref typing

### DIFF
--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -21,6 +21,9 @@ type PageHeaderElementProps = Omit<
 
 type PageHeaderFrameElement = React.ElementRef<typeof NeomorphicHeroFrame>;
 
+type HeaderKey = string;
+type HeroKey = string;
+
 export interface PageHeaderBaseProps<
   HeaderKey extends string = string,
   HeroKey extends string = string,
@@ -137,18 +140,16 @@ const PageHeaderInner = <
   );
 };
 
-const PageHeaderWithForwardRef = React.forwardRef(PageHeaderInner);
+const PageHeader = React.forwardRef<
+  PageHeaderFrameElement,
+  PageHeaderBaseProps<HeaderKey, HeroKey>
+>(PageHeaderInner);
 
-PageHeaderWithForwardRef.displayName = "PageHeader";
+PageHeader.displayName = "PageHeader";
 
-type PageHeaderComponent = <
+export default PageHeader as <
   HeaderKey extends string = string,
   HeroKey extends string = string,
 >(
-  props: PageHeaderBaseProps<HeaderKey, HeroKey> &
-    React.RefAttributes<PageHeaderFrameElement>,
+  props: PageHeaderProps<HeaderKey, HeroKey>,
 ) => React.ReactElement | null;
-
-const PageHeader = PageHeaderWithForwardRef as unknown as PageHeaderComponent;
-
-export default PageHeader;


### PR DESCRIPTION
## Summary
- update PageHeader to call `React.forwardRef` with explicit generic arguments
- export the component with its generic prop signature while removing the redundant alias

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8e89cc9fc832c9719621cd83504bd