### PR TITLE
Rename progress helper

### DIFF
--- a/scripts/generate-tokens.ts
+++ b/scripts/generate-tokens.ts
@@ -8,7 +8,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spacingTokens, radiusScale } from "../src/lib/tokens.ts";
-import { createTaskBar, stopBars } from "../src/utils/progress.ts";
+import { createProgressBar, stopBars } from "../src/utils/progress.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -103,7 +103,7 @@ async function buildTokens(): Promise<void> {
     },
   });
 
-  const bar = createTaskBar(3);
+  const bar = createProgressBar(3);
   sd.buildPlatform("css");
   bar.update(1);
   sd.buildPlatform("js");

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -5,8 +5,11 @@ const bars = new MultiBar(
   Presets.shades_grey,
 );
 
-export const createTaskBar = (totalSteps: number): ReturnType<MultiBar["create"]> =>
-  bars.create(totalSteps, 0);
+export function createProgressBar(
+  totalSteps: number,
+): ReturnType<MultiBar["create"]> {
+  return bars.create(totalSteps, 0);
+}
 
 export const stopBars = (): void => {
   bars.stop();


### PR DESCRIPTION
## Summary
- rename the CLI progress helper to `createProgressBar` and use a standard function declaration
- update the token generation script to import and use the renamed helper

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c911063c90832cbce3a73f50e34f64