### PR TITLE
Adjust theme context memo dependencies and hook typing

### DIFF
--- a/src/lib/theme-context.tsx
+++ b/src/lib/theme-context.tsx
@@ -24,12 +24,14 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     applyTheme(theme);
   }, [theme]);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const value = React.useMemo(() => [theme, setTheme] as const, [theme]);
+  const value = React.useMemo(() => [theme, setTheme] as const, [theme, setTheme]);
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }
 
-export function useTheme() {
+export function useTheme(): readonly [
+  ThemeState,
+  React.Dispatch<React.SetStateAction<ThemeState>>,
+] {
   const ctx = React.useContext(ThemeContext);
   if (!ctx) {
     throw new Error("useTheme must be used within ThemeProvider");


### PR DESCRIPTION
## Summary
- update the theme context memo to rely on the theme setter in its dependency array without suppressing lint rules
- annotate the useTheme hook to return a readonly tuple of the theme state and setter

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c911eaadec832c9258e7320158b305