### PR TITLE
Align planner task image spacing token

### DIFF
--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -30,8 +30,9 @@ export default function TaskRow({
   onAddImage,
   onRemoveImage,
 }: Props) {
-  const taskImageSize = spacingTokens[6];
-  const taskImageCssValue = "var(--space-7)" as const;
+  const taskImageSpacingToken = 7;
+  const taskImageSize = spacingTokens[taskImageSpacingToken - 1];
+  const taskImageCssValue = `var(--space-${taskImageSpacingToken})` as const;
   const [editing, setEditing] = React.useState(false);
   const [title, setTitle] = React.useState(task.title);
   const [imageUrl, setImageUrl] = React.useState("");


### PR DESCRIPTION
## Summary
- derive TaskRow image sizing and CSS var from the same spacing token to avoid mismatches

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ff6fa5c8832c910f240ecab649e1