### PR TITLE
Add aria labels to prompts page tabs

### DIFF
--- a/src/app/prompts/PromptsPage.tsx
+++ b/src/app/prompts/PromptsPage.tsx
@@ -124,6 +124,7 @@ function PageContent() {
             items: VIEW_TABS,
             value: view,
             onChange: (k) => setView(k as View),
+            ariaLabel: "Playground view",
           },
         }}
         hero={{
@@ -137,6 +138,7 @@ function PageContent() {
           ...(view === "components"
             ? {
                 subTabs: {
+                  ariaLabel: "Component section",
                   items: SECTION_TABS,
                   value: section,
                   onChange: (k: string) => setSection(k as Section),


### PR DESCRIPTION
## Summary
- add an aria label to the prompts header tabs for the playground view
- label the component sub-tabs with an aria label when the components view is active

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ee606478832c830548cfb52dcda6