### PR TITLE
Add optional Vercel deployment to Next.js workflow

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -66,6 +66,12 @@ jobs:
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b
         with:
           path: ./out
+      - name: Deploy to Vercel
+        if: ${{ env.VERCEL_TOKEN != '' }}
+        uses: vercel/vercel-action@v2
+        with:
+          token: ${{ secrets.VERCEL_TOKEN }}
+          project-name: planner
 
   # Deployment job
   deploy:


### PR DESCRIPTION
## Summary
- add a conditional Vercel deployment step to the Next.js Pages workflow
- ensure the Vercel action only runs when a VERCEL_TOKEN secret is provided while keeping the GitHub Pages deployment as default

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9610ffa04832ca870f15292ef2246