### PR TITLE
Use semantic accent overlay background

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1814,6 +1814,20 @@ a:active .lucide {
     background: var(--seg-active-grad);
   }
 
+  .bg-accent-overlay {
+    background-color: var(--accent-overlay);
+  }
+
+  @supports (color: color-mix(in oklab, white, black)) {
+    .bg-accent-overlay {
+      background-color: color-mix(
+        in oklab,
+        var(--accent-overlay) 32%,
+        transparent
+      );
+    }
+  }
+
   .text-neon-soft {
     color: var(--neon-soft);
   }

--- a/src/app/prompts/PromptsPage.tsx
+++ b/src/app/prompts/PromptsPage.tsx
@@ -190,11 +190,7 @@ function PageContent() {
                 tone="accent"
                 size="sm"
                 aria-label="Accent color preview: Accent 3"
-                className="bg-accent-soft/20 text-[color:var(--text-on-accent)]"
-                style={{
-                  backgroundColor:
-                    "color-mix(in oklab, var(--accent-overlay) 32%, transparent)",
-                }}
+                className="bg-accent-overlay text-[color:var(--text-on-accent)]"
               >
                 <span
                   aria-hidden="true"


### PR DESCRIPTION
## Summary
- replace the prompts badge inline accent background with a semantic utility class
- add a reusable `bg-accent-overlay` utility that blends the accent overlay token in CSS

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8fa0f6660832cb0366d590963bc56