### PR TITLE
feat: calm page header hero tone by default

### DIFF
--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -274,13 +274,82 @@ export default function PageHeaderDemo() {
           barClassName: "p-0",
         }}
       />
+      <PageHeader
+        id="page-header-elevated"
+        aria-labelledby="page-header-elevated-heading"
+        subTabs={{
+          items: heroFilters,
+          value: activeFilter,
+          onChange: (key) => setActiveFilter(key as HeroFilter),
+          ariaLabel: "Filter spotlight content",
+        }}
+        search={{
+          id: "page-header-elevated-search",
+          value: query,
+          onValueChange: setQuery,
+          debounceMs: 200,
+          placeholder: "Search highlight reels…",
+          "aria-label": "Search highlight reels",
+        }}
+        header={{
+          heading: (
+            <span id="page-header-elevated-heading">Planner Spotlight</span>
+          ),
+          subtitle: "Stage a high-energy announcement right in the app.",
+          icon: (
+            <Image
+              src="/planner-logo.svg"
+              alt="Planner logo"
+              width={48}
+              height={48}
+              className="h-12 w-auto object-contain"
+            />
+          ),
+          sticky: false,
+          rail: false,
+          barClassName: "p-0",
+        }}
+        hero={{
+          eyebrow: "Launch highlight",
+          heading: "Rally the squad",
+          subtitle: "Pull focus for milestone beats",
+          tone: "heroic",
+          frame: true,
+          children: (
+            <p className="text-ui text-muted-foreground">
+              Spotlight a major update with the neon treatment while keeping
+              navigation close at hand.
+            </p>
+          ),
+          actions: (
+            <div className="flex items-center gap-2">
+              <ThemeToggle ariaLabel="Toggle theme" className="shrink-0" />
+              <Button
+                variant="primary"
+                size="sm"
+                className="px-4 whitespace-nowrap"
+              >
+                Launch Event
+              </Button>
+            </div>
+          ),
+          sticky: false,
+          topClassName: "top-0",
+          barClassName: "p-0",
+        }}
+      />
       <p className="text-ui text-muted-foreground">
-        The PageHeader now keeps the inner hero calm by default. When you need
-        the full glitch shell for a marketing moment, pass the
+        PageHeader now keeps the inner hero calm by default. When a launch calls
+        for the elevated treatment, combine
+        <code className="ml-1 rounded bg-[hsl(var(--card)/0.6)] px-1.5 py-0.5 font-mono text-[0.75rem] text-foreground/80">
+          {"hero.tone = \"heroic\""}
+        </code>
+        and
         <code className="ml-1 rounded bg-[hsl(var(--card)/0.6)] px-1.5 py-0.5 font-mono text-[0.75rem] text-foreground/80">
           hero.frame = true
         </code>
-        flag to opt back into the beams and scanlines.
+        to bring back the beams and scanlines while keeping the heading hierarchy
+        intact.
       </p>
     </div>
   );

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -40,6 +40,8 @@ export interface HeroProps<Key extends string = string>
   barClassName?: string;
   bodyClassName?: string;
   rail?: boolean;
+  /** Typography profile for the heading/subtitle. */
+  tone?: "heroic" | "supportive";
 
   /** Whether to include glitchy frame and background layers. */
   frame?: boolean;
