### PR TITLE
Simplify PageHeader search fallback handling

### DIFF
--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -93,14 +93,11 @@ const PageHeaderInner = <
 
   const resolvedSubTabs = heroSubTabs ?? subTabs;
 
-  const searchSource =
-    heroSearch === null ? null : heroSearch ?? search;
+  const baseSearch = heroSearch === null ? null : heroSearch ?? search;
   const resolvedSearch =
-    searchSource === undefined
-      ? undefined
-      : searchSource === null
-        ? null
-        : { ...searchSource, round: searchSource.round ?? true };
+    baseSearch !== null && baseSearch !== undefined
+      ? { ...baseSearch, round: baseSearch.round ?? true }
+      : baseSearch;
 
   const resolvedActions =
     heroActions === null ? null : heroActions ?? actions;


### PR DESCRIPTION
## Summary
- simplify PageHeader search handling by deriving the hero search config via nullish coalescing
- maintain the default round styling whenever a search configuration is provided

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f87ad2d0832c9d8f902c0bc713b3