### PR TITLE
Refactor project rename handling

### DIFF
--- a/src/components/planner/ProjectList.tsx
+++ b/src/components/planner/ProjectList.tsx
@@ -46,6 +46,14 @@ export default function ProjectList({
     if (id) setSelectedProjectId(id);
   }
 
+  const commitRename = React.useCallback(
+    (projectId: string, fallbackName: string) => {
+      renameProject(projectId, editingProjectName || fallbackName);
+      setEditingProjectId(null);
+    },
+    [editingProjectName, renameProject, setEditingProjectId],
+  );
+
   const onRowKey = React.useCallback(
     (idx: number, p: Project) => (e: React.KeyboardEvent) => {
       if (e.key === " " || e.key === "Enter") {
@@ -151,8 +159,7 @@ export default function ProjectList({
                         onChange={(e) => setEditingProjectName(e.target.value)}
                         onKeyDown={(e) => {
                           if (e.key === "Enter") {
-                            renameProject(p.id, editingProjectName || p.name);
-                            setEditingProjectId(null);
+                            commitRename(p.id, p.name);
                           }
                           if (e.key === "Escape") {
                             setEditingProjectId(null);
@@ -160,8 +167,7 @@ export default function ProjectList({
                           }
                         }}
                         onBlur={() => {
-                          renameProject(p.id, editingProjectName || p.name);
-                          setEditingProjectId(null);
+                          commitRename(p.id, p.name);
                         }}
                         aria-label={`Rename project ${p.name}`}
                       />


### PR DESCRIPTION
## Summary
- extract a commitRename helper to share the rename-and-close flow
- use the helper from the input submit and blur paths to avoid duplication

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c940021268832cba27ee458f36bfb4