### PR TITLE
Refactor reminders hero into page header

### DIFF
--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -3,94 +3,20 @@
 
 import * as React from "react";
 import SectionCard from "@/components/ui/layout/SectionCard";
-import Button from "@/components/ui/primitives/Button";
-import Hero from "@/components/ui/layout/Hero";
-import { Search, Sparkles, Gamepad2, GraduationCap, Plus } from "lucide-react";
-import ReminderQuickAddForm from "./reminders/ReminderQuickAddForm";
 import ReminderFilters from "./reminders/ReminderFilters";
 import ReminderList from "./reminders/ReminderList";
-import {
-  RemindersProvider,
-  useReminders,
-  Domain,
-} from "./reminders/useReminders";
-
-const DOMAIN_ITEMS: Array<{
-  key: Domain;
-  label: string;
-  icon: React.ReactNode;
-}> = [
-  { key: "Life", label: "Life", icon: <Sparkles className="mr-1" /> },
-  { key: "League", label: "League", icon: <Gamepad2 className="mr-1" /> },
-  { key: "Learn", label: "Learn", icon: <GraduationCap className="mr-1" /> },
-];
+import ReminderQuickAddForm from "./reminders/ReminderQuickAddForm";
 
 export default function RemindersTab() {
   return (
-    <RemindersProvider>
-      <RemindersContent />
-    </RemindersProvider>
+    <SectionCard className="goal-card">
+      <SectionCard.Body>
+        <div className="grid gap-3">
+          <ReminderQuickAddForm />
+          <ReminderFilters />
+          <ReminderList />
+        </div>
+      </SectionCard.Body>
+    </SectionCard>
   );
 }
-
-function RemindersContent() {
-  const { domain, setDomain, query, setQuery, filtered, addReminder } = useReminders();
-
-  return (
-    <>
-      <Hero
-        frame={false}
-        topClassName="top-[var(--header-stack)]"
-        eyebrow={domain}
-        heading="Reminders"
-        subtitle="Tiny brain pings you’ll totally ignore until 23:59."
-        dividerTint={domain === "Life" ? "life" : "primary"}
-        subTabs={{
-          items: DOMAIN_ITEMS,
-          value: domain,
-          onChange: (key: Domain) => setDomain(key),
-          align: "end",
-          size: "md",
-          ariaLabel: "Reminder domain",
-          showBaseline: true,
-        }}
-        search={{
-          value: query,
-          onValueChange: setQuery,
-          placeholder: "Search title, text, tags…",
-          debounceMs: 80,
-          right: (
-            <div className="flex items-center gap-2">
-              <span className="text-label font-medium tracking-[0.02em] opacity-75">
-                {filtered.length}
-              </span>
-              <Search className="opacity-80" size={16} />
-            </div>
-          ),
-        }}
-        actions={
-          <Button
-            variant="primary"
-            size="md"
-            className="px-4 whitespace-nowrap"
-            onClick={() => addReminder()}
-          >
-            <Plus />
-            <span>New Reminder</span>
-          </Button>
-        }
-      />
-
-      <SectionCard className="goal-card">
-        <SectionCard.Body>
-          <div className="grid gap-3">
-            <ReminderQuickAddForm />
-            <ReminderFilters />
-            <ReminderList />
-          </div>
-        </SectionCard.Body>
-      </SectionCard>
-    </>
-  );
-}
-


### PR DESCRIPTION
## Summary
- wrap the goals page content with RemindersProvider and expose reminder domain/search/actions through the PageHeader hero
- keep the reminders hero eyebrow in sync with the selected domain and reuse the reminder controls from useReminders
- simplify RemindersTab to assume context is provided and render only the quick add, filters, and list card

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c9e15fefc4832c9e206383fe28888e