### PR TITLE
Shorten WeekPicker aria labels and announce instruction updates

### DIFF
--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -181,7 +181,12 @@ const DayChip = React.forwardRef<HTMLButtonElement, DayChipProps>(function DayCh
         <span className="tabular-nums">{done}</span>
         <span className="text-foreground/70"> / {total}</span>
       </div>
-      <span id={instructionsId} className="sr-only">
+      <span
+        id={instructionsId}
+        className="sr-only"
+        aria-live="polite"
+        aria-atomic="true"
+      >
         {instructionsText}
       </span>
       {/* decorative layers */}


### PR DESCRIPTION
## Summary
- shorten the WeekPicker chip aria-label to a concise date selection string
- wire the visible counts and hidden interaction tips through aria-describedby for clearer guidance
- make the WeekPicker instruction description a polite live region so selection guidance is announced when selection changes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f8b29598832ca368b5f3ff64133a