### PR TITLE
Adjust WeekPicker chip text contrast

### DIFF
--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -87,17 +87,17 @@ const DayChip = React.forwardRef<HTMLButtonElement, DayChipProps>(function DayCh
     }
     return ratio;
   }, [done, total]);
-  const completionTint = React.useMemo(() => {
+  const { tint: completionTint, text: completionTextClass } = React.useMemo(() => {
     if (total === 0) {
-      return "bg-card";
+      return { tint: "bg-card", text: "text-muted-foreground" };
     }
     if (completionRatio >= 2 / 3) {
-      return "bg-success-soft";
+      return { tint: "bg-success-soft", text: "text-foreground" };
     }
     if (completionRatio >= 1 / 3) {
-      return "bg-warning-soft";
+      return { tint: "bg-warning-soft", text: "text-foreground" };
     }
-    return "bg-warning-soft-strong";
+    return { tint: "bg-warning-soft-strong", text: "text-foreground" };
   }, [completionRatio, total]);
   const instructionsId = React.useId();
   const countsId = React.useId();
@@ -174,7 +174,8 @@ const DayChip = React.forwardRef<HTMLButtonElement, DayChipProps>(function DayCh
       <div
         className={cn(
           "chip__date",
-          today ? "text-accent" : "text-muted-foreground",
+          completionTextClass,
+          today && completionTint === "bg-card" ? "text-accent" : undefined,
         )}
         data-text={localizedLabel}
       >

--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -512,7 +512,8 @@
 
 /* compact internals */
 .chip__date {
-  @apply text-label font-medium tracking-[0.02em] text-muted-foreground;
+  @apply text-label font-medium tracking-[0.02em];
+  color: inherit;
 }
 .chip__counts {
   margin-top: var(--space-1);


### PR DESCRIPTION
## Summary
- derive chip completion tones that pair tinted backgrounds with accessible text tokens in WeekPicker
- keep the “today” accent limited to the neutral card tone and let tinted chips fall back to foreground text
- update the chip date base style to inherit color so React controls the state-specific text classes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca3469eba8832ca45a85cf8b116821