### PR TITLE
Default PageHeader wrapper to section

### DIFF
--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -40,7 +40,7 @@ export interface PageHeaderBaseProps<
   frameProps?: NeomorphicHeroFrameProps;
   /** Optional className for the inner content wrapper */
   contentClassName?: string;
-  /** Semantic element for the header container */
+  /** Semantic element for the header container (defaults to a <section>) */
   as?: PageHeaderElement;
   /** Optional hero sub-tabs override */
   subTabs?: HeroProps<HeroKey>["subTabs"];
@@ -82,7 +82,7 @@ const PageHeaderInner = <
   }: PageHeaderBaseProps<HeaderKey, HeroKey>,
   ref: React.ForwardedRef<PageHeaderFrameElement>,
 ) => {
-  const Component = (as ?? "header") as PageHeaderElement;
+  const Component = (as ?? "section") as PageHeaderElement;
 
   const {
     subTabs: heroSubTabs,

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`ReviewsPage > renders default state 1`] = `
     aria-labelledby="reviews-header"
     class="page-shell py-6 space-y-6"
   >
-    <header
+    <section
       class="sticky top-0"
     >
       <style
@@ -751,7 +751,7 @@ exports[`ReviewsPage > renders default state 1`] = `
           class="absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/55"
         />
       </div>
-    </header>
+    </section>
     <div
       class="grid grid-cols-1 items-start gap-6 md:grid-cols-12"
     >


### PR DESCRIPTION
## Summary
- default the PageHeader wrapper to render a `<section>` when no `as` prop is provided
- document the new semantic default on the `as` prop and refresh the reviews page snapshot to expect the section wrapper

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c909509c6c832c918a33664245c5ba