### PR TITLE
Add weekly npm Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- add weekly npm updates to the dependabot configuration

## Testing
- npm run check *(fails: tests/components/PageHeader.test.tsx > PageHeader > renders header and hero within the default neomorphic frame)*

------
https://chatgpt.com/codex/tasks/task_e_68c90a92011c832cb482250b9133ddb2