### PR TITLE
Adjust review controls to large size

### DIFF
--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -185,7 +185,7 @@ export default function ReviewEditor({
               <IconButton
                 aria-label="Delete review"
                 title="Delete review"
-                size="md"
+                size="lg"
                 iconSize="md"
                 variant="ring"
                 onClick={onDelete}
@@ -198,7 +198,7 @@ export default function ReviewEditor({
               <IconButton
                 aria-label="Done"
                 title="Save and close"
-                size="md"
+                size="lg"
                 iconSize="md"
                 variant="ring"
                 onClick={() => {

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -120,13 +120,13 @@ export default function ReviewsPage({
                     { value: "title", label: "Title" },
                   ]}
                   className="w-full sm:w-auto"
-                  buttonClassName="!h-[var(--control-h-md)] !px-[var(--space-4)]"
+                  buttonClassName="!h-[var(--control-h-lg)] !px-[var(--space-4)]"
                 />
               </label>
               <Button
                 type="button"
                 variant="primary"
-                size="md"
+                size="lg"
                 className="w-full whitespace-nowrap px-[var(--space-4)] sm:w-auto"
                 onClick={() => {
                   setQ("");

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -249,7 +249,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-label="Sort reviews"
-                      class="_glitchTrigger_843152 relative flex items-center h-[var(--control-h-sm)] rounded-[var(--radius-full)] px-[var(--space-3)] overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none !h-[var(--control-h-md)] !px-[var(--space-4)]"
+                      class="_glitchTrigger_843152 relative flex items-center h-[var(--control-h-sm)] rounded-[var(--radius-full)] px-[var(--space-3)] overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none !h-[var(--control-h-lg)] !px-[var(--space-4)]"
                       data-lit="true"
                       data-open="false"
                       type="button"
@@ -297,7 +297,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                 </div>
               </label>
               <button
-                class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[disabled=true]:opacity-[var(--disabled)] data-[disabled=true]:pointer-events-none h-[var(--control-h-md)] text-ui gap-[var(--space-2)] [&_svg]:size-[var(--space-5)] w-full whitespace-nowrap px-[var(--space-4)] sm:w-auto shadow-glow-sm hover:shadow-glow-md active:translate-y-px active:shadow-btn-primary-active bg-[hsl(var(--foreground)/0.12)] border-[hsl(var(--foreground)/0.35)] text-[hsl(var(--primary-foreground))] [--hover:theme('colors.interaction.primary.hover')] [--active:theme('colors.interaction.primary.active')]"
+                class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[disabled=true]:opacity-[var(--disabled)] data-[disabled=true]:pointer-events-none h-[var(--control-h-lg)] text-title gap-[var(--space-4)] [&_svg]:size-[var(--space-8)] w-full whitespace-nowrap px-[var(--space-4)] sm:w-auto shadow-glow-sm hover:shadow-glow-md active:translate-y-px active:shadow-btn-primary-active bg-[hsl(var(--foreground)/0.12)] border-[hsl(var(--foreground)/0.35)] text-[hsl(var(--primary-foreground))] [--hover:theme('colors.interaction.primary.hover')] [--active:theme('colors.interaction.primary.active')]"
                 style="--glow-active: hsl(var(--foreground) / 0.35); --btn-primary-hover-shadow: 0 2px 6px -1px hsl(var(--foreground) / 0.25); --btn-primary-active-shadow: inset 0 0 0 1px hsl(var(--foreground) / 0.6);"
                 tabindex="0"
                 type="button"


### PR DESCRIPTION
## Summary
- align the reviews page sort trigger with large control height and enlarge the New Review button
- bump the review editor rail icon buttons to the large size for consistent padding
- update the reviews page snapshot to reflect the larger controls

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca36117e38832caa8a90a6a2169a32