### PR TITLE
Configure static image export on GitHub Pages

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,6 +16,9 @@ const nextConfig = {
   output: isGitHubPages ? "export" : undefined,
   basePath: isGitHubPages ? normalizedBasePath : undefined,
   assetPrefix: isGitHubPages ? normalizedBasePath : undefined,
+  images: {
+    unoptimized: isGitHubPages,
+  },
   env: {
     NEXT_PUBLIC_BASE_PATH: isGitHubPages ? normalizedBasePath ?? "" : "",
   },


### PR DESCRIPTION
## Summary
- ensure GitHub Pages exports mark Next.js images as unoptimized so static exports work without configure-pages

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c988c82314832c84f277ee41c8249d