### PR TITLE
Disable hero tab panel linking without panel ids

### DIFF
--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -203,6 +203,7 @@ export default function ComponentGallery() {
               { key: "three", label: "Three" },
             ]}
             className="w-56"
+            linkPanels={false}
           />
         ),
       },
@@ -219,6 +220,7 @@ export default function ComponentGallery() {
             onValueChange={setAppTab}
             ariaLabel="Component gallery sections"
             className="w-56"
+            linkPanels={false}
           />
         ),
       },
@@ -235,6 +237,7 @@ export default function ComponentGallery() {
             onValueChange={setFilterTab}
             ariaLabel="Filter items"
             className="w-56"
+            linkPanels={false}
           />
         ),
       },
@@ -443,6 +446,7 @@ export default function ComponentGallery() {
                   value="demo"
                   onValueChange={() => {}}
                   ariaLabel="Demo tabs"
+                  linkPanels={false}
                 />
                 <Card className="h-24" />
               </div>
@@ -820,6 +824,7 @@ export default function ComponentGallery() {
                 ],
                 value: headerTab,
                 onChange: setHeaderTab,
+                linkPanels: false,
               }}
               search={{ value: "", onValueChange: () => {}, round: true }}
               actions={<Button size="sm">Action</Button>}
@@ -949,6 +954,7 @@ export default function ComponentGallery() {
         value={view}
         onValueChange={setView}
         ariaLabel="Component gallery"
+        linkPanels={false}
       />
       <div className="grid grid-cols-12 gap-8">
         {itemsMap[view].map((item) => (

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -69,6 +69,7 @@ export interface HeroProps<Key extends string = string>
     className?: string;
     showBaseline?: boolean;
     variant?: TabBarProps["variant"];
+    linkPanels?: boolean;
   };
 
   /** Built-in bottom search (preferred). `round` makes it pill. */
@@ -123,6 +124,7 @@ function Hero<Key extends string = string>({
       variant={subTabs.variant ?? heroVariant}
       className={cx("justify-end", subTabs.className)}
       ariaLabel={subTabs.ariaLabel ?? "Hero sub-tabs"}
+      linkPanels={subTabs.linkPanels}
     />
   ) : tabs ? (
     <TabBar
@@ -135,6 +137,7 @@ function Hero<Key extends string = string>({
       variant={tabs.variant ?? heroVariant}
       className={cx("justify-end", tabs.className)}
       ariaLabel="Hero tabs"
+      linkPanels={tabs.linkPanels}
     />
   ) : null;
 
@@ -247,14 +250,9 @@ function Hero<Key extends string = string>({
 export default Hero;
 
 /* ───────────── Adapter: HeroTabs (kept for parity) ───────── */
-export type HeroTab<K extends string> = {
-  key: K;
-  label: React.ReactNode;
+export interface HeroTab<K extends string> extends TabItem<K> {
   hint?: string;
-  icon?: React.ReactNode;
-  disabled?: boolean;
-  badge?: React.ReactNode;
-};
+}
 export function HeroTabs<K extends string>(props: {
   tabs: Array<HeroTab<K>>;
   activeKey: K;
@@ -266,6 +264,7 @@ export function HeroTabs<K extends string>(props: {
   right?: React.ReactNode;
   showBaseline?: boolean;
   variant?: TabBarProps["variant"];
+  linkPanels?: boolean;
 }) {
   const {
     tabs,
@@ -278,17 +277,18 @@ export function HeroTabs<K extends string>(props: {
     right,
     showBaseline = false,
     variant,
+    linkPanels = false,
   } = props;
 
   const items: TabItem[] = React.useMemo(
     () =>
-      tabs.map((t) => ({
-        key: String(t.key),
-        label: t.label,
-        icon: t.icon,
-        disabled: t.disabled,
-        badge: t.badge,
-      })),
+      tabs.map(({ key, hint, ...rest }) => {
+        void hint;
+        return {
+          ...rest,
+          key: String(key),
+        };
+      }),
     [tabs],
   );
 
@@ -304,6 +304,7 @@ export function HeroTabs<K extends string>(props: {
       className={className}
       showBaseline={showBaseline}
       variant={variant}
+      linkPanels={linkPanels}
     />
   );
 }


### PR DESCRIPTION
## Summary
- stop HeroTabs from linking to missing panels by default and allow explicit linking when provided
- forward linkPanels through Hero subTabs/tabs and update component gallery demos to avoid stray aria-controls

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c99ae30fa8832c9a5f91e5ccde19f2