### PR TITLE
Add aria label to week notes aside

### DIFF
--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -115,7 +115,10 @@ function Inner() {
           </div>
 
           {/* Sticky only on large so it doesn’t eat the viewport on mobile */}
-          <aside className="lg:col-span-4 space-y-6 lg:sticky lg:top-8">
+          <aside
+            aria-label="Week notes"
+            className="lg:col-span-4 space-y-6 lg:sticky lg:top-8"
+          >
             <WeekNotes iso={iso} />
           </aside>
         </section>


### PR DESCRIPTION
## Summary
- add an aria label to the planner week notes aside to improve accessibility context for screen readers

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f1339b34832ca4a083bb5e312210