### PR TITLE
Adjust PageHeader container semantics

### DIFF
--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -79,7 +79,7 @@ const PageHeaderInner = <
   }: PageHeaderBaseProps<HeaderKey, HeroKey>,
   ref: React.ForwardedRef<PageHeaderFrameElement>,
 ) => {
-  const Component = (as ?? "header") as PageHeaderElement;
+  const Component = (as ?? "section") as PageHeaderElement;
 
   const {
     subTabs: heroSubTabs,
@@ -126,7 +126,7 @@ const PageHeaderInner = <
           <Header {...header} underline={header.underline ?? false} />
           <Hero
             {...heroRest}
-            as={heroAs ?? "header"}
+            as={heroAs ?? "section"}
             frame={heroFrame ?? true}
             topClassName={cn("top-[var(--header-stack)]", heroTopClassName)}
             subTabs={resolvedSubTabs}

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`ReviewsPage > renders default state 1`] = `
     aria-labelledby="reviews-header"
     class="page-shell py-6 space-y-6"
   >
-    <header>
+    <section>
       <style
         global="true"
         jsx="true"
@@ -245,7 +245,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                 </div>
               </div>
             </header>
-            <header>
+            <section>
               <style
                 global="true"
                 jsx="true"
@@ -748,7 +748,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                   </div>
                 </div>
               </div>
-            </header>
+            </section>
           </div>
         </div>
         <div
@@ -756,7 +756,7 @@ exports[`ReviewsPage > renders default state 1`] = `
           class="absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/55"
         />
       </div>
-    </header>
+    </section>
     <div
       class="grid grid-cols-1 items-start gap-6 md:grid-cols-12"
     >


### PR DESCRIPTION
## Summary
- default PageHeader's outer element to `<section>` so the layout hero no longer renders a `<header>` tag by default
- fall back Hero `as` prop to `<section>` and refresh the reviews page snapshot to reflect the new markup

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f806b8b4832c8ed3683300ff1566