### PR TITLE
feat(goals): add tab-aware hero copy

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -54,6 +54,26 @@ const TABS: HeaderTab<Tab>[] = [
   },
 ];
 
+const HERO_HEADINGS: Record<Tab, string> = {
+  goals: "Goals overview",
+  reminders: "Reminder board",
+  timer: "Focus timer",
+};
+
+const HERO_HEADING_IDS: Record<Tab, string> = {
+  goals: "goals-hero-heading",
+  reminders: "reminders-hero-heading",
+  timer: "timer-hero-heading",
+};
+
+const HERO_SUBTITLE_IDS: Record<Tab, string> = {
+  goals: "goals-hero-summary",
+  reminders: "reminders-hero-summary",
+  timer: "timer-hero-summary",
+};
+
+const HERO_REGION_ID = "goals-hero-region";
+
 /* ====================================================================== */
 
 export default function GoalsPage() {
@@ -144,12 +164,77 @@ export default function GoalsPage() {
     map[tab].current?.focus();
   }, [tab]);
 
-  const summary =
-    tab === "goals"
-      ? `Cap: ${ACTIVE_CAP} active · Remaining: ${remaining} · ${pctDone}% done · ${totalCount} total`
-      : tab === "reminders"
-        ? "Pin quick cues. Edit between queues."
-        : "Pick a duration and focus.";
+  const summary: React.ReactNode =
+    tab === "goals" ? (
+      <>
+        <span className="font-semibold text-foreground">Cap</span> {ACTIVE_CAP} active ·{" "}
+        <span className="font-semibold text-accent">Remaining</span>{" "}
+        <span className="text-accent">{remaining}</span> ·{" "}
+        <span className="font-semibold text-success">Complete</span>{" "}
+        <span className="text-success">{pctDone}%</span> ·{" "}
+        <span className="font-semibold text-primary">Total</span>{" "}
+        <span className="text-primary">{totalCount}</span>
+      </>
+    ) : tab === "reminders" ? (
+      <>
+        Keep <span className="font-semibold text-accent">nudges</span> handy with quick edit loops.
+      </>
+    ) : (
+      <>
+        <span className="font-semibold text-primary">Timebox</span> focus runs and reset between sets.
+      </>
+    );
+
+  const heroHeadingId = HERO_HEADING_IDS[tab];
+  const heroSubtitleId = HERO_SUBTITLE_IDS[tab];
+
+  const heroHeading = (
+    <span id={heroHeadingId}>{HERO_HEADINGS[tab]}</span>
+  );
+
+  let heroSubtitle: React.ReactNode;
+  if (tab === "goals") {
+    heroSubtitle = (
+      <span
+        id={heroSubtitleId}
+        className="flex flex-wrap items-center gap-x-[var(--space-3)] gap-y-[var(--space-1)] text-muted-foreground"
+      >
+        <span className="inline-flex items-center gap-[var(--space-1)]">
+          <span className="text-label font-semibold text-foreground">Cap</span>
+          <span className="text-label text-foreground">{ACTIVE_CAP}</span>
+        </span>
+        <span className="inline-flex items-center gap-[var(--space-1)]">
+          <span className="text-label font-semibold text-primary">Active</span>
+          <span className="text-label text-primary">{activeCount}</span>
+        </span>
+        <span className="inline-flex items-center gap-[var(--space-1)]">
+          <span className="text-label font-semibold text-accent">Remaining</span>
+          <span className="text-label text-accent">{remaining}</span>
+        </span>
+        <span className="inline-flex items-center gap-[var(--space-1)]">
+          <span className="text-label font-semibold text-success">Done</span>
+          <span className="text-label text-success">
+            {doneCount} ({pctDone}%)
+          </span>
+        </span>
+      </span>
+    );
+  } else if (tab === "reminders") {
+    heroSubtitle = (
+      <span id={heroSubtitleId} className="text-muted-foreground">
+        Stage <span className="font-semibold text-accent">nudges</span> with contexts and cadence.
+      </span>
+    );
+  } else {
+    heroSubtitle = (
+      <span id={heroSubtitleId} className="text-muted-foreground">
+        Dial in <span className="font-semibold text-primary">focus sprints</span> and steady breaks.
+      </span>
+    );
+  }
+
+  const heroAriaDescribedby =
+    heroSubtitle != null ? heroSubtitleId : undefined;
 
   return (
     <PageShell
@@ -178,12 +263,15 @@ export default function GoalsPage() {
             },
           }}
           hero={{
+            id: HERO_REGION_ID,
+            role: "region",
             eyebrow: "Guide",
-            heading: "Overview",
-            subtitle: `Cap ${ACTIVE_CAP}, ${remaining} remaining (${activeCount} active, ${doneCount} done)`,
+            heading: heroHeading,
+            subtitle: heroSubtitle,
             sticky: false,
             topClassName: "top-0",
-            hidden: tab !== "goals",
+            "aria-labelledby": heroHeadingId,
+            "aria-describedby": heroAriaDescribedby,
           }}
         />
 

--- a/tests/goals/goals-page.test.tsx
+++ b/tests/goals/goals-page.test.tsx
@@ -20,12 +20,35 @@ describe("GoalsPage", () => {
 
   it("renders hero heading and subtitle", () => {
     render(<GoalsPage />);
+    const heroRegion = screen.getByRole("region", {
+      name: "Goals overview",
+    });
     expect(
-      screen.getByRole("heading", { name: "Overview" }),
+      within(heroRegion).getByRole("heading", { name: "Goals overview" }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText("Cap 3, 3 remaining (0 active, 0 done)"),
-    ).toBeInTheDocument();
+    const heroSummary = within(heroRegion).getByText((_, node) => {
+      if (!(node instanceof HTMLElement)) {
+        return false;
+      }
+      return node.id === "goals-hero-summary";
+    });
+    const capSegment = within(heroSummary)
+      .getByText("Cap", { selector: "span" })
+      .parentElement as HTMLElement;
+    const activeSegment = within(heroSummary)
+      .getByText("Active", { selector: "span" })
+      .parentElement as HTMLElement;
+    const remainingSegment = within(heroSummary)
+      .getByText("Remaining", { selector: "span" })
+      .parentElement as HTMLElement;
+    const doneSegment = within(heroSummary)
+      .getByText("Done", { selector: "span" })
+      .parentElement as HTMLElement;
+
+    expect(capSegment).toHaveTextContent(/Cap\s*3/);
+    expect(activeSegment).toHaveTextContent(/Active\s*0/);
+    expect(remainingSegment).toHaveTextContent(/Remaining\s*3/);
+    expect(doneSegment).toHaveTextContent(/Done\s*0\s*\(0%\)/);
   });
 
   it("allows editing goal fields", async () => {
@@ -60,9 +83,18 @@ describe("GoalsPage", () => {
 
   it("renders dynamic subtitle with counts", () => {
     render(<GoalsPage />);
-    expect(
-      screen.getByText("Cap 3, 3 remaining (0 active, 0 done)"),
-    ).toBeInTheDocument();
+    const headerHeading = screen.getByRole("heading", {
+      name: "Today’s Goals",
+    });
+    const summaryElement = headerHeading.parentElement?.querySelector(
+      ":scope > span",
+    ) as HTMLElement | null;
+    if (!summaryElement) {
+      throw new Error("Expected header summary to render");
+    }
+    expect(summaryElement).toHaveTextContent(
+      /Cap\s*3\s*active\s*·\s*Remaining\s*3\s*·\s*Complete\s*0%\s*·\s*Total\s*0/,
+    );
   });
 
   it("shows domain in reminders hero and updates on change", () => {


### PR DESCRIPTION
## Summary
- add tab-specific hero headings and subtitles for Goals, Reminders, and Timer views with consistent aria wiring
- refresh the header summary tokens and adjust GoalsPage tests for the new hero copy

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f0358b24832c92ef1cfc608bd1d4