### PR TITLE
Improve dashboard link interaction states

### DIFF
--- a/src/components/home/DashboardCard.tsx
+++ b/src/components/home/DashboardCard.tsx
@@ -31,7 +31,7 @@ export default function DashboardCard({
       {cta && (
         <Link
           href={cta.href}
-          className="text-ui font-medium text-accent underline"
+          className="inline-flex items-center text-ui font-medium text-accent underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
         >
           {cta.label}
         </Link>

--- a/src/components/home/GoalsCard.tsx
+++ b/src/components/home/GoalsCard.tsx
@@ -35,7 +35,10 @@ export default function GoalsCard() {
               <CircleSlash className="size-3" />
               No active goals
             </span>
-            <Link href="/goals" className="text-label underline">
+            <Link
+              href="/goals"
+              className="inline-flex items-center text-label font-medium text-accent underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
+            >
               Create
             </Link>
           </li>

--- a/src/components/home/ReviewsCard.tsx
+++ b/src/components/home/ReviewsCard.tsx
@@ -35,7 +35,10 @@ export default function ReviewsCard() {
               <CircleSlash className="size-3" />
               No reviews yet
             </span>
-            <Link href="/reviews" className="text-label underline">
+            <Link
+              href="/reviews"
+              className="inline-flex items-center text-label font-medium text-accent underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
+            >
               Create
             </Link>
           </li>

--- a/src/components/home/TodayCard.tsx
+++ b/src/components/home/TodayCard.tsx
@@ -34,7 +34,10 @@ export default function TodayCard() {
               <CircleSlash className="size-3" />
               No tasks
             </span>
-            <Link href="/planner" className="text-label underline">
+            <Link
+              href="/planner"
+              className="inline-flex items-center text-label font-medium text-accent underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
+            >
               Create
             </Link>
           </li>


### PR DESCRIPTION
## Summary
- style the dashboard card CTA link with design-system hover, active, and focus-visible tokens
- mirror the same interactive link treatment on the Today, Goals, and Reviews fallback "Create" links

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c999e0d768832ca7b7354c24fc21e6