### PR TITLE
chore: use offline npm ci in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             nextjs-${{ runner.os }}-
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --prefer-offline --no-audit --no-fund
 
       - name: Run checks
         run: npm run check

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -56,7 +56,7 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}') }}-
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --prefer-offline --no-audit --no-fund
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
         with:


### PR DESCRIPTION
## Summary
- update the CI workflow to install dependencies with npm ci using offline-friendly flags
- align the Next.js deployment workflow to use the same npm ci flags for dependency installation

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c97c329630832caa2972885ebb3990