### PR TITLE
Use primary token for CTA button

### DIFF
--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -83,7 +83,7 @@ export type ButtonProps =
   | ButtonAsChildProps;
 
 export const colorVar: Record<Tone, string> = {
-  primary: "--foreground",
+  primary: "--primary",
   accent: "--accent",
   info: "--accent-2",
   danger: "--danger",
@@ -200,7 +200,8 @@ export const Button = React.forwardRef<
   const isDisabled = Boolean(disabledProp) || Boolean(loading);
   const isLink =
     !asChild && "href" in props && typeof props.href !== "undefined";
-    const s = buttonSizes[size];
+  const toneColorVar = colorVar[tone];
+  const s = buttonSizes[size];
     const spinnerSize = spinnerSizes[size];
     const base = cn(
       "relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)]",
@@ -238,11 +239,10 @@ export const Button = React.forwardRef<
     let resolvedStyle = style;
 
     if (variant === "primary") {
-      const toneColor = colorVar[tone];
       const glowStyles = {
-        "--glow-active": `hsl(var(${toneColor}) / 0.35)`,
-        "--btn-primary-hover-shadow": `0 2px 6px -1px hsl(var(${toneColor}) / 0.25)`,
-        "--btn-primary-active-shadow": `inset 0 0 0 1px hsl(var(${toneColor}) / 0.6)`,
+        "--glow-active": `hsl(var(${toneColorVar}) / 0.35)`,
+        "--btn-primary-hover-shadow": `0 2px 6px -1px hsl(var(${toneColorVar}) / 0.25)`,
+        "--btn-primary-active-shadow": `inset 0 0 0 1px hsl(var(${toneColorVar}) / 0.6)`,
       } as CSSProperties;
       resolvedStyle = {
         ...glowStyles,
@@ -258,7 +258,7 @@ export const Button = React.forwardRef<
           <span
             className={cn(
               "absolute inset-0 pointer-events-none rounded-[inherit]",
-              `bg-[linear-gradient(90deg,hsl(var(${colorVar[tone]})/.18),hsl(var(${colorVar[tone]})/.18))]`,
+              `bg-[linear-gradient(90deg,hsl(var(${toneColorVar})/.18),hsl(var(${toneColorVar})/.18))]`,
             )}
           />
         ) : (

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -297,13 +297,13 @@ exports[`ReviewsPage > renders default state 1`] = `
                 </div>
               </label>
               <button
-                class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[disabled=true]:opacity-[var(--disabled)] data-[disabled=true]:pointer-events-none h-[var(--control-h-lg)] text-title gap-[var(--space-4)] [&_svg]:size-[var(--space-8)] w-full whitespace-nowrap px-[var(--space-4)] sm:w-auto shadow-glow-sm hover:shadow-glow-md active:translate-y-px active:shadow-btn-primary-active bg-[hsl(var(--foreground)/0.12)] border-[hsl(var(--foreground)/0.35)] text-[hsl(var(--primary-foreground))] [--hover:theme('colors.interaction.primary.hover')] [--active:theme('colors.interaction.primary.active')]"
-                style="--glow-active: hsl(var(--foreground) / 0.35); --btn-primary-hover-shadow: 0 2px 6px -1px hsl(var(--foreground) / 0.25); --btn-primary-active-shadow: inset 0 0 0 1px hsl(var(--foreground) / 0.6);"
+                class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[disabled=true]:opacity-[var(--disabled)] data-[disabled=true]:pointer-events-none h-[var(--control-h-lg)] text-title gap-[var(--space-4)] [&_svg]:size-[var(--space-8)] w-full whitespace-nowrap px-[var(--space-4)] sm:w-auto shadow-glow-sm hover:shadow-glow-md active:translate-y-px active:shadow-btn-primary-active bg-[hsl(var(--primary)/0.12)] border-[hsl(var(--primary)/0.35)] text-[hsl(var(--primary-foreground))] [--hover:theme('colors.interaction.primary.hover')] [--active:theme('colors.interaction.primary.active')]"
+                style="--glow-active: hsl(var(--primary) / 0.35); --btn-primary-hover-shadow: 0 2px 6px -1px hsl(var(--primary) / 0.25); --btn-primary-active-shadow: inset 0 0 0 1px hsl(var(--primary) / 0.6);"
                 tabindex="0"
                 type="button"
               >
                 <span
-                  class="absolute inset-0 pointer-events-none rounded-[inherit] bg-[linear-gradient(90deg,hsl(var(--foreground)/.18),hsl(var(--foreground)/.18))]"
+                  class="absolute inset-0 pointer-events-none rounded-[inherit] bg-[linear-gradient(90deg,hsl(var(--primary)/.18),hsl(var(--primary)/.18))]"
                 />
                 <span
                   class="relative z-10 inline-flex items-center gap-[var(--space-2)]"

--- a/tests/ui/button.test.tsx
+++ b/tests/ui/button.test.tsx
@@ -23,8 +23,8 @@ describe("Button", () => {
     primary: {
       primary: [
         "text-[hsl(var(--primary-foreground))]",
-        "bg-[hsl(var(--foreground)/0.12)]",
-        "border-[hsl(var(--foreground)/0.35)]",
+        "bg-[hsl(var(--primary)/0.12)]",
+        "border-[hsl(var(--primary)/0.35)]",
         "[--hover:theme('colors.interaction.primary.hover')]",
         "[--active:theme('colors.interaction.primary.active')]",
       ],


### PR DESCRIPTION
## Summary
- point the primary tone token at `--primary` so primary buttons pull the correct color
- update primary button glow/gradient usage and adjust tests and snapshots accordingly

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca3d76ca58832cbae1a0cedf893c29