### PR TITLE
Add aria-pressed to team comp edit toggles

### DIFF
--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -233,6 +233,7 @@ export default function TeamCompPage() {
             size="sm"
             variant="ghost"
             onClick={() => toggleEditing(editingKey)}
+            aria-pressed={editing[editingKey]}
           >
             {editing[editingKey] ? "Done" : "Edit"}
           </Button>
@@ -271,6 +272,7 @@ export default function TeamCompPage() {
               size="sm"
               variant="ghost"
               onClick={() => toggleEditing("builder")}
+              aria-pressed={editing.builder}
             >
               {editing.builder ? "Done" : "Edit"}
             </Button>
@@ -311,6 +313,7 @@ export default function TeamCompPage() {
             size="sm"
             variant="ghost"
             onClick={() => toggleEditing("clears")}
+            aria-pressed={editing.clears}
           >
             {editing.clears ? "Done" : "Edit"}
           </Button>


### PR DESCRIPTION
## Summary
- add aria-pressed state to each Team Comp edit toggle so assistive tech reads their active state

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f50dcad0832ca237dbf5af473b73