### PR TITLE
Remove hero overlay beams

### DIFF
--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -153,13 +153,6 @@ export default function Header<Key extends string = string>({
         )}
         {...rest}
       >
-        {isNeo ? (
-          <>
-            <span aria-hidden className="hero2-beams" />
-            <span aria-hidden className="hero2-scanlines" />
-            <span aria-hidden className="hero2-noise opacity-[0.03]" />
-          </>
-        ) : null}
         {/* Top bar */}
         <div
           className={cx(

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -208,7 +208,6 @@ function Hero<Key extends string = string>({
       {frame ? <NeomorphicFrameStyles /> : null}
 
       <div className={shellClass}>
-        {frame ? <span aria-hidden className="hero2-beams" /> : null}
 
         <div className={cx(barSpacingClass, barClassName)}>
           {rail ? <span aria-hidden className="rail" /> : null}

--- a/src/components/ui/layout/NeomorphicFrameStyles.tsx
+++ b/src/components/ui/layout/NeomorphicFrameStyles.tsx
@@ -6,23 +6,6 @@ import * as React from "react";
 export function NeomorphicFrameStyles() {
   return (
     <style jsx global>{`
-      .hero2-beams {
-        position: absolute;
-        inset: var(--space-1);
-        border-radius: calc(var(--radius-2xl) - var(--space-1) / 2);
-        z-index: 0;
-        pointer-events: none;
-        background: linear-gradient(
-          150deg,
-          hsl(var(--highlight) / 0.16),
-          hsl(var(--accent) / 0.08) 45%,
-          hsl(var(--ring) / 0.06)
-        );
-      }
-      .hero2-scanlines,
-      .hero2-noise {
-        display: none !important;
-      }
       .hero2-neomorph {
         background: linear-gradient(
           145deg,
@@ -37,11 +20,6 @@ export function NeomorphicFrameStyles() {
           0 0 var(--space-4) hsl(var(--ring) / 0.25);
       }
       @media (prefers-contrast: more) {
-        .hero2-beams,
-        .hero2-scanlines,
-        .hero2-noise {
-          display: none !important;
-        }
         .hero2-frame {
           border-color: hsl(var(--foreground) / 0.7) !important;
         }
@@ -56,11 +34,6 @@ export function NeomorphicFrameStyles() {
         }
       }
       @media (forced-colors: active) {
-        .hero2-beams,
-        .hero2-scanlines,
-        .hero2-noise {
-          display: none !important;
-        }
         .hero2-frame {
           border-color: CanvasText !important;
           background: Canvas !important;

--- a/src/components/ui/layout/NeomorphicHeroFrame.tsx
+++ b/src/components/ui/layout/NeomorphicHeroFrame.tsx
@@ -266,17 +266,6 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
           )}
           {...rest}
         >
-          {showFrame ? (
-            <span
-              aria-hidden
-              className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]"
-            >
-              <span aria-hidden className="hero2-beams" />
-              <span aria-hidden className="hero2-scanlines" />
-              <span aria-hidden className="hero2-noise opacity-[0.03]" />
-            </span>
-          ) : null}
-
           {content}
 
           {hasActionArea ? (

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -14,23 +14,6 @@ exports[`ReviewsPage > renders default state 1`] = `
         jsx="true"
       >
         
-      .hero2-beams {
-        position: absolute;
-        inset: var(--space-1);
-        border-radius: calc(var(--radius-2xl) - var(--space-1) / 2);
-        z-index: 0;
-        pointer-events: none;
-        background: linear-gradient(
-          150deg,
-          hsl(var(--highlight) / 0.16),
-          hsl(var(--accent) / 0.08) 45%,
-          hsl(var(--ring) / 0.06)
-        );
-      }
-      .hero2-scanlines,
-      .hero2-noise {
-        display: none !important;
-      }
       .hero2-neomorph {
         background: linear-gradient(
           145deg,
@@ -45,11 +28,6 @@ exports[`ReviewsPage > renders default state 1`] = `
           0 0 var(--space-4) hsl(var(--ring) / 0.25);
       }
       @media (prefers-contrast: more) {
-        .hero2-beams,
-        .hero2-scanlines,
-        .hero2-noise {
-          display: none !important;
-        }
         .hero2-frame {
           border-color: hsl(var(--foreground) / 0.7) !important;
         }
@@ -64,11 +42,6 @@ exports[`ReviewsPage > renders default state 1`] = `
         }
       }
       @media (forced-colors: active) {
-        .hero2-beams,
-        .hero2-scanlines,
-        .hero2-noise {
-          display: none !important;
-        }
         .hero2-frame {
           border-color: CanvasText !important;
           background: Canvas !important;
@@ -83,23 +56,6 @@ exports[`ReviewsPage > renders default state 1`] = `
       <div
         class="relative overflow-visible hero2-frame hero2-neomorph rounded-card r-card-lg border border-border/40 bg-card/70 shadow-outline-subtle md:px-[var(--space-7)] md:py-[var(--space-7)] lg:px-[var(--space-8)] lg:py-[var(--space-8)] rounded-card r-card-lg px-4 py-4"
       >
-        <span
-          aria-hidden="true"
-          class="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]"
-        >
-          <span
-            aria-hidden="true"
-            class="hero2-beams"
-          />
-          <span
-            aria-hidden="true"
-            class="hero2-scanlines"
-          />
-          <span
-            aria-hidden="true"
-            class="hero2-noise opacity-[0.03]"
-          />
-        </span>
         <div
           class="relative z-[2] space-y-[var(--space-5)] md:space-y-[var(--space-6)]"
         >


### PR DESCRIPTION
## Summary
- drop the hero beam overlays so the neomorphic shell renders on the base surface
- remove the unused beam/scanline/noise styles from the shared frame styles and hero frame wrapper
- update the reviews page snapshot to reflect the simplified markup

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca2172b508832cabafd38286394d51