### PR TITLE
feat: allow Skeleton aria-hidden override

### DIFF
--- a/src/components/prompts/SkeletonShowcase.tsx
+++ b/src/components/prompts/SkeletonShowcase.tsx
@@ -4,7 +4,13 @@ export default function SkeletonShowcase() {
   return (
     <div className="space-y-4">
       <div className="space-y-2">
-        <Skeleton className="h-6 w-2/5 sm:w-1/3" radius="card" />
+        <Skeleton
+          ariaHidden={false}
+          role="status"
+          aria-label="Loading primary title"
+          className="h-6 w-2/5 sm:w-1/3"
+          radius="card"
+        />
         <Skeleton className="w-full" />
         <Skeleton className="w-5/6" />
       </div>

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -984,7 +984,13 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       element: <SkeletonShowcase />,
       tags: ["skeleton", "loading", "feedback"],
       code: `<div className="space-y-2">
-  <Skeleton />
+  <Skeleton
+    ariaHidden={false}
+    role="status"
+    aria-label="Loading primary title"
+    className="h-6 w-2/5 sm:w-1/3"
+    radius="card"
+  />
   <Skeleton className="w-3/4" />
   <Skeleton radius="full" className="h-10 w-10" />
 </div>`,

--- a/src/components/ui/feedback/Skeleton.tsx
+++ b/src/components/ui/feedback/Skeleton.tsx
@@ -15,21 +15,28 @@ export type SkeletonRadius = keyof typeof radiusClasses;
 
 export interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
   radius?: SkeletonRadius;
+  ariaHidden?: React.AriaAttributes["aria-hidden"];
 }
 
 const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(
-  ({ className, radius = "md", ...props }, ref) => (
-    <div
-      ref={ref}
-      aria-hidden="true"
-      className={cn(
-        "skeleton h-[var(--space-4)] w-full",
-        radiusClasses[radius],
-        className,
-      )}
-      {...props}
-    />
-  ),
+  ({ className, radius = "md", ariaHidden, ...props }, ref) => {
+    const { ["aria-hidden"]: ariaHiddenAttr, ...rest } = props;
+    const resolvedAriaHidden =
+      ariaHidden ?? ariaHiddenAttr ?? true;
+
+    return (
+      <div
+        ref={ref}
+        aria-hidden={resolvedAriaHidden}
+        className={cn(
+          "skeleton h-[var(--space-4)] w-full",
+          radiusClasses[radius],
+          className,
+        )}
+        {...rest}
+      />
+    );
+  },
 );
 
 Skeleton.displayName = "Skeleton";


### PR DESCRIPTION
## Summary
- default the Skeleton primitive to aria-hidden while adding an ariaHidden prop for opt-in semantics
- update the component gallery Skeleton showcase and snippet to demonstrate the accessible override

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f7284454832ca046c1860fa89b0a