### PR TITLE
Allow hero frame overflow for sticky content

### DIFF
--- a/src/components/ui/layout/NeomorphicHeroFrame.tsx
+++ b/src/components/ui/layout/NeomorphicHeroFrame.tsx
@@ -49,6 +49,8 @@ export interface NeomorphicHeroFrameProps
   variant?: NeomorphicHeroFrameVariant;
   /** Toggle animated frame layers */
   frame?: boolean;
+  /** Allow content to overflow the frame while clipping neon backdrops */
+  allowOverflow?: boolean;
   /** Optional class applied to the inner content wrapper */
   contentClassName?: string;
   /** Optional action row (tabs, search, buttons) */
@@ -197,6 +199,7 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
       children,
       actionArea,
       highContrast,
+      allowOverflow = false,
       ...rest
     },
     ref,
@@ -252,7 +255,10 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
           ref={ref}
           className={cn(
             "relative",
-            showFrame && "overflow-hidden hero2-frame hero2-neomorph",
+            showFrame &&
+              (allowOverflow
+                ? "overflow-visible hero2-frame hero2-neomorph"
+                : "overflow-hidden hero2-frame hero2-neomorph"),
             variantStyles?.container,
             contrastStyles?.container,
             variantStyles?.padding,
@@ -261,11 +267,14 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
           {...rest}
         >
           {showFrame ? (
-            <>
+            <span
+              aria-hidden
+              className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]"
+            >
               <span aria-hidden className="hero2-beams" />
               <span aria-hidden className="hero2-scanlines" />
               <span aria-hidden className="hero2-noise opacity-[0.03]" />
-            </>
+            </span>
           ) : null}
 
           {content}

--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -89,6 +89,9 @@ const PageHeaderInner = <
 ) => {
   const Component: PageHeaderElement = as ?? "section";
 
+  const headerSticky = header.sticky ?? true;
+  const heroSticky = hero.sticky ?? true;
+
   const {
     tabs: headerTabs,
     underline: headerUnderline,
@@ -154,8 +157,11 @@ const PageHeaderInner = <
     className: frameClassName,
     variant: frameVariant,
     actionArea: frameActionArea,
+    allowOverflow: frameAllowOverflow,
     ...restFrameProps
   } = frameProps ?? {};
+
+  const stickyChildrenPresent = Boolean(headerSticky) || Boolean(heroSticky);
 
   const heroShouldRenderActionArea = frameActionArea === null;
   const heroShouldRenderTabs = heroShouldRenderActionArea || tabsInHero;
@@ -286,6 +292,9 @@ const PageHeaderInner = <
         ref={ref}
         variant={frameVariant ?? "default"}
         actionArea={resolvedFrameActionArea}
+        allowOverflow={
+          frameAllowOverflow ?? stickyChildrenPresent
+        }
         {...restFrameProps}
         className={cn(className, frameClassName)}
       >

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -170,20 +170,25 @@ exports[`ReviewsPage > renders default state 1`] = `
     
       </style>
       <div
-        class="relative overflow-hidden hero2-frame hero2-neomorph rounded-card r-card-lg border border-border/40 bg-card/70 shadow-outline-subtle md:px-[var(--space-7)] md:py-[var(--space-7)] lg:px-[var(--space-8)] lg:py-[var(--space-8)] rounded-card r-card-lg px-4 py-4"
+        class="relative overflow-visible hero2-frame hero2-neomorph rounded-card r-card-lg border border-border/40 bg-card/70 shadow-outline-subtle md:px-[var(--space-7)] md:py-[var(--space-7)] lg:px-[var(--space-8)] lg:py-[var(--space-8)] rounded-card r-card-lg px-4 py-4"
       >
         <span
           aria-hidden="true"
-          class="hero2-beams"
-        />
-        <span
-          aria-hidden="true"
-          class="hero2-scanlines"
-        />
-        <span
-          aria-hidden="true"
-          class="hero2-noise opacity-[0.03]"
-        />
+          class="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]"
+        >
+          <span
+            aria-hidden="true"
+            class="hero2-beams"
+          />
+          <span
+            aria-hidden="true"
+            class="hero2-scanlines"
+          />
+          <span
+            aria-hidden="true"
+            class="hero2-noise opacity-[0.03]"
+          />
+        </span>
         <div
           class="relative z-[2] space-y-[var(--space-5)] md:space-y-[var(--space-6)]"
         >


### PR DESCRIPTION
## Summary
- add an `allowOverflow` toggle to `NeomorphicHeroFrame` and move the neon layers into an inner clipped backdrop so sticky children can extend outside the container without visual regressions
- default `PageHeader` frames to enable the relaxed overflow whenever either the header or hero stays sticky and refresh the Reviews page snapshot

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9e25fec8c832c9c714e270a9dd2fe