### PR TITLE
Improve review sort control responsiveness

### DIFF
--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -100,11 +100,18 @@ export default function ReviewsPage({
             className: "flex-1",
           },
           actions: (
-            <div className="flex items-center gap-3">
-              <div className="hidden sm:flex items-center gap-2 text-label text-muted-foreground">
-                <span>Sort</span>
+            <div className="flex flex-col gap-[var(--space-2)] sm:flex-row sm:items-center sm:gap-[var(--space-3)]">
+              <div className="flex w-full flex-col gap-[var(--space-1)] sm:w-auto sm:flex-row sm:items-center sm:gap-[var(--space-2)]">
+                <span
+                  aria-hidden="true"
+                  className="text-label font-medium text-muted-foreground"
+                >
+                  Sort
+                </span>
                 <Select
                   variant="animated"
+                  label="Sort reviews"
+                  hideLabel
                   value={sort}
                   onChange={(v) => setSort(v as SortKey)}
                   items={[
@@ -112,14 +119,15 @@ export default function ReviewsPage({
                     { value: "oldest", label: "Oldest" },
                     { value: "title", label: "Title" },
                   ]}
-                  buttonClassName="h-10 px-4"
+                  className="w-full sm:w-auto"
+                  buttonClassName="!h-[var(--control-h-md)] !px-[var(--space-4)]"
                 />
               </div>
               <Button
                 type="button"
                 variant="primary"
                 size="md"
-                className="px-4 whitespace-nowrap"
+                className="w-full whitespace-nowrap px-[var(--space-4)] sm:w-auto"
                 onClick={() => {
                   setQ("");
                   setSort("newest");

--- a/tests/reviews/ReviewsPage.test.tsx
+++ b/tests/reviews/ReviewsPage.test.tsx
@@ -100,7 +100,7 @@ describe("ReviewsPage", () => {
 
     expect(getTitles()).toEqual(["Alpha", "Gamma", "Beta"]);
 
-    const sortBtn = screen.getByRole("button", { name: "Select option" });
+    const sortBtn = screen.getByRole("button", { name: "Sort reviews" });
     fireEvent.click(sortBtn);
     fireEvent.click(screen.getByRole("option", { name: "Title" }));
 

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -631,17 +631,26 @@ exports[`ReviewsPage > renders default state 1`] = `
                         class="flex items-center gap-[var(--space-2)]"
                       >
                         <div
-                          class="flex items-center gap-3"
+                          class="flex flex-col gap-[var(--space-2)] sm:flex-row sm:items-center sm:gap-[var(--space-3)]"
                         >
                           <div
-                            class="hidden sm:flex items-center gap-2 text-label text-muted-foreground"
+                            class="flex w-full flex-col gap-[var(--space-1)] sm:w-auto sm:flex-row sm:items-center sm:gap-[var(--space-2)]"
                           >
-                            <span>
+                            <span
+                              aria-hidden="true"
+                              class="text-label font-medium text-muted-foreground"
+                            >
                               Sort
                             </span>
                             <div
-                              class="glitch-wrap"
+                              class="glitch-wrap w-full sm:w-auto"
                             >
+                              <div
+                                class="sr-only"
+                                id=":r2:-label"
+                              >
+                                Sort reviews
+                              </div>
                               <div
                                 class="group inline-flex rounded-[var(--radius-full)] border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0"
                               >
@@ -649,8 +658,8 @@ exports[`ReviewsPage > renders default state 1`] = `
                                   aria-controls=":r2:-listbox"
                                   aria-expanded="false"
                                   aria-haspopup="listbox"
-                                  aria-label="Select option"
-                                  class="_glitchTrigger_843152 relative flex items-center rounded-[var(--radius-full)] overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none h-10 px-4"
+                                  aria-labelledby=":r2:-label"
+                                  class="_glitchTrigger_843152 relative flex items-center h-[var(--control-h-sm)] rounded-[var(--radius-full)] px-[var(--space-3)] overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none !h-[var(--control-h-md)] !px-[var(--space-4)]"
                                   data-lit="true"
                                   data-open="false"
                                   type="button"
@@ -698,7 +707,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                             </div>
                           </div>
                           <button
-                            class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-[var(--control-h-md)] text-ui gap-[var(--space-2)] [&_svg]:size-[var(--space-5)] px-4 whitespace-nowrap shadow-glow-sm bg-[hsl(var(--accent)/0.12)] border-[hsl(var(--accent)/0.35)] hover:shadow-glow-md active:translate-y-px active:shadow-btn-primary-active text-foreground [--hover:theme('colors.interaction.primary.hover')] [--active:theme('colors.interaction.primary.active')]"
+                            class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-[var(--control-h-md)] text-ui gap-[var(--space-2)] [&_svg]:size-[var(--space-5)] w-full whitespace-nowrap px-[var(--space-4)] sm:w-auto shadow-glow-sm bg-[hsl(var(--accent)/0.12)] border-[hsl(var(--accent)/0.35)] hover:shadow-glow-md active:translate-y-px active:shadow-btn-primary-active text-foreground [--hover:theme('colors.interaction.primary.hover')] [--active:theme('colors.interaction.primary.active')]"
                             style="--glow-active: hsl(var(--foreground) / 0.35);"
                             tabindex="0"
                             type="button"


### PR DESCRIPTION
## Summary
- replace the reviews sort wrapper with a responsive layout that keeps the dropdown available on small screens
- apply design token spacing to the sort control and button while wiring the select to an accessible label
- update the reviews page test snapshot and queries for the new accessible name

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c8f21f8b38832cb9dd5e3d86ec477b