### PR TITLE
Adjust planner header hero spacing

### DIFF
--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -99,7 +99,7 @@ function Inner() {
             sticky: false,
             rail: false,
             barClassName: "hidden",
-            bodyClassName: "-mt-5 md:-mt-6",
+            className: "planner-header__hero",
             heading: <span className="sr-only">Week picker</span>,
             children: <WeekPicker />,
           }}

--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -4,6 +4,26 @@
    Avoids redefining global shells/rails/pills.
 */
 
+/* ============ Page header tweaks ============ */
+.planner-header__hero {
+  --planner-header-hero-offset: calc(var(--space-5) - var(--space-5));
+  --planner-header-hero-offset-md: calc(var(--space-6) - var(--space-6));
+}
+
+.planner-header__hero > :where(div) > :where(.mt-\[var\(--space-5\)\]) {
+  margin-top: var(--planner-header-hero-offset);
+}
+
+@media (min-width: 768px) {
+  .planner-header__hero > :where(div) > :where(.mt-\[var\(--space-5\)\]) {
+    margin-top: var(--planner-header-hero-offset-md);
+  }
+
+  .planner-header__hero > :where(div) > :where(.md\:mt-\[var\(--space-6\)\]) {
+    margin-top: var(--planner-header-hero-offset-md);
+  }
+}
+
 /* ============ Panel internals / scroll sizing ============ */
 /* Apply sizing chrome only when the element actually scrolls (has .overflow-y-auto). */
 .daycard .overflow-y-auto {


### PR DESCRIPTION
## Summary
- remove the negative margin override from the planner header hero
- add a scoped class that resets the hero body offset with semantic tokens so spacing stays consistent across viewports

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ed6eb564832ca1ff86bb8d98d248