### PR TITLE
Memoize PageHeader hero props

### DIFF
--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -94,16 +94,22 @@ const PageHeaderInner = <
     ...heroRest
   } = hero;
 
-  const resolvedSubTabs = heroSubTabs ?? subTabs;
+  const resolvedSubTabs = React.useMemo(
+    () => heroSubTabs ?? subTabs,
+    [heroSubTabs, subTabs],
+  );
 
-  const baseSearch = heroSearch === null ? null : heroSearch ?? search;
-  const resolvedSearch =
-    baseSearch !== null && baseSearch !== undefined
+  const resolvedSearch = React.useMemo(() => {
+    const baseSearch = heroSearch === null ? null : heroSearch ?? search;
+    return baseSearch !== null && baseSearch !== undefined
       ? { ...baseSearch, round: baseSearch.round ?? true }
       : baseSearch;
+  }, [heroSearch, search]);
 
-  const resolvedActions =
-    heroActions === null ? null : heroActions ?? actions;
+  const resolvedActions = React.useMemo(
+    () => (heroActions === null ? null : heroActions ?? actions),
+    [heroActions, actions],
+  );
 
   const { className: frameClassName, variant: frameVariant, ...restFrameProps } =
     frameProps ?? {};


### PR DESCRIPTION
## Summary
- memoize the derived Hero props in PageHeader to avoid recreating references between renders

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8fef35e20832c86c38274c69cb0a9