@@ -83,6 +85,7 @@ function Hero<Key extends string = string>({
   icon,
   children,
   actions,
+  tone = "heroic",
   frame = true,
   sticky = true,
   topClassName = "top-[var(--space-8)]",
@@ -108,6 +111,8 @@ function Hero<Key extends string = string>({
 
   const Component: HeroElement = as ?? "section";
 
+  const isSupportiveTone = tone === "supportive";
+
   const stickyClasses = sticky
     ? cx("sticky sticky-blur", topClassName)
     : "";
@@ -132,8 +137,16 @@ function Hero<Key extends string = string>({
     : "flex flex-wrap items-center gap-[var(--space-2)] md:flex-nowrap md:gap-[var(--space-3)] lg:gap-[var(--space-4)] pt-[var(--space-4)] md:pt-[var(--space-5)]";
 
   const headingClassName = cx(
-    "title-glow text-title-lg md:text-title-lg font-semibold tracking-[-0.01em] truncate",
+    "title-glow font-semibold tracking-[-0.01em] truncate",
     frame ? "hero2-title" : undefined,
+    isSupportiveTone
+      ? "text-title md:text-title"
+      : "text-title-lg md:text-title-lg",
+  );
+
+  const subtitleClassName = cx(
+    "text-ui md:text-body text-muted-foreground truncate",
+    isSupportiveTone ? "font-normal" : "font-medium",
   );
 
   // Compose right area: prefer built-in sub-tabs if provided.
@@ -212,9 +225,7 @@ function Hero<Key extends string = string>({
                 {heading}
               </h2>
               {subtitle ? (
-                <span className="text-ui md:text-body font-medium text-muted-foreground truncate">
-                  {subtitle}
-                </span>
+                <span className={subtitleClassName}>{subtitle}</span>
               ) : null}
             </div>
           </div>

--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -88,6 +88,7 @@ const PageHeaderInner = <
     subTabs: heroSubTabs,
     search: heroSearch,
     actions: heroActions,
+    tone: heroTone,
     frame: heroFrame,
     topClassName: heroTopClassName,
     as: heroAs,
@@ -138,6 +139,7 @@ const PageHeaderInner = <
             as={heroAs ?? "section"}
             frame={heroFrame ?? false}
             topClassName={cn("top-[var(--header-stack)]", heroTopClassName)}
+            tone={heroTone ?? "supportive"}
             subTabs={resolvedSubTabs}
             search={resolvedSearch}
             actions={resolvedActions}

--- a/tests/components/PageHeader.test.tsx
+++ b/tests/components/PageHeader.test.tsx
@@ -13,6 +13,7 @@ describe("PageHeader", () => {
 
   const baseHero = {
     heading: "Team roadmap",
+    subtitle: "Supporting updates",
   } as const;
 
   it("renders a single semantic header element by default", () => {
@@ -52,5 +53,45 @@ describe("PageHeader", () => {
     expect(heroHeading.closest("nav")).not.toBeNull();
     expect(container.querySelectorAll("nav")).toHaveLength(1);
     expect(container.querySelectorAll("section")).toHaveLength(1);
+  });
+
+  it("calms the hero typography by default", () => {
+    render(<PageHeader header={baseHeader} hero={baseHero} />);
+
+    const heroHeading = screen.getByRole("heading", {
+      level: 2,
+      name: baseHero.heading,
+    });
+    expect(heroHeading).toHaveClass("text-title");
+    expect(heroHeading).toHaveClass("md:text-title");
+    expect(heroHeading).not.toHaveClass("text-title-lg");
+    expect(heroHeading).not.toHaveClass("md:text-title-lg");
+
+    const subtitle = screen.getByText(baseHero.subtitle);
+    expect(subtitle).toHaveClass("font-normal");
+    expect(subtitle).not.toHaveClass("font-medium");
+  });
+
+  it("allows opting into the elevated hero tone", () => {
+    render(
+      <PageHeader
+        header={baseHeader}
+        hero={{
+          ...baseHero,
+          tone: "heroic",
+        }}
+      />,
+    );
+
+    const heroHeading = screen.getByRole("heading", {
+      level: 2,
+      name: baseHero.heading,
+    });
+    expect(heroHeading).toHaveClass("text-title-lg");
+    expect(heroHeading).toHaveClass("md:text-title-lg");
+
+    const subtitle = screen.getByText(baseHero.subtitle);
+    expect(subtitle).toHaveClass("font-medium");
+    expect(subtitle).not.toHaveClass("font-normal");
   });
 });

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -266,13 +266,13 @@ exports[`ReviewsPage > renders default state 1`] = `
                       class="flex items-baseline gap-[var(--space-2)]"
                     >
                       <h2
-                        class="title-glow text-title-lg md:text-title-lg font-semibold tracking-[-0.01em] truncate"
+                        class="title-glow font-semibold tracking-[-0.01em] truncate text-title md:text-title"
                         data-text="Browse Reviews"
                       >
                         Browse Reviews
                       </h2>
                       <span
-                        class="text-ui md:text-body font-medium text-muted-foreground truncate"
+                        class="text-ui md:text-body text-muted-foreground truncate font-normal"
                       >
                         <span
                           class="pill"


### PR DESCRIPTION
## Summary
- add a tone control to Hero so the heading/subtitle can use a supportive typography ramp
- default PageHeader to the calmer Hero tone while keeping an elevated option for marketing beats
- refresh demos, tests, and snapshots to cover both tone modes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9b5de2bb8832c9793311866c92fbb