### PR TITLE
Allow Hero headings and subtitles to wrap

### DIFF
--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -137,7 +137,7 @@ function Hero<Key extends string = string>({
     : "flex flex-wrap items-center gap-[var(--space-2)] md:flex-nowrap md:gap-[var(--space-3)] lg:gap-[var(--space-4)] pt-[var(--space-4)] md:pt-[var(--space-5)]";
 
   const headingClassName = cx(
-    "title-glow font-semibold tracking-[-0.01em] truncate",
+    "title-glow font-semibold tracking-[-0.01em] text-balance break-words",
     frame ? "hero2-title" : undefined,
     isSupportiveTone
       ? "text-title md:text-title"
@@ -145,7 +145,7 @@ function Hero<Key extends string = string>({
   );
 
   const subtitleClassName = cx(
-    "text-ui md:text-body text-muted-foreground truncate",
+    "text-ui md:text-body text-muted-foreground break-words",
     isSupportiveTone ? "font-normal" : "font-medium",
   );
 
@@ -220,7 +220,7 @@ function Hero<Key extends string = string>({
               </div>
             ) : null}
 
-            <div className="flex items-baseline gap-[var(--space-2)]">
+            <div className="flex min-w-0 flex-wrap items-baseline gap-x-[var(--space-2)] gap-y-[var(--space-1)]">
               <h2 className={headingClassName} data-text={headingStr}>
                 {heading}
               </h2>
@@ -230,7 +230,9 @@ function Hero<Key extends string = string>({
             </div>
           </div>
 
-          {subTabsNode ? <div className="ml-auto">{subTabsNode}</div> : null}
+          {subTabsNode ? (
+            <div className="ml-auto self-start">{subTabsNode}</div>
+          ) : null}
         </div>
 
         {children || searchProps || actions ? (

--- a/tests/components/PageHeader.test.tsx
+++ b/tests/components/PageHeader.test.tsx
@@ -64,11 +64,16 @@ describe("PageHeader", () => {
     });
     expect(heroHeading).toHaveClass("text-title");
     expect(heroHeading).toHaveClass("md:text-title");
+    expect(heroHeading).toHaveClass("break-words");
+    expect(heroHeading).toHaveClass("text-balance");
     expect(heroHeading).not.toHaveClass("text-title-lg");
     expect(heroHeading).not.toHaveClass("md:text-title-lg");
+    expect(heroHeading).not.toHaveClass("truncate");
 
     const subtitle = screen.getByText(baseHero.subtitle);
     expect(subtitle).toHaveClass("font-normal");
+    expect(subtitle).toHaveClass("break-words");
+    expect(subtitle).not.toHaveClass("truncate");
     expect(subtitle).not.toHaveClass("font-medium");
   });
 
@@ -89,9 +94,14 @@ describe("PageHeader", () => {
     });
     expect(heroHeading).toHaveClass("text-title-lg");
     expect(heroHeading).toHaveClass("md:text-title-lg");
+    expect(heroHeading).toHaveClass("break-words");
+    expect(heroHeading).toHaveClass("text-balance");
+    expect(heroHeading).not.toHaveClass("truncate");
 
     const subtitle = screen.getByText(baseHero.subtitle);
     expect(subtitle).toHaveClass("font-medium");
+    expect(subtitle).toHaveClass("break-words");
+    expect(subtitle).not.toHaveClass("truncate");
     expect(subtitle).not.toHaveClass("font-normal");
   });
 

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -263,16 +263,16 @@ exports[`ReviewsPage > renders default state 1`] = `
                     class="min-w-0"
                   >
                     <div
-                      class="flex items-baseline gap-[var(--space-2)]"
+                      class="flex min-w-0 flex-wrap items-baseline gap-x-[var(--space-2)] gap-y-[var(--space-1)]"
                     >
                       <h2
-                        class="title-glow font-semibold tracking-[-0.01em] truncate text-title md:text-title"
+                        class="title-glow font-semibold tracking-[-0.01em] text-balance break-words text-title md:text-title"
                         data-text="Browse Reviews"
                       >
                         Browse Reviews
                       </h2>
                       <span
-                        class="text-ui md:text-body text-muted-foreground truncate font-normal"
+                        class="text-ui md:text-body text-muted-foreground break-words font-normal"
                       >
                         <span
                           class="pill"


### PR DESCRIPTION
## Summary
- replace the Hero heading and subtitle truncation with balanced, break-word wrapping and update the heading row layout to support multi-line titles
- ensure PageHeader tests assert the new wrapping behavior and refresh the reviews snapshot for the updated markup

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9bfe1c28c832cb19c97e741ef0d26