### PR TITLE
Improve accent text contrast across home and goals

### DIFF
--- a/src/components/goals/GoalList.tsx
+++ b/src/components/goals/GoalList.tsx
@@ -209,7 +209,7 @@ export default function GoalList({
                     </time>
                   </span>
                   <span
-                    className={g.done ? "text-muted-foreground" : "text-accent"}
+                    className={g.done ? "text-muted-foreground" : "text-accent-3"}
                   >
                     {g.done ? "Done" : "Active"}
                   </span>

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -234,8 +234,8 @@ function GoalsPageContent() {
           <span className="text-foreground">{ACTIVE_CAP} active</span>
         </li>
         <li className="inline-flex items-center gap-[var(--space-1)]">
-          <span className="font-semibold text-accent">Remaining</span>
-          <span className="text-accent">{remaining}</span>
+          <span className="font-semibold text-accent-3">Remaining</span>
+          <span className="text-accent-3">{remaining}</span>
         </li>
         <li className="inline-flex items-center gap-[var(--space-1)]">
           <span className="font-semibold text-success">Complete</span>
@@ -248,7 +248,7 @@ function GoalsPageContent() {
       </ul>
     ) : tab === "reminders" ? (
       <>
-        Keep <span className="font-semibold text-accent">nudges</span> handy with quick edit loops.
+        Keep <span className="font-semibold text-accent-3">nudges</span> handy with quick edit loops.
       </>
     ) : (
       <>
@@ -281,8 +281,8 @@ function GoalsPageContent() {
           <span className="text-label text-primary">{activeCount}</span>
         </span>
         <span className="inline-flex items-center gap-[var(--space-1)]">
-          <span className="text-label font-semibold text-accent">Remaining</span>
-          <span className="text-label text-accent">{remaining}</span>
+          <span className="text-label font-semibold text-accent-3">Remaining</span>
+          <span className="text-label text-accent-3">{remaining}</span>
         </span>
         <span className="inline-flex items-center gap-[var(--space-1)]">
           <span className="text-label font-semibold text-success">Done</span>
@@ -295,7 +295,7 @@ function GoalsPageContent() {
   } else if (tab === "reminders") {
     heroSubtitle = (
       <span id={heroSubtitleId} className="text-muted-foreground">
-        Stage <span className="font-semibold text-accent">nudges</span> with contexts and cadence.
+        Stage <span className="font-semibold text-accent-3">nudges</span> with contexts and cadence.
       </span>
     );
   } else {

--- a/src/components/home/BottomNav.tsx
+++ b/src/components/home/BottomNav.tsx
@@ -38,7 +38,7 @@ export default function BottomNav() {
                 className={cn(
                   "group flex flex-col items-center gap-[var(--space-1)] rounded-xl px-[var(--space-3)] py-[var(--space-2)] text-label font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none",
                   active
-                    ? "text-accent ring-2 ring-[--theme-ring]"
+                    ? "text-accent-3 ring-2 ring-[--theme-ring]"
                     : "text-muted-foreground hover:text-foreground"
                 )}
               >

--- a/src/components/home/DashboardCard.tsx
+++ b/src/components/home/DashboardCard.tsx
@@ -31,7 +31,7 @@ export default function DashboardCard({
       {cta && (
         <Link
           href={cta.href}
-          className="inline-flex items-center text-ui font-medium text-accent underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
+          className="inline-flex items-center text-ui font-medium text-accent-3 underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent-3 active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
         >
           {cta.label}
         </Link>

--- a/src/components/home/GoalsCard.tsx
+++ b/src/components/home/GoalsCard.tsx
@@ -128,7 +128,7 @@ export default function GoalsCard() {
             </span>
             <Link
               href="/goals"
-              className="inline-flex items-center text-label font-medium text-accent underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
+              className="inline-flex items-center text-label font-medium text-accent-3 underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent-3 active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
             >
               Create
             </Link>

--- a/src/components/home/ReviewsCard.tsx
+++ b/src/components/home/ReviewsCard.tsx
@@ -37,7 +37,7 @@ export default function ReviewsCard() {
             </span>
             <Link
               href="/reviews"
-              className="inline-flex items-center text-label font-medium text-accent underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
+              className="inline-flex items-center text-label font-medium text-accent-3 underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent-3 active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
             >
               Create
             </Link>

--- a/src/components/home/TodayCard.tsx
+++ b/src/components/home/TodayCard.tsx
@@ -36,7 +36,7 @@ export default function TodayCard() {
             </span>
             <Link
               href="/planner"
-              className="inline-flex items-center text-label font-medium text-accent underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
+              className="inline-flex items-center text-label font-medium text-accent-3 underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent-3 active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
             >
               Create
             </Link>

--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -175,7 +175,7 @@ const DayChip = React.forwardRef<HTMLButtonElement, DayChipProps>(function DayCh
         className={cn(
           "chip__date",
           completionTextClass,
-          today && completionTint === "bg-card" ? "text-accent" : undefined,
+          today && completionTint === "bg-card" ? "text-accent-3" : undefined,
         )}
         data-text={localizedLabel}
       >

--- a/src/components/prompts/ColorGallery.tsx
+++ b/src/components/prompts/ColorGallery.tsx
@@ -61,7 +61,7 @@ export default function ColorGallery() {
           )}
           {COLOR_PALETTES[p.key].map((c) => (
             <div key={c} className="flex flex-col items-center gap-2">
-              <span className="text-label uppercase tracking-wide text-accent">
+              <span className="text-label uppercase tracking-wide text-accent-3">
                 {c}
               </span>
               <div

--- a/src/components/ui/feedback/Snackbar.tsx
+++ b/src/components/ui/feedback/Snackbar.tsx
@@ -35,10 +35,10 @@ export default function Snackbar({
           <button
             type="button"
             className={cn(
-              "inline-flex items-center font-medium text-accent underline underline-offset-4 transition-colors",
+              "inline-flex items-center font-medium text-accent-3 underline underline-offset-4 transition-colors",
               "hover:text-accent-foreground focus-visible:rounded-sm focus-visible:outline-none",
               "focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--surface-2))]",
-              "active:text-accent active:opacity-80 disabled:text-muted-foreground disabled:no-underline disabled:pointer-events-none",
+              "active:text-accent-3 active:opacity-80 disabled:text-muted-foreground disabled:no-underline disabled:pointer-events-none",
             )}
             onClick={onAction}
             aria-label={actionAriaLabel ?? actionLabel}


### PR DESCRIPTION
## Summary
- update dashboard CTA links to use `text-accent-3` for better contrast on neutral surfaces
- align goal metrics, goal list statuses, week picker highlight, and snackbar action text with contrast-safe accent tokens
- refresh bottom nav active state and color gallery labels to rely on the new accent emphasis color

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca3d0ba708832cb7a7dd5aafcd8729