### PR TITLE
Memoize PageHeader derived props

### DIFF
--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -79,7 +79,7 @@ const PageHeaderInner = <
   }: PageHeaderBaseProps<HeaderKey, HeroKey>,
   ref: React.ForwardedRef<PageHeaderFrameElement>,
 ) => {
-  const Component = (as ?? "section") as PageHeaderElement;
+  const Component = (as ?? "header") as PageHeaderElement;
 
   const {
     subTabs: heroSubTabs,
@@ -91,16 +91,32 @@ const PageHeaderInner = <
     ...heroRest
   } = hero;
 
-  const resolvedSubTabs = heroSubTabs ?? subTabs;
+  const resolvedSubTabs = React.useMemo(
+    () => heroSubTabs ?? subTabs,
+    [heroSubTabs, subTabs],
+  );
 
-  const baseSearch = heroSearch === null ? null : heroSearch ?? search;
-  const resolvedSearch =
-    baseSearch !== null && baseSearch !== undefined
-      ? { ...baseSearch, round: baseSearch.round ?? true }
-      : baseSearch;
+  const resolvedSearch = React.useMemo(() => {
+    if (heroSearch === null) {
+      return null;
+    }
 
-  const resolvedActions =
-    heroActions === null ? null : heroActions ?? actions;
+    const baseSearch = heroSearch ?? search;
+
+    if (baseSearch === null || baseSearch === undefined) {
+      return baseSearch;
+    }
+
+    return {
+      ...baseSearch,
+      round: baseSearch.round ?? true,
+    };
+  }, [heroSearch, search]);
+
+  const resolvedActions = React.useMemo(
+    () => (heroActions === null ? null : heroActions ?? actions),
+    [heroActions, actions],
+  );
 
   const { className: frameClassName, variant: frameVariant, ...restFrameProps } =
     frameProps ?? {};

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`ReviewsPage > renders default state 1`] = `
     aria-labelledby="reviews-header"
     class="page-shell py-6 space-y-6"
   >
-    <section>
+    <header>
       <style
         global="true"
         jsx="true"
@@ -749,7 +749,7 @@ exports[`ReviewsPage > renders default state 1`] = `
           class="absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/55"
         />
       </div>
-    </section>
+    </header>
     <div
       class="grid grid-cols-1 items-start gap-6 md:grid-cols-12"
     >


### PR DESCRIPTION
## Summary
- memoize derived PageHeader props so Hero and Header receive stable data references
- default the PageHeader root element to `<header>` for correct semantics
- update the ReviewsPage snapshot for the new header markup

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8fb1a91b4832c882fcf219bdfa3eb