### PR TITLE
Calm PageHeader hero defaults

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -73,6 +73,8 @@ function HomePageContent() {
             }}
             hero={{
               heading: "Your day at a glance",
+              sticky: false,
+              topClassName: "top-0",
               actions: (
                 <>
                   <ThemeToggle className="shrink-0" />

--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -10,16 +10,19 @@
   --planner-header-hero-offset-md: calc(var(--space-6) - var(--space-6));
 }
 
-.planner-header__hero > :where(div) > :where(.mt-\[var\(--space-5\)\]) {
+.planner-header__hero > :where(div)
+  > :where(.mt-\[var\(--space-5\)\], .mt-\[var\(--space-4\)\]) {
   margin-top: var(--planner-header-hero-offset);
 }
 
 @media (min-width: 768px) {
-  .planner-header__hero > :where(div) > :where(.mt-\[var\(--space-5\)\]) {
+  .planner-header__hero > :where(div)
+    > :where(.mt-\[var\(--space-5\)\], .mt-\[var\(--space-4\)\]) {
     margin-top: var(--planner-header-hero-offset-md);
   }
 
-  .planner-header__hero > :where(div) > :where(.md\:mt-\[var\(--space-6\)\]) {
+  .planner-header__hero > :where(div)
+    > :where(.md\:mt-\[var\(--space-6\)\], .md\:mt-\[var\(--space-5\)\]) {
     margin-top: var(--planner-header-hero-offset-md);
   }
 }

--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -274,6 +274,14 @@ export default function PageHeaderDemo() {
           barClassName: "p-0",
         }}
       />
+      <p className="text-ui text-muted-foreground">
+        The PageHeader now keeps the inner hero calm by default. When you need
+        the full glitch shell for a marketing moment, pass the
+        <code className="ml-1 rounded bg-[hsl(var(--card)/0.6)] px-1.5 py-0.5 font-mono text-[0.75rem] text-foreground/80">
+          hero.frame = true
+        </code>
+        flag to opt back into the beams and scanlines.
+      </p>
     </div>
   );
 }

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -108,6 +108,31 @@ function Hero<Key extends string = string>({
 
   const Component: HeroElement = as ?? "section";
 
+  const shellClass = cx(
+    sticky ? "sticky-blur" : "",
+    frame
+      ? "relative overflow-hidden rounded-[var(--radius-2xl)] border border-[hsl(var(--border))/0.4] px-[var(--space-6)] hero2-frame hero2-neomorph"
+      : "px-[var(--space-3)] sm:px-[var(--space-4)] lg:px-[var(--space-5)]",
+    sticky && topClassName,
+  );
+
+  const barSpacingClass = frame
+    ? "relative z-[2] flex items-center gap-[var(--space-3)] md:gap-[var(--space-4)] lg:gap-[var(--space-6)] py-[var(--space-6)]"
+    : "relative z-[2] flex items-center gap-[var(--space-2)] md:gap-[var(--space-3)] lg:gap-[var(--space-4)] py-[var(--space-4)]";
+
+  const bodySpacingClass = frame
+    ? "relative z-[2] mt-[var(--space-5)] md:mt-[var(--space-6)] flex flex-col gap-[var(--space-5)] md:gap-[var(--space-6)]"
+    : "relative z-[2] mt-[var(--space-4)] md:mt-[var(--space-5)] flex flex-col gap-[var(--space-4)] md:gap-[var(--space-5)]";
+
+  const actionRowClass = frame
+    ? "flex items-center gap-[var(--space-3)] md:gap-[var(--space-4)] lg:gap-[var(--space-6)] pt-[var(--space-5)] md:pt-[var(--space-6)]"
+    : "flex flex-wrap items-center gap-[var(--space-2)] md:flex-nowrap md:gap-[var(--space-3)] lg:gap-[var(--space-4)] pt-[var(--space-4)] md:pt-[var(--space-5)]";
+
+  const headingClassName = cx(
+    "title-glow text-title-lg md:text-title-lg font-semibold tracking-[-0.01em] truncate",
+    frame ? "hero2-title" : undefined,
+  );
+
   // Compose right area: prefer built-in sub-tabs if provided.
   const subTabsNode = subTabs ? (
     <TabBar
@@ -152,18 +177,10 @@ function Hero<Key extends string = string>({
 
   return (
     <Component className={className} {...(rest as React.HTMLAttributes<HTMLElement>)}>
-      <HeroGlitchStyles />
-      <NeomorphicFrameStyles />
+      {frame ? <HeroGlitchStyles /> : null}
+      {frame ? <NeomorphicFrameStyles /> : null}
 
-      <div
-        className={cx(
-          sticky ? "sticky-blur" : "",
-          frame
-            ? "relative overflow-hidden rounded-[var(--radius-2xl)] border border-[hsl(var(--border))/0.4] px-[var(--space-6)] hero2-frame hero2-neomorph"
-            : "",
-          sticky && topClassName,
-        )}
-      >
+      <div className={shellClass}>
         {frame ? (
           <>
             <span aria-hidden className="hero2-beams" />
@@ -172,12 +189,7 @@ function Hero<Key extends string = string>({
           </>
         ) : null}
 
-        <div
-          className={cx(
-            "relative z-[2] flex items-center gap-[var(--space-3)] md:gap-[var(--space-4)] lg:gap-[var(--space-6)] py-[var(--space-6)]",
-            barClassName,
-          )}
-        >
+        <div className={cx(barSpacingClass, barClassName)}>
           {rail ? <span aria-hidden className="rail" /> : null}
           {icon ? (
             <div className="opacity-70 hover:opacity-100 focus-visible:opacity-100 transition-opacity">
@@ -193,10 +205,7 @@ function Hero<Key extends string = string>({
             ) : null}
 
             <div className="flex items-baseline gap-[var(--space-2)]">
-              <h2
-                className="hero2-title title-glow text-title-lg md:text-title-lg font-semibold tracking-[-0.01em] truncate"
-                data-text={headingStr}
-              >
+              <h2 className={headingClassName} data-text={headingStr}>
                 {heading}
               </h2>
               {subtitle ? (
@@ -211,7 +220,7 @@ function Hero<Key extends string = string>({
         </div>
 
         {children || searchProps || actions ? (
-          <div className="relative z-[2] mt-[var(--space-5)] md:mt-[var(--space-6)] flex flex-col gap-[var(--space-5)] md:gap-[var(--space-6)]">
+          <div className={bodySpacingClass}>
             {children ? (
               <div className={cx(bodyClassName)}>{children}</div>
             ) : null}
@@ -219,13 +228,20 @@ function Hero<Key extends string = string>({
               <div className="relative" style={dividerStyle}>
                 <span
                   aria-hidden
-                  className="hero2-divider-line block h-px bg-[hsl(var(--divider))/0.35]"
+                  className={cx(
+                    "block h-px",
+                    frame
+                      ? "hero2-divider-line bg-[hsl(var(--divider))/0.35]"
+                      : "bg-[hsl(var(--divider))/0.28]",
+                  )}
                 />
-                <span
-                  aria-hidden
-                  className="hero2-divider-glow absolute inset-x-0 top-0 h-px blur-[6px] opacity-60 bg-[hsl(var(--divider))]"
-                />
-                <div className="flex items-center gap-[var(--space-3)] md:gap-[var(--space-4)] lg:gap-[var(--space-6)] pt-[var(--space-5)] md:pt-[var(--space-6)]">
+                {frame ? (
+                  <span
+                    aria-hidden
+                    className="hero2-divider-glow absolute inset-x-0 top-0 h-px blur-[6px] opacity-60 bg-[hsl(var(--divider))]"
+                  />
+                ) : null}
+                <div className={actionRowClass}>
                   {searchProps ? <HeroSearchBar {...searchProps} /> : null}
                   {actions ? (
                     <div className="flex items-center gap-[var(--space-2)]">{actions}</div>

--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -136,7 +136,7 @@ const PageHeaderInner = <
           <Hero
             {...heroRest}
             as={heroAs ?? "section"}
-            frame={heroFrame ?? true}
+            frame={heroFrame ?? false}
             topClassName={cn("top-[var(--header-stack)]", heroTopClassName)}
             subTabs={resolvedSubTabs}
             search={resolvedSearch}

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -249,291 +249,11 @@ exports[`ReviewsPage > renders default state 1`] = `
               </div>
             </header>
             <section>
-              <style
-                global="true"
-                jsx="true"
-              >
-                
-      /* === Glitch title ================================================== */
-      .hero2-title {
-        position: relative;
-        text-shadow:
-          -0.02em 0 hsl(var(--accent-2) / 0.65),
-          0.02em 0 hsl(var(--lav-deep) / 0.65),
-          0 0 0.25em hsl(var(--foreground) / 0.35);
-      }
-      .hero2-title::before,
-      .hero2-title::after {
-        content: attr(data-text);
-        position: absolute;
-        inset: 0;
-        pointer-events: none;
-        clip-path: inset(0 0 0 0);
-        opacity: 0.75;
-      }
-      .hero2-title::before {
-        transform: translate(
-          calc(var(--hairline-w) / 2),
-          calc(-1 * var(--hairline-w) / 2)
-        );
-        color: hsl(var(--accent-2) / 0.85);
-        mix-blend-mode: screen;
-        animation: hero2-glitch-a 2.4s infinite steps(8, end);
-      }
-      .hero2-title::after {
-        transform: translate(
-          calc(-1 * var(--hairline-w) / 2),
-          calc(var(--hairline-w) / 2)
-        );
-        color: hsl(var(--lav-deep) / 0.85);
-        mix-blend-mode: screen;
-        animation: hero2-glitch-b 2.4s infinite steps(9, end);
-      }
-      @keyframes hero2-glitch-a {
-        0% {
-          clip-path: inset(0);
-        }
-        10% {
-          clip-path: inset(0 0 8% 0);
-        }
-        20% {
-          clip-path: inset(60% 0 0 0);
-        }
-        40% {
-          clip-path: inset(30% 0 40% 0);
-        }
-        80% {
-          clip-path: inset(10% 0 70% 0);
-        }
-        100% {
-          clip-path: inset(0);
-        }
-      }
-      @keyframes hero2-glitch-b {
-        0% {
-          clip-path: inset(0);
-        }
-        15% {
-          clip-path: inset(70% 0 10% 0);
-        }
-        55% {
-          clip-path: inset(0 0 60% 0);
-        }
-        95% {
-          clip-path: inset(20% 0 30% 0);
-        }
-        100% {
-          clip-path: inset(0);
-        }
-      }
-
-      /* === HUD Tabs container (legacy hook, optional) ==================== */
-      .tabs-hud {
-        background: transparent;
-        box-shadow: none;
-      }
-
-      /* === Neon divider (unchanged) ===================================== */
-      .neon-primary {
-        --neon: var(--primary);
-      }
-      .neon-life {
-        --neon: var(--accent);
-      }
-      @media (prefers-contrast: more) {
-        .hero2-divider-line {
-          background-color: hsl(var(--foreground)) !important;
-          opacity: 0.85 !important;
-        }
-        .hero2-divider-glow {
-          background-color: hsl(var(--foreground)) !important;
-          opacity: 0.9 !important;
-          filter: none !important;
-        }
-      }
-      @media (forced-colors: active) {
-        .hero2-divider-line {
-          background-color: CanvasText !important;
-          opacity: 1 !important;
-        }
-        .hero2-divider-glow {
-          display: none !important;
-        }
-      }
-      @media (prefers-reduced-motion: reduce) {
-        .hero2-title::before,
-        .hero2-title::after {
-          animation: none !important;
-          transition: none !important;
-        }
-      }
-    
-              </style>
-              <style
-                global="true"
-                jsx="true"
-              >
-                
-      .hero2-beams {
-        position: absolute;
-        inset: calc(var(--space-1) / -2);
-        border-radius: var(--radius-2xl);
-        z-index: 0;
-        pointer-events: none;
-        background:
-          linear-gradient(
-              100deg,
-              transparent 0%,
-              hsl(var(--primary) / 0.18) 10%,
-              transparent 22%
-            )
-            0 0/100% 100%,
-          linear-gradient(
-              260deg,
-              transparent 0%,
-              hsl(var(--accent) / 0.2) 8%,
-              transparent 20%
-            )
-            0 0/100% 100%;
-        mix-blend-mode: screen;
-        animation: hero2-beam-pan 7s linear infinite;
-      }
-      @media (prefers-reduced-motion: reduce) {
-        .hero2-beams {
-          animation: none;
-          display: none;
-        }
-      }
-      @keyframes hero2-beam-pan {
-        0% {
-          transform: translateX(-3%);
-        }
-        50% {
-          transform: translateX(3%);
-        }
-        100% {
-          transform: translateX(-3%);
-        }
-      }
-      .hero2-scanlines {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        pointer-events: none;
-        background:
-          linear-gradient(
-            transparent 94%,
-            hsl(var(--foreground) / 0.5) 96%,
-            transparent 98%
-          ),
-          linear-gradient(
-            90deg,
-            transparent 94%,
-            hsl(var(--foreground) / 0.4) 96%,
-            transparent 98%
-          );
-        background-size:
-          100% calc(var(--space-4) - var(--space-1) / 2),
-          calc(var(--space-4) - var(--space-1) / 2) 100%;
-        opacity: 0.07;
-        animation: hero2-scan-move 6s linear infinite;
-      }
-      @media (prefers-reduced-motion: reduce) {
-        .hero2-scanlines {
-          animation: none;
-          display: none;
-        }
-      }
-      @keyframes hero2-scan-move {
-        0% {
-          background-position:
-            0 0,
-            0 0;
-        }
-        100% {
-          background-position:
-            0 calc(var(--space-4) - var(--space-1) / 2),
-            calc(var(--space-4) - var(--space-1) / 2) 0;
-        }
-      }
-      .hero2-noise {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        pointer-events: none;
-        opacity: 0.03;
-        mix-blend-mode: overlay;
-        background-image: url("data:image/svg+xml;utf8,        &lt;svg xmlns='http://www.w3.org/2000/svg' width='140' height='140' viewBox='0 0 140 140'&gt;          &lt;filter id='n'&gt;&lt;feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/&gt;&lt;/filter&gt;          &lt;rect width='100%' height='100%' filter='url(%23n)' opacity='0.38'/&gt;&lt;/svg&gt;");
-        background-size: calc(var(--space-8) * 4 + var(--space-5))
-          calc(var(--space-8) * 4 + var(--space-5));
-        animation: hero2-noise-shift 1.8s steps(2, end) infinite;
-      }
-      @media (prefers-reduced-motion: reduce) {
-        .hero2-noise {
-          animation: none;
-          background-position: 0 0;
-          display: none;
-        }
-      }
-      @keyframes hero2-noise-shift {
-        50% {
-          background-position: 50% 50%;
-        }
-      }
-      .hero2-neomorph {
-        background: linear-gradient(
-          145deg,
-          hsl(var(--card)),
-          hsl(var(--panel))
-        );
-        box-shadow:
-          inset var(--space-1) var(--space-1) var(--space-2)
-            hsl(var(--background) / 0.55),
-          inset calc(-1 * var(--space-1)) calc(-1 * var(--space-1))
-            var(--space-2) hsl(var(--highlight) / 0.05),
-          0 0 var(--space-4) hsl(var(--ring) / 0.25);
-      }
-      @media (prefers-contrast: more) {
-        .hero2-beams,
-        .hero2-scanlines,
-        .hero2-noise {
-          display: none !important;
-        }
-        .hero2-frame {
-          border-color: hsl(var(--foreground) / 0.7) !important;
-        }
-        .hero2-neomorph {
-          box-shadow:
-            inset var(--space-1) var(--space-1) var(--space-2)
-              hsl(var(--background) / 0.65),
-            inset calc(-1 * var(--space-1)) calc(-1 * var(--space-1))
-              var(--space-2) hsl(var(--highlight) / 0.08),
-            0 0 0 1px hsl(var(--ring) / 0.7),
-            0 0 var(--space-5) hsl(var(--ring) / 0.5);
-        }
-      }
-      @media (forced-colors: active) {
-        .hero2-beams,
-        .hero2-scanlines,
-        .hero2-noise {
-          display: none !important;
-        }
-        .hero2-frame {
-          border-color: CanvasText !important;
-          background: Canvas !important;
-        }
-        .hero2-neomorph {
-          background: Canvas !important;
-          box-shadow: none !important;
-        }
-      }
-    
-              </style>
               <div
-                class="sticky-blur top-[var(--header-stack)]"
+                class="sticky-blur px-[var(--space-3)] sm:px-[var(--space-4)] lg:px-[var(--space-5)] top-[var(--header-stack)]"
               >
                 <div
-                  class="relative z-[2] flex items-center gap-[var(--space-3)] md:gap-[var(--space-4)] lg:gap-[var(--space-6)] py-[var(--space-6)]"
+                  class="relative z-[2] flex items-center gap-[var(--space-2)] md:gap-[var(--space-3)] lg:gap-[var(--space-4)] py-[var(--space-4)]"
                 >
                   <span
                     aria-hidden="true"
@@ -546,7 +266,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                       class="flex items-baseline gap-[var(--space-2)]"
                     >
                       <h2
-                        class="hero2-title title-glow text-title-lg md:text-title-lg font-semibold tracking-[-0.01em] truncate"
+                        class="title-glow text-title-lg md:text-title-lg font-semibold tracking-[-0.01em] truncate"
                         data-text="Browse Reviews"
                       >
                         Browse Reviews
@@ -565,7 +285,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                   </div>
                 </div>
                 <div
-                  class="relative z-[2] mt-[var(--space-5)] md:mt-[var(--space-6)] flex flex-col gap-[var(--space-5)] md:gap-[var(--space-6)]"
+                  class="relative z-[2] mt-[var(--space-4)] md:mt-[var(--space-5)] flex flex-col gap-[var(--space-4)] md:gap-[var(--space-5)]"
                 >
                   <div
                     class="relative"
@@ -573,14 +293,10 @@ exports[`ReviewsPage > renders default state 1`] = `
                   >
                     <span
                       aria-hidden="true"
-                      class="hero2-divider-line block h-px bg-[hsl(var(--divider))/0.35]"
-                    />
-                    <span
-                      aria-hidden="true"
-                      class="hero2-divider-glow absolute inset-x-0 top-0 h-px blur-[6px] opacity-60 bg-[hsl(var(--divider))]"
+                      class="block h-px bg-[hsl(var(--divider))/0.28]"
                     />
                     <div
-                      class="flex items-center gap-[var(--space-3)] md:gap-[var(--space-4)] lg:gap-[var(--space-6)] pt-[var(--space-5)] md:pt-[var(--space-6)]"
+                      class="flex flex-wrap items-center gap-[var(--space-2)] md:flex-nowrap md:gap-[var(--space-3)] lg:gap-[var(--space-4)] pt-[var(--space-4)] md:pt-[var(--space-5)]"
                     >
                       <form
                         class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-[var(--space-2)] data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"


### PR DESCRIPTION
## Summary
- default PageHeader hero frames to the calm shell and gate glitch layers/spacing in the Hero component when the frame flag is disabled
- tweak planner/home usages to align with the softer preset and keep custom spacing overrides in sync
- document how to opt back into the glitch variant in the PageHeader demo and refresh the reviews snapshot

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9ab9fcfe4832cbd098b309cb782a9