### PR TITLE
Configure Vercel deployment to use prebuilt output

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           token: ${{ secrets.VERCEL_TOKEN }}
           project-name: planner
+          vercel-args: '--prebuilt ./out --prod'
 
   # Deployment job
   deploy:


### PR DESCRIPTION
## Summary
- add the `--prebuilt ./out --prod` argument to the Vercel deploy workflow so the build artifact is uploaded directly

## Testing
- npm run check *(fails: environment is missing the `@tailwindcss/postcss` dependency required by postcss.config.cjs)*

------
https://chatgpt.com/codex/tasks/task_e_68c98693e980832c8328f740bdf3e569