### PR TITLE
Increase shell width to 1280px

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 @layer base {
   :root {
-    --shell-width: 1120px;
+    --shell-width: 1280px;
     --shell-max: var(--shell-width);
     --accent-2-foreground: var(--primary-foreground);
     --danger-foreground: var(--primary-foreground);


### PR DESCRIPTION
## Summary
- update the global shell width token to 1280px so layouts can expand while keeping overrides in sync

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca33eccf54832cba2dc40b260f9818