### PR TITLE
ci: cache dependencies and stabilize banner test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,22 @@ jobs:
           restore-keys: |
             nextjs-${{ runner.os }}-
 
+      - name: Restore node_modules cache
+        id: node-modules-cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install dependencies
         run: npm ci
+
+      - name: Save node_modules cache
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Run checks
         run: npm run check

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -47,8 +47,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}') }}-
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
+      - name: Restore node_modules cache
+        id: node-modules-cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install dependencies
         run: npm ci
+
+      - name: Save node_modules cache
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
       - name: Run checks
         run: npm run check
 
@@ -85,8 +100,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}') }}-
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
+      - name: Restore node_modules cache
+        id: node-modules-cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install dependencies
         run: npm ci
+
+      - name: Save node_modules cache
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
       - name: Build with Next.js
         run: npm run build
       - name: Upload artifact

--- a/tests/chrome/Banner.test.tsx
+++ b/tests/chrome/Banner.test.tsx
@@ -34,7 +34,10 @@ describe("Banner", () => {
     const header = screen.getByRole("banner");
 
     expect(header).toHaveClass("sticky", "top-0", "z-30", "sticky-blur", "border-b");
-    expect(header).toHaveStyle({ borderColor: "hsl(var(--border))" });
+    expect(header).toHaveAttribute(
+      "style",
+      expect.stringContaining("border-color: hsl(var(--border))")
+    );
     expect(screen.getByRole("button", { name: "Action" })).toBeInTheDocument();
   });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
-import { vi } from "vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach, vi } from "vitest";
 import type { ElementType, ReactNode } from "react";
 
 type ReactModule = typeof import("react");
@@ -83,3 +84,7 @@ Object.defineProperty(window, "matchMedia", {
 export function resetLocalStorage() {
   window.localStorage.clear();
 }
+
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
## Summary
- add explicit node_modules cache restore/save steps around npm ci in the CI and Pages workflows
- ensure Testing Library cleanup runs after each test to remove leftover DOM between cases
- adjust the banner test to assert against the inline style string so the CSS variable expectation passes under jsdom

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c95b2accf4832ca88315d8e4e0a8ca