### PR TITLE
Conditionally export Next build for GitHub Pages

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,7 +13,7 @@ const normalizedBasePath = cleanSlug ? `/${cleanSlug}` : undefined;
 
 const nextConfig = {
   reactStrictMode: true,
-  output: "export",
+  output: isGitHubPages ? "export" : undefined,
   basePath: isGitHubPages ? normalizedBasePath : undefined,
   assetPrefix: isGitHubPages ? normalizedBasePath : undefined,
   env: {


### PR DESCRIPTION
## Summary
- conditionally enable Next.js static export only when `GITHUB_PAGES` is set for GitHub Pages deployments

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c95fac07b8832caddb8b31536bed73