### PR TITLE
Unify workflow checks and build job

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -25,9 +25,10 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Checks job
-  checks:
+  build:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_PAGES: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -51,21 +52,6 @@ jobs:
         run: npm ci
       - name: Run checks
         run: npm run check
-
-  # Build job
-  build:
-    runs-on: ubuntu-latest
-    needs: checks
-    env:
-      GITHUB_PAGES: "true"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-      - name: Setup Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
-        with:
-          node-version-file: ".nvmrc"
-          cache: npm
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
         with:
@@ -74,19 +60,6 @@ jobs:
           #
           # You may remove this line if you want to manage the configuration yourself.
           static_site_generator: next
-      - name: Restore cache
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
-        with:
-          path: |
-            .next/cache
-          # Generate a new cache whenever packages or source files change.
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}') }}
-          # If source files changed but packages didn't, rebuild from a prior cache.
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}') }}-
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
-      - name: Install dependencies
-        run: npm ci
       - name: Build with Next.js
         run: npm run build
       - name: Upload artifact

--- a/tests/chrome/Banner.test.tsx
+++ b/tests/chrome/Banner.test.tsx
@@ -1,10 +1,12 @@
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, it, expect } from "vitest";
 
 import Banner from "@/components/chrome/Banner";
 
 describe("Banner", () => {
+  afterEach(cleanup);
+
   it("renders header structure without sticky or actions", () => {
     render(
       <Banner title="Banner Title">
@@ -34,7 +36,10 @@ describe("Banner", () => {
     const header = screen.getByRole("banner");
 
     expect(header).toHaveClass("sticky", "top-0", "z-30", "sticky-blur", "border-b");
-    expect(header).toHaveStyle({ borderColor: "hsl(var(--border))" });
+    expect(header).toHaveAttribute(
+      "style",
+      expect.stringContaining("border-color: hsl(var(--border))"),
+    );
     expect(screen.getByRole("button", { name: "Action" })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- merge the GitHub Actions checks and build steps into a single job so the build can reuse installed dependencies while keeping the GITHUB_PAGES flag
- continue to run project checks before building and upload the Next.js artifact for deployment
- add explicit cleanup and a stable style assertion to the Banner test to prevent cross-test leakage and verify the sticky border styling

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c95ae15fdc832cb3885760c4373811