### PR TITLE
Allow PageHeader titles to wrap cleanly

### DIFF
--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -123,8 +123,8 @@ export default function PageHeaderDemo() {
     <div className="space-y-6">
       <Header
         eyebrow="Planner"
-        heading="Compact Header"
-        subtitle="Navigation & utilities"
+        heading="Compact Header Layout with Balanced Wrapping"
+        subtitle="Navigation & utilities stay aligned"
         compact
         sticky={false}
         topClassName="top-0"
@@ -148,8 +148,8 @@ export default function PageHeaderDemo() {
       <Header
         variant="minimal"
         eyebrow="Planner"
-        heading="Minimal Header"
-        subtitle="Lean chrome with neon focus"
+        heading="Minimal Header Layout for Extended Multi-line Titles"
+        subtitle="Lean chrome with neon focus even when headlines wrap"
         sticky={false}
         topClassName="top-0"
         rail={false}
@@ -232,7 +232,9 @@ export default function PageHeaderDemo() {
         }}
         header={{
           heading: (
-            <span id="page-header-demo-heading">Welcome to Planner</span>
+            <span id="page-header-demo-heading">
+              Welcome to Planner — plan smarter with multi-line titles
+            </span>
           ),
           subtitle: "Plan your day, track goals, and review games.",
           icon: (

--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -192,12 +192,12 @@ export default function Header<Key extends string = string>({
               ) : null}
               <div className="min-w-0">
                 {eyebrow ? (
-                  <div className="mb-[var(--space-1)] truncate text-label font-medium tracking-[0.02em] uppercase text-muted-foreground">
+                  <div className="mb-[var(--space-1)] text-balance break-words text-label font-medium tracking-[0.02em] uppercase text-muted-foreground">
                     {eyebrow}
                   </div>
                 ) : null}
                 <div className="flex min-w-0 items-baseline gap-[var(--space-2)]">
-                  <h1 className="truncate text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow">
+                  <h1 className="text-balance break-words text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow">
                     {heading}
                   </h1>
                   {subtitle ? (
@@ -224,7 +224,7 @@ export default function Header<Key extends string = string>({
 
           {/* Right slot / tabs */}
           {showRightStack ? (
-            <div className="ml-auto flex min-w-0 items-center gap-[var(--space-3)] sm:gap-[var(--space-4)]">
+            <div className="ml-auto flex min-w-0 items-center gap-[var(--space-3)] self-start sm:gap-[var(--space-4)]">
               {hasTabs ? tabControl : null}
               {hasRight ? (
                 <div className="flex shrink-0 items-center gap-[var(--space-2)]">

--- a/tests/components/PageHeader.test.tsx
+++ b/tests/components/PageHeader.test.tsx
@@ -94,4 +94,35 @@ describe("PageHeader", () => {
     expect(subtitle).toHaveClass("font-medium");
     expect(subtitle).not.toHaveClass("font-normal");
   });
+
+  it("balances header text when titles span multiple lines", () => {
+    const wrappingHeading =
+      "Expanded overview with multi-line planning guidance";
+    const eyebrow = "Planner daily briefing";
+
+    render(
+      <PageHeader
+        header={{
+          ...baseHeader,
+          eyebrow,
+          heading: wrappingHeading,
+        }}
+        hero={{
+          ...baseHero,
+          eyebrow: undefined,
+        }}
+      />,
+    );
+
+    const headerHeading = screen.getByRole("heading", {
+      level: 1,
+      name: wrappingHeading,
+    });
+    expect(headerHeading).toHaveClass("text-balance");
+    expect(headerHeading).toHaveClass("break-words");
+
+    const headerEyebrow = screen.getByText(eyebrow);
+    expect(headerEyebrow).toHaveClass("text-balance");
+    expect(headerEyebrow).toHaveClass("break-words");
+  });
 });

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -238,7 +238,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                         class="flex min-w-0 items-baseline gap-[var(--space-2)]"
                       >
                         <h1
-                          class="truncate text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow"
+                          class="text-balance break-words text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow"
                         >
                           Reviews
                         </h1>


### PR DESCRIPTION
## Summary
- replace header truncation with balanced wrapping utilities and keep the right-hand stack aligned when titles grow
- update the PageHeader demo copy and add a regression test that asserts the new wrapping classes
- refresh the ReviewsPage snapshot to reflect the updated heading markup

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9bbeccee0832cbccc27a5f899690f