### PR TITLE
Remove keyboard focus from decorative room card

### DIFF
--- a/src/components/home/IsometricRoom.tsx
+++ b/src/components/home/IsometricRoom.tsx
@@ -29,7 +29,6 @@ export default function IsometricRoom({ variant }: IsometricRoomProps) {
     <Card
       role="img"
       aria-label={`Isometric room with ${label}`}
-      tabIndex={0}
       className={`relative h-48 overflow-hidden bg-background border shadow-neo transition-transform motion-reduce:transition-none hover:-translate-y-1 hover:shadow-neo active:shadow-neo-inset focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:hover:translate-y-0 ${VARIANT_STYLES[variant]}`}
     >
       <div className="absolute inset-0 [transform-style:preserve-3d]">


### PR DESCRIPTION
## Summary
- remove the `tabIndex` attribute from the home page isometric room card so the decorative figure is no longer tabbable

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca31b61a84832ca046f42826086e2a