### PR TITLE
Add review detail TabBar with accessible panels

### DIFF
--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -11,9 +11,10 @@ import ReviewPanel from "./ReviewPanel";
 import { getSearchBlob } from "./reviewSearch";
 import { BookOpen, Ghost, Plus } from "lucide-react";
 
-import { Button, Select, PageHeader, PageShell } from "@/components/ui";
+import { Button, Select, PageHeader, PageShell, TabBar } from "@/components/ui";
 
 type SortKey = "newest" | "oldest" | "title";
+type DetailMode = "summary" | "edit";
 
 export type ReviewsPageProps = {
   reviews: Review[] | null | undefined;
@@ -40,7 +41,7 @@ export default function ReviewsPage({
 }: ReviewsPageProps) {
   const [q, setQ] = useState("");
   const [sort, setSort] = useState<SortKey>("newest");
-  const [panelMode, setPanelMode] = useState<"summary" | "edit">("summary");
+  const [detailMode, setDetailMode] = useState<DetailMode>("summary");
 
   const base = useMemo<Review[]>(
     () => (Array.isArray(reviews) ? reviews : []),
@@ -70,6 +71,7 @@ export default function ReviewsPage({
 
   const active = base.find((r) => r.id === selectedId) || null;
   const panelClass = "mx-auto";
+  const detailBaseId = active ? `review-${active.id}` : "review-detail";
 
   return (
     <PageShell
@@ -123,7 +125,7 @@ export default function ReviewsPage({
                 onClick={() => {
                   setQ("");
                   setSort("newest");
-                  setPanelMode("edit");
+                  setDetailMode("edit");
                   onCreate();
                 }}
               >
@@ -146,7 +148,7 @@ export default function ReviewsPage({
                 reviews={filtered}
                 selectedId={selectedId}
                 onSelect={(id) => {
-                  setPanelMode("summary");
+                  setDetailMode("summary");
                   onSelect(id);
                 }}
                 onCreate={onCreate}
@@ -166,33 +168,68 @@ export default function ReviewsPage({
               <Ghost className="h-6 w-6 opacity-60" />
               <p>Select a review from the list or create a new one.</p>
             </ReviewPanel>
-          ) : panelMode === "summary" ? (
-            <ReviewPanel className={panelClass}>
-              <ReviewSummary
-                key={`summary-${active.id}`}
-                review={active}
-                onEdit={() => setPanelMode("edit")}
-              />
-            </ReviewPanel>
           ) : (
-            <ReviewPanel className={panelClass}>
-              <ReviewEditor
-                key={`editor-${active.id}`}
-                review={active}
-                onChangeNotes={(value: string) =>
-                  onChangeNotes?.(active.id, value)
-                }
-                onChangeTags={(values: string[]) =>
-                  onChangeTags?.(active.id, values)
-                }
-                onRename={(title: string) => onRename(active.id, title)}
-                onChangeMeta={(partial: Partial<Review>) =>
-                  onChangeMeta?.(active.id, partial)
-                }
-                onDone={() => setPanelMode("summary")}
-                onDelete={onDelete ? () => onDelete(active.id) : undefined}
+            <div className="space-y-4">
+              <TabBar<DetailMode>
+                items={[
+                  { key: "summary", label: "Summary" },
+                  { key: "edit", label: "Edit" },
+                ]}
+                value={detailMode}
+                onValueChange={setDetailMode}
+                ariaLabel="Review detail mode"
+                idBase={detailBaseId}
               />
-            </ReviewPanel>
+              <div
+                id={`${detailBaseId}-summary-panel`}
+                role="tabpanel"
+                aria-labelledby={`${detailBaseId}-summary-tab`}
+                hidden={detailMode !== "summary"}
+                tabIndex={detailMode === "summary" ? 0 : -1}
+              >
+                {detailMode === "summary" ? (
+                  <ReviewPanel className={panelClass}>
+                    <ReviewSummary
+                      key={`summary-${active.id}`}
+                      review={active}
+                      onEdit={() => setDetailMode("edit")}
+                    />
+                  </ReviewPanel>
+                ) : null}
+              </div>
+              <div
+                id={`${detailBaseId}-edit-panel`}
+                role="tabpanel"
+                aria-labelledby={`${detailBaseId}-edit-tab`}
+                hidden={detailMode !== "edit"}
+                tabIndex={detailMode === "edit" ? 0 : -1}
+              >
+                {detailMode === "edit" ? (
+                  <ReviewPanel className={panelClass}>
+                    <ReviewEditor
+                      key={`editor-${active.id}`}
+                      review={active}
+                      onChangeNotes={(value: string) =>
+                        onChangeNotes?.(active.id, value)
+                      }
+                      onChangeTags={(values: string[]) =>
+                        onChangeTags?.(active.id, values)
+                      }
+                      onRename={(title: string) =>
+                        onRename(active.id, title)
+                      }
+                      onChangeMeta={(partial: Partial<Review>) =>
+                        onChangeMeta?.(active.id, partial)
+                      }
+                      onDone={() => setDetailMode("summary")}
+                      onDelete={
+                        onDelete ? () => onDelete(active.id) : undefined
+                      }
+                    />
+                  </ReviewPanel>
+                ) : null}
+              </div>
+            </div>
           )}
         </div>
       </div>

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -42,6 +42,11 @@ export type TabBarProps<K extends string = string> = {
   showBaseline?: boolean;
   linkPanels?: boolean;
   variant?: Variant;
+  /**
+   * Base string applied to tab and panel ids when linking panels.
+   * Defaults to an auto-generated React id to ensure uniqueness.
+   */
+  idBase?: string;
 };
 
 const sizeMap: Record<Size, { h: string; px: string; text: string }> = {
@@ -75,8 +80,10 @@ export default function TabBar<K extends string = string>({
   showBaseline = false,
   linkPanels = true,
   variant = "default",
+  idBase,
 }: TabBarProps<K>) {
   const uid = useId();
+  const baseId = idBase ?? uid;
   const isControlled = value !== undefined;
   const [internal, setInternal] = React.useState<K>(() => {
     if (value !== undefined) return value;
@@ -164,8 +171,8 @@ export default function TabBar<K extends string = string>({
         >
           {items.map((item) => {
             const active = item.key === activeKey;
-            const tabId = `${uid}-${item.id ?? `${item.key}-tab`}`;
-            const panelId = `${uid}-${item.controls ?? `${item.key}-panel`}`;
+            const tabId = `${baseId}-${item.id ?? `${item.key}-tab`}`;
+            const panelId = `${baseId}-${item.controls ?? `${item.key}-panel`}`;
             return (
               <button
                 key={item.key}


### PR DESCRIPTION
## Summary
- replace the reviews detail toggle with a TabBar that switches between Summary and Edit modes
- wrap review detail content in tabpanel containers tied to the new tabs for accessibility
- extend TabBar with an optional id base so tab and panel ids stay aligned

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f03f4cc4832c976d81c4309168db