### PR TITLE
Adjust accent text colors for contrast

### DIFF
--- a/src/components/goals/GoalList.tsx
+++ b/src/components/goals/GoalList.tsx
@@ -209,7 +209,9 @@ export default function GoalList({
                     </time>
                   </span>
                   <span
-                    className={g.done ? "text-muted-foreground" : "text-accent"}
+                    className={
+                      g.done ? "text-muted-foreground" : "text-accent-3"
+                    }
                   >
                     {g.done ? "Done" : "Active"}
                   </span>

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -234,8 +234,8 @@ function GoalsPageContent() {
           <span className="text-foreground">{ACTIVE_CAP} active</span>
         </li>
         <li className="inline-flex items-center gap-[var(--space-1)]">
-          <span className="font-semibold text-accent">Remaining</span>
-          <span className="text-accent">{remaining}</span>
+          <span className="font-semibold text-accent-3">Remaining</span>
+          <span className="text-accent-3">{remaining}</span>
         </li>
         <li className="inline-flex items-center gap-[var(--space-1)]">
           <span className="font-semibold text-success">Complete</span>
@@ -248,7 +248,7 @@ function GoalsPageContent() {
       </ul>
     ) : tab === "reminders" ? (
       <>
-        Keep <span className="font-semibold text-accent">nudges</span> handy with quick edit loops.
+        Keep <span className="font-semibold text-accent-3">nudges</span> handy with quick edit loops.
       </>
     ) : (
       <>
@@ -281,8 +281,8 @@ function GoalsPageContent() {
           <span className="text-label text-primary">{activeCount}</span>
         </span>
         <span className="inline-flex items-center gap-[var(--space-1)]">
-          <span className="text-label font-semibold text-accent">Remaining</span>
-          <span className="text-label text-accent">{remaining}</span>
+          <span className="text-label font-semibold text-accent-3">Remaining</span>
+          <span className="text-label text-accent-3">{remaining}</span>
         </span>
         <span className="inline-flex items-center gap-[var(--space-1)]">
           <span className="text-label font-semibold text-success">Done</span>
@@ -295,7 +295,7 @@ function GoalsPageContent() {
   } else if (tab === "reminders") {
     heroSubtitle = (
       <span id={heroSubtitleId} className="text-muted-foreground">
-        Stage <span className="font-semibold text-accent">nudges</span> with contexts and cadence.
+        Stage <span className="font-semibold text-accent-3">nudges</span> with contexts and cadence.
       </span>
     );
   } else {

--- a/src/components/home/BottomNav.tsx
+++ b/src/components/home/BottomNav.tsx
@@ -38,7 +38,7 @@ export default function BottomNav() {
                 className={cn(
                   "group flex flex-col items-center gap-[var(--space-1)] rounded-xl px-[var(--space-3)] py-[var(--space-2)] text-label font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none",
                   active
-                    ? "text-accent ring-2 ring-[--theme-ring]"
+                    ? "text-accent-3 ring-2 ring-[--theme-ring]"
                     : "text-muted-foreground hover:text-foreground"
                 )}
               >

--- a/src/components/home/DashboardCard.tsx
+++ b/src/components/home/DashboardCard.tsx
@@ -31,7 +31,7 @@ export default function DashboardCard({
       {cta && (
         <Link
           href={cta.href}
-          className="inline-flex items-center text-ui font-medium text-accent underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
+          className="inline-flex items-center text-ui font-medium text-accent-3 underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent-3 active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
         >
           {cta.label}
         </Link>

--- a/src/components/home/GoalsCard.tsx
+++ b/src/components/home/GoalsCard.tsx
@@ -128,7 +128,7 @@ export default function GoalsCard() {
             </span>
             <Link
               href="/goals"
-              className="inline-flex items-center text-label font-medium text-accent underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
+              className="inline-flex items-center text-label font-medium text-accent-3 underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent-3 active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
             >
               Create
             </Link>

--- a/src/components/home/ReviewsCard.tsx
+++ b/src/components/home/ReviewsCard.tsx
@@ -37,7 +37,7 @@ export default function ReviewsCard() {
             </span>
             <Link
               href="/reviews"
-              className="inline-flex items-center text-label font-medium text-accent underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
+              className="inline-flex items-center text-label font-medium text-accent-3 underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent-3 active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
             >
               Create
             </Link>

--- a/src/components/home/TodayCard.tsx
+++ b/src/components/home/TodayCard.tsx
@@ -36,7 +36,7 @@ export default function TodayCard() {
             </span>
             <Link
               href="/planner"
-              className="inline-flex items-center text-label font-medium text-accent underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
+              className="inline-flex items-center text-label font-medium text-accent-3 underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent-3 active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
             >
               Create
             </Link>

--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -174,7 +174,7 @@ const DayChip = React.forwardRef<HTMLButtonElement, DayChipProps>(function DayCh
       <div
         className={cn(
           "chip__date",
-          today ? "text-accent" : "text-muted-foreground",
+          today ? "text-accent-3" : "text-muted-foreground",
         )}
         data-text={localizedLabel}
       >

--- a/src/components/prompts/ColorGallery.tsx
+++ b/src/components/prompts/ColorGallery.tsx
@@ -61,7 +61,7 @@ export default function ColorGallery() {
           )}
           {COLOR_PALETTES[p.key].map((c) => (
             <div key={c} className="flex flex-col items-center gap-2">
-              <span className="text-label uppercase tracking-wide text-accent">
+              <span className="text-label uppercase tracking-wide text-accent-3">
                 {c}
               </span>
               <div

--- a/src/components/ui/feedback/Snackbar.tsx
+++ b/src/components/ui/feedback/Snackbar.tsx
@@ -35,10 +35,10 @@ export default function Snackbar({
           <button
             type="button"
             className={cn(
-              "inline-flex items-center font-medium text-accent underline underline-offset-4 transition-colors",
+              "inline-flex items-center font-medium text-accent-3 underline underline-offset-4 transition-colors",
               "hover:text-accent-foreground focus-visible:rounded-sm focus-visible:outline-none",
               "focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--surface-2))]",
-              "active:text-accent active:opacity-80 disabled:text-muted-foreground disabled:no-underline disabled:pointer-events-none",
+              "active:text-accent-3 active:opacity-80 disabled:text-muted-foreground disabled:no-underline disabled:pointer-events-none",
             )}
             onClick={onAction}
             aria-label={actionAriaLabel ?? actionLabel}

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -95,7 +95,7 @@ export const toneClasses: Record<
   secondary: {
     primary: "text-foreground",
     accent:
-      "text-accent bg-accent/15 [--hover:theme('colors.interaction.accent.surfaceHover')] [--active:theme('colors.interaction.accent.surfaceActive')]",
+      "text-accent-foreground bg-accent/15 [--hover:theme('colors.interaction.accent.surfaceHover')] [--active:theme('colors.interaction.accent.surfaceActive')]",
     info:
       "text-accent-2 bg-accent-2/15 [--hover:theme('colors.interaction.info.surfaceHover')] [--active:theme('colors.interaction.info.surfaceActive')]",
     danger:
@@ -105,7 +105,7 @@ export const toneClasses: Record<
     primary:
       "text-foreground [--hover:theme('colors.interaction.foreground.tintHover')] [--active:theme('colors.interaction.foreground.tintActive')]",
     accent:
-      "text-accent [--hover:theme('colors.interaction.accent.tintHover')] [--active:theme('colors.interaction.accent.tintActive')]",
+      "text-accent-3 [--hover:theme('colors.interaction.accent.tintHover')] [--active:theme('colors.interaction.accent.tintActive')]",
     info:
       "text-accent-2 [--hover:theme('colors.interaction.info.tintHover')] [--active:theme('colors.interaction.info.tintActive')]",
     danger:

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -81,7 +81,7 @@ const variantBase: Record<Variant, string> = {
 const toneClasses: Record<Variant, Record<Tone, string>> = {
   ring: {
     primary: "border-line/35 text-foreground",
-    accent: "border-accent/35 text-accent",
+    accent: "border-accent/35 text-accent-3",
     info: "border-accent-2/35 text-accent-2",
     danger: "border-danger/35 text-danger",
   },
@@ -89,14 +89,14 @@ const toneClasses: Record<Variant, Record<Tone, string>> = {
     primary:
       "border-transparent bg-foreground/15 text-foreground [--hover:hsl(var(--foreground)/0.25)] [--active:hsl(var(--foreground)/0.35)]",
     accent:
-      "border-transparent bg-accent/15 text-accent [--hover:hsl(var(--accent)/0.25)] [--active:hsl(var(--accent)/0.35)]",
+      "border-transparent bg-accent/15 text-accent-foreground [--hover:hsl(var(--accent)/0.25)] [--active:hsl(var(--accent)/0.35)]",
     info: "border-transparent bg-accent-2/15 text-accent-2 [--hover:hsl(var(--accent-2)/0.25)] [--active:hsl(var(--accent-2)/0.35)]",
     danger:
       "border-transparent bg-danger/15 text-danger [--hover:hsl(var(--danger)/0.25)] [--active:hsl(var(--danger)/0.35)]",
   },
   glow: {
     primary: "border-foreground/35 text-foreground",
-    accent: "border-accent/35 text-accent",
+    accent: "border-accent/35 text-accent-3",
     info: "border-accent-2/35 text-accent-2",
     danger: "border-danger/35 text-danger",
   },

--- a/tests/primitives/icon-button.test.tsx
+++ b/tests/primitives/icon-button.test.tsx
@@ -106,7 +106,7 @@ describe("IconButton", () => {
     );
     const classes = getByRole("button").className;
     expect(classes).toContain("border");
-    expect(classes).toContain("border-transparent bg-accent/15 text-accent");
+    expect(classes).toContain("border-transparent bg-accent/15 text-accent-foreground");
     expect(classes).toContain("[--hover:hsl(var(--accent)/0.25)]");
   });
 

--- a/tests/ui/button.test.tsx
+++ b/tests/ui/button.test.tsx
@@ -52,13 +52,13 @@ describe("Button", () => {
     },
     secondary: {
       primary: ["text-foreground"],
-      accent: ["text-accent", "bg-accent/15"],
+      accent: ["text-accent-foreground", "bg-accent/15"],
       info: ["text-accent-2", "bg-accent-2/15"],
       danger: ["text-danger", "bg-danger/15"],
     },
     ghost: {
       primary: ["text-foreground"],
-      accent: ["text-accent"],
+      accent: ["text-accent-3"],
       info: ["text-accent-2"],
       danger: ["text-danger"],
     },


### PR DESCRIPTION
## Summary
- swap accent links and labels on home, planner, and goals views to use the higher-contrast accent-3 token
- update button and icon button accent variants to rely on accent-foreground or accent-3 where appropriate and refresh associated tests
- refresh snackbar and gallery accent text treatments to maintain accessible contrast on accent surfaces

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca35a2d02c832c902b47b6412726cf