### PR TITLE
refactor: rename cap utility to capitalize

### DIFF
--- a/src/components/goals/reminders/ReminderList.tsx
+++ b/src/components/goals/reminders/ReminderList.tsx
@@ -7,6 +7,7 @@ import Input from "@/components/ui/primitives/Input";
 import SegmentedButton from "@/components/ui/primitives/SegmentedButton";
 import Textarea from "@/components/ui/primitives/Textarea";
 import useAutoFocus from "@/lib/useAutoFocus";
+import { capitalize } from "@/lib/utils";
 import { Pencil, Trash2, Pin, PinOff } from "lucide-react";
 import {
   useReminders,
@@ -190,7 +191,7 @@ function RemTile({
                   isActive={value.group === groupKey}
                   className="m-1"
                 >
-                  {groupKey === "pregame" ? "Pre-Game" : cap(groupKey)}
+                  {groupKey === "pregame" ? "Pre-Game" : capitalize(groupKey)}
                 </SegmentedButton>
               ))}
             </div>
@@ -284,9 +285,5 @@ function pad(value: number) {
 function fmtDate(timestamp: number) {
   const date = new Date(timestamp);
   return `${pad(date.getDate())}/${pad(date.getMonth() + 1)}/${date.getFullYear()}`;
-}
-
-function cap(value: string) {
-  return value.slice(0, 1).toUpperCase() + value.slice(1);
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -41,7 +41,7 @@ export function withBasePath(path: string): string {
 }
 
 /** Capitalize first letter (not Unicode-smart on purpose). */
-export function cap(s: string): string {
+export function capitalize(s: string): string {
   return s.length ? s[0].toUpperCase() + s.slice(1) : s;
 }
 


### PR DESCRIPTION
## Summary
- rename the `cap` helper in `src/lib/utils.ts` to `capitalize`
- update reminders list to consume the renamed helper instead of a local copy

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c90f46ef40832ca97e2a5f2f649692