### PR TITLE
Add icons to goals tabs and document variant

### DIFF
--- a/src/components/goals/GoalsTabs.tsx
+++ b/src/components/goals/GoalsTabs.tsx
@@ -2,14 +2,21 @@
 
 import * as React from "react";
 import TabBar, { type TabItem } from "@/components/ui/layout/TabBar";
+import { Circle, CircleDot, CircleCheck } from "lucide-react";
 
 export type FilterKey = "All" | "Active" | "Done";
 
 const FILTER_ITEMS: TabItem<FilterKey>[] = [
-  { key: "All", label: "All" },
-  { key: "Active", label: "Active" },
-  { key: "Done", label: "Done" },
+  { key: "All", label: "All", icon: <Circle aria-hidden="true" /> },
+  { key: "Active", label: "Active", icon: <CircleDot aria-hidden="true" /> },
+  { key: "Done", label: "Done", icon: <CircleCheck aria-hidden="true" /> },
 ];
+
+const FILTER_ARIA_LABEL: Record<FilterKey, string> = {
+  All: "Show all goals",
+  Active: "Show active goals",
+  Done: "Show completed goals",
+};
 
 interface GoalsTabsProps {
   value: FilterKey;
@@ -23,7 +30,7 @@ export default function GoalsTabs({ value, onChange }: GoalsTabsProps) {
       value={value}
       onValueChange={onChange}
       size="sm"
-      ariaLabel="Filter goals"
+      ariaLabel={FILTER_ARIA_LABEL[value]}
       linkPanels={false}
     />
   );

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -67,7 +67,7 @@ import {
   TimerTab,
 } from "@/components/goals";
 import { ProgressRingIcon, TimerRingIcon } from "@/icons";
-import { Plus } from "lucide-react";
+import { Circle, CircleDot, CircleCheck, Plus } from "lucide-react";
 
 export type View = "components" | "colors" | "onboarding";
 export type Section =
@@ -343,27 +343,43 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
     {
       id: "tab-bar-filters",
       name: "TabBar (filters)",
-      description: "Preset filter tabs",
+      description: "Preset filter tabs with icons",
       element: (
         <TabBar
           items={[
-            { key: "all", label: "All" },
-            { key: "active", label: "Active" },
-            { key: "done", label: "Done" },
+            { key: "all", label: "All", icon: <Circle aria-hidden="true" /> },
+            {
+              key: "active",
+              label: "Active",
+              icon: <CircleDot aria-hidden="true" />,
+            },
+            {
+              key: "done",
+              label: "Done",
+              icon: <CircleCheck aria-hidden="true" />,
+            },
           ]}
-          defaultValue="all"
-          ariaLabel="Filter items"
+          defaultValue="active"
+          ariaLabel="Show active goals"
         />
       ),
       tags: ["button", "segmented"],
       code: `<TabBar
   items={[
-    { key: "all", label: "All" },
-    { key: "active", label: "Active" },
-    { key: "done", label: "Done" },
+    { key: "all", label: "All", icon: <Circle aria-hidden="true" /> },
+    {
+      key: "active",
+      label: "Active",
+      icon: <CircleDot aria-hidden="true" />,
+    },
+    {
+      key: "done",
+      label: "Done",
+      icon: <CircleCheck aria-hidden="true" />,
+    },
   ]}
-  defaultValue="all"
-  ariaLabel="Filter items"
+  defaultValue="active"
+  ariaLabel="Show active goals"
 />`,
     },
     {


### PR DESCRIPTION
## Summary
- add Lucide icons to each goals filter tab and provide descriptive aria labels
- showcase the icon-enhanced filter tabs in the component gallery documentation

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ef038b0c832cb2a06334f5ad6861