### PR TITLE
feat: allow Button to render anchors

### DIFF
--- a/src/components/home/QuickActions.tsx
+++ b/src/components/home/QuickActions.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 import Button from "@/components/ui/primitives/Button";
-import Link from "next/link";
 
 const quickActionButtonClassName =
   "rounded-[var(--radius-2xl)] [--focus:var(--theme-ring)] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none";
@@ -11,14 +10,14 @@ export default function QuickActions() {
   return (
     <section aria-label="Quick actions" className="grid gap-[var(--space-4)]">
       <div className="flex flex-col gap-[var(--space-4)] md:flex-row md:items-center md:justify-between">
-        <Button asChild className={quickActionButtonClassName}>
-          <Link href="/planner">Planner Today</Link>
+        <Button href="/planner" className={quickActionButtonClassName}>
+          Planner Today
         </Button>
-        <Button asChild className={quickActionButtonClassName} tone="accent">
-          <Link href="/goals">New Goal</Link>
+        <Button href="/goals" className={quickActionButtonClassName} tone="accent">
+          New Goal
         </Button>
-        <Button asChild className={quickActionButtonClassName} tone="accent">
-          <Link href="/reviews">New Review</Link>
+        <Button href="/reviews" className={quickActionButtonClassName} tone="accent">
+          New Review
         </Button>
       </div>
     </section>

--- a/storybook/src/components/ui/Button.stories.tsx
+++ b/storybook/src/components/ui/Button.stories.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "@/components/ui";
+
+const meta: Meta<typeof Button> = {
+  title: "Primitives/Button",
+  component: Button,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Buttons can render native buttons by default or anchors when `href` is provided. The same size, tone, and motion tokens apply across both variants.",
+      },
+    },
+  },
+  args: {
+    tone: "primary",
+    variant: "secondary",
+    size: "md",
+    children: "Action",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const Playground: Story = {};
+
+export const AsAnchor: Story = {
+  args: {
+    href: "https://planner.example/link",
+    tone: "accent",
+    variant: "primary",
+    children: "Anchor CTA",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Passing `href` renders the button as an anchor while keeping hover, focus, active, loading, and disabled behavior aligned with the button variant.",
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- extend the button primitive so href/asChild render anchors without losing existing motion, tone, and loading behaviours
- update home quick actions to use the anchor-aware button API
- document the anchor variant in Storybook for future regressions

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca317c9270832cb007688490bffdc1