### PR TITLE
Improve review list accessibility roles

### DIFF
--- a/src/components/reviews/ReviewList.tsx
+++ b/src/components/reviews/ReviewList.tsx
@@ -44,7 +44,7 @@ export default function ReviewList({
 
   return (
     <Card className={containerClass}>
-      <ul className="flex flex-col gap-3">
+      <ul className="flex flex-col gap-3" role="listbox">
         {reviews.map((r) => (
           <li key={r.id}>
             <ReviewListItem

--- a/src/components/reviews/ReviewListItem.tsx
+++ b/src/components/reviews/ReviewListItem.tsx
@@ -69,9 +69,12 @@ export default function ReviewListItem({
     <button
       data-scope="reviews"
       type="button"
+      role="option"
       disabled={disabled}
       onClick={onClick}
       aria-label={`Open review: ${title}`}
+      aria-selected={selected}
+      aria-current={selected ? "true" : undefined}
       data-selected={selected ? "true" : undefined}
       className={shellBase}
     >

--- a/tests/reviews/ReviewsPage.test.tsx
+++ b/tests/reviews/ReviewsPage.test.tsx
@@ -92,10 +92,10 @@ describe("ReviewsPage", () => {
       />,
     );
 
-    const list = screen.getAllByRole("list")[0];
+    const list = screen.getAllByRole("listbox")[0];
     const getTitles = () =>
       within(list)
-        .getAllByRole("button")
+        .getAllByRole("option")
         .map((b) => b.getAttribute("aria-label")?.replace("Open review: ", ""));
 
     expect(getTitles()).toEqual(["Alpha", "Gamma", "Beta"]);

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -4,8 +4,10 @@ exports[`ReviewListItem > renders default state 1`] = `
 <div>
   <button
     aria-label="Open review: Sample Review"
+    aria-selected="false"
     class="relative w-full text-left rounded-card r-card-lg p-3 bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-theme focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-theme active:bg-accent/20 active:ring-2 active:ring-theme data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
     data-scope="reviews"
+    role="option"
     type="button"
   >
     <div
@@ -58,9 +60,11 @@ exports[`ReviewListItem > renders disabled state 1`] = `
 <div>
   <button
     aria-label="Open review: Sample Review"
+    aria-selected="false"
     class="relative w-full text-left rounded-card r-card-lg p-3 bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-theme focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-theme active:bg-accent/20 active:ring-2 active:ring-theme data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
     data-scope="reviews"
     disabled=""
+    role="option"
     type="button"
   >
     <div
@@ -128,10 +132,13 @@ exports[`ReviewListItem > renders loading state 1`] = `
 exports[`ReviewListItem > renders selected state 1`] = `
 <div>
   <button
+    aria-current="true"
     aria-label="Open review: Sample Review"
+    aria-selected="true"
     class="relative w-full text-left rounded-card r-card-lg p-3 bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-theme focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-theme active:bg-accent/20 active:ring-2 active:ring-theme data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
     data-scope="reviews"
     data-selected="true"
+    role="option"
     type="button"
   >
     <div
@@ -184,8 +191,10 @@ exports[`ReviewListItem > renders untitled state 1`] = `
 <div>
   <button
     aria-label="Open review: Untitled Review"
+    aria-selected="false"
     class="relative w-full text-left rounded-card r-card-lg p-3 bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-theme focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-theme active:bg-accent/20 active:ring-2 active:ring-theme data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
     data-scope="reviews"
+    role="option"
     type="button"
   >
     <div

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -772,12 +772,15 @@ exports[`ReviewsPage > renders default state 1`] = `
             >
               <ul
                 class="flex flex-col gap-3"
+                role="listbox"
               >
                 <li>
                   <button
                     aria-label="Open review: Alpha"
+                    aria-selected="false"
                     class="relative w-full text-left rounded-card r-card-lg p-3 bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-theme focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-theme active:bg-accent/20 active:ring-2 active:ring-theme data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
                     data-scope="reviews"
+                    role="option"
                     type="button"
                   >
                     <div
@@ -820,8 +823,10 @@ exports[`ReviewsPage > renders default state 1`] = `
                 <li>
                   <button
                     aria-label="Open review: Gamma"
+                    aria-selected="false"
                     class="relative w-full text-left rounded-card r-card-lg p-3 bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-theme focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-theme active:bg-accent/20 active:ring-2 active:ring-theme data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
                     data-scope="reviews"
+                    role="option"
                     type="button"
                   >
                     <div
@@ -864,8 +869,10 @@ exports[`ReviewsPage > renders default state 1`] = `
                 <li>
                   <button
                     aria-label="Open review: Beta"
+                    aria-selected="false"
                     class="relative w-full text-left rounded-card r-card-lg p-3 bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-theme focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-theme active:bg-accent/20 active:ring-2 active:ring-theme data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
                     data-scope="reviews"
+                    role="option"
                     type="button"
                   >
                     <div


### PR DESCRIPTION
## Summary
- mark review list items as options with aria-selected and aria-current to expose selection state
- label the review list container as a listbox and refresh tests/snapshots for the new accessibility roles

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f1cff9d8832c802d665e697fc1b5