### PR TITLE
Add aria-live week announcement for planner navigation

### DIFF
--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -23,13 +23,17 @@ import { PageHeader } from "@/components/ui";
 import PageShell from "@/components/ui/layout/PageShell";
 import Button from "@/components/ui/primitives/Button";
 import { CalendarDays, ChevronLeft, ChevronRight } from "lucide-react";
-import { addDays, toISODate } from "@/lib/date";
+import { addDays, formatWeekRangeLabel, toISODate } from "@/lib/date";
 
 /* ───────── Page body under provider ───────── */
 
 function Inner() {
   const { iso, today, setIso } = useFocusDate();
-  const { start, days } = useWeek(iso);
+  const { start, end, days } = useWeek(iso);
+  const weekAnnouncement = React.useMemo(
+    () => formatWeekRangeLabel(start, end),
+    [start, end],
+  );
 
   // Derive once per week change; keeps list stable during edits elsewhere
   const dayItems = React.useMemo<Array<{ iso: ISODate; isToday: boolean }>>(
@@ -39,13 +43,13 @@ function Inner() {
 
   const prevWeek = React.useCallback(() => {
     setIso(toISODate(addDays(start, -7)));
-  }, [start, setIso]);
+  }, [setIso, start]);
   const nextWeek = React.useCallback(() => {
     setIso(toISODate(addDays(start, 7)));
-  }, [start, setIso]);
+  }, [setIso, start]);
   const jumpToday = React.useCallback(() => {
     setIso(today);
-  }, [today, setIso]);
+  }, [setIso, today]);
 
   const heroRef = React.useRef<HTMLDivElement>(null);
 
@@ -101,7 +105,14 @@ function Inner() {
             barClassName: "hidden",
             className: "planner-header__hero",
             heading: <span className="sr-only">Week picker</span>,
-            children: <WeekPicker />,
+            children: (
+              <>
+                <WeekPicker />
+                <div aria-live="polite" className="sr-only">
+                  {weekAnnouncement}
+                </div>
+              </>
+            ),
           }}
         />
 

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -14,6 +14,19 @@ const weekDayFormatter = new Intl.DateTimeFormat(LOCALE, {
   month: "short",
 });
 
+const weekRangeLabelFormatter = new Intl.DateTimeFormat(LOCALE, {
+  month: "long",
+  day: "numeric",
+});
+
+const weekRangeMonthFormatter = new Intl.DateTimeFormat(LOCALE, {
+  month: "long",
+});
+
+const weekRangeDayFormatter = new Intl.DateTimeFormat(LOCALE, {
+  day: "numeric",
+});
+
 const isoLabelWeekdayFormatter = new Intl.DateTimeFormat(LOCALE, {
   weekday: "long",
 });
@@ -165,4 +178,28 @@ export function sundayEndOfWeek(d: Date): Date {
 export function weekRangeFromISO(iso: string): { start: Date; end: Date } {
   const d = fromISODate(iso) ?? new Date();
   return { start: mondayStartOfWeek(d), end: sundayEndOfWeek(d) };
+}
+
+export function formatWeekRangeLabel(start: Date, end: Date): string {
+  if (typeof weekRangeLabelFormatter.formatRange === "function") {
+    try {
+      return `Week of ${weekRangeLabelFormatter.formatRange(start, end)}`;
+    } catch {
+      // Fall through to manual formatting below.
+    }
+  }
+
+  const sameMonth =
+    start.getFullYear() === end.getFullYear() && start.getMonth() === end.getMonth();
+
+  if (sameMonth) {
+    const month = weekRangeMonthFormatter.format(start);
+    const startDay = weekRangeDayFormatter.format(start);
+    const endDay = weekRangeDayFormatter.format(end);
+    return `Week of ${month} ${startDay} – ${endDay}`;
+  }
+
+  const startLabel = weekRangeLabelFormatter.format(start);
+  const endLabel = weekRangeLabelFormatter.format(end);
+  return `Week of ${startLabel} – ${endLabel}`;
 }


### PR DESCRIPTION
## Summary
- expose a reusable `formatWeekRangeLabel` helper for human-readable week ranges
- announce the active week via an aria-live region alongside the WeekPicker

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f28a99e8832c8d799ae3bfc47c80