### PR TITLE
Add neomorphic variant for TabBar

### DIFF
--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -117,6 +117,7 @@ export default function ComponentGallery() {
   const [seg, setSeg] = React.useState("one");
   const [appTab, setAppTab] = React.useState("reviews");
   const [filterTab, setFilterTab] = React.useState("all");
+  const [neoTab, setNeoTab] = React.useState("overview");
   const [checked, setChecked] = React.useState(false);
   const [toggleSide, setToggleSide] = React.useState<"Left" | "Right">("Left");
   const [side, setSide] = React.useState<GameSide>("Blue");
@@ -208,6 +209,23 @@ export default function ComponentGallery() {
         ),
       },
       {
+        label: "TabBar (neo)",
+        element: (
+          <TabBar
+            items={[
+              { key: "overview", label: "Overview" },
+              { key: "metrics", label: "Metrics" },
+              { key: "alerts", label: "Alerts" },
+            ]}
+            value={neoTab}
+            onValueChange={setNeoTab}
+            ariaLabel="Neomorphic tabs"
+            className="w-56"
+            variant="neo"
+          />
+        ),
+      },
+      {
         label: "TabBar (filters)",
         element: (
           <TabBar
@@ -230,7 +248,7 @@ export default function ComponentGallery() {
         ),
       },
     ],
-    [seg, appTab, filterTab, checked, toggleSide, side],
+    [seg, appTab, neoTab, filterTab, checked, toggleSide, side],
   );
 
   const inputItems = React.useMemo(

--- a/src/components/prompts/NeomorphicHeroFrameDemo.tsx
+++ b/src/components/prompts/NeomorphicHeroFrameDemo.tsx
@@ -52,6 +52,7 @@ export default function NeomorphicHeroFrameDemo() {
                 </Button>
               }
               showBaseline
+              variant="neo"
             />
           ),
           search: (
@@ -124,6 +125,7 @@ export default function NeomorphicHeroFrameDemo() {
               onValueChange={(key) => setStatus(key as MissionStatus)}
               ariaLabel="Filter mission status"
               size="sm"
+              variant="neo"
             />
           ),
           search: (

--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -97,6 +97,7 @@ export default function Header<Key extends string = string>({
       size: tabSize,
       align: tabAlign,
       className: tabClassName,
+      variant: tabVariant,
       ...tabBarRest
     } = tabs;
 
@@ -109,6 +110,7 @@ export default function Header<Key extends string = string>({
         size={tabSize ?? "sm"}
         align={tabAlign ?? "end"}
         className={cx("w-auto max-w-full shrink-0", tabClassName)}
+        variant={tabVariant ?? (isNeo ? "neo" : "default")}
         {...tabBarRest}
       />
     );

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -68,6 +68,7 @@ export interface HeroProps<Key extends string = string>
     align?: TabBarProps["align"];
     className?: string;
     showBaseline?: boolean;
+    variant?: TabBarProps["variant"];
   };
 
   /** Built-in bottom search (preferred). `round` makes it pill. */
@@ -103,34 +104,55 @@ function Hero<Key extends string = string>({
   const Component = (as ?? "section") as HeroElement;
 
   // Compose right area: prefer built-in sub-tabs if provided.
-  const subTabsNode = subTabs ? (
-    <TabBar
-      items={subTabs.items.map((t) => ({
-        key: t.key,
-        label: t.label,
-        icon: t.icon,
-      }))}
-      value={String(subTabs.value)}
-      onValueChange={(k) => subTabs.onChange(k as Key)}
-      size={subTabs.size ?? "md"}
-      align={subTabs.align ?? "end"}
-      right={subTabs.right}
-      showBaseline={subTabs.showBaseline ?? true}
-      className={cx("justify-end", subTabs.className)}
-      ariaLabel={subTabs.ariaLabel ?? "Hero sub-tabs"}
-    />
-  ) : tabs ? (
-    <TabBar
-      items={tabs.items}
-      value={tabs.value}
-      onValueChange={tabs.onChange}
-      size={tabs.size ?? "md"}
-      align={tabs.align ?? "end"}
-      showBaseline={tabs.showBaseline ?? true}
-      className={cx("justify-end", tabs.className)}
-      ariaLabel="Hero tabs"
-    />
-  ) : null;
+  const subTabsNode = subTabs
+    ? (() => {
+        const {
+          items: subTabItems,
+          value: subTabValue,
+          onChange: subTabOnChange,
+          ariaLabel: subTabAriaLabel,
+          size: subTabSize,
+          align: subTabAlign,
+          className: subTabClassName,
+          showBaseline: subTabShowBaseline,
+          right: subTabRight,
+          variant: subTabVariant,
+          ...subTabRest
+        } = subTabs;
+        const mappedItems = subTabItems.map(({ hint: _ignoredHint, ...item }) => {
+          void _ignoredHint;
+          return item;
+        });
+        return (
+          <TabBar
+            items={mappedItems as TabItem<Key>[]}
+            value={String(subTabValue)}
+            onValueChange={(k) => subTabOnChange(k as Key)}
+            size={subTabSize ?? "md"}
+            align={subTabAlign ?? "end"}
+            right={subTabRight}
+            showBaseline={subTabShowBaseline ?? true}
+            className={cx("justify-end", subTabClassName)}
+            ariaLabel={subTabAriaLabel ?? "Hero sub-tabs"}
+            variant={subTabVariant ?? (frame ? "neo" : "default")}
+            {...subTabRest}
+          />
+        );
+      })()
+    : tabs ? (
+        <TabBar
+          items={tabs.items}
+          value={tabs.value}
+          onValueChange={tabs.onChange}
+          size={tabs.size ?? "md"}
+          align={tabs.align ?? "end"}
+          showBaseline={tabs.showBaseline ?? true}
+          className={cx("justify-end", tabs.className)}
+          ariaLabel="Hero tabs"
+          variant={tabs.variant ?? (frame ? "neo" : "default")}
+        />
+      )
+    : null;
 
   const searchProps =
     search != null


### PR DESCRIPTION
## Summary
- extend `TabBar` with a `variant` option and neo styling tokens for hover, focus, active, disabled, and loading states
- ensure `Header` and `Hero` propagate the neo variant while preserving existing controls
- showcase the neo tabs in the component gallery and neomorphic hero demo

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ea0da714832c9711ca3554a61e5b