### PR TITLE
Scope planner notes hook by ISO date

### DIFF
--- a/src/components/planner/useDayNotes.ts
+++ b/src/components/planner/useDayNotes.ts
@@ -8,6 +8,7 @@ import type { ISODate } from "./plannerStore";
 export function useDayNotes(iso: ISODate) {
   const { getDay, upsertDay } = usePlannerStore();
   const day = getDay(iso);
+  const persistedNotes = day.notes ?? "";
 
   const setNotesForIso = React.useCallback(
     (notes: string) => {
@@ -16,9 +17,9 @@ export function useDayNotes(iso: ISODate) {
     [iso, upsertDay],
   );
 
-  const [value, setValue] = React.useState<string>(() => day.notes ?? "");
+  const [value, setValue] = React.useState<string>(() => persistedNotes);
   const [saving, setSaving] = React.useState(false);
-  const lastSavedRef = React.useRef((day.notes ?? "").trim());
+  const lastSavedRef = React.useRef(persistedNotes.trim());
 
   const trimmed = React.useMemo(() => value.trim(), [value]);
   const isDirty = trimmed !== lastSavedRef.current;
@@ -35,10 +36,9 @@ export function useDayNotes(iso: ISODate) {
   }, [isDirty, setNotesForIso, trimmed]);
 
   React.useEffect(() => {
-    const nextValue = getDay(iso).notes ?? "";
-    setValue(nextValue);
-    lastSavedRef.current = nextValue.trim();
-  }, [getDay, iso]);
+    setValue(persistedNotes);
+    lastSavedRef.current = persistedNotes.trim();
+  }, [iso, persistedNotes]);
 
   return { value, setValue, saving, isDirty, lastSavedRef, commit } as const;
 }


### PR DESCRIPTION
## Summary
- update the planner day notes hook to accept an ISO date and save via `getDay`/`upsertDay`
- pass the active ISO date into `useDayNotes` from `FocusPanel` and `WeekNotes`
- ensure the notes sync effect only responds to the targeted day's saved text so unsaved drafts survive other store updates

## Testing
- npm run check *(fails: repository setup still missing installed dependencies; `concurrently` command unavailable because install is blocked by React 18/19 type conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_68c949c4acfc832cac8ac4be302af114