### PR TITLE
feat(ui): add neomorphic tab bar styling

### DIFF
--- a/src/components/prompts/NeomorphicHeroFrameDemo.tsx
+++ b/src/components/prompts/NeomorphicHeroFrameDemo.tsx
@@ -52,6 +52,7 @@ export default function NeomorphicHeroFrameDemo() {
                 </Button>
               }
               showBaseline
+              variant="neo"
             />
           ),
           search: (
@@ -124,6 +125,7 @@ export default function NeomorphicHeroFrameDemo() {
               onValueChange={(key) => setStatus(key as MissionStatus)}
               ariaLabel="Filter mission status"
               size="sm"
+              variant="neo"
             />
           ),
           search: (

--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -97,6 +97,7 @@ export default function Header<Key extends string = string>({
       size: tabSize,
       align: tabAlign,
       className: tabClassName,
+      variant: tabVariant,
       ...tabBarRest
     } = tabs;
 
@@ -109,6 +110,7 @@ export default function Header<Key extends string = string>({
         size={tabSize ?? "sm"}
         align={tabAlign ?? "end"}
         className={cx("w-auto max-w-full shrink-0", tabClassName)}
+        variant={tabVariant ?? (isNeo ? "neo" : "default")}
         {...tabBarRest}
       />
     );
@@ -268,11 +270,13 @@ export function HeaderTabs<Key extends string = string>({
   activeKey,
   onChange,
   ariaLabel,
+  variant,
 }: {
   tabs: HeaderTab<Key>[];
   activeKey: Key;
   onChange: (key: Key) => void;
   ariaLabel?: string;
+  variant?: TabBarProps["variant"];
 }) {
   return (
     <TabBar
@@ -282,6 +286,7 @@ export function HeaderTabs<Key extends string = string>({
       ariaLabel={ariaLabel}
       align="end"
       size="sm"
+      variant={variant}
     />
   );
 }


### PR DESCRIPTION
## Summary
- add neomorphic background, shadow tokens, and loading state support to the TabBar component
- default Header tabs to the neo treatment when the frame variant is selected and allow HeaderTabs to opt in
- showcase the neo tab style inside the NeomorphicHeroFrame demo for visual coverage

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f39a0700832c9a76c0647f9fae29