### PR TITLE
Adjust review list height for sticky header

### DIFF
--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -161,7 +161,7 @@ export default function ReviewsPage({
                   onSelect(id);
                 }}
                 onCreate={onCreate}
-                className="max-h-screen overflow-auto p-2"
+                className="h-[calc(100vh-var(--header-stack)-var(--space-6))] overflow-auto p-2"
               />
             </div>
           </div>

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -777,7 +777,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                shown
             </div>
             <div
-              class="rounded-card r-card-lg border border-border/25 bg-card/60 shadow-outline-subtle w-full mx-auto backdrop-blur-sm max-h-screen overflow-auto p-2"
+              class="rounded-card r-card-lg border border-border/25 bg-card/60 shadow-outline-subtle w-full mx-auto backdrop-blur-sm h-[calc(100vh-var(--header-stack)-var(--space-6))] overflow-auto p-2"
             >
               <ul
                 class="flex flex-col gap-3"


### PR DESCRIPTION
## Summary
- ensure the reviews sidebar list uses `calc(100vh - var(--header-stack) - var(--space-6))` so it remains visible beneath the sticky header
- update the reviews page snapshot to reflect the new height utility

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f8490cd4832c803413f5289ae1ba