### PR TITLE
Ensure HeroTabs always have accessible name

### DIFF
--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -340,7 +340,7 @@ export function HeroTabs<K extends string>(props: {
       align={align}
       size={size}
       right={right}
-      ariaLabel={ariaLabel}
+      ariaLabel={ariaLabel ?? "Hero tabs"}
       className={className}
       showBaseline={showBaseline}
       variant={variant}


### PR DESCRIPTION
## Summary
- default the HeroTabs adapter aria-label to "Hero tabs" so the rendered tablist always announces a name

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68ca2f61fe64832c95c4ebfac79ab21b