### PR TITLE
Fix sort select label association on reviews page

### DIFF
--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -104,17 +104,13 @@ export default function ReviewsPage({
           },
           actions: (
             <div className="flex flex-col gap-[var(--space-2)] sm:flex-row sm:items-center sm:gap-[var(--space-3)]">
-              <div className="flex w-full flex-col gap-[var(--space-1)] sm:w-auto sm:flex-row sm:items-center sm:gap-[var(--space-2)]">
-                <span
-                  aria-hidden="true"
-                  className="text-label font-medium text-muted-foreground"
-                >
+              <label className="flex w-full flex-col gap-[var(--space-1)] sm:w-auto sm:flex-row sm:items-center sm:gap-[var(--space-2)]">
+                <span className="text-label font-medium text-muted-foreground">
                   Sort
                 </span>
                 <Select
                   variant="animated"
-                  label="Sort reviews"
-                  hideLabel
+                  ariaLabel="Sort reviews"
                   value={sort}
                   onChange={(v) => setSort(v as SortKey)}
                   items={[
@@ -125,7 +121,7 @@ export default function ReviewsPage({
                   className="w-full sm:w-auto"
                   buttonClassName="!h-[var(--control-h-md)] !px-[var(--space-4)]"
                 />
-              </div>
+              </label>
               <Button
                 type="button"
                 variant="primary"

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -633,11 +633,10 @@ exports[`ReviewsPage > renders default state 1`] = `
                         <div
                           class="flex flex-col gap-[var(--space-2)] sm:flex-row sm:items-center sm:gap-[var(--space-3)]"
                         >
-                          <div
+                          <label
                             class="flex w-full flex-col gap-[var(--space-1)] sm:w-auto sm:flex-row sm:items-center sm:gap-[var(--space-2)]"
                           >
                             <span
-                              aria-hidden="true"
                               class="text-label font-medium text-muted-foreground"
                             >
                               Sort
@@ -646,19 +645,13 @@ exports[`ReviewsPage > renders default state 1`] = `
                               class="glitch-wrap w-full sm:w-auto"
                             >
                               <div
-                                class="sr-only"
-                                id=":r2:-label"
-                              >
-                                Sort reviews
-                              </div>
-                              <div
                                 class="group inline-flex rounded-[var(--radius-full)] border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0"
                               >
                                 <button
                                   aria-controls=":r2:-listbox"
                                   aria-expanded="false"
                                   aria-haspopup="listbox"
-                                  aria-labelledby=":r2:-label"
+                                  aria-label="Sort reviews"
                                   class="_glitchTrigger_843152 relative flex items-center h-[var(--control-h-sm)] rounded-[var(--radius-full)] px-[var(--space-3)] overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none !h-[var(--control-h-md)] !px-[var(--space-4)]"
                                   data-lit="true"
                                   data-open="false"
@@ -705,7 +698,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                                 </button>
                               </div>
                             </div>
-                          </div>
+                          </label>
                           <button
                             class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] h-[var(--control-h-md)] text-ui gap-[var(--space-2)] [&_svg]:size-[var(--space-5)] w-full whitespace-nowrap px-[var(--space-4)] sm:w-auto shadow-glow-sm bg-[hsl(var(--accent)/0.12)] border-[hsl(var(--accent)/0.35)] hover:shadow-glow-md active:translate-y-px active:shadow-btn-primary-active text-foreground [--hover:theme('colors.interaction.primary.hover')] [--active:theme('colors.interaction.primary.active')]"
                             style="--glow-active: hsl(var(--foreground) / 0.35);"


### PR DESCRIPTION
## Summary
- wrap the reviews page sort control in a label so the visible text is tied to the Select trigger
- add an explicit aria label to the Select for screen reader context and remove the redundant hidden label
- refresh the affected snapshot to capture the updated markup

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f71dac6c832cb79bffa7fd285e7d