### PR TITLE
Index planner tasks for constant-time lookup

### DIFF
--- a/src/components/planner/DayCard.tsx
+++ b/src/components/planner/DayCard.tsx
@@ -26,7 +26,8 @@ export default function DayCard({ iso, isToday }: Props) {
     renameProject,
     deleteProject,
     toggleProject,
-    tasks,
+    tasksById,
+    tasksByProject,
     addTask,
     renameTask,
     toggleTask,
@@ -92,7 +93,8 @@ export default function DayCard({ iso, isToday }: Props) {
 
           <div className="col-span-1 lg:col-span-8">
             <TaskList
-              tasks={tasks}
+              tasksById={tasksById}
+              tasksByProject={tasksByProject}
               selectedProjectId={selectedProjectId}
               addTask={addTask}
               renameTask={renameTask}

--- a/src/components/planner/TaskList.tsx
+++ b/src/components/planner/TaskList.tsx
@@ -7,7 +7,8 @@ import TaskRow from "./TaskRow";
 import type { DayTask } from "./plannerStore";
 
 type Props = {
-  tasks: DayTask[];
+  tasksById: Record<string, DayTask>;
+  tasksByProject: Record<string, string[]>;
   selectedProjectId: string;
   addTask: (title: string, projectId?: string) => string | undefined;
   renameTask: (id: string, title: string) => void;
@@ -19,7 +20,8 @@ type Props = {
 };
 
 export default function TaskList({
-  tasks,
+  tasksById,
+  tasksByProject,
   selectedProjectId,
   addTask,
   renameTask,
@@ -31,8 +33,14 @@ export default function TaskList({
 }: Props) {
   const [draftTask, setDraftTask] = React.useState("");
   const tasksForSelected = React.useMemo(
-    () => tasks.filter((t) => t.projectId === selectedProjectId),
-    [tasks, selectedProjectId],
+    () => {
+      if (!selectedProjectId) return [] as DayTask[];
+      const ids = tasksByProject[selectedProjectId] ?? [];
+      return ids
+        .map((taskId) => tasksById[taskId])
+        .filter((task): task is DayTask => Boolean(task));
+    },
+    [selectedProjectId, tasksByProject, tasksById],
   );
 
   const onSubmit = React.useCallback(

--- a/src/components/planner/plannerCrud.ts
+++ b/src/components/planner/plannerCrud.ts
@@ -29,29 +29,11 @@ export function makeCrud(iso: ISODate, upsertDay: UpsertDay) {
     upsertDay(iso, (d) => dayToggleProject(d, id));
 
   const removeProject = (id: string) =>
-    upsertDay(iso, (d) => {
-      const next = dayRemoveProject(d, id);
-      const { [id]: _removed, ...rest } = next.tasksByProject;
-      void _removed;
-      return { ...next, tasksByProject: rest };
-    });
+    upsertDay(iso, (d) => dayRemoveProject(d, id));
 
   const addTask = (title: string, projectId?: string) => {
     const id = uid("task");
-    upsertDay(iso, (d) => {
-      const next = dayAddTask(d, id, title, projectId);
-      if (projectId) {
-        const ids = next.tasksByProject[projectId] ?? [];
-        return {
-          ...next,
-          tasksByProject: {
-            ...next.tasksByProject,
-            [projectId]: [...ids, id],
-          },
-        };
-      }
-      return next;
-    });
+    upsertDay(iso, (d) => dayAddTask(d, id, title, projectId));
     return id;
   };
 
@@ -62,20 +44,7 @@ export function makeCrud(iso: ISODate, upsertDay: UpsertDay) {
     upsertDay(iso, (d) => dayToggleTask(d, id));
 
   const removeTask = (id: string) =>
-    upsertDay(iso, (d) => {
-      const projectId = d.tasks.find((t) => t.id === id)?.projectId;
-      const next = dayRemoveTask(d, id);
-      if (projectId) {
-        const ids = (next.tasksByProject[projectId] ?? []).filter(
-          (tid) => tid !== id,
-        );
-        return {
-          ...next,
-          tasksByProject: { ...next.tasksByProject, [projectId]: ids },
-        };
-      }
-      return next;
-    });
+    upsertDay(iso, (d) => dayRemoveTask(d, id));
 
   const addTaskImage = (id: string, url: string) =>
     upsertDay(iso, (d) => dayAddTaskImage(d, id, url));

--- a/src/components/planner/useDay.ts
+++ b/src/components/planner/useDay.ts
@@ -11,6 +11,8 @@ export function useDay(iso: ISODate) {
   const rec = React.useMemo(() => ensureDay(days, iso), [days, iso]);
 
   const tasks = rec.tasks;
+  const tasksById = rec.tasksById;
+  const tasksByProject = rec.tasksByProject;
 
   const crud = React.useMemo(() => makeCrud(iso, upsertDay), [iso, upsertDay]);
   const doneCount = rec.doneCount;
@@ -19,6 +21,8 @@ export function useDay(iso: ISODate) {
   return {
     projects: rec.projects,
     tasks,
+    tasksById,
+    tasksByProject,
     addProject: crud.addProject,
     renameProject: crud.renameProject,
     deleteProject: crud.removeProject,

--- a/src/components/planner/usePlannerStore.ts
+++ b/src/components/planner/usePlannerStore.ts
@@ -38,10 +38,12 @@ function migrateLegacy(
   }
   if (tasks) {
     const map: Record<string, string[]> = {};
+    const byId: Record<string, DayTask> = {};
     for (const t of tasks) {
+      byId[t.id] = t;
       if (t.projectId) (map[t.projectId] ??= []).push(t.id);
     }
-    updated = { ...updated, tasks, tasksByProject: map };
+    updated = { ...updated, tasks, tasksById: byId, tasksByProject: map };
   }
   const { doneCount, totalCount } = computeDayCounts(
     updated.projects,

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -111,6 +111,21 @@ const demoTasks = [
   },
 ];
 
+const demoTasksById = Object.fromEntries(
+  demoTasks.map((task) => [task.id, task]),
+);
+
+const demoTasksByProject = demoTasks.reduce<Record<string, string[]>>(
+  (acc, task) => {
+    const projectId = task.projectId;
+    if (projectId) {
+      (acc[projectId] ??= []).push(task.id);
+    }
+    return acc;
+  },
+  {},
+);
+
 export default function ComponentGallery() {
   const [goalFilter, setGoalFilter] = React.useState<FilterKey>("All");
   const [query, setQuery] = React.useState("");
@@ -508,7 +523,8 @@ export default function ComponentGallery() {
         label: "TaskList",
         element: (
           <TaskList
-            tasks={demoTasks}
+            tasksById={demoTasksById}
+            tasksByProject={demoTasksByProject}
             selectedProjectId="p1"
             addTask={() => ""}
             renameTask={() => {}}


### PR DESCRIPTION
## Summary
- add a tasksById map to each DayRecord and ensure planner state sanitization keeps it in sync with tasksByProject
- rebuild both task lookup dictionaries inside dayCrud helpers and simplify plannerCrud task updates
- update TaskList to consume the indexed lookups and adjust gallery/demo data accordingly

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8e8dea564832cb689448008366a5e