### PR TITLE
Add ARIA labels to team comps tabs

### DIFF
--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -219,6 +219,7 @@ export default function TeamCompPage() {
           items: subTabs,
           value: subTab,
           onChange: (next: SubTab) => setSubTab(next),
+          ariaLabel: "Cheat sheet sections",
           showBaseline: true,
         },
         search: {
@@ -352,7 +353,12 @@ export default function TeamCompPage() {
           heading: "Team Comps Today",
           subtitle: "Readable. Fast. On brand.",
           icon: <Users2 className="opacity-80" />,
-          tabs: { items: TABS, value: tab, onChange: (next: Tab) => setTab(next) },
+          tabs: {
+            items: TABS,
+            value: tab,
+            onChange: (next: Tab) => setTab(next),
+            ariaLabel: "Team comps mode",
+          },
           underline: true,
         }}
         hero={hero}


### PR DESCRIPTION
## Summary
- add an aria-label for the hero cheat sheet sub-tabs so screen readers describe the section choices
- label the team comps header tab set, relying on TabBar to surface the aria-label

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f055f10c832ca283b31119f46ea0