### PR TITLE
Add container class override for PageHeader container

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -64,7 +64,7 @@ function HomePageContent() {
       >
         <div className="col-span-12">
           <PageHeader
-            className="sticky top-0"
+            containerClassName="sticky top-0"
             header={{
               id: "home-header",
               heading: "Welcome to Planner",

--- a/src/app/prompts/PromptsPage.tsx
+++ b/src/app/prompts/PromptsPage.tsx
@@ -128,7 +128,7 @@ function PageContent() {
       aria-labelledby="prompts-header"
     >
       <PageHeader
-        className="sticky top-0"
+        containerClassName="sticky top-0"
         header={{
           id: "prompts-header",
           heading: "Prompts Playground",

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -80,7 +80,8 @@ export default function ReviewsPage({
       aria-labelledby="reviews-header"
     >
       <PageHeader
-        className="sticky top-0 rounded-card r-card-lg px-4 py-4"
+        containerClassName="sticky top-0"
+        className="rounded-card r-card-lg px-4 py-4"
         contentClassName="space-y-2"
         header={{
           id: "reviews-header",

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -354,7 +354,8 @@ export default function TeamCompPage() {
       aria-labelledby="teamcomp-header"
     >
       <PageHeader
-        className="sticky top-0 rounded-card r-card-lg px-4 py-4 md:col-span-12"
+        containerClassName="sticky top-0 md:col-span-12"
+        className="rounded-card r-card-lg px-4 py-4"
         contentClassName="space-y-2"
         frameProps={{ variant: "unstyled" }}
         header={{

--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -34,6 +34,8 @@ export interface PageHeaderBaseProps<
   hero: HeroProps<HeroKey>;
   /** Optional className for the outer frame */
   className?: string;
+  /** Optional className for the semantic container element */
+  containerClassName?: string;
   /** Additional props for the outer frame */
   frameProps?: NeomorphicHeroFrameProps;
   /** Optional className for the inner content wrapper */
@@ -69,6 +71,7 @@ const PageHeaderInner = <
     header,
     hero,
     className,
+    containerClassName,
     frameProps,
     contentClassName,
     as,
@@ -109,7 +112,10 @@ const PageHeaderInner = <
     frameProps ?? {};
 
   return (
-    <Component {...(elementProps as React.HTMLAttributes<HTMLElement>)}>
+    <Component
+      {...(elementProps as React.HTMLAttributes<HTMLElement>)}
+      className={containerClassName}
+    >
       <NeomorphicHeroFrame
         ref={ref}
         variant={frameVariant ?? "default"}

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -6,7 +6,9 @@ exports[`ReviewsPage > renders default state 1`] = `
     aria-labelledby="reviews-header"
     class="page-shell py-6 space-y-6"
   >
-    <header>
+    <header
+      class="sticky top-0"
+    >
       <style
         global="true"
         jsx="true"
@@ -168,7 +170,7 @@ exports[`ReviewsPage > renders default state 1`] = `
     
       </style>
       <div
-        class="overflow-hidden hero2-frame hero2-neomorph rounded-card r-card-lg border border-border/40 bg-card/70 shadow-outline-subtle md:px-[var(--space-7)] md:py-[var(--space-7)] lg:px-[var(--space-8)] lg:py-[var(--space-8)] sticky top-0 rounded-card r-card-lg px-4 py-4"
+        class="relative overflow-hidden hero2-frame hero2-neomorph rounded-card r-card-lg border border-border/40 bg-card/70 shadow-outline-subtle md:px-[var(--space-7)] md:py-[var(--space-7)] lg:px-[var(--space-8)] lg:py-[var(--space-8)] rounded-card r-card-lg px-4 py-4"
       >
         <span
           aria-hidden="true"


### PR DESCRIPTION
## Summary
- add a `containerClassName` prop to `PageHeader` so layout styles can target the semantic wrapper
- update pages that relied on frame `className` for sticky/grid positioning to use the new prop
- refresh the ReviewsPage snapshot to reflect the container layout change

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f91df180832c91cbb3456a6945dc