### PR TITLE
Refine sticky blur utilities

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1867,12 +1867,12 @@ a:active .lucide {
   }
 
   .sticky-blur {
-    position: sticky;
-    top: 0;
-    z-index: 30;
     backdrop-filter: saturate(120%) blur(12px);
     background: color-mix(in oklab, hsl(var(--background)) 65%, transparent);
-    border-bottom: 1px solid hsl(var(--card-hairline));
+    border-bottom: var(
+      --sticky-blur-border,
+      1px solid hsl(var(--card-hairline))
+    );
   }
 
   .r-card-sm {

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -16,7 +16,7 @@ import "@/app/globals.css";
  */
 export default function SiteChrome() {
   return (
-    <header role="banner" className="sticky-blur top-0 z-50">
+    <header role="banner" className="sticky top-0 z-50 sticky-blur">
       {/* Bar content */}
       <PageShell className="flex items-center justify-between py-2">
         <Link href="/" aria-label="Home" className="flex items-center gap-2">

--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -122,6 +122,8 @@ export default function Header<Key extends string = string>({
   const hasNav = nav != null;
   const showRightStack = hasTabs || hasRight || hasUtilities;
 
+  const stickyClasses = sticky ? cx("sticky", topClassName) : "";
+
   const barPadding = compact
     ? isMinimal
       ? "px-[var(--space-4)] py-[var(--space-3)]"
@@ -161,7 +163,7 @@ export default function Header<Key extends string = string>({
         {/* Top bar */}
         <div
           className={cx(
-            sticky && cx("sticky", topClassName),
+            stickyClasses,
             "relative flex items-center gap-[var(--space-3)] sm:gap-[var(--space-4)]",
             barPadding,
             minHeightClass,

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -108,12 +108,15 @@ function Hero<Key extends string = string>({
 
   const Component: HeroElement = as ?? "section";
 
+  const stickyClasses = sticky
+    ? cx("sticky sticky-blur", topClassName)
+    : "";
+
   const shellClass = cx(
-    sticky ? "sticky-blur" : "",
+    stickyClasses,
     frame
       ? "relative overflow-hidden rounded-[var(--radius-2xl)] border border-[hsl(var(--border))/0.4] px-[var(--space-6)] hero2-frame hero2-neomorph"
       : "px-[var(--space-3)] sm:px-[var(--space-4)] lg:px-[var(--space-5)]",
-    sticky && topClassName,
   );
 
   const barSpacingClass = frame

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -250,7 +250,7 @@ exports[`ReviewsPage > renders default state 1`] = `
             </header>
             <section>
               <div
-                class="sticky-blur px-[var(--space-3)] sm:px-[var(--space-4)] lg:px-[var(--space-5)] top-[var(--header-stack)]"
+                class="sticky sticky-blur top-[var(--header-stack)] px-[var(--space-3)] sm:px-[var(--space-4)] lg:px-[var(--space-5)]"
               >
                 <div
                   class="relative z-[2] flex items-center gap-[var(--space-2)] md:gap-[var(--space-3)] lg:gap-[var(--space-4)] py-[var(--space-4)]"


### PR DESCRIPTION
## Summary
- scope the `.sticky-blur` surface to backdrop styling with an overridable border token
- ensure hero and chrome headers apply Tailwind `sticky`/`top` utilities alongside the blur surface
- refresh the reviews snapshot to capture the updated class list

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9b306bbf8832c8c5077d3f5b7a38b