### PR TITLE
Add neomorphic TabBar variant styling

### DIFF
--- a/src/components/prompts/NeomorphicHeroFrameDemo.tsx
+++ b/src/components/prompts/NeomorphicHeroFrameDemo.tsx
@@ -42,6 +42,7 @@ export default function NeomorphicHeroFrameDemo() {
               value={activeView}
               onValueChange={(key) => setActiveView(key as MissionView)}
               ariaLabel="Switch mission focus"
+              variant="neo"
               right={
                 <Button
                   variant="ghost"
@@ -124,6 +125,7 @@ export default function NeomorphicHeroFrameDemo() {
               onValueChange={(key) => setStatus(key as MissionStatus)}
               ariaLabel="Filter mission status"
               size="sm"
+              variant="neo"
             />
           ),
           search: (

--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -97,6 +97,7 @@ export default function Header<Key extends string = string>({
       size: tabSize,
       align: tabAlign,
       className: tabClassName,
+      variant: tabVariant,
       ...tabBarRest
     } = tabs;
 
@@ -109,6 +110,7 @@ export default function Header<Key extends string = string>({
         size={tabSize ?? "sm"}
         align={tabAlign ?? "end"}
         className={cx("w-auto max-w-full shrink-0", tabClassName)}
+        variant={tabVariant ?? (variant === "neo" ? "neo" : undefined)}
         {...tabBarRest}
       />
     );
@@ -268,11 +270,13 @@ export function HeaderTabs<Key extends string = string>({
   activeKey,
   onChange,
   ariaLabel,
+  variant,
 }: {
   tabs: HeaderTab<Key>[];
   activeKey: Key;
   onChange: (key: Key) => void;
   ariaLabel?: string;
+  variant?: TabBarProps["variant"];
 }) {
   return (
     <TabBar
@@ -282,6 +286,7 @@ export function HeaderTabs<Key extends string = string>({
       ariaLabel={ariaLabel}
       align="end"
       size="sm"
+      variant={variant}
     />
   );
 }


### PR DESCRIPTION
## Summary
- add semantic state tokens and a loading flag to TabBar along with the new neomorphic variant styling
- default Header-provided tabs to the neomorphic variant when the Header itself is using that frame
- surface the neomorphic TabBar treatment in the NeomorphicHeroFrame demo

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8eeda4d88832c955aeab47eaadd7a