### PR TITLE
Refine team comp tab accessibility

### DIFF
--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -105,11 +105,10 @@ function Hero<Key extends string = string>({
   // Compose right area: prefer built-in sub-tabs if provided.
   const subTabsNode = subTabs ? (
     <TabBar
-      items={subTabs.items.map((t) => ({
-        key: t.key,
-        label: t.label,
-        icon: t.icon,
-      }))}
+      items={subTabs.items.map(({ hint, ...item }) => {
+        void hint;
+        return item;
+      })}
       value={String(subTabs.value)}
       onValueChange={(k) => subTabs.onChange(k as Key)}
       size={subTabs.size ?? "md"}


### PR DESCRIPTION
## Summary
- generate deterministic IDs for TeamCompPage tabs and sub-tabs using `useId`
- wire explicit `id` and `aria-controls` between tab buttons and panels without DOM queries
- allow Hero sub-tabs to forward TabBar item metadata for accessibility attributes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ea9960a8832ca4c3c64712cb6c07