### PR TITLE
Adjust PageHeader hero default wrapper

### DIFF
--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -30,7 +30,10 @@ export interface PageHeaderBaseProps<
 > extends PageHeaderElementProps {
   /** Props forwarded to <Header> */
   header: HeaderProps<HeaderKey>;
-  /** Props forwarded to <Hero> */
+  /**
+   * Props forwarded to <Hero>.
+   * When the page header renders as a `<header>`, the hero defaults to a `<section>`.
+   */
   hero: HeroProps<HeroKey>;
   /** Optional className for the outer frame */
   className?: string;
@@ -94,6 +97,9 @@ const PageHeaderInner = <
     ...heroRest
   } = hero;
 
+  const resolvedHeroAs =
+    heroAs ?? (Component === "header" ? "section" : undefined);
+
   const resolvedSubTabs = heroSubTabs ?? subTabs;
 
   const baseSearch = heroSearch === null ? null : heroSearch ?? search;
@@ -129,7 +135,7 @@ const PageHeaderInner = <
           <Header {...header} underline={header.underline ?? false} />
           <Hero
             {...heroRest}
-            as={heroAs ?? "section"}
+            as={resolvedHeroAs}
             frame={heroFrame ?? true}
             topClassName={cn("top-[var(--header-stack)]", heroTopClassName)}
             subTabs={resolvedSubTabs}


### PR DESCRIPTION
## Summary
- default the PageHeader hero to a non-header element when the surrounding PageHeader renders as a header
- document the adjusted default in the PageHeader props JSDoc

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ff325fa0832ca5e2b3b70ac015f4