### PR TITLE
Align PageHeader nav aria state handling

### DIFF
--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -75,7 +75,7 @@ export default function PageHeaderDemo() {
                 type="button"
                 onClick={() => setActivePrimaryNav(item.key)}
                 data-state={isActive ? "active" : "inactive"}
-                aria-pressed={isActive}
+                aria-current={isActive ? "page" : undefined}
                 className="inline-flex items-center rounded-full border border-transparent px-3 py-1.5 text-label font-semibold uppercase tracking-[0.08em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=inactive]:hover:bg-[--hover] data-[state=inactive]:hover:text-foreground data-[state=active]:bg-[hsl(var(--card)/0.85)] data-[state=active]:text-foreground data-[state=active]:shadow-[0_0_0_1px_hsl(var(--ring)/0.35)]"
               >
                 {item.label}
@@ -93,7 +93,6 @@ export default function PageHeaderDemo() {
       <IconButton
         size="sm"
         aria-label="Show notifications"
-        aria-pressed
         className="text-muted-foreground data-[state=active]:text-foreground"
         data-state="active"
       >

--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -79,7 +79,7 @@ const PageHeaderInner = <
   }: PageHeaderBaseProps<HeaderKey, HeroKey>,
   ref: React.ForwardedRef<PageHeaderFrameElement>,
 ) => {
-  const Component = (as ?? "section") as PageHeaderElement;
+  const Component = (as ?? "header") as PageHeaderElement;
 
   const {
     subTabs: heroSubTabs,

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`ReviewsPage > renders default state 1`] = `
     aria-labelledby="reviews-header"
     class="page-shell py-6 space-y-6"
   >
-    <section>
+    <header>
       <style
         global="true"
         jsx="true"
@@ -749,7 +749,7 @@ exports[`ReviewsPage > renders default state 1`] = `
           class="absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/55"
         />
       </div>
-    </section>
+    </header>
     <div
       class="grid grid-cols-1 items-start gap-6 md:grid-cols-12"
     >


### PR DESCRIPTION
## Summary
- switch the PageHeader demo navigation buttons to use aria-current for the active tab and drop redundant aria-pressed
- default the PageHeader wrapper element to <header> for more accurate semantics and update the reviews snapshot

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8fc6cdf9c832cafaf0cb4f7934200