### PR TITLE
refactor: align globals with spacing tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -93,15 +93,15 @@ html.no-animations *::after {
 
 /* Global focus & selection styling */
 *:focus-visible {
-  outline: 2px solid hsl(var(--ring-contrast));
-  outline-offset: 2px;
-  box-shadow: 0 0 6px hsl(var(--glow) / 0.6);
+  outline: var(--space-0-5) solid hsl(var(--ring-contrast));
+  outline-offset: var(--space-0-5);
+  box-shadow: 0 0 var(--space-1-5) hsl(var(--glow) / 0.6);
 }
 
 @media (forced-colors: active) {
   *:focus-visible {
-    outline: 2px solid CanvasText;
-    outline-offset: 2px;
+    outline: var(--space-0-5) solid CanvasText;
+    outline-offset: var(--space-0-5);
     box-shadow: none;
   }
 }
@@ -124,7 +124,7 @@ html.bg-intense body::before {
   opacity: 0.05;
 }
 html.bg-intense body::after {
-  filter: blur(2px) saturate(120%);
+  filter: blur(var(--space-0-5)) saturate(120%);
 }
 
 @layer base {
@@ -147,8 +147,8 @@ html.bg-intense body::after {
 :where(h1, h2, h3, .card-title) {
   position: relative;
   text-shadow:
-    1px 0 hsl(var(--accent-2)),
-    -1px 0 hsl(var(--lav-deep));
+    var(--hairline-w) 0 hsl(var(--accent-2)),
+    calc(var(--hairline-w) * -1) 0 hsl(var(--lav-deep));
   animation: ghost 3.2s ease-in-out infinite;
 }
 .no-ghost {
@@ -156,20 +156,20 @@ html.bg-intense body::after {
   animation: none !important;
 }
 .title-glow {
-  text-shadow: 0 0 20px hsl(var(--ring) / 0.3);
+  text-shadow: 0 0 calc(var(--space-4) + var(--space-1)) hsl(var(--ring) / 0.3);
 }
 
 /* Glitch utility (subtle RGB offset) */
 .glitch {
   position: relative;
-  filter: drop-shadow(1px 0 0 hsl(var(--accent-2)))
-    drop-shadow(-1px 0 0 hsl(var(--lav-deep)));
+  filter: drop-shadow(var(--hairline-w) 0 0 hsl(var(--accent-2)))
+    drop-shadow(calc(var(--hairline-w) * -1) 0 0 hsl(var(--lav-deep)));
 }
 /* Hero glow rim (used on Hero card) */
 .title-glow {
   text-shadow:
-    0 0 6px hsl(var(--ring) / 0.6),
-    0 0 14px hsl(var(--accent) / 0.5);
+    0 0 var(--space-1-5) hsl(var(--ring) / 0.6),
+    0 0 calc(var(--space-3) + var(--space-0-5)) hsl(var(--accent) / 0.5);
 }
 
 /* Neon text glow */
@@ -225,7 +225,7 @@ html.bg-intense body::after {
   .header-rail::after {
     content: "";
     position: absolute;
-    inset: -1px;
+    inset: calc(var(--hairline-w) * -1);
     border-radius: inherit;
     pointer-events: none;
   }
@@ -252,7 +252,7 @@ html.bg-intense body::after {
       hsl(var(--ring) / 0.35),
       transparent 70%
     );
-    filter: blur(4px);
+    filter: blur(var(--space-1));
     mix-blend-mode: screen;
     animation: hero-rail-flicker 3.2s steps(24, end) infinite alternate;
     opacity: 0.3;
@@ -280,7 +280,8 @@ html.bg-intense body::after {
     background: hsl(var(--card) / 0.75);
     box-shadow:
       0 0 0 var(--hairline-w) hsl(var(--card-hairline)) inset,
-      0 30px 60px hsl(var(--shadow-base) / 0.35);
+      0 calc(var(--space-5) + var(--space-1-5))
+        calc(var(--space-8) - var(--space-1)) hsl(var(--shadow-base) / 0.35);
   }
   .card-neo-soft {
     background: linear-gradient(
@@ -288,20 +289,21 @@ html.bg-intense body::after {
       hsl(var(--card) / 0.75),
       hsl(var(--card) / 0.55)
     );
-    -webkit-backdrop-filter: blur(6px);
-    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(var(--space-1-5));
+    backdrop-filter: blur(var(--space-1-5));
     box-shadow:
       0 0 0 var(--hairline-w) hsl(var(--card-hairline)) inset,
-      inset 0 1px 0 hsl(var(--foreground) / 0.05),
-      0 30px 60px hsl(var(--shadow-base) / 0.35);
+      inset 0 var(--hairline-w) 0 hsl(var(--foreground) / 0.05),
+      0 calc(var(--space-5) + var(--space-1-5))
+        calc(var(--space-8) - var(--space-1)) hsl(var(--shadow-base) / 0.35);
   }
   .card-neo::before,
   .card-neo-soft::before {
     content: "";
     position: absolute;
-    inset: -1px;
-    padding: 1px;
-    border-radius: calc(var(--_r) + 1px);
+    inset: calc(var(--hairline-w) * -1);
+    padding: var(--hairline-w);
+    border-radius: calc(var(--_r) + var(--hairline-w));
     background: var(--edge-iris);
     mask:
       linear-gradient(hsl(var(--foreground)) 0 0) content-box,
@@ -321,10 +323,10 @@ html.bg-intense body::after {
     pointer-events: none;
     background: repeating-linear-gradient(
       to bottom,
-      hsl(var(--foreground) / 0.035) 0px,
-      hsl(var(--foreground) / 0.035) 1px,
-      transparent 2px,
-      transparent 3px
+      hsl(var(--foreground) / 0.035) 0,
+      hsl(var(--foreground) / 0.035) var(--hairline-w),
+      transparent var(--space-0-5),
+      transparent calc(var(--space-0-5) + var(--hairline-w))
     );
     mix-blend-mode: soft-light;
     opacity: 0;
@@ -333,7 +335,8 @@ html.bg-intense body::after {
   /* HOVER: no translate */
   .card-neo:hover,
   .card-neo-soft:hover {
-    box-shadow: 0 22px 48px hsl(var(--shadow-color) / 0.25);
+    box-shadow: 0 calc(var(--space-5) - var(--space-0-5)) var(--space-7)
+      hsl(var(--shadow-color) / 0.25);
   }
   .card-neo:hover::before,
   .card-neo-soft:hover::before {
@@ -347,15 +350,17 @@ html.bg-intense body::after {
   .card-neo-soft[data-active="true"] {
     box-shadow:
       0 0 0 var(--hairline-w) hsl(var(--ring)) inset,
-      0 0 0 2px hsl(var(--ring) / 0.22),
-      0 26px 60px hsl(var(--shadow-color) / 0.28);
+      0 0 0 var(--space-0-5) hsl(var(--ring) / 0.22),
+      0 calc(var(--space-5) + var(--space-0-5))
+        calc(var(--space-8) - var(--space-1)) hsl(var(--shadow-color) / 0.28);
   }
   .card-neo:focus-within,
   .card-neo-soft:focus-within {
     outline: none;
     box-shadow:
-      0 0 0 3px hsl(var(--ring) / 0.35),
-      0 26px 60px hsl(var(--shadow-color) / 0.28);
+      0 0 0 calc(var(--hairline-w) * 3) hsl(var(--ring) / 0.35),
+      0 calc(var(--space-5) + var(--space-0-5))
+        calc(var(--space-8) - var(--space-1)) hsl(var(--shadow-color) / 0.28);
   }
 
   /* Buttons */
@@ -401,7 +406,7 @@ html.bg-intense body::after {
   @keyframes igniteFlicker {
     0% {
       opacity: 0.1;
-      filter: blur(0.6px);
+      filter: blur(calc(var(--hairline-w) * 0.6));
     }
     8% {
       opacity: 1;
@@ -420,7 +425,7 @@ html.bg-intense body::after {
     }
     55% {
       opacity: 0.45;
-      filter: blur(0.2px);
+      filter: blur(calc(var(--hairline-w) * 0.2));
     }
     70% {
       opacity: 1;
@@ -504,7 +509,7 @@ html.bg-intense body::after {
   @keyframes igniteFlicker {
     0% {
       opacity: 0.1;
-      filter: blur(0.6px);
+      filter: blur(calc(var(--hairline-w) * 0.6));
     }
     8% {
       opacity: 1;
@@ -523,7 +528,7 @@ html.bg-intense body::after {
     }
     55% {
       opacity: 0.45;
-      filter: blur(0.2px);
+      filter: blur(calc(var(--hairline-w) * 0.2));
     }
     70% {
       opacity: 1;
@@ -566,7 +571,7 @@ html.bg-intense body::after {
       linear-gradient(90deg, hsl(var(--primary) / 0.12) 0%, transparent 100%),
       hsl(var(--card));
     color: hsl(var(--foreground));
-    text-shadow: 0 0 6px hsl(var(--accent) / 0.25);
+    text-shadow: 0 0 var(--space-1-5) hsl(var(--accent) / 0.25);
   }
   .btn-like-segmented:active {
     background:
@@ -605,8 +610,9 @@ html.bg-intense body::after {
     background: color-mix(in oklab, hsl(var(--card)) 75%, transparent);
     border-color: hsl(var(--ring));
     box-shadow:
-      0 0 0 2px hsl(var(--ring) / 0.35),
-      0 12px 28px hsl(var(--ring) / 0.25);
+      0 0 0 var(--space-0-5) hsl(var(--ring) / 0.35),
+      0 var(--space-3) calc(var(--space-6) - var(--space-1))
+        hsl(var(--ring) / 0.25);
   }
 
   .btn-glitch {
@@ -614,8 +620,8 @@ html.bg-intense body::after {
     color: hsl(var(--primary-foreground));
     background: var(--seg-active-grad);
     box-shadow:
-      0 0 25px hsl(var(--accent) / 0.6),
-      0 0 50px hsl(var(--accent-2) / 0.4);
+      0 0 calc(var(--space-5) + var(--hairline-w)) hsl(var(--accent) / 0.6),
+      0 0 calc(var(--space-7) + var(--space-0-5)) hsl(var(--accent-2) / 0.4);
     transition:
       transform var(--dur-quick) var(--ease-out),
       filter var(--dur-quick);
@@ -627,14 +633,16 @@ html.bg-intense body::after {
   .btn-lift {
     border-radius: var(--radius-2xl);
     background: hsl(var(--card));
-    border: 1px solid hsl(var(--card-hairline));
-    box-shadow: 0 6px 18px hsl(var(--shadow-color) / 0.18);
+    border: var(--hairline-w) solid hsl(var(--card-hairline));
+    box-shadow: 0 var(--space-1-5)
+      calc(var(--space-4) + var(--space-0-5)) hsl(var(--shadow-color) / 0.18);
     transition:
       transform var(--dur-quick) var(--ease-out),
       box-shadow var(--dur-quick);
   }
   .btn-lift:hover {
-    box-shadow: 0 10px 24px hsl(var(--shadow-color) / 0.25);
+    box-shadow: 0 calc(var(--space-2) + var(--space-0-5)) var(--space-5)
+      hsl(var(--shadow-color) / 0.25);
   }
 
   /* Inputs */
@@ -659,7 +667,7 @@ html.bg-intense body::after {
   }
   .input-base:focus {
     outline: none;
-    box-shadow: 0 0 0 3px hsl(var(--ring) / 0.35);
+    box-shadow: 0 0 0 calc(var(--hairline-w) * 3) hsl(var(--ring) / 0.35);
     border-color: hsl(var(--ring));
   }
 
@@ -670,13 +678,14 @@ html.bg-intense body::after {
     background: hsl(var(--card));
     box-shadow:
       0 0 0 var(--hairline-w) hsl(var(--card-hairline)) inset,
-      0 10px 30px hsl(var(--shadow-base) / 0.25);
+      0 calc(var(--space-2) + var(--space-0-5))
+        calc(var(--space-5) + var(--space-1-5)) hsl(var(--shadow-base) / 0.25);
   }
   .section-h {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 14px 16px;
+    padding: calc(var(--space-3) + var(--space-0-5)) var(--space-4);
     border-bottom: 1px solid hsl(var(--card-hairline) / 0.55);
     border-top-left-radius: calc(var(--radius-card) - var(--hairline-w));
     border-top-right-radius: calc(var(--radius-card) - var(--hairline-w));
@@ -691,10 +700,10 @@ html.bg-intense body::after {
     position: sticky;
     top: 0;
     z-index: 5;
-    backdrop-filter: blur(8px);
+    backdrop-filter: blur(var(--space-2));
   }
   .section-b {
-    padding: 1.5rem;
+    padding: var(--space-5);
   }
 
   /* Sheen border utility */
@@ -706,7 +715,7 @@ html.bg-intense body::after {
     content: "";
     position: absolute;
     inset: 0;
-    padding: 1px;
+    padding: var(--hairline-w);
     border-radius: var(--radius-card);
     background: conic-gradient(
       from var(--a, 0deg),
@@ -732,7 +741,7 @@ html.bg-intense body::after {
   /* Hero & cards used elsewhere */
   .bg-hero-soft {
     position: relative;
-    border: 1px solid hsl(var(--card-hairline));
+    border: var(--hairline-w) solid hsl(var(--card-hairline));
     background:
       radial-gradient(
         120% 200% at 0% 0%,
@@ -746,9 +755,10 @@ html.bg-intense body::after {
       ),
       linear-gradient(180deg, hsl(var(--card)), hsl(var(--background)));
     box-shadow:
-      0 1px 0 hsl(var(--foreground) / 0.08) inset,
-      0 0 0 1px hsl(var(--card-hairline) / 0.65),
-      0 14px 40px hsl(var(--shadow-color) / 0.45);
+      0 var(--hairline-w) 0 hsl(var(--foreground) / 0.08) inset,
+      0 0 0 var(--hairline-w) hsl(var(--card-hairline) / 0.65),
+      0 calc(var(--space-3) + var(--space-0-5))
+        calc(var(--space-6) + var(--space-2)) hsl(var(--shadow-color) / 0.45);
   }
   .bg-hero-soft::after {
     content: "";
@@ -759,9 +769,9 @@ html.bg-intense body::after {
     background-image: repeating-linear-gradient(
       to bottom,
       hsl(var(--foreground) / 0.04),
-      hsl(var(--foreground) / 0.04) 1px,
-      transparent 1px,
-      transparent 3px
+      hsl(var(--foreground) / 0.04) var(--hairline-w),
+      transparent var(--hairline-w),
+      transparent calc(var(--space-0-5) + var(--hairline-w))
     );
   }
 
@@ -841,14 +851,16 @@ html.bg-intense body::after {
 
 .glitch-track {
   position: relative;
-  height: 10px;
+  height: calc(var(--space-2) + var(--space-0-5));
   border-radius: var(--radius-full);
   background: hsl(var(--foreground) / 0.08);
   overflow: hidden;
   box-shadow:
-    inset 0 0 0 1px hsl(var(--foreground) / 0.06),
-    inset 2px 2px 4px hsl(var(--shadow-color) / 0.45),
-    inset -2px -2px 4px hsl(var(--foreground) / 0.06);
+    inset 0 0 0 var(--hairline-w) hsl(var(--foreground) / 0.06),
+    inset var(--space-0-5) var(--space-0-5) var(--space-1)
+      hsl(var(--shadow-color) / 0.45),
+    inset calc(var(--space-0-5) * -1) calc(var(--space-0-5) * -1) var(--space-1)
+      hsl(var(--foreground) / 0.06);
 }
 .glitch-fill {
   height: 100%;
@@ -858,7 +870,7 @@ html.bg-intense body::after {
   background-size: 200% 100%;
   transition: width 0.35s cubic-bezier(0.22, 0.99, 0.28, 0.99);
   animation: glitchSheen 3s linear infinite;
-  box-shadow: 0 0 8px hsl(var(--accent) / 0.5);
+  box-shadow: 0 0 var(--space-2) hsl(var(--accent) / 0.5);
 }
 .glitch-scan {
   position: absolute;
@@ -866,8 +878,9 @@ html.bg-intense body::after {
   background: repeating-linear-gradient(
     to bottom,
     transparent 0,
-    transparent 2px,
-    hsl(var(--foreground) / 0.06) 2px 3px
+    transparent var(--space-0-5),
+    hsl(var(--foreground) / 0.06) var(--space-0-5)
+      calc(var(--space-0-5) + var(--hairline-w))
   );
   mix-blend-mode: screen;
   pointer-events: none;
@@ -876,7 +889,7 @@ html.bg-intense body::after {
     glitchJitter 0.8s steps(3, end) infinite;
 }
 .glitch-track.is-complete .glitch-fill {
-  filter: drop-shadow(0 0 8px hsl(var(--accent)));
+  filter: drop-shadow(0 0 var(--space-2) hsl(var(--accent)));
 }
 .glitch-percent {
   font-variant-numeric: tabular-nums;
@@ -896,11 +909,11 @@ html.bg-intense body::after {
   line-height: 1;
   padding: 0.45rem 0.55rem;
   border-radius: var(--radius-full);
-  border: 1px solid var(--b);
+  border: var(--hairline-w) solid var(--b);
   background: linear-gradient(180deg, var(--bg), hsl(var(--card)));
   color: hsl(var(--muted-foreground));
   text-transform: uppercase;
-  box-shadow: inset 0 0 0 1px hsl(var(--card-hairline) / 0.4);
+  box-shadow: inset 0 0 0 var(--hairline-w) hsl(var(--card-hairline) / 0.4);
 }
 .pill--trace {
   border-color: transparent;
@@ -912,12 +925,12 @@ html.bg-intense body::after {
 .pill--ok {
   border-color: hsl(var(--accent));
   color: hsl(var(--accent));
-  box-shadow: 0 0 12px hsl(var(--accent) / 0.35);
+  box-shadow: 0 0 var(--space-3) hsl(var(--accent) / 0.35);
 }
 .pill--warn {
   border-color: hsl(var(--muted-foreground));
   color: hsl(var(--muted-foreground));
-  box-shadow: 0 0 12px hsl(var(--muted-foreground) / 0.25);
+  box-shadow: 0 0 var(--space-3) hsl(var(--muted-foreground) / 0.25);
 }
 .pill--pulse {
   position: relative;
@@ -927,9 +940,9 @@ html.bg-intense body::after {
 .pill--pulse::after {
   content: "";
   position: absolute;
-  inset: -2px;
+  inset: calc(var(--hairline-w) * -2);
   border-radius: var(--radius-full);
-  border: 1px solid hsl(var(--accent) / 0.45);
+  border: var(--hairline-w) solid hsl(var(--accent) / 0.45);
   animation: pill-pulse 1.6s ease-out infinite;
 }
 
@@ -961,8 +974,8 @@ html.bg-intense body::after {
 
 /* ---------- Scrollbar ---------- */
 *::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
+  width: calc(var(--space-2) + var(--space-0-5));
+  height: calc(var(--space-2) + var(--space-0-5));
 }
 *::-webkit-scrollbar-thumb {
   background: linear-gradient(
@@ -971,7 +984,7 @@ html.bg-intense body::after {
     hsl(var(--accent) / 0.7)
   );
   border-radius: var(--radius-full);
-  border: 2px solid hsl(var(--background));
+  border: var(--space-0-5) solid hsl(var(--background));
 }
 *::-webkit-scrollbar-track {
   background: hsl(var(--background));
@@ -995,17 +1008,18 @@ html.bg-intense body::after {
     ),
     linear-gradient(180deg, hsl(var(--card)), hsl(var(--background)));
   box-shadow:
-    0 18px 48px hsl(var(--shadow-color) / 0.35),
+    0 calc(var(--space-4) + var(--space-0-5)) var(--space-7)
+      hsl(var(--shadow-color) / 0.35),
     inset 0 0 0 var(--hairline-w) hsl(var(--card-hairline));
   overflow: hidden;
 }
 .week-outline::before {
   content: "";
   position: absolute;
-  inset: -1px;
+  inset: calc(var(--hairline-w) * -1);
   border-radius: inherit;
   pointer-events: none;
-  padding: 1px;
+  padding: var(--hairline-w);
   background: conic-gradient(
     from 180deg,
     hsl(var(--ring) / 0),
@@ -1055,15 +1069,15 @@ html.bg-intense body::after {
 
 .week-outline .section-header {
   border-bottom: 0 !important;
-  box-shadow: 0 1px 0 hsl(var(--accent) / 0.14) inset;
+  box-shadow: 0 var(--hairline-w) 0 hsl(var(--accent) / 0.14) inset;
   background: color-mix(in oklab, hsl(var(--background)) 72%, transparent);
-  backdrop-filter: blur(8px);
+  backdrop-filter: blur(var(--space-2));
 }
 
 /* Autofill fix */
 input:-webkit-autofill,
 textarea:-webkit-autofill {
-  box-shadow: 0 0 0 1000px hsl(var(--card)) inset;
+  box-shadow: 0 0 0 var(--shadow-autofill-mask) hsl(var(--card)) inset;
   -webkit-text-fill-color: hsl(var(--foreground));
   transition: background-color 9999s ease-out 0s;
   caret-color: hsl(var(--foreground));
@@ -1109,11 +1123,12 @@ textarea:-webkit-autofill {
   font-weight: 500;
   letter-spacing: -0.01em;
   background: color-mix(in oklab, hsl(var(--muted)) 18%, transparent);
-  border: 1px solid hsl(var(--card-hairline));
+  border: var(--hairline-w) solid hsl(var(--card-hairline));
   box-shadow:
-    inset 0 1px 0 hsl(var(--foreground) / 0.06),
-    0 0 0 0.5px hsl(var(--card-hairline) / 0.35),
-    0 10px 20px hsl(var(--shadow-color) / 0.18);
+    inset 0 var(--hairline-w) 0 hsl(var(--foreground) / 0.06),
+    0 0 0 calc(var(--hairline-w) / 2) hsl(var(--card-hairline) / 0.35),
+    0 calc(var(--space-2) + var(--space-0-5))
+      calc(var(--space-4) + var(--space-0-5)) hsl(var(--shadow-color) / 0.18);
   transition:
     background 0.15s ease,
     box-shadow 0.15s ease,
@@ -1132,7 +1147,7 @@ textarea:-webkit-autofill {
 .badge__icon {
   display: inline-flex;
   opacity: 0.85;
-  transform: translateY(0.5px);
+  transform: translateY(calc(var(--hairline-w) / 2));
 }
 .badge[data-interactive="true"]:hover {
   background: color-mix(in oklab, hsl(var(--muted)) 28%, transparent);
@@ -1141,8 +1156,9 @@ textarea:-webkit-autofill {
   background: color-mix(in oklab, hsl(var(--primary-soft)) 36%, transparent);
   border-color: hsl(var(--ring));
   box-shadow:
-    0 0 0 1px hsl(var(--ring) / 0.6) inset,
-    0 8px 22px hsl(var(--shadow-color) / 0.6);
+    0 0 0 var(--hairline-w) hsl(var(--ring) / 0.6) inset,
+    0 var(--space-2) calc(var(--space-5) - var(--space-0-5))
+      hsl(var(--shadow-color) / 0.6);
 }
 .badge[data-tone="primary"] {
   border-color: hsl(var(--ring));
@@ -1177,24 +1193,27 @@ textarea:-webkit-autofill {
   background-size: 100% 200%;
   animation: lg-railShift 5.5s ease-in-out infinite;
   box-shadow:
-    0 0 14px hsl(var(--primary) / 0.35),
-    0 0 28px hsl(var(--accent) / 0.25);
+    0 0 calc(var(--space-3) + var(--space-0-5))
+      hsl(var(--primary) / 0.35),
+    0 0 calc(var(--space-6) - var(--space-1)) hsl(var(--accent) / 0.25);
 }
 .glitch-card {
   position: relative;
   border-radius: var(--radius-xl);
-  border: 1px solid hsl(var(--card-hairline));
+  border: var(--hairline-w) solid hsl(var(--card-hairline));
   background: hsl(var(--card) / 0.7);
   box-shadow:
-    inset 0 1px 0 hsl(var(--foreground) / 0.05),
-    0 10px 24px hsl(var(--shadow-color) / 0.35);
+    inset 0 var(--hairline-w) 0 hsl(var(--foreground) / 0.05),
+    0 calc(var(--space-2) + var(--space-0-5)) var(--space-5)
+      hsl(var(--shadow-color) / 0.35);
   transition:
     transform 0.12s ease,
     box-shadow 0.2s ease,
     background 0.2s ease;
 }
 .glitch-card:hover {
-  box-shadow: 0 14px 30px hsl(var(--shadow-color) / 0.42);
+  box-shadow: 0 calc(var(--space-3) + var(--space-0-5))
+    calc(var(--space-5) + var(--space-1-5)) hsl(var(--shadow-color) / 0.42);
 }
 .glitch-card::after {
   content: "";
@@ -1202,7 +1221,7 @@ textarea:-webkit-autofill {
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  padding: 1px;
+  padding: var(--hairline-w);
   background: linear-gradient(
     90deg,
     hsl(var(--primary) / 0.55),
@@ -1230,8 +1249,8 @@ textarea:-webkit-autofill {
   pointer-events: none;
   background: repeating-linear-gradient(
     to bottom,
-    hsl(var(--foreground) / 0.035) 0 1px,
-    transparent 1px 3px
+    hsl(var(--foreground) / 0.035) 0 var(--hairline-w),
+    transparent var(--hairline-w) calc(var(--space-0-5) + var(--hairline-w))
   );
   mix-blend-mode: overlay;
   opacity: 0.2;
@@ -1239,8 +1258,8 @@ textarea:-webkit-autofill {
 .glitch-title {
   position: relative;
   text-shadow:
-    0 0 6px hsl(var(--primary) / 0.45),
-    0 0 18px hsl(var(--accent) / 0.35);
+    0 0 var(--space-1-5) hsl(var(--primary) / 0.45),
+    0 0 calc(var(--space-4) + var(--space-0-5)) hsl(var(--accent) / 0.35);
   transition:
     text-shadow 0.18s ease,
     transform 0.12s ease;
@@ -1256,10 +1275,10 @@ textarea:-webkit-autofill {
   .glitch-title:hover,
   .glitch-title:focus-visible {
     text-shadow:
-      1px 0 hsl(var(--accent) / 0.9),
-      -1px 0 hsl(var(--primary) / 0.9),
-      0 0 12px hsl(var(--ring) / 0.6),
-      0 0 26px hsl(var(--accent) / 0.35);
+      var(--hairline-w) 0 hsl(var(--accent) / 0.9),
+      calc(var(--hairline-w) * -1) 0 hsl(var(--primary) / 0.9),
+      0 0 var(--space-3) hsl(var(--ring) / 0.6),
+      0 0 calc(var(--space-6) - var(--space-0-5)) hsl(var(--accent) / 0.35);
   }
 }
 .badge[data-glitch="true"] {
@@ -1269,13 +1288,13 @@ textarea:-webkit-autofill {
     color-mix(in oklab, hsl(var(--muted)) 34%, transparent) 100%
   );
   box-shadow:
-    0 0 0 1px hsl(var(--card-hairline)) inset,
-    0 0 16px hsl(var(--accent) / 0.25);
+    0 0 0 var(--hairline-w) hsl(var(--card-hairline)) inset,
+    0 0 var(--space-4) hsl(var(--accent) / 0.25);
 }
 .badge[data-glitch="true"]:hover {
   box-shadow:
-    0 0 0 1px hsl(var(--ring)) inset,
-    0 0 20px hsl(var(--accent) / 0.35);
+    0 0 0 var(--hairline-w) hsl(var(--ring)) inset,
+    0 0 calc(var(--space-4) + var(--space-1)) hsl(var(--accent) / 0.35);
 }
 
 @keyframes lg-railShift {
@@ -1343,11 +1362,12 @@ textarea:-webkit-autofill {
   }
   .title-ghost {
     @apply text-title-lg font-semibold opacity-60;
-    filter: blur(1px);
+    filter: blur(var(--hairline-w));
   }
   .title-glow {
     @apply text-2xl font-semibold;
-    text-shadow: 0 0 20px hsl(var(--glow-strong));
+    text-shadow: 0 0 calc(var(--space-4) + var(--space-1))
+      hsl(var(--glow-strong));
   }
 }
 .ds-grid-gap {
@@ -1423,7 +1443,7 @@ textarea:-webkit-autofill {
   height: 1.75rem;
   padding: 0 0.6rem;
   border-radius: var(--radius-full);
-  border: 1px solid hsl(var(--card-hairline));
+  border: var(--hairline-w) solid hsl(var(--card-hairline));
   background: hsl(var(--card));
   color: hsl(var(--foreground));
   @apply text-label font-medium tracking-[0.02em];
@@ -1585,15 +1605,15 @@ textarea:-webkit-autofill {
   }
   1% {
     opacity: 0.86;
-    filter: blur(0.2px);
+    filter: blur(calc(var(--hairline-w) * 0.2));
   }
   36% {
     opacity: 0.92;
-    filter: blur(0.1px);
+    filter: blur(calc(var(--hairline-w) * 0.1));
   }
   60% {
     opacity: 0.88;
-    filter: blur(0.22px);
+    filter: blur(calc(var(--hairline-w) * 0.22));
   }
   61% {
     opacity: 1;
@@ -1614,14 +1634,16 @@ textarea:-webkit-autofill {
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 2px;
-  padding: 2px;
-  border: 1px solid hsl(var(--card-hairline));
+  gap: var(--space-0-5);
+  padding: var(--space-0-5);
+  border: var(--hairline-w) solid hsl(var(--card-hairline));
   border-radius: var(--gt-radius);
   background: linear-gradient(90deg, hsl(var(--card)), hsl(var(--card)));
   box-shadow:
-    0 0 0 1px color-mix(in oklab, hsl(var(--shadow-color)) 30%, transparent),
-    0 10px 30px -12px
+    0 0 0 var(--hairline-w)
+      color-mix(in oklab, hsl(var(--shadow-color)) 30%, transparent),
+    0 calc(var(--space-2) + var(--space-0-5))
+      calc(var(--space-5) + var(--space-1-5)) calc(var(--space-3) * -1)
       color-mix(in oklab, hsl(var(--shadow-color)) 55%, transparent);
   isolation: isolate;
   cursor: pointer;
@@ -1631,7 +1653,7 @@ textarea:-webkit-autofill {
   position: absolute;
   inset: 0;
   border-radius: var(--gt-radius);
-  padding: 1px;
+  padding: var(--hairline-w);
   background: linear-gradient(
     90deg,
     hsl(var(--accent)) 0%,
@@ -1656,8 +1678,8 @@ textarea:-webkit-autofill {
   pointer-events: none;
   background: repeating-linear-gradient(
     180deg,
-    hsl(var(--foreground) / 0.06) 0 1px,
-    transparent 1px 3px
+    hsl(var(--foreground) / 0.06) 0 var(--hairline-w),
+    transparent var(--hairline-w) calc(var(--space-0-5) + var(--hairline-w))
   );
   mix-blend-mode: overlay;
   opacity: 0.35;
@@ -1674,7 +1696,7 @@ textarea:-webkit-autofill {
 .glitch-toggle__seg {
   position: relative;
   z-index: 1;
-  padding: 6px 12px;
+  padding: calc(var(--space-1) + var(--space-0-5)) var(--space-3);
   @apply text-label font-medium tracking-[0.02em];
   color: hsl(var(--muted-foreground));
   border-radius: var(--radius-full);
@@ -1687,16 +1709,18 @@ textarea:-webkit-autofill {
 .glitch-toggle__seg.is-active {
   color: hsl(var(--primary-foreground));
   text-shadow:
-    0 0 10px color-mix(in oklab, hsl(var(--primary)) 70%, transparent),
-    0 0 18px color-mix(in oklab, hsl(var(--accent)) 40%, transparent);
+    0 0 calc(var(--space-2) + var(--space-0-5))
+      color-mix(in oklab, hsl(var(--primary)) 70%, transparent),
+    0 0 calc(var(--space-4) + var(--space-0-5))
+      color-mix(in oklab, hsl(var(--accent)) 40%, transparent);
   transform: translateZ(0);
 }
 
 .glitch-toggle__indicator {
   content: "";
   position: absolute;
-  inset: 2px;
-  width: calc(50% - 2px);
+  inset: var(--space-0-5);
+  width: calc(50% - var(--space-0-5));
   border-radius: var(--radius-full);
   background:
     radial-gradient(
@@ -1710,8 +1734,10 @@ textarea:-webkit-autofill {
       color-mix(in oklab, hsl(var(--accent)) 55%, transparent)
     );
   box-shadow:
-    0 0 18px color-mix(in oklab, hsl(var(--primary)) 50%, transparent),
-    inset 0 0 14px color-mix(in oklab, hsl(var(--primary)) 40%, transparent);
+    0 0 calc(var(--space-4) + var(--space-0-5))
+      color-mix(in oklab, hsl(var(--primary)) 50%, transparent),
+    inset 0 0 calc(var(--space-3) + var(--space-0-5))
+      color-mix(in oklab, hsl(var(--primary)) 40%, transparent);
   transform: translateX(0%);
   transition: transform 0.2s cubic-bezier(0.2, 0.7, 0.2, 1);
   mix-blend-mode: screen;
@@ -1755,13 +1781,17 @@ textarea:-webkit-autofill {
   0%,
   100% {
     box-shadow:
-      0 0 18px hsl(var(--foreground) / 0.18),
-      inset 0 0 14px hsl(var(--foreground) / 0.15);
+      0 0 calc(var(--space-4) + var(--space-0-5))
+        hsl(var(--foreground) / 0.18),
+      inset 0 0 calc(var(--space-3) + var(--space-0-5))
+        hsl(var(--foreground) / 0.15);
   }
   50% {
     box-shadow:
-      0 0 28px hsl(var(--foreground) / 0.28),
-      inset 0 0 18px hsl(var(--foreground) / 0.22);
+      0 0 calc(var(--space-6) - var(--space-1))
+        hsl(var(--foreground) / 0.28),
+      inset 0 0 calc(var(--space-4) + var(--space-0-5))
+        hsl(var(--foreground) / 0.22);
   }
 }
 
@@ -1775,8 +1805,9 @@ textarea:-webkit-autofill {
     hsl(var(--card-hairline))
   );
   box-shadow:
-    0 0 0 1px hsl(var(--ring) / 0.28),
-    0 12px 28px hsl(var(--shadow-color) / 0.28);
+    0 0 0 var(--hairline-w) hsl(var(--ring) / 0.28),
+    0 var(--space-3) calc(var(--space-6) - var(--space-1))
+      hsl(var(--shadow-color) / 0.28);
 }
 .btn-cta.is-active,
 .btn-cta[aria-current="page"],
@@ -1784,8 +1815,9 @@ textarea:-webkit-autofill {
   background: var(--seg-active-grad);
   color: hsl(var(--primary-foreground));
   box-shadow:
-    0 0 0 2px hsl(var(--ring) / 0.38),
-    0 16px 36px hsl(var(--shadow-color) / 0.35);
+    0 0 0 var(--space-0-5) hsl(var(--ring) / 0.38),
+    0 var(--space-4) calc(var(--space-5) + var(--space-3))
+      hsl(var(--shadow-color) / 0.35);
 }
 /* ---------- Icon styling ---------- */
 .lucide {
@@ -1802,7 +1834,7 @@ button:active .lucide,
 a:hover .lucide,
 a:active .lucide {
   color: hsl(var(--accent));
-  filter: drop-shadow(0 0 6px hsl(var(--accent) / 0.8));
+  filter: drop-shadow(0 0 var(--space-1-5) hsl(var(--accent) / 0.8));
 }
 
 @layer utilities {
@@ -1822,7 +1854,7 @@ a:active .lucide {
     position: sticky;
     top: 0;
     z-index: 30;
-    backdrop-filter: saturate(120%) blur(12px);
+    backdrop-filter: saturate(120%) blur(var(--space-3));
     background: color-mix(in oklab, hsl(var(--background)) 65%, transparent);
     border-bottom: 1px solid hsl(var(--card-hairline));
   }
@@ -1946,8 +1978,8 @@ a:active .lucide {
       hsl(var(--surface))
     );
     box-shadow:
-      0 0 0 1px hsl(var(--border)) inset,
-      0 0 30px hsl(var(--accent) / 0.15);
+      0 0 0 var(--hairline-w) hsl(var(--border)) inset,
+      0 0 calc(var(--space-5) + var(--space-1-5)) hsl(var(--accent) / 0.15);
   }
   .goal-card::before {
     content: "";
@@ -1955,8 +1987,8 @@ a:active .lucide {
     border-radius: inherit;
     background: repeating-linear-gradient(
       to bottom,
-      hsl(var(--foreground) / 0.06) 0 1px,
-      transparent 1px 3px
+      hsl(var(--foreground) / 0.06) 0 var(--hairline-w),
+      transparent var(--hairline-w) calc(var(--space-0-5) + var(--hairline-w))
     );
     mix-blend-mode: overlay;
   }
@@ -2217,13 +2249,13 @@ a:active .lucide {
     0%,
     100% {
       text-shadow:
-        0.5px 0 hsl(var(--accent)),
-        -0.5px 0 hsl(var(--accent-2));
+        calc(var(--hairline-w) / 2) 0 hsl(var(--accent)),
+        calc(var(--hairline-w) / -2) 0 hsl(var(--accent-2));
     }
     50% {
       text-shadow:
-        -0.5px 0 hsl(var(--accent)),
-        0.5px 0 hsl(var(--accent-2));
+        calc(var(--hairline-w) / -2) 0 hsl(var(--accent)),
+        calc(var(--hairline-w) / 2) 0 hsl(var(--accent-2));
     }
   }
 

--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -79,7 +79,7 @@ const PageHeaderInner = <
   }: PageHeaderBaseProps<HeaderKey, HeroKey>,
   ref: React.ForwardedRef<PageHeaderFrameElement>,
 ) => {
-  const Component = (as ?? "section") as PageHeaderElement;
+  const Component = (as ?? "header") as PageHeaderElement;
 
   const {
     subTabs: heroSubTabs,

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`ReviewsPage > renders default state 1`] = `
     aria-labelledby="reviews-header"
     class="page-shell py-6 space-y-6"
   >
-    <section>
+    <header>
       <style
         global="true"
         jsx="true"
@@ -749,7 +749,7 @@ exports[`ReviewsPage > renders default state 1`] = `
           class="absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/55"
         />
       </div>
-    </section>
+    </header>
     <div
       class="grid grid-cols-1 items-start gap-6 md:grid-cols-12"
     >

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -111,6 +111,8 @@
   --space-6: var(--spacing-6);
   --space-7: var(--spacing-7);
   --space-8: var(--spacing-8);
+  --space-0-5: calc(var(--space-1) / 2);
+  --space-1-5: calc(var(--space-1) + var(--space-0-5));
   --font-size-md: 20px;
   --font-weight-bold: 800;
   --shadow-neon: 0 0 var(--space-1) hsl(var(--neon) / 0.55),
@@ -123,6 +125,7 @@
   --font-title-lg: 24px;
   --btn-primary-hover-shadow: 0 2px 6px -1px hsl(var(--accent) / 0.25);
   --btn-primary-active-shadow: inset 0 0 0 1px hsl(var(--accent) / 0.6);
+  --shadow-autofill-mask: 1000px;
   --spacing-1: 4px;
   --spacing-2: 8px;
   --spacing-3: 12px;

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -101,6 +101,8 @@ export default {
   space6: "var(--spacing-6)",
   space7: "var(--spacing-7)",
   space8: "var(--spacing-8)",
+  space0_5: "calc(var(--space-1) / 2)",
+  space1_5: "calc(var(--space-1) + var(--space-0-5))",
   fontSizeMd: "20px",
   fontWeightBold: "800",
   shadowNeon:
@@ -112,6 +114,7 @@ export default {
   fontTitleLg: "24px",
   btnPrimaryHoverShadow: "0 2px 6px -1px hsl(var(--accent) / 0.25)",
   btnPrimaryActiveShadow: "inset 0 0 0 1px hsl(var(--accent) / 0.6)",
+  shadowAutofillMask: "1000px",
   spacing1: "4px",
   spacing2: "8px",
   spacing3: "12px",


### PR DESCRIPTION
## Summary
- replace pixel-based shadows and spacing in `globals.css` with combinations of spacing tokens
- extend the design token set with half-step spacing values and an autofill mask radius
- default `PageHeader` to render as a `<header>` and refresh the related snapshot

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8fceced58832ca0f6d3aaafd69d16