### PR TITLE
Improve GitHub Pages deploy script

### DIFF
--- a/scripts/deploy-gh-pages.ts
+++ b/scripts/deploy-gh-pages.ts
@@ -23,9 +23,10 @@ function parseRemoteSlug(remoteUrl: string): string | undefined {
 }
 
 function detectRepositorySlug(): string {
-  const fromEnv = sanitizeSlug(process.env.BASE_PATH);
-  if (fromEnv) {
-    return fromEnv;
+  const basePathEnv = process.env.BASE_PATH;
+  if (basePathEnv !== undefined) {
+    const fromEnv = sanitizeSlug(basePathEnv);
+    return fromEnv ?? "";
   }
 
   const repoSlug = sanitizeSlug(process.env.GITHUB_REPOSITORY?.split("/").pop());


### PR DESCRIPTION
## Summary
- add a typed deployment helper that infers the repository slug for GitHub Pages builds
- run the helper from `npm run deploy` so static exports use the correct base path before publishing
- ensure an explicitly configured BASE_PATH (including a root path) is respected when detecting the slug

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c994ff7114832cb125ac83713e4ec0