### PR TITLE
Improve accent preview badge accessibility

### DIFF
--- a/src/app/prompts/PromptsPage.tsx
+++ b/src/app/prompts/PromptsPage.tsx
@@ -156,11 +156,17 @@ function PageContent() {
               <Badge
                 tone="accent"
                 size="sm"
-                className="bg-accent-soft/20 text-accent-foreground"
+                aria-label="Accent color preview: Accent 3"
+                className="bg-accent-soft/20 text-[color:var(--text-on-accent)]"
+                style={{
+                  backgroundColor:
+                    "color-mix(in oklab, var(--accent-overlay) 32%, transparent)",
+                }}
               >
                 <span
-                  aria-hidden
-                  className="h-2 w-2 rounded-full bg-accent"
+                  aria-hidden="true"
+                  className="h-2 w-2 rounded-full"
+                  style={{ backgroundColor: "hsl(var(--accent-3))" }}
                 />
                 Accent 3
               </Badge>


### PR DESCRIPTION
## Summary
- add a descriptive aria label to the accent preview badge and mark the swatch dot as decorative
- use accent overlay and text-on-accent tokens so the preview adapts in high-contrast themes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ed4e56d4832c84529e981d6bf4f3