### PR TITLE
Add region landmarks to goals panels

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -277,7 +277,7 @@ export default function GoalsPage() {
 
         {/* ======= PANELS ======= */}
         <div
-          role="tabpanel"
+          role="region"
           id="goals-panel"
           aria-labelledby="goals-tab"
           hidden={tab !== "goals"}
@@ -346,7 +346,7 @@ export default function GoalsPage() {
         </div>
 
         <div
-          role="tabpanel"
+          role="region"
           id="reminders-panel"
           aria-labelledby="reminders-tab"
           hidden={tab !== "reminders"}
@@ -358,7 +358,7 @@ export default function GoalsPage() {
         </div>
 
         <div
-          role="tabpanel"
+          role="region"
           id="timer-panel"
           aria-labelledby="timer-tab"
           hidden={tab !== "timer"}


### PR DESCRIPTION
## Summary
- change the goals, reminders, and timer tab panels to expose region landmarks
- keep each panel labelled by its controlling tab for consistent accessibility context

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f4d0bf1c832c863da129269f205d