### PR TITLE
Remove decorative hero text shadows

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -169,16 +169,10 @@ html.bg-intense body::after {
 }
 
 .title-ghost {
-  text-shadow:
-    var(--space-0-25) 0 hsl(var(--accent-2)),
-    calc(var(--space-0-25) * -1) 0 hsl(var(--lav-deep));
   animation: ghost 3.2s ease-in-out infinite;
 }
 
 html.fx-overdrive :where(h1, h2, h3, .card-title) {
-  text-shadow:
-    var(--space-0-25) 0 hsl(var(--accent-2)),
-    calc(var(--space-0-25) * -1) 0 hsl(var(--lav-deep));
   animation: ghost 3.2s ease-in-out infinite;
 }
 .no-ghost {
@@ -196,12 +190,6 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
     drop-shadow(calc(var(--space-0-25) * -1) 0 0 hsl(var(--lav-deep)));
 }
 /* Hero glow rim (used on Hero card) */
-html.fx-overdrive .title-glow {
-  text-shadow:
-    0 0 calc(var(--space-2) - var(--space-0-5)) hsl(var(--ring) / 0.6),
-    0 0 calc(var(--space-3) + var(--space-0-5)) hsl(var(--accent) / 0.5);
-}
-
 /* Neon text glow */
 .neon-glow {
   color: hsl(var(--neon));
@@ -1404,8 +1392,6 @@ textarea:-webkit-autofill {
   }
   .title-glow {
     @apply text-2xl font-semibold;
-    text-shadow: 0 0 calc(var(--space-4) + var(--space-1))
-      hsl(var(--glow-strong));
   }
 }
 .ds-grid-gap {

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -149,7 +149,6 @@ function Hero<Key extends string = string>({
 
   const headingClassName = cx(
     "font-semibold tracking-[-0.01em] text-balance break-words text-foreground",
-    frame ? "hero2-title" : undefined,
     isSupportiveTone
       ? "text-title md:text-title"
       : "text-title-lg md:text-title-lg",
@@ -386,10 +385,6 @@ export function HeroGlitchStyles() {
       /* === Glitch title ================================================== */
       .hero2-title {
         position: relative;
-        text-shadow:
-          -0.02em 0 hsl(var(--accent-2) / 0.65),
-          0.02em 0 hsl(var(--lav-deep) / 0.65),
-          0 0 0.25em hsl(var(--foreground) / 0.35);
       }
       .hero2-title::before,
       .hero2-title::after {


### PR DESCRIPTION
## Summary
- remove legacy text-shadow effects from global ghost/glow utility selectors so headings and card titles inherit theme surfaces
- drop the hero-specific `hero2-title` class and strip text-shadow rules from the injected glitch styles to leave typography clean

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68ca29287288832cac1e5b58b39827ee