### PR TITLE
Adjust reviews page responsive grid gap

### DIFF
--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -143,7 +143,11 @@ export default function ReviewsPage({
         }}
       />
 
-      <div className={cn("grid grid-cols-1 items-start gap-6 md:grid-cols-12")}>
+      <div
+        className={cn(
+          "grid grid-cols-1 items-start gap-4 sm:gap-6 lg:gap-8 md:grid-cols-12",
+        )}
+      >
         <nav aria-label="Review list" className="md:col-span-4">
           <div className="card-neo-soft rounded-card r-card-lg overflow-hidden bg-card/50 shadow-neo-strong">
             <div className="section-b">

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -343,7 +343,7 @@ exports[`ReviewsPage > renders default state 1`] = `
       </div>
     </section>
     <div
-      class="grid grid-cols-1 items-start gap-6 md:grid-cols-12"
+      class="grid grid-cols-1 items-start gap-4 sm:gap-6 lg:gap-8 md:grid-cols-12"
     >
       <nav
         aria-label="Review list"


### PR DESCRIPTION
## Summary
- update the reviews page grid wrapper to use responsive gap spacing
- refresh the stored ReviewsPage snapshot to reflect the spacing change

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca3d9ffc44832c809705b451bb1531