### PR TITLE
Refactor home and planner spacing to use tokens

### DIFF
--- a/src/components/home/BottomNav.tsx
+++ b/src/components/home/BottomNav.tsx
@@ -25,7 +25,7 @@ const LINKS = [
 export default function BottomNav() {
   const pathname = usePathname();
   return (
-    <nav aria-label="Primary" className="border-t border-border pt-4 md:hidden">
+    <nav aria-label="Primary" className="border-t border-border pt-[var(--space-4)] md:hidden">
       <ul className="flex justify-around">
         {LINKS.map(({ href, label, icon: Icon }) => {
           const active = pathname.startsWith(href);
@@ -36,7 +36,7 @@ export default function BottomNav() {
                 aria-current={active ? "page" : undefined}
                 data-active={active}
                 className={cn(
-                  "group flex flex-col items-center gap-1 rounded-xl px-3 py-2 text-label font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none",
+                  "group flex flex-col items-center gap-[var(--space-1)] rounded-xl px-[var(--space-3)] py-[var(--space-2)] text-label font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none",
                   active
                     ? "text-accent ring-2 ring-[--theme-ring]"
                     : "text-muted-foreground hover:text-foreground"

--- a/src/components/home/DashboardCard.tsx
+++ b/src/components/home/DashboardCard.tsx
@@ -18,13 +18,13 @@ export default function DashboardCard({
   actions,
 }: DashboardCardProps) {
   return (
-    <NeoCard className="p-4 md:p-6 space-y-4">
+    <NeoCard className="p-[var(--space-4)] md:p-[var(--space-6)] space-y-[var(--space-4)]">
       <div className="flex items-center justify-between">
         <h2 className="text-body font-semibold tracking-[-0.01em]">{title}</h2>
         {actions}
       </div>
       {children && (
-        <div className="border-t border-border pt-4 space-y-4">
+        <div className="border-t border-border pt-[var(--space-4)] space-y-[var(--space-4)]">
           {children}
         </div>
       )}

--- a/src/components/home/GoalsCard.tsx
+++ b/src/components/home/GoalsCard.tsx
@@ -22,16 +22,16 @@ export default function GoalsCard() {
     >
       <ul className="divide-y divide-[hsl(var(--border))]">
         {activeGoals.map((g) => (
-          <li key={g.id} className="py-2">
+          <li key={g.id} className="py-[var(--space-2)]">
             <p className="text-ui">{g.title}</p>
-            <div className="mt-2">
+            <div className="mt-[var(--space-2)]">
               <Progress value={0} />
             </div>
           </li>
         ))}
         {activeGoals.length === 0 && (
-          <li className="flex justify-between py-2 text-ui text-muted-foreground">
-            <span className="flex items-center gap-2">
+          <li className="flex justify-between py-[var(--space-2)] text-ui text-muted-foreground">
+            <span className="flex items-center gap-[var(--space-2)]">
               <CircleSlash className="size-3" />
               No active goals
             </span>

--- a/src/components/home/QuickActions.tsx
+++ b/src/components/home/QuickActions.tsx
@@ -9,8 +9,8 @@ const quickActionButtonClassName =
 
 export default function QuickActions() {
   return (
-    <section aria-label="Quick actions" className="grid gap-4">
-      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+    <section aria-label="Quick actions" className="grid gap-[var(--space-4)]">
+      <div className="flex flex-col gap-[var(--space-4)] md:flex-row md:items-center md:justify-between">
         <Link href="/planner">
           <Button className={quickActionButtonClassName}>
             Planner Today

--- a/src/components/home/ReviewsCard.tsx
+++ b/src/components/home/ReviewsCard.tsx
@@ -22,7 +22,7 @@ export default function ReviewsCard() {
     >
       <ul className="divide-y divide-[hsl(var(--border))]">
         {recentReviews.map((r) => (
-          <li key={r.id} className="flex justify-between py-2 text-ui">
+          <li key={r.id} className="flex justify-between py-[var(--space-2)] text-ui">
             <span>{r.title || "Untitled"}</span>
             <span className="text-label text-muted-foreground">
               {new Date(r.createdAt).toLocaleDateString(LOCALE)}
@@ -30,8 +30,8 @@ export default function ReviewsCard() {
           </li>
         ))}
         {recentReviews.length === 0 && (
-          <li className="flex justify-between py-2 text-ui text-muted-foreground">
-            <span className="flex items-center gap-2">
+          <li className="flex justify-between py-[var(--space-2)] text-ui text-muted-foreground">
+            <span className="flex items-center gap-[var(--space-2)]">
               <CircleSlash className="size-3" />
               No reviews yet
             </span>

--- a/src/components/home/TeamPromptsCard.tsx
+++ b/src/components/home/TeamPromptsCard.tsx
@@ -6,25 +6,25 @@ import DashboardCard from "./DashboardCard";
 
 export default function TeamPromptsCard() {
   return (
-    <div className="grid grid-cols-1 gap-6 md:grid-cols-12">
+    <div className="grid grid-cols-1 gap-[var(--space-6)] md:grid-cols-12">
       <div className="md:col-span-6">
         <DashboardCard title="Team quick actions">
-          <div className="grid grid-cols-12 gap-4">
+          <div className="grid grid-cols-12 gap-[var(--space-4)]">
             <Link
               href="/team"
-              className="col-span-12 rounded-card r-card-md border border-border px-3 py-1 text-label hover:bg-[--hover] active:bg-[--active] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 sm:col-span-6 lg:col-span-4"
+              className="col-span-12 rounded-card r-card-md border border-border px-[var(--space-3)] py-[var(--space-1)] text-label hover:bg-[--hover] active:bg-[--active] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 sm:col-span-6 lg:col-span-4"
             >
               Archetypes
             </Link>
             <Link
               href="/team"
-              className="col-span-12 rounded-card r-card-md border border-border px-3 py-1 text-label hover:bg-[--hover] active:bg-[--active] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 sm:col-span-6 lg:col-span-4"
+              className="col-span-12 rounded-card r-card-md border border-border px-[var(--space-3)] py-[var(--space-1)] text-label hover:bg-[--hover] active:bg-[--active] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 sm:col-span-6 lg:col-span-4"
             >
               Team Builder
             </Link>
             <Link
               href="/team"
-              className="col-span-12 rounded-card r-card-md border border-border px-3 py-1 text-label hover:bg-[--hover] active:bg-[--active] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 sm:col-span-6 lg:col-span-4"
+              className="col-span-12 rounded-card r-card-md border border-border px-[var(--space-3)] py-[var(--space-1)] text-label hover:bg-[--hover] active:bg-[--active] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 sm:col-span-6 lg:col-span-4"
             >
               Jungle Clears
             </Link>
@@ -36,7 +36,7 @@ export default function TeamPromptsCard() {
           title="Prompts peek"
           cta={{ label: "Explore Prompts", href: "/prompts" }}
         >
-          <div className="rounded-card r-card-md bg-seg-active-grad p-4 text-center text-ui text-neon-soft">
+          <div className="rounded-card r-card-md bg-seg-active-grad p-[var(--space-4)] text-center text-ui text-neon-soft">
             Get inspired with curated prompts
           </div>
         </DashboardCard>

--- a/src/components/home/TodayCard.tsx
+++ b/src/components/home/TodayCard.tsx
@@ -23,14 +23,14 @@ export default function TodayCard() {
     <DashboardCard title="Today" cta={{ label: "Planner", href: "/planner" }}>
       <ul className="divide-y divide-[hsl(var(--border))]">
         {topTasks.map((t) => (
-          <li key={t.id} className="flex justify-between py-2 text-ui">
+          <li key={t.id} className="flex justify-between py-[var(--space-2)] text-ui">
             <span>{t.title}</span>
             <span className="text-label text-muted-foreground">Today</span>
           </li>
         ))}
         {topTasks.length === 0 && (
-          <li className="flex justify-between py-2 text-ui text-muted-foreground">
-            <span className="flex items-center gap-2">
+          <li className="flex justify-between py-[var(--space-2)] text-ui text-muted-foreground">
+            <span className="flex items-center gap-[var(--space-2)]">
               <CircleSlash className="size-3" />
               No tasks
             </span>

--- a/src/components/planner/DayCard.tsx
+++ b/src/components/planner/DayCard.tsx
@@ -54,10 +54,10 @@ export default function DayCard({ iso, isToday }: Props) {
     <section
       className={cn(
         "daycard relative overflow-hidden card-neo-soft rounded-card r-card-lg border card-pad",
-        "grid gap-4 lg:gap-6",
+        "grid gap-[var(--space-4)] lg:gap-[var(--space-6)]",
         "grid-cols-1 lg:grid-cols-12",
         isToday && "ring-1 ring-ring/65 title-glow",
-        "before:pointer-events-none before:absolute before:inset-x-4 before:top-0 before:h-px before:bg-gradient-to-r",
+        "before:pointer-events-none before:absolute before:inset-x-[var(--space-4)] before:top-0 before:h-px before:bg-gradient-to-r",
         "before:from-transparent before:via-ring/45 before:to-transparent",
         "after:pointer-events-none after:absolute after:-inset-px after:[border-radius:var(--radius-card)] after:bg-[radial-gradient(60%_40%_at_100%_0%,hsl(var(--ring)/.12),transparent_60%)]",
       )}

--- a/src/components/planner/DayCardHeader.tsx
+++ b/src/components/planner/DayCardHeader.tsx
@@ -23,7 +23,7 @@ export default function DayCardHeader({
     totalCount === 0 ? 0 : Math.round((doneCount / totalCount) * 100);
 
   return (
-    <div className="col-span-1 lg:col-span-3 flex items-center gap-3 min-w-0">
+    <div className="col-span-1 lg:col-span-3 flex items-center gap-[var(--space-3)] min-w-0">
       <span
         className="glitch glitch-label text-ui font-semibold tracking-wide shrink-0"
         data-text={headerText}
@@ -35,7 +35,7 @@ export default function DayCardHeader({
         <GlitchProgress current={doneCount} total={totalCount} />
       </div>
 
-      <div className="shrink-0 flex items-baseline gap-3 text-label text-muted-foreground">
+      <div className="shrink-0 flex items-baseline gap-[var(--space-3)] text-label text-muted-foreground">
         <span className="tabular-nums font-medium text-foreground">
           {pctNum}%
         </span>

--- a/src/components/planner/DayRow.tsx
+++ b/src/components/planner/DayRow.tsx
@@ -10,7 +10,7 @@ const DayRow = React.memo(
       <li
         id={`day-${iso}`}
         aria-label={`Day ${iso}${isToday ? " (Today)" : ""}`}
-        className="w-full scroll-m-24 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="w-full scroll-m-[calc(var(--space-8)+var(--space-6))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         tabIndex={-1}
       >
         <DayCard iso={iso} isToday={isToday} />

--- a/src/components/planner/FocusPanel.tsx
+++ b/src/components/planner/FocusPanel.tsx
@@ -32,7 +32,7 @@ export default function FocusPanel({ iso }: Props) {
     <SectionCard className="card-neo-soft">
       <SectionCard.Header title="Daily Focus" />
       <SectionCard.Body>
-        <form onSubmit={onSubmit} className="flex items-center gap-2">
+        <form onSubmit={onSubmit} className="flex items-center gap-[var(--space-2)]">
           <Input
             placeholder="What’s the one thing today?"
             value={value}
@@ -55,7 +55,7 @@ export default function FocusPanel({ iso }: Props) {
         </form>
 
         {/* Subtle status text without yelling at the user */}
-        <div className="mt-2 text-label text-muted-foreground" aria-live="polite">
+        <div className="mt-[var(--space-2)] text-label text-muted-foreground" aria-live="polite">
           {saving
             ? "Saving changes…"
             : isDirty

--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -54,7 +54,7 @@ function Inner() {
   const heroRef = React.useRef<HTMLDivElement>(null);
 
   const right = (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-[var(--space-2)]">
       <Button
         variant="ghost"
         size="sm"
@@ -83,12 +83,12 @@ function Inner() {
     <>
       <PageShell
         as="main"
-        className="py-6 space-y-6"
+        className="py-[var(--space-6)] space-y-[var(--space-6)]"
         aria-labelledby="planner-header"
       >
         {/* Week header (range, nav, totals, day chips) */}
         <PageHeader
-          contentClassName="space-y-2"
+          contentClassName="space-y-[var(--space-2)]"
           header={{
             id: "planner-header",
             tabIndex: -1,
@@ -119,7 +119,7 @@ function Inner() {
         {/* Today + Side column */}
         <section
           aria-label="Today and weekly panels"
-          className="grid grid-cols-1 gap-6 lg:grid-cols-12"
+          className="grid grid-cols-1 gap-[var(--space-6)] lg:grid-cols-12"
         >
           <div className="lg:col-span-8" ref={heroRef}>
             <TodayHero iso={iso} />
@@ -128,7 +128,7 @@ function Inner() {
           {/* Sticky only on large so it doesn’t eat the viewport on mobile */}
           <aside
             aria-label="Week notes"
-            className="lg:col-span-4 space-y-6 lg:sticky lg:top-8"
+            className="lg:col-span-4 space-y-[var(--space-6)] lg:sticky lg:top-[var(--space-8)]"
           >
             <WeekNotes iso={iso} />
           </aside>
@@ -137,7 +137,7 @@ function Inner() {
         {/* Week list (Mon→Sun) — anchors used by WeekPicker’s selectAndScroll */}
         <ul
           aria-label="Week days (Monday to Sunday)"
-          className="flex flex-col gap-4"
+          className="flex flex-col gap-[var(--space-4)]"
         >
           {dayItems.map((item) => (
             <DayRow key={item.iso} iso={item.iso} isToday={item.isToday} />

--- a/src/components/planner/ProjectList.tsx
+++ b/src/components/planner/ProjectList.tsx
@@ -75,7 +75,7 @@ export default function ProjectList({
   );
 
   return (
-    <div className="flex flex-col gap-3 min-w-0">
+    <div className="flex flex-col gap-[var(--space-3)] min-w-0">
       <div
         className={cn(
           "px-0 w-full",
@@ -88,7 +88,7 @@ export default function ProjectList({
         }
       >
         <ul
-          className="w-full space-y-2 py-2"
+          className="w-full space-y-[var(--space-2)] py-[var(--space-2)]"
           role="radiogroup"
           aria-label="Projects"
         >
@@ -131,9 +131,9 @@ export default function ProjectList({
                       if (active) setSelectedTaskId("");
                     }}
                     className={cn(
-                      "proj-card group relative [overflow:visible] w-full text-left rounded-card r-card-lg border pl-4 pr-2 py-2",
+                      "proj-card group relative [overflow:visible] w-full text-left rounded-card r-card-lg border pl-[var(--space-4)] pr-[var(--space-2)] py-[var(--space-2)]",
                       "bg-card/55 hover:bg-card/70 transition",
-                      "grid min-h-12 grid-cols-[auto,1fr,auto] items-center gap-4",
+                      "grid min-h-[var(--space-7)] grid-cols-[auto,1fr,auto] items-center gap-[var(--space-4)]",
                       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                       active && "proj-card--active ring-1 ring-ring",
                     )}
@@ -177,7 +177,7 @@ export default function ProjectList({
                       </span>
                     )}
 
-                    <div className="ml-auto flex items-center gap-2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+                    <div className="ml-auto flex items-center gap-[var(--space-2)] opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
                       <IconButton
                         aria-label="Edit project"
                         title="Edit"

--- a/src/components/planner/ScrollTopFloatingButton.tsx
+++ b/src/components/planner/ScrollTopFloatingButton.tsx
@@ -43,7 +43,7 @@ export default function ScrollTopFloatingButton({
     <IconButton
       aria-label="Scroll to top"
       onClick={scrollTop}
-      className="fixed bottom-8 right-2 z-50"
+      className="fixed bottom-[var(--space-8)] right-[var(--space-2)] z-50"
     >
       <ArrowUp />
     </IconButton>

--- a/src/components/planner/TaskList.tsx
+++ b/src/components/planner/TaskList.tsx
@@ -56,7 +56,7 @@ export default function TaskList({
   );
 
   return (
-    <div className="flex flex-col gap-3 min-w-0">
+    <div className="flex flex-col gap-[var(--space-3)] min-w-0">
       {selectedProjectId && (
         <form onSubmit={onSubmit}>
           <Input
@@ -68,14 +68,14 @@ export default function TaskList({
           />
         </form>
       )}
-      <div className="min-h-32 max-h-80 overflow-y-auto px-2 py-2">
+      <div className="min-h-[calc(var(--space-8)*2)] max-h-[calc(var(--space-8)*5)] overflow-y-auto px-[var(--space-2)] py-[var(--space-2)]">
         {!selectedProjectId ? (
           <EmptyRow text="Select a project to view tasks" />
         ) : tasksForSelected.length === 0 ? (
           <EmptyRow text="No tasks yet" />
         ) : (
           <ul
-            className="space-y-2 [&>li:first-child]:mt-2 [&>li:last-child]:mb-2"
+            className="space-y-[var(--space-2)] [&>li:first-child]:mt-[var(--space-2)] [&>li:last-child]:mb-[var(--space-2)]"
             aria-label="Tasks"
           >
             {tasksForSelected.map((t) => (

--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -15,7 +15,7 @@ const taskImageSpacingToken = 7;
 const taskImageSize = spacingTokens[taskImageSpacingToken - 1];
 const taskImageCssValue = `var(--space-${taskImageSpacingToken})` as const;
 const layoutClasses =
-  "[overflow:visible] grid min-h-12 min-w-0 grid-cols-[auto,1fr,auto] items-center gap-4 pl-4 pr-2 py-2";
+  "[overflow:visible] grid min-h-[var(--space-7)] min-w-0 grid-cols-[auto,1fr,auto] items-center gap-[var(--space-4)] pl-[var(--space-4)] pr-[var(--space-2)] py-[var(--space-2)]";
 
 type Props = {
   task: DayTask;
@@ -105,7 +105,7 @@ export default function TaskRow({
           onBlurCapture={handleBlurWithin}
         >
           <div
-            className="pointer-events-auto shrink-0 ml-1"
+            className="pointer-events-auto shrink-0 ml-[var(--space-1)]"
             onClick={(e) => e.stopPropagation()}
             onPointerDown={(e) => e.stopPropagation()}
           >
@@ -119,7 +119,7 @@ export default function TaskRow({
             />
           </div>
 
-          <div className="pointer-events-auto flex-1 min-w-0 px-1">
+          <div className="pointer-events-auto flex-1 min-w-0 px-[var(--space-1)]">
             {!editing ? (
               <button
                 type="button"
@@ -162,7 +162,7 @@ export default function TaskRow({
 
           <div
             className={cn(
-              "pointer-events-auto flex shrink-0 items-center gap-2",
+              "pointer-events-auto flex shrink-0 items-center gap-[var(--space-2)]",
               editing
                 ? "opacity-0 pointer-events-none"
                 : "opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto",
@@ -198,9 +198,9 @@ export default function TaskRow({
         </div>
       </div>
       {task.images.length > 0 && (
-        <ul className="mt-2 space-y-2">
+        <ul className="mt-[var(--space-2)] space-y-[var(--space-2)]">
           {task.images.map((url) => (
-            <li key={url} className="flex items-center gap-2">
+            <li key={url} className="flex items-center gap-[var(--space-2)]">
               <Image
                 src={url}
                 alt={`Task image for ${task.title}`}
@@ -233,7 +233,7 @@ export default function TaskRow({
           e.preventDefault();
           addImage();
         }}
-        className="mt-2"
+        className="mt-[var(--space-2)]"
       >
         <label htmlFor={`task-image-${task.id}`} className="sr-only">
           Add image URL

--- a/src/components/planner/TodayHero.tsx
+++ b/src/components/planner/TodayHero.tsx
@@ -205,8 +205,8 @@ export default function TodayHero({ iso }: Props) {
   return (
     <section className="bg-hero-soft rounded-card r-card-lg card-pad-lg anim-in">
       {/* Header */}
-      <div className="mb-4 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-        <div className="flex items-center gap-3">
+      <div className="mb-[var(--space-4)] flex flex-col gap-[var(--space-2)] md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-[var(--space-3)]">
           <h2
             className="glitch text-title font-semibold tracking-[-0.01em]"
             data-text={isToday ? "Today" : viewIso}
@@ -215,7 +215,7 @@ export default function TodayHero({ iso }: Props) {
           </h2>
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-[var(--space-2)]">
           <input
             ref={dateRef}
             type="date"
@@ -242,13 +242,13 @@ export default function TodayHero({ iso }: Props) {
         current={done}
         total={total}
         showPercentage
-        className="mb-4 flex items-center gap-3"
+        className="mb-[var(--space-4)] flex items-center gap-[var(--space-3)]"
         trackClassName="w-full"
-        percentageClassName="glitch-percent w-12 text-right text-ui font-medium"
+        percentageClassName="glitch-percent w-[var(--space-7)] text-right text-ui font-medium"
       />
 
       {/* Projects */}
-      <div className="mt-4 space-y-4">
+      <div className="mt-[var(--space-4)] space-y-[var(--space-4)]">
         <form
           onSubmit={(e) => {
             e.preventDefault();
@@ -270,7 +270,7 @@ export default function TodayHero({ iso }: Props) {
         </form>
 
         {projects.length > 0 && (
-          <ul className="space-y-2" role="list" aria-label="Projects">
+          <ul className="space-y-[var(--space-2)]" role="list" aria-label="Projects">
             {projects.slice(0, 12).map((p) => {
               const isEditing = editingProjectId === p.id;
               const isSelected = selProjectId === p.id;
@@ -278,7 +278,7 @@ export default function TodayHero({ iso }: Props) {
                 <li
                   key={p.id}
                   className={cn(
-                    "group flex select-none items-center justify-between rounded-card r-card-lg border px-3 py-2 text-ui font-medium transition",
+                    "group flex select-none items-center justify-between rounded-card r-card-lg border px-[var(--space-3)] py-[var(--space-2)] text-ui font-medium transition",
                     "border-border bg-card/55 hover:bg-card/70",
                     isSelected && "ring-1 ring-ring",
                   )}
@@ -313,7 +313,7 @@ export default function TodayHero({ iso }: Props) {
                       onClick={(e) => e.stopPropagation()}
                     />
                   ) : (
-                    <div className="flex items-center gap-3 min-w-0">
+                    <div className="flex items-center gap-[var(--space-3)] min-w-0">
                       <span
                         className="shrink-0"
                         onMouseDown={(e) => e.stopPropagation()}
@@ -337,7 +337,7 @@ export default function TodayHero({ iso }: Props) {
                     </div>
                   )}
 
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-[var(--space-2)]">
                     <IconButton
                       aria-label={`Edit project ${p.name}`}
                       title="Edit"
@@ -371,7 +371,7 @@ export default function TodayHero({ iso }: Props) {
               );
             })}
             {projects.length > 12 && (
-              <li className="pr-1 text-right text-label font-medium tracking-[0.02em] opacity-70">
+              <li className="pr-[var(--space-1)] text-right text-label font-medium tracking-[0.02em] opacity-70">
                 + {projects.length - 12} more…
               </li>
             )}
@@ -381,11 +381,11 @@ export default function TodayHero({ iso }: Props) {
 
       {/* Tasks (only when a project is selected) */}
       {!selProjectId ? (
-        <div className="mt-4 text-ui font-medium text-muted-foreground">
+        <div className="mt-[var(--space-4)] text-ui font-medium text-muted-foreground">
           Select a project to add and view tasks.
         </div>
       ) : (
-        <div className="mt-4 space-y-4">
+        <div className="mt-[var(--space-4)] space-y-[var(--space-4)]">
           <form
             onSubmit={(e) => {
               e.preventDefault();
@@ -414,10 +414,10 @@ export default function TodayHero({ iso }: Props) {
           {scopedTasks.length === 0 ? (
             <div className="tasks-placeholder">No tasks yet.</div>
           ) : (
-            <div className="space-y-2">
+            <div className="space-y-[var(--space-2)]">
               <ul
                 id={tasksListId}
-                className="space-y-2"
+                className="space-y-[var(--space-2)]"
                 role="list"
                 aria-label="Tasks"
               >
@@ -427,13 +427,13 @@ export default function TodayHero({ iso }: Props) {
                     <li
                       key={t.id}
                       className={cn(
-                      "task-tile flex items-center justify-between rounded-card r-card-lg border px-3 py-2",
+                      "task-tile flex items-center justify-between rounded-card r-card-lg border px-[var(--space-3)] py-[var(--space-2)]",
                       "border-border bg-card/55 hover:bg-card/70",
                     )}
                     role="listitem"
                     onClick={() => setSelTaskId(t.id)}
                   >
-                    <div className="flex items-center gap-3">
+                    <div className="flex items-center gap-[var(--space-3)]">
                       <CheckCircle
                         checked={t.done}
                         onChange={() => {
@@ -483,7 +483,7 @@ export default function TodayHero({ iso }: Props) {
                       )}
                     </div>
 
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-[var(--space-2)]">
                       <IconButton
                         aria-label={`Edit task ${t.title}`}
                         title="Edit"

--- a/src/components/planner/WeekNotes.tsx
+++ b/src/components/planner/WeekNotes.tsx
@@ -32,7 +32,7 @@ export default function WeekNotes({ iso }: Props) {
           textareaClassName="min-h-[calc(var(--space-8)*3_-_var(--space-3))] leading-relaxed"
           onBlur={commit}
         />
-        <div className="mt-2 text-label text-muted-foreground" aria-live="polite">
+        <div className="mt-[var(--space-2)] text-label text-muted-foreground" aria-live="polite">
           {saving
             ? "Saving changes…"
             : isDirty

--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -154,7 +154,7 @@ const DayChip = React.forwardRef<HTMLButtonElement, DayChipProps>(function DayCh
           : "Click or press Enter to focus"
       }
       className={cn(
-        "chip relative flex-none w-[--chip-width] rounded-card r-card-lg border text-left px-3 py-2 transition snap-start",
+        "chip relative flex-none w-[--chip-width] rounded-card r-card-lg border text-left px-[var(--space-3)] py-[var(--space-2)] transition snap-start",
         // default border is NOT white; use card hairline tint
         "border-card-hairline",
         completionTint,
@@ -347,7 +347,7 @@ export default function WeekPicker() {
       aria-label="Jump to top"
       onClick={jumpToTop}
       title="Jump to top"
-      className="px-4"
+      className="px-[var(--space-4)]"
     >
       <ArrowUpToLine />
       <span>Top</span>
@@ -363,12 +363,12 @@ export default function WeekPicker() {
       sticky
       dividerTint="primary"
     >
-      <div className="grid gap-3 flex-1">
+      <div className="grid gap-[var(--space-3)] flex-1">
         {/* Range + totals */}
-        <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center justify-between gap-[var(--space-3)]">
           <span
             className={cn(
-              "inline-flex items-center gap-2 rounded-card r-card-lg px-3 py-2 text-ui",
+              "inline-flex items-center gap-[var(--space-2)] rounded-card r-card-lg px-[var(--space-3)] py-[var(--space-2)] text-ui",
               "bg-card/72 ring-1 ring-border/55 backdrop-blur",
             )}
             aria-label={`Week range ${rangeLabel}`}
@@ -386,7 +386,7 @@ export default function WeekPicker() {
         </div>
 
         {/* Day chips */}
-        <div className="flex gap-3 overflow-x-auto snap-x snap-mandatory lg:overflow-visible">
+        <div className="flex gap-[var(--space-3)] overflow-x-auto snap-x snap-mandatory lg:overflow-visible">
           {days.map((d, i) => (
             <DayChip
               key={d}

--- a/src/components/planner/WeekSummary.tsx
+++ b/src/components/planner/WeekSummary.tsx
@@ -50,14 +50,14 @@ export default function WeekSummary({
 
   const grid =
     variant === "inline"
-      ? "grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-7 gap-2"
-      : "grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-7 gap-3";
+      ? "grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-7 gap-[var(--space-2)]"
+      : "grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-7 gap-[var(--space-3)]";
 
   const headingRow =
     variant === "inline" ? (
       showLabel ? (
-        <div className="mb-2 flex items-center justify-between gap-2 text-label font-medium tracking-[0.02em] text-muted-foreground">
-          <div className="flex items-center gap-2">
+        <div className="mb-[var(--space-2)] flex items-center justify-between gap-[var(--space-2)] text-label font-medium tracking-[0.02em] text-muted-foreground">
+          <div className="flex items-center gap-[var(--space-2)]">
             <span className="uppercase tracking-[0.02em]">Week</span>
             <span aria-hidden>•</span>
             <span>{rangeLabel}</span>
@@ -69,7 +69,7 @@ export default function WeekSummary({
         </div>
       ) : null
     ) : (
-      <div className="mb-3 flex items-center gap-3">
+      <div className="mb-[var(--space-3)] flex items-center gap-[var(--space-3)]">
         <div className="text-ui font-medium text-muted-foreground">{rangeLabel}</div>
         <span
           className="ml-auto badge badge--sm"
@@ -96,8 +96,8 @@ export default function WeekSummary({
             className={cn(
               "ws-tile group",
               variant === "inline"
-                ? "p-2 rounded-card r-card-lg"
-                : "p-3 rounded-card r-card-lg",
+                ? "p-[var(--space-2)] rounded-card r-card-lg"
+                : "p-[var(--space-3)] rounded-card r-card-lg",
               today && "ws-tile--today",
               empty && "ws-tile--empty",
             )}


### PR DESCRIPTION
## Summary
- replace hardcoded spacing utilities in home cards and navigation with spacing tokens from the design scale
- refactor planner layout components to express padding, gaps, and offsets through the shared spacing variables
- normalize scroll offsets and floating control placement so responsive layouts continue to match the 12-column grid rhythm

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9dcc07d68832c8dfe08be6c40d025