### PR TITLE
Add hero padding toggle and refresh demos

### DIFF
--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -18,6 +18,7 @@ import {
   TitleBar,
   Header,
   Hero,
+  NeomorphicHeroFrame,
   PageShell,
   SearchBar,
   Snackbar,
@@ -810,7 +811,7 @@ export default function ComponentGallery() {
       {
         label: "Hero",
         element: (
-          <div className="w-56">
+          <div className="w-56 space-y-4">
             <Hero
               heading="Hero"
               eyebrow="Eyebrow"
@@ -833,6 +834,23 @@ export default function ComponentGallery() {
                 Body
               </div>
             </Hero>
+            <NeomorphicHeroFrame variant="plain">
+              <Hero
+                heading="Frame-ready"
+                eyebrow="No padding"
+                subtitle="Outer shell provides spacing"
+                sticky={false}
+                topClassName="top-0"
+                tone="supportive"
+                frame={false}
+                rail={false}
+                padding="none"
+              >
+                <div className="text-ui text-muted-foreground">
+                  Flush to the frame
+                </div>
+              </Hero>
+            </NeomorphicHeroFrame>
           </div>
         ),
       },

--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -4,6 +4,7 @@ import {
   PageHeader,
   Header,
   Hero,
+  NeomorphicHeroFrame,
   Button,
   ThemeToggle,
   IconButton,
@@ -213,6 +214,43 @@ export default function PageHeaderDemo() {
         </p>
       </Hero>
 
+      <NeomorphicHeroFrame
+        as="section"
+        variant="plain"
+        contentClassName="space-y-[var(--space-4)]"
+      >
+        <Hero
+          as="section"
+          eyebrow="Frame-ready hero"
+          heading="Flush supportive layout"
+          subtitle="Let the outer frame handle breathing room."
+          sticky={false}
+          topClassName="top-0"
+          tone="supportive"
+          frame={false}
+          rail={false}
+          padding="none"
+          search={{
+            id: "hero-flush-search",
+            value: query,
+            onValueChange: setQuery,
+            debounceMs: 150,
+            placeholder: "Search frame highlights…",
+            "aria-label": "Search frame highlights",
+          }}
+          actions={
+            <Button size="sm" variant="secondary" className="whitespace-nowrap">
+              Assign scout
+            </Button>
+          }
+        >
+          <p className="text-ui text-muted-foreground">
+            When the hero sits inside another shell, drop its padding so the
+            divider and actions align perfectly with the parent grid.
+          </p>
+        </Hero>
+      </NeomorphicHeroFrame>
+
       <PageHeader
         id="page-header-demo"
         aria-labelledby="page-header-demo-heading"
@@ -342,8 +380,13 @@ export default function PageHeaderDemo() {
         }}
       />
       <p className="text-ui text-muted-foreground">
-        PageHeader now keeps the inner hero calm and single-framed by default.
-        When a launch calls for the elevated treatment, combine
+        PageHeader now keeps the inner hero calm, single-framed, and flush by
+        default. It forwards{" "}
+        <code className="ml-1 rounded bg-[hsl(var(--card)/0.6)] px-1.5 py-0.5 font-mono text-[0.75rem] text-foreground/80">
+          {"hero.padding = \"none\""}
+        </code>{" "}
+        so the content hugs the frame while staying grid-aligned. When a launch
+        calls for the elevated treatment, combine
         <code className="ml-1 rounded bg-[hsl(var(--card)/0.6)] px-1.5 py-0.5 font-mono text-[0.75rem] text-foreground/80">
           {"hero.tone = \"heroic\""}
         </code>
@@ -351,8 +394,8 @@ export default function PageHeaderDemo() {
         <code className="ml-1 rounded bg-[hsl(var(--card)/0.6)] px-1.5 py-0.5 font-mono text-[0.75rem] text-foreground/80">
           hero.frame = true
         </code>
-        to bring back the beams and scanlines while keeping the heading hierarchy
-        intact.
+        to bring back the beams and scanlines while keeping the heading
+        hierarchy intact.
       </p>
     </div>
   );

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -30,6 +30,7 @@ import {
   PillarSelector,
   Header,
   Hero,
+  NeomorphicHeroFrame,
   PageShell,
   SectionCard as UiSectionCard,
   FieldShell,
@@ -811,18 +812,35 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
     {
       id: "hero",
       name: "Hero",
-      description: "Stacked hero shell with search and actions",
+      description:
+        "Stacked hero shell with search and actions — default spacing plus frame-ready paddingless variant.",
       element: (
-        <Hero
-          heading="Hero"
-          eyebrow="Eyebrow"
-          subtitle="Subtitle"
-          sticky={false}
-          search={{ value: "", onValueChange: () => {}, round: true }}
-          actions={<Button size="sm">Action</Button>}
-        >
-          <div className="text-ui text-muted-foreground">Body content</div>
-        </Hero>
+        <div className="space-y-[var(--space-4)]">
+          <Hero
+            heading="Hero"
+            eyebrow="Eyebrow"
+            subtitle="Subtitle"
+            sticky={false}
+            search={{ value: "", onValueChange: () => {}, round: true }}
+            actions={<Button size="sm">Action</Button>}
+          >
+            <div className="text-ui text-muted-foreground">Body content</div>
+          </Hero>
+          <NeomorphicHeroFrame variant="plain">
+            <Hero
+              heading="Frame-ready hero"
+              eyebrow="No padding"
+              subtitle="Outer shell handles spacing"
+              sticky={false}
+              tone="supportive"
+              frame={false}
+              rail={false}
+              padding="none"
+            >
+              <div className="text-ui text-muted-foreground">Body content</div>
+            </Hero>
+          </NeomorphicHeroFrame>
+        </div>
       ),
       tags: ["hero", "layout"],
       code: `<Hero
@@ -834,7 +852,22 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
   actions={<Button size="sm">Action</Button>}
 >
   <div className="text-ui text-muted-foreground">Body content</div>
-</Hero>`,
+</Hero>
+
+<NeomorphicHeroFrame variant="plain">
+  <Hero
+    heading="Frame-ready hero"
+    eyebrow="No padding"
+    subtitle="Outer shell handles spacing"
+    sticky={false}
+    tone="supportive"
+    frame={false}
+    rail={false}
+    padding="none"
+  >
+    <div className="text-ui text-muted-foreground">Body content</div>
+  </Hero>
+</NeomorphicHeroFrame>`,
     },
     {
       id: "page-shell",

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -52,6 +52,9 @@ export interface HeroProps<Key extends string = string>
   /** Semantic wrapper element (defaults to `section`). */
   as?: HeroElement;
 
+  /** Horizontal padding for the outer shell. */
+  padding?: "default" | "none";
+
   /** Built-in top-right sub-tabs (preferred). */
   subTabs?: HeaderTabsProps<Key> & {
     size?: TabBarProps["size"];
@@ -98,6 +101,7 @@ function Hero<Key extends string = string>({
   search,
   className,
   as,
+  padding = "default",
   ...rest
 }: HeroProps<Key>) {
   const headingStr = typeof heading === "string" ? heading : undefined;
@@ -120,8 +124,15 @@ function Hero<Key extends string = string>({
   const shellClass = cx(
     stickyClasses,
     frame
-      ? "relative overflow-hidden rounded-[var(--radius-2xl)] border border-[hsl(var(--border))/0.4] px-[var(--space-6)] hero2-frame hero2-neomorph"
-      : "px-[var(--space-3)] sm:px-[var(--space-4)] lg:px-[var(--space-5)]",
+      ? "relative overflow-hidden rounded-[var(--radius-2xl)] border border-[hsl(var(--border))/0.4] hero2-frame hero2-neomorph"
+      : undefined,
+    frame
+      ? padding === "default"
+        ? "px-[var(--space-6)]"
+        : undefined
+      : padding === "default"
+        ? "px-[var(--space-3)] sm:px-[var(--space-4)] lg:px-[var(--space-5)]"
+        : undefined,
   );
 
   const barSpacingClass = frame

--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -92,6 +92,7 @@ const PageHeaderInner = <
     frame: heroFrame,
     topClassName: heroTopClassName,
     as: heroAs,
+    padding: heroPadding,
     ...heroRest
   } = hero;
 
@@ -142,6 +143,7 @@ const PageHeaderInner = <
             frame={resolvedHeroFrame}
             topClassName={cn("top-[var(--header-stack)]", heroTopClassName)}
             tone={heroTone ?? "supportive"}
+            padding={heroPadding ?? "none"}
             subTabs={resolvedSubTabs}
             search={resolvedSearch}
             actions={resolvedActions}

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -250,7 +250,7 @@ exports[`ReviewsPage > renders default state 1`] = `
             </header>
             <section>
               <div
-                class="sticky sticky-blur top-[var(--header-stack)] px-[var(--space-3)] sm:px-[var(--space-4)] lg:px-[var(--space-5)]"
+                class="sticky sticky-blur top-[var(--header-stack)]"
               >
                 <div
                   class="relative z-[2] flex items-center gap-[var(--space-2)] md:gap-[var(--space-3)] lg:gap-[var(--space-4)] py-[var(--space-4)]"


### PR DESCRIPTION
## Summary
- add a `padding` prop to `Hero` so its outer shell can drop spacing when needed while keeping the default behavior intact
- make `PageHeader` pass `padding="none"` to its inner hero to avoid double frame padding
- update the PageHeader demo, gallery entry, and snippets to showcase both padded and frame-ready hero variants

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9c7f0fef8832cbaf5bf23b2a3d0a1