### PR TITLE
Fix TeamComp sub-tab id generation

### DIFF
--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -44,6 +44,7 @@ export default function TeamCompPage() {
   const [subTab, setSubTab] = usePersistentState<SubTab>(SUB_TAB_KEY, "sheet");
   const [query, setQuery] = usePersistentState<string>(QUERY_KEY, "");
   const tabBaseId = React.useId();
+  const subTabBaseId = React.useId();
   const cheatRef = React.useRef<HTMLDivElement>(null);
   const builderRef = React.useRef<HTMLDivElement>(null);
   const builderApi = React.useRef<BuilderHandle>(null);
@@ -74,10 +75,16 @@ export default function TeamCompPage() {
   const subIds = React.useMemo(
     () =>
       ({
-        sheet: { tab: "sheet-tab", panel: "sheet-panel" },
-        comps: { tab: "comps-tab", panel: "comps-panel" },
+        sheet: {
+          tab: `${subTabBaseId}-sheet-tab`,
+          panel: `${subTabBaseId}-sheet-panel`,
+        },
+        comps: {
+          tab: `${subTabBaseId}-comps-tab`,
+          panel: `${subTabBaseId}-comps-panel`,
+        },
       }) satisfies Record<SubTab, { tab: string; panel: string }>,
-    [],
+    [subTabBaseId],
   );
   const [editing, setEditing] = React.useState({
     cheatSheet: false,

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -164,8 +164,10 @@ export default function TabBar<K extends string = string>({
         >
           {items.map((item) => {
             const active = item.key === activeKey;
-            const tabId = `${uid}-${item.id ?? `${item.key}-tab`}`;
-            const panelId = `${uid}-${item.controls ?? `${item.key}-panel`}`;
+            const rawTabId = item.id ?? `${item.key}-tab`;
+            const rawPanelId = item.controls ?? `${item.key}-panel`;
+            const tabId = item.id ? rawTabId : `${uid}-${rawTabId}`;
+            const panelId = item.controls ? rawPanelId : `${uid}-${rawPanelId}`;
             return (
               <button
                 key={item.key}


### PR DESCRIPTION
## Summary
- generate stable sub-tab ids in TeamCompPage with useId and pass them to TabBar and panels to preserve aria links
- respect explicit tab and panel ids in TabBar so provided identifiers are not prefixed automatically

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f11b8148832c855f1b1377e9118a