### PR TITLE
Scope planner notes hook by ISO date

### DIFF
--- a/src/components/planner/FocusPanel.tsx
+++ b/src/components/planner/FocusPanel.tsx
@@ -21,7 +21,7 @@ type Props = { iso: ISODate };
 
 export default function FocusPanel({ iso }: Props) {
   const { value, setValue, saving, isDirty, lastSavedRef, commit } =
-    useDayNotes();
+    useDayNotes(iso);
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/planner/WeekNotes.tsx
+++ b/src/components/planner/WeekNotes.tsx
@@ -17,7 +17,7 @@ type Props = { iso: ISODate };
 
 export default function WeekNotes({ iso }: Props) {
   const { value, setValue, saving, isDirty, lastSavedRef, commit } =
-    useDayNotes();
+    useDayNotes(iso);
 
   return (
     <SectionCard className="card-neo-soft">


### PR DESCRIPTION
## Summary
- update the planner day notes hook to accept an ISO date and save via `getDay`/`upsertDay`
- pass the active ISO date into `useDayNotes` from `FocusPanel` and `WeekNotes`

## Testing
- npm run check *(fails: repository typecheck/test setup reports missing @testing-library DOM types and React 19 runtime pieces)*

------
https://chatgpt.com/codex/tasks/task_e_68c9463d83a4832cae324ece3bfdc72e