### PR TITLE
Add Banner chrome tests

### DIFF
--- a/tests/chrome/Banner.test.tsx
+++ b/tests/chrome/Banner.test.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+
+import Banner from "@/components/chrome/Banner";
+
+describe("Banner", () => {
+  it("renders header structure without sticky or actions", () => {
+    render(
+      <Banner title="Banner Title">
+        <p>Body content</p>
+      </Banner>,
+    );
+
+    const header = screen.getByRole("banner");
+
+    expect(header).toBeInTheDocument();
+    expect(header).not.toHaveClass("sticky");
+    expect(screen.getByText("Banner Title")).toBeInTheDocument();
+    expect(screen.getByText("Body content")).toBeInTheDocument();
+  });
+
+  it("applies sticky styling and renders actions when provided", () => {
+    render(
+      <Banner
+        sticky
+        title="Sticky Title"
+        actions={<button type="button">Action</button>}
+      >
+        <span>Content</span>
+      </Banner>,
+    );
+
+    const header = screen.getByRole("banner");
+
+    expect(header).toHaveClass("sticky", "top-0", "z-30", "sticky-blur", "border-b");
+    expect(header).toHaveStyle({ borderColor: "hsl(var(--border))" });
+    expect(screen.getByRole("button", { name: "Action" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for the chrome Banner component without sticky props
- verify sticky styling and action rendering when Banner props are provided

## Testing
- npm run check *(fails: existing repository type errors and numerous vitest suite failures in the test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68c950826cb4832c91baa96f54888cb9