### PR TITLE
Align Lavender-Glitch backdrop with page shell

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,6 +16,24 @@
     padding-inline: clamp(var(--space-3), 2.5vw, var(--space-6));
   }
 
+  .page-backdrop {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .page-backdrop > .page-shell {
+    position: relative;
+    height: 100%;
+  }
+
+  .page-backdrop__layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
   /* Optional global overlays */
   html.fx-scanlines::after,
   body.fx-scanlines::after {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -59,6 +59,11 @@ export default function RootLayout({
           Skip to main content
         </a>
         <ThemeProvider>
+          <div aria-hidden className="page-backdrop">
+            <div className="page-shell">
+              <div className="page-backdrop__layer" />
+            </div>
+          </div>
           <SiteChrome />
           <CatCompanion />
           <div id="main-content" tabIndex={-1} className="relative z-10">

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -302,7 +302,13 @@ html:not(.theme-citrus):not(.theme-noir):not(.theme-ocean):not(
   body::before {
   content: "";
   position: fixed;
-  inset: 0;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin-inline: auto;
+  width: min(100vw, var(--shell-max, var(--shell-width)));
+  max-width: var(--shell-max, var(--shell-width));
   pointer-events: none;
   z-index: 0;
   opacity: 0.1;
@@ -320,17 +326,12 @@ html:not(.theme-citrus):not(.theme-noir):not(.theme-ocean):not(
   mix-blend-mode: screen;
   animation: lg-grid-drift 18s linear infinite;
 }
-html.theme-lg body::after,
-html.theme-lg-dark body::after,
+html.theme-lg .page-backdrop__layer,
+html.theme-lg-dark .page-backdrop__layer,
 html:not(.theme-citrus):not(.theme-noir):not(.theme-ocean):not(
     .theme-kitten
   ):not(.theme-aurora):not(.theme-hardstuck)
-  body::after {
-  content: "";
-  position: fixed;
-  inset: -10%;
-  pointer-events: none;
-  z-index: 0;
+  .page-backdrop__layer {
   background:
     radial-gradient(
       60% 40% at 10% 0%,
@@ -885,7 +886,8 @@ html.bg-streak body::after {
 html.bg-intense body::before {
   opacity: 0.05;
 }
-html.bg-intense body::after {
+html.bg-intense body::after,
+html.bg-intense .page-backdrop__layer {
   filter: blur(2px) saturate(120%);
 }
 


### PR DESCRIPTION
## Summary
- add a page-shell-aligned backdrop wrapper so theme layers sit within the layout gutters
- constrain the Lavender-Glitch grid overlay width and move the aurora wash to the new backdrop element
- keep intensity mode blur effects working with the updated backdrop structure

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9f08f3d94832ca4d9881b19d44049