### PR TITLE
Improve Goals page snackbar accessibility

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -336,8 +336,11 @@ export default function GoalsPage() {
 
               {lastDeleted && (
                 <Snackbar
+                  role="status"
+                  aria-live="assertive"
                   message={<>Deleted “{lastDeleted.title}”.</>}
                   actionLabel="Undo"
+                  actionAriaLabel="Undo delete goal"
                   onAction={handleUndo}
                 />
               )}

--- a/src/components/ui/feedback/Snackbar.tsx
+++ b/src/components/ui/feedback/Snackbar.tsx
@@ -6,12 +6,14 @@ import { cn } from "@/lib/utils";
 interface SnackbarProps extends React.HTMLAttributes<HTMLDivElement> {
   message: React.ReactNode;
   actionLabel?: string;
+  actionAriaLabel?: string;
   onAction?: () => void;
 }
 
 export default function Snackbar({
   message,
   actionLabel,
+  actionAriaLabel,
   onAction,
   className,
   ...props
@@ -39,6 +41,7 @@ export default function Snackbar({
               "active:text-accent active:opacity-80 disabled:text-muted-foreground disabled:no-underline disabled:pointer-events-none",
             )}
             onClick={onAction}
+            aria-label={actionAriaLabel ?? actionLabel}
           >
             {actionLabel}
           </button>

--- a/tests/goals/goals-page.test.tsx
+++ b/tests/goals/goals-page.test.tsx
@@ -181,7 +181,7 @@ describe("GoalsPage", () => {
     await waitFor(() =>
       expect(screen.queryByText("Goal 4")).not.toBeInTheDocument(),
     );
-    const undoButton = screen.getByRole("button", { name: "Undo" });
+    const undoButton = screen.getByRole("button", { name: "Undo delete goal" });
     fireEvent.click(undoButton);
     expect(await screen.findByText("Goal 4")).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- pass assertive status role attributes to the Goals page snackbar
- allow snackbar actions to receive explicit aria labels and cover with updated test

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f61f705c832c858d3ecb227166a9