### PR TITLE
Use accent token classes on prompts badge

### DIFF
--- a/src/app/prompts/PromptsPage.tsx
+++ b/src/app/prompts/PromptsPage.tsx
@@ -173,16 +173,11 @@ function PageContent() {
                 tone="accent"
                 size="sm"
                 aria-label="Accent color preview: Accent 3"
-                className="bg-accent-soft/20 text-[color:var(--text-on-accent)]"
-                style={{
-                  backgroundColor:
-                    "color-mix(in oklab, var(--accent-overlay) 32%, transparent)",
-                }}
+                className="bg-interaction-accent-surfaceHover text-[color:var(--text-on-accent)]"
               >
                 <span
                   aria-hidden="true"
-                  className="h-2 w-2 rounded-full"
-                  style={{ backgroundColor: "hsl(var(--accent-3))" }}
+                  className="h-2 w-2 rounded-full bg-[hsl(var(--accent-3))]"
                 />
                 Accent 3
               </Badge>


### PR DESCRIPTION
## Summary
- swap the prompts badge preview background to use the accent interaction surface token
- render the accent swatch with a token-based utility class instead of inline styles

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f8ffef1c832c98a86c4b5264cb57