### PR TITLE
Set GitHub Pages flag during workflow build

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -56,6 +56,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: checks
+    env:
+      GITHUB_PAGES: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -86,8 +88,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build with Next.js
-        run: |
-          npm run build
+        run: npm run build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b
         with:


### PR DESCRIPTION
## Summary
- set the GITHUB_PAGES environment variable for the GitHub Pages build job so Next.js exports use the repository base path

## Testing
- npm run check *(fails: existing type errors in installed dependencies prevent the suite from running)*

------
https://chatgpt.com/codex/tasks/task_e_68c943dd13b0832ca1c7b73c0921f80a