### PR TITLE
Use neutral tint for empty WeekPicker days

### DIFF
--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -88,6 +88,9 @@ const DayChip = React.forwardRef<HTMLButtonElement, DayChipProps>(function DayCh
     return ratio;
   }, [done, total]);
   const completionTint = React.useMemo(() => {
+    if (total === 0) {
+      return "bg-card";
+    }
     if (completionRatio >= 2 / 3) {
       return "bg-success-soft";
     }
@@ -95,7 +98,7 @@ const DayChip = React.forwardRef<HTMLButtonElement, DayChipProps>(function DayCh
       return "bg-warning-soft";
     }
     return "bg-warning-soft-strong";
-  }, [completionRatio]);
+  }, [completionRatio, total]);
   const instructionsId = React.useId();
   const countsId = React.useId();
   const instructionsText = selected


### PR DESCRIPTION
## Summary
- short-circuit the WeekPicker completion tint when a day has no tasks and apply the neutral card background
- preserve the existing tint thresholds for partially and fully completed days

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9dbbe5738832c8ad4e532f1d43d5e