### PR TITLE
Enable responsive wrapping in hero action row

### DIFF
--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -144,8 +144,8 @@ function Hero<Key extends string = string>({
     : "relative z-[2] mt-[var(--space-4)] md:mt-[var(--space-5)] flex flex-col gap-[var(--space-4)] md:gap-[var(--space-5)]";
 
   const actionRowClass = frame
-    ? "flex items-center gap-[var(--space-3)] md:gap-[var(--space-4)] lg:gap-[var(--space-6)] pt-[var(--space-5)] md:pt-[var(--space-6)]"
-    : "flex flex-wrap items-center gap-[var(--space-2)] md:flex-nowrap md:gap-[var(--space-3)] lg:gap-[var(--space-4)] pt-[var(--space-4)] md:pt-[var(--space-5)]";
+    ? "flex flex-wrap items-start gap-[var(--space-3)] md:flex-nowrap md:items-center md:gap-[var(--space-4)] lg:gap-[var(--space-6)] pt-[var(--space-5)] md:pt-[var(--space-6)]"
+    : "flex flex-wrap items-start gap-[var(--space-2)] md:flex-nowrap md:items-center md:gap-[var(--space-3)] lg:gap-[var(--space-4)] pt-[var(--space-4)] md:pt-[var(--space-5)]";
 
   const headingClassName = cx(
     "title-glow font-semibold tracking-[-0.01em] text-balance break-words",
@@ -271,7 +271,11 @@ function Hero<Key extends string = string>({
                 <div className={actionRowClass}>
                   {searchProps ? <HeroSearchBar {...searchProps} /> : null}
                   {actions ? (
-                    <div className="flex items-center gap-[var(--space-2)]">{actions}</div>
+                    <div
+                      className="flex w-full flex-wrap items-center gap-[var(--space-2)] md:w-auto md:flex-nowrap"
+                    >
+                      {actions}
+                    </div>
                   ) : null}
                 </div>
               </div>

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -296,7 +296,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                       class="block h-px bg-[hsl(var(--divider))/0.28]"
                     />
                     <div
-                      class="flex flex-wrap items-center gap-[var(--space-2)] md:flex-nowrap md:gap-[var(--space-3)] lg:gap-[var(--space-4)] pt-[var(--space-4)] md:pt-[var(--space-5)]"
+                      class="flex flex-wrap items-start gap-[var(--space-2)] md:flex-nowrap md:items-center md:gap-[var(--space-3)] lg:gap-[var(--space-4)] pt-[var(--space-4)] md:pt-[var(--space-5)]"
                     >
                       <form
                         class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-[var(--space-2)] data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"
@@ -347,7 +347,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                         </div>
                       </form>
                       <div
-                        class="flex items-center gap-[var(--space-2)]"
+                        class="flex w-full flex-wrap items-center gap-[var(--space-2)] md:w-auto md:flex-nowrap"
                       >
                         <div
                           class="flex flex-col gap-[var(--space-2)] sm:flex-row sm:items-center sm:gap-[var(--space-3)]"


### PR DESCRIPTION
## Summary
- allow Hero action rows to wrap and stack responsively while keeping tokenized spacing
- ensure action groups expand full width on small screens and update the reviews snapshot for the new layout

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9d193c718832c985e9340f85cd7b7