### PR TITLE
Adjust reviews empty state padding

### DIFF
--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -168,7 +168,7 @@ export default function ReviewsPage({
             <ReviewPanel
               className={cn(
                 panelClass,
-                "flex flex-col items-center justify-center gap-2 py-7 text-ui text-muted-foreground",
+                "flex flex-col items-center justify-center gap-2 py-8 text-ui text-muted-foreground",
               )}
             >
               <Ghost className="h-6 w-6 opacity-60" />

--- a/src/components/ui/toggles/CheckCircle.tsx
+++ b/src/components/ui/toggles/CheckCircle.tsx
@@ -93,14 +93,14 @@ export default function CheckCircle({
     if (wantsOn !== prev.current) {
       if (wantsOn) {
         setPhase("ignite");
-        const t = window.setTimeout(() => setPhase("steady-on"), 620);
+        const t = setTimeout(() => setPhase("steady-on"), 620);
         prev.current = wantsOn;
-        return () => window.clearTimeout(t);
+        return () => clearTimeout(t);
       } else {
         setPhase("powerdown");
-        const t = window.setTimeout(() => setPhase("off"), 360);
+        const t = setTimeout(() => setPhase("off"), 360);
         prev.current = wantsOn;
-        return () => window.clearTimeout(t);
+        return () => clearTimeout(t);
       }
     }
     prev.current = wantsOn;
@@ -108,7 +108,7 @@ export default function CheckCircle({
 
   function retriggerIgnite() {
     setPhase("ignite");
-    window.setTimeout(() => setPhase(wantsOn ? "steady-on" : "off"), 620);
+    setTimeout(() => setPhase(wantsOn ? "steady-on" : "off"), 620);
   }
 
   function onKey(e: React.KeyboardEvent<HTMLButtonElement>) {

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -517,7 +517,7 @@ exports[`ReviewsPage > renders default state 1`] = `
       >
         <div
           aria-live="polite"
-          class="rounded-card r-card-lg p-[var(--space-4)] border border-border/25 bg-card/60 shadow-outline-subtle w-full container mx-auto flex flex-col items-center justify-center gap-2 py-7 text-ui text-muted-foreground"
+          class="rounded-card r-card-lg p-[var(--space-4)] border border-border/25 bg-card/60 shadow-outline-subtle w-full container mx-auto flex flex-col items-center justify-center gap-2 py-8 text-ui text-muted-foreground"
         >
           <svg
             aria-hidden="true"


### PR DESCRIPTION
## Summary
- increase the empty reviews panel padding to align with the spacing scale
- rely on global timers in CheckCircle to avoid accessing window during tests
- update the reviews page snapshot to reflect the padding change

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca3dab93dc832cbc2bcfbcc66163eb