### PR TITLE
Remove default glow styling from headings

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -166,6 +166,16 @@ html.bg-intense body::after {
 .title-ghost,
 :where(h1, h2, h3, .card-title) {
   position: relative;
+}
+
+.title-ghost {
+  text-shadow:
+    var(--space-0-25) 0 hsl(var(--accent-2)),
+    calc(var(--space-0-25) * -1) 0 hsl(var(--lav-deep));
+  animation: ghost 3.2s ease-in-out infinite;
+}
+
+html.fx-overdrive :where(h1, h2, h3, .card-title) {
   text-shadow:
     var(--space-0-25) 0 hsl(var(--accent-2)),
     calc(var(--space-0-25) * -1) 0 hsl(var(--lav-deep));
@@ -176,7 +186,7 @@ html.bg-intense body::after {
   animation: none !important;
 }
 .title-glow {
-  text-shadow: 0 0 calc(var(--space-4) + var(--space-1)) hsl(var(--ring) / 0.3);
+  position: relative;
 }
 
 /* Glitch utility (subtle RGB offset) */
@@ -186,7 +196,7 @@ html.bg-intense body::after {
     drop-shadow(calc(var(--space-0-25) * -1) 0 0 hsl(var(--lav-deep)));
 }
 /* Hero glow rim (used on Hero card) */
-.title-glow {
+html.fx-overdrive .title-glow {
   text-shadow:
     0 0 calc(var(--space-2) - var(--space-0-5)) hsl(var(--ring) / 0.6),
     0 0 calc(var(--space-3) + var(--space-0-5)) hsl(var(--accent) / 0.5);

--- a/src/components/home/DashboardCard.tsx
+++ b/src/components/home/DashboardCard.tsx
@@ -20,7 +20,7 @@ export default function DashboardCard({
   return (
     <NeoCard className="p-[var(--space-4)] md:p-[var(--space-6)] space-y-[var(--space-4)]">
       <div className="flex items-center justify-between">
-        <h2 className="text-body font-semibold tracking-[-0.01em]">{title}</h2>
+        <h2 className="text-body font-semibold tracking-[-0.01em] text-card-foreground">{title}</h2>
         {actions}
       </div>
       {children && (

--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -197,7 +197,7 @@ export default function Header<Key extends string = string>({
                   </div>
                 ) : null}
                 <div className="flex min-w-0 items-baseline gap-[var(--space-2)]">
-                  <h1 className="text-balance break-words text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow">
+                  <h1 className="text-balance break-words text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em]">
                     {heading}
                   </h1>
                   {subtitle ? (

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -148,7 +148,7 @@ function Hero<Key extends string = string>({
     : "flex flex-wrap items-start gap-[var(--space-2)] md:flex-nowrap md:items-center md:gap-[var(--space-3)] lg:gap-[var(--space-4)] pt-[var(--space-4)] md:pt-[var(--space-5)]";
 
   const headingClassName = cx(
-    "title-glow font-semibold tracking-[-0.01em] text-balance break-words",
+    "font-semibold tracking-[-0.01em] text-balance break-words text-foreground",
     frame ? "hero2-title" : undefined,
     isSupportiveTone
       ? "text-title md:text-title"

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -154,7 +154,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                         class="flex min-w-0 items-baseline gap-[var(--space-2)]"
                       >
                         <h1
-                          class="text-balance break-words text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em] title-glow"
+                          class="text-balance break-words text-title leading-tight text-foreground sm:text-title-lg font-semibold tracking-[-0.01em]"
                         >
                           Reviews
                         </h1>
@@ -182,7 +182,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                       class="flex min-w-0 flex-wrap items-baseline gap-x-[var(--space-2)] gap-y-[var(--space-1)]"
                     >
                       <h2
-                        class="title-glow font-semibold tracking-[-0.01em] text-balance break-words text-title md:text-title"
+                        class="font-semibold tracking-[-0.01em] text-balance break-words text-foreground text-title md:text-title"
                         data-text="Browse Reviews"
                       >
                         Browse Reviews


### PR DESCRIPTION
## Summary
- gate the global heading and helper glow text-shadows behind the fx-overdrive toggle so default typography stays crisp
- stop applying the `title-glow` utility in the hero and header layouts, leaning on the existing type ramp and color tokens
- ensure dashboard card titles use the card foreground token for AA contrast without relying on glow effects

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9fae13380832cbb2d2dda8a2fbb42