### PR TITLE
Fix TeamComp sub-tab IDs and TabBar linking

### DIFF
--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -72,20 +72,37 @@ export default function TeamCompPage() {
       }) satisfies Record<Tab, { tab: string; panel: string }>,
     [tabBaseId],
   );
-  const subTabIds = React.useMemo(
-    () =>
-      ({
-        sheet: {
-          tab: `${subTabBaseId}-sheet-tab`,
-          panel: `${subTabBaseId}-sheet-panel`,
-        },
-        comps: {
-          tab: `${subTabBaseId}-comps-tab`,
-          panel: `${subTabBaseId}-comps-panel`,
-        },
-      }) satisfies Record<SubTab, { tab: string; panel: string }>,
-    [subTabBaseId],
-  );
+  const { items: subTabs, ids: subTabIds } = React.useMemo(() => {
+    const ids = {
+      sheet: {
+        tab: `${subTabBaseId}-sheet-tab`,
+        panel: `${subTabBaseId}-sheet-panel`,
+      },
+      comps: {
+        tab: `${subTabBaseId}-comps-tab`,
+        panel: `${subTabBaseId}-comps-panel`,
+      },
+    } satisfies Record<SubTab, { tab: string; panel: string }>;
+
+    const items: HeaderTab<SubTab>[] = [
+      {
+        key: "sheet",
+        label: "Cheat Sheet",
+        icon: <BookOpen />,
+        id: ids.sheet.tab,
+        controls: ids.sheet.panel,
+      },
+      {
+        key: "comps",
+        label: "My Comps",
+        icon: <Users2 />,
+        id: ids.comps.tab,
+        controls: ids.comps.panel,
+      },
+    ];
+
+    return { items, ids };
+  }, [subTabBaseId]);
   const [editing, setEditing] = React.useState({
     cheatSheet: false,
     myComps: false,
@@ -100,25 +117,6 @@ export default function TeamCompPage() {
   React.useEffect(() => {
     subPanelRefs.current[subTab]?.focus();
   }, [subTab]);
-  const subTabs = React.useMemo<HeaderTab<SubTab>[]>(
-    () => [
-      {
-        key: "sheet",
-        label: "Cheat Sheet",
-        icon: <BookOpen />,
-        id: subTabIds.sheet.tab,
-        controls: subTabIds.sheet.panel,
-      },
-      {
-        key: "comps",
-        label: "My Comps",
-        icon: <Users2 />,
-        id: subTabIds.comps.tab,
-        controls: subTabIds.comps.panel,
-      },
-    ],
-    [subTabIds],
-  );
   const renderCheat = React.useCallback(
     () => (
       <div>

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -154,8 +154,8 @@ export default function TabBar<K extends string = string>({
         >
           {items.map((item) => {
             const active = item.key === activeKey;
-            const tabId = `${uid}-${item.id ?? `${item.key}-tab`}`;
-            const panelId = `${uid}-${item.controls ?? `${item.key}-panel`}`;
+            const tabId = item.id ?? `${uid}-${item.key}-tab`;
+            const panelId = item.controls ?? `${uid}-${item.key}-panel`;
             return (
               <button
                 key={item.key}


### PR DESCRIPTION
## Summary
- memoize TeamComp sub-tab definitions with stable tab/panel ids
- ensure TabBar respects explicit tab and panel ids for callers

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8edd70ff8832c8ac942fceb2bc902