### PR TITLE
Simplify hero overlay styling

### DIFF
--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -208,13 +208,7 @@ function Hero<Key extends string = string>({
       {frame ? <NeomorphicFrameStyles /> : null}
 
       <div className={shellClass}>
-        {frame ? (
-          <>
-            <span aria-hidden className="hero2-beams" />
-            <span aria-hidden className="hero2-scanlines" />
-            <span aria-hidden className="hero2-noise opacity-[0.03]" />
-          </>
-        ) : null}
+        {frame ? <span aria-hidden className="hero2-beams" /> : null}
 
         <div className={cx(barSpacingClass, barClassName)}>
           {rail ? <span aria-hidden className="rail" /> : null}

--- a/src/components/ui/layout/NeomorphicFrameStyles.tsx
+++ b/src/components/ui/layout/NeomorphicFrameStyles.tsx
@@ -8,112 +8,20 @@ export function NeomorphicFrameStyles() {
     <style jsx global>{`
       .hero2-beams {
         position: absolute;
-        inset: calc(var(--space-1) / -2);
-        border-radius: var(--radius-2xl);
+        inset: var(--space-1);
+        border-radius: calc(var(--radius-2xl) - var(--space-1) / 2);
         z-index: 0;
         pointer-events: none;
-        background:
-          linear-gradient(
-              100deg,
-              transparent 0%,
-              hsl(var(--primary) / 0.18) 10%,
-              transparent 22%
-            )
-            0 0/100% 100%,
-          linear-gradient(
-              260deg,
-              transparent 0%,
-              hsl(var(--accent) / 0.2) 8%,
-              transparent 20%
-            )
-            0 0/100% 100%;
-        mix-blend-mode: screen;
-        animation: hero2-beam-pan 7s linear infinite;
+        background: linear-gradient(
+          150deg,
+          hsl(var(--highlight) / 0.16),
+          hsl(var(--accent) / 0.08) 45%,
+          hsl(var(--ring) / 0.06)
+        );
       }
-      @media (prefers-reduced-motion: reduce) {
-        .hero2-beams {
-          animation: none;
-          display: none;
-        }
-      }
-      @keyframes hero2-beam-pan {
-        0% {
-          transform: translateX(-3%);
-        }
-        50% {
-          transform: translateX(3%);
-        }
-        100% {
-          transform: translateX(-3%);
-        }
-      }
-      .hero2-scanlines {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        pointer-events: none;
-        background:
-          linear-gradient(
-            transparent 94%,
-            hsl(var(--foreground) / 0.5) 96%,
-            transparent 98%
-          ),
-          linear-gradient(
-            90deg,
-            transparent 94%,
-            hsl(var(--foreground) / 0.4) 96%,
-            transparent 98%
-          );
-        background-size:
-          100% calc(var(--space-4) - var(--space-1) / 2),
-          calc(var(--space-4) - var(--space-1) / 2) 100%;
-        opacity: 0.07;
-        animation: hero2-scan-move 6s linear infinite;
-      }
-      @media (prefers-reduced-motion: reduce) {
-        .hero2-scanlines {
-          animation: none;
-          display: none;
-        }
-      }
-      @keyframes hero2-scan-move {
-        0% {
-          background-position:
-            0 0,
-            0 0;
-        }
-        100% {
-          background-position:
-            0 calc(var(--space-4) - var(--space-1) / 2),
-            calc(var(--space-4) - var(--space-1) / 2) 0;
-        }
-      }
+      .hero2-scanlines,
       .hero2-noise {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        pointer-events: none;
-        opacity: 0.03;
-        mix-blend-mode: overlay;
-        background-image: url("data:image/svg+xml;utf8,\
-        <svg xmlns='http://www.w3.org/2000/svg' width='140' height='140' viewBox='0 0 140 140'>\
-          <filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/></filter>\
-          <rect width='100%' height='100%' filter='url(%23n)' opacity='0.38'/></svg>");
-        background-size: calc(var(--space-8) * 4 + var(--space-5))
-          calc(var(--space-8) * 4 + var(--space-5));
-        animation: hero2-noise-shift 1.8s steps(2, end) infinite;
-      }
-      @media (prefers-reduced-motion: reduce) {
-        .hero2-noise {
-          animation: none;
-          background-position: 0 0;
-          display: none;
-        }
-      }
-      @keyframes hero2-noise-shift {
-        50% {
-          background-position: 50% 50%;
-        }
+        display: none !important;
       }
       .hero2-neomorph {
         background: linear-gradient(

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -16,109 +16,20 @@ exports[`ReviewsPage > renders default state 1`] = `
         
       .hero2-beams {
         position: absolute;
-        inset: calc(var(--space-1) / -2);
-        border-radius: var(--radius-2xl);
+        inset: var(--space-1);
+        border-radius: calc(var(--radius-2xl) - var(--space-1) / 2);
         z-index: 0;
         pointer-events: none;
-        background:
-          linear-gradient(
-              100deg,
-              transparent 0%,
-              hsl(var(--primary) / 0.18) 10%,
-              transparent 22%
-            )
-            0 0/100% 100%,
-          linear-gradient(
-              260deg,
-              transparent 0%,
-              hsl(var(--accent) / 0.2) 8%,
-              transparent 20%
-            )
-            0 0/100% 100%;
-        mix-blend-mode: screen;
-        animation: hero2-beam-pan 7s linear infinite;
+        background: linear-gradient(
+          150deg,
+          hsl(var(--highlight) / 0.16),
+          hsl(var(--accent) / 0.08) 45%,
+          hsl(var(--ring) / 0.06)
+        );
       }
-      @media (prefers-reduced-motion: reduce) {
-        .hero2-beams {
-          animation: none;
-          display: none;
-        }
-      }
-      @keyframes hero2-beam-pan {
-        0% {
-          transform: translateX(-3%);
-        }
-        50% {
-          transform: translateX(3%);
-        }
-        100% {
-          transform: translateX(-3%);
-        }
-      }
-      .hero2-scanlines {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        pointer-events: none;
-        background:
-          linear-gradient(
-            transparent 94%,
-            hsl(var(--foreground) / 0.5) 96%,
-            transparent 98%
-          ),
-          linear-gradient(
-            90deg,
-            transparent 94%,
-            hsl(var(--foreground) / 0.4) 96%,
-            transparent 98%
-          );
-        background-size:
-          100% calc(var(--space-4) - var(--space-1) / 2),
-          calc(var(--space-4) - var(--space-1) / 2) 100%;
-        opacity: 0.07;
-        animation: hero2-scan-move 6s linear infinite;
-      }
-      @media (prefers-reduced-motion: reduce) {
-        .hero2-scanlines {
-          animation: none;
-          display: none;
-        }
-      }
-      @keyframes hero2-scan-move {
-        0% {
-          background-position:
-            0 0,
-            0 0;
-        }
-        100% {
-          background-position:
-            0 calc(var(--space-4) - var(--space-1) / 2),
-            calc(var(--space-4) - var(--space-1) / 2) 0;
-        }
-      }
+      .hero2-scanlines,
       .hero2-noise {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        pointer-events: none;
-        opacity: 0.03;
-        mix-blend-mode: overlay;
-        background-image: url("data:image/svg+xml;utf8,        &lt;svg xmlns='http://www.w3.org/2000/svg' width='140' height='140' viewBox='0 0 140 140'&gt;          &lt;filter id='n'&gt;&lt;feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/&gt;&lt;/filter&gt;          &lt;rect width='100%' height='100%' filter='url(%23n)' opacity='0.38'/&gt;&lt;/svg&gt;");
-        background-size: calc(var(--space-8) * 4 + var(--space-5))
-          calc(var(--space-8) * 4 + var(--space-5));
-        animation: hero2-noise-shift 1.8s steps(2, end) infinite;
-      }
-      @media (prefers-reduced-motion: reduce) {
-        .hero2-noise {
-          animation: none;
-          background-position: 0 0;
-          display: none;
-        }
-      }
-      @keyframes hero2-noise-shift {
-        50% {
-          background-position: 50% 50%;
-        }
+        display: none !important;
       }
       .hero2-neomorph {
         background: linear-gradient(


### PR DESCRIPTION
## Summary
- replace the hero frame beam/scanline/noise layers with a single subtle gradient
- stop rendering the extra scanline and noise spans in the Hero soft-3D frame
- refresh the ReviewsPage snapshot to capture the updated frame styling

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9e753a028832c85e35cdd963bd196