### PR TITLE
Improve AnimatedSelect option accessibility

### DIFF
--- a/src/components/ui/select/AnimatedSelect.tsx
+++ b/src/components/ui/select/AnimatedSelect.tsx
@@ -7,6 +7,8 @@ import { Check, ChevronDown, ChevronRight } from "lucide-react";
 import useMounted from "@/lib/useMounted";
 import { cn } from "@/lib/utils";
 
+import Spinner from "../feedback/Spinner";
+
 import defaultStyles from "./Select.module.css";
 import type { AnimatedSelectProps } from "./shared";
 
@@ -422,6 +424,8 @@ const AnimatedSelect = React.forwardRef<
                           aria-selected={active}
                           data-index={idx}
                           disabled={disabledItem}
+                          aria-disabled={disabledItem || undefined}
+                          aria-busy={it.loading || undefined}
                           onClick={() => selectByIndex(idx)}
                           onFocus={() => setActiveIndex(idx)}
                           className={cn(
@@ -442,15 +446,27 @@ const AnimatedSelect = React.forwardRef<
                             <span className={cn("text-ui leading-none", styles.glitchText)}>
                               {it.label}
                             </span>
-                            <Check
-                              className={cn(
-                                "size-[var(--space-4)] shrink-0 transition-opacity duration-[var(--dur-quick)] ease-out motion-reduce:transition-none",
-                                active
-                                  ? "opacity-90"
-                                  : "opacity-0 group-hover:opacity-30",
-                              )}
-                              aria-hidden="true"
-                            />
+                            {it.loading ? (
+                              <span
+                                aria-hidden="true"
+                                className="flex size-[var(--space-4)] shrink-0 items-center justify-center"
+                              >
+                                <Spinner
+                                  size="var(--space-4)"
+                                  className="border-border border-t-transparent opacity-80"
+                                />
+                              </span>
+                            ) : (
+                              <Check
+                                className={cn(
+                                  "size-[var(--space-4)] shrink-0 transition-opacity duration-[var(--dur-quick)] ease-out motion-reduce:transition-none",
+                                  active
+                                    ? "opacity-90"
+                                    : "opacity-0 group-hover:opacity-30",
+                                )}
+                                aria-hidden="true"
+                              />
+                            )}
                           </div>
 
                           <span

--- a/tests/ui/animated-select.accessibility.test.tsx
+++ b/tests/ui/animated-select.accessibility.test.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import Select from "../../src/components/ui/Select";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("AnimatedSelect accessibility", () => {
+  it("marks disabled and loading options with appropriate ARIA attributes", async () => {
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    const originalCancelAnimationFrame = window.cancelAnimationFrame;
+
+    window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    }) as typeof window.requestAnimationFrame;
+    window.cancelAnimationFrame = vi.fn() as unknown as typeof window.cancelAnimationFrame;
+
+    try {
+      render(
+        <Select
+          variant="animated"
+          label="Schedule"
+          items={[
+            { value: "now", label: "Immediate" },
+            { value: "soon", label: "Later today", disabled: true },
+            { value: "later", label: "Tomorrow", loading: true },
+          ]}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Schedule" }));
+
+      const disabledOption = await screen.findByRole("option", { name: "Later today" });
+      expect(disabledOption).toHaveAttribute("aria-disabled", "true");
+      expect(disabledOption).toBeDisabled();
+
+      const loadingOption = await screen.findByRole("option", { name: "Tomorrow" });
+      expect(loadingOption).toHaveAttribute("aria-disabled", "true");
+      expect(loadingOption).toHaveAttribute("aria-busy", "true");
+      expect(loadingOption).toHaveAccessibleName("Tomorrow");
+    } finally {
+      window.requestAnimationFrame = originalRequestAnimationFrame;
+      window.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary
- add aria-disabled and aria-busy attributes to AnimatedSelect options and display a loading spinner that is hidden from assistive tech
- ensure loading visuals stay out of the accessible name while preserving the active check indicator for ready options
- cover the new semantics with a focused accessibility test for disabled and loading items

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca23ac6324832c82aa2561b42be1c1