### PR TITLE
Register accent-3 Tailwind color token

### DIFF
--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -13,6 +13,7 @@ export const colorTokens = [
   "bg-accent",
   "bg-accent-foreground",
   "bg-accent-soft",
+  "bg-accent-3",
   "bg-accent-2",
   "bg-accent-2-foreground",
   "bg-glow",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -39,6 +39,9 @@ const config: Config = {
           foreground: "hsl(var(--accent-foreground))",
           soft: "hsl(var(--accent-soft))",
         },
+        "accent-3": {
+          DEFAULT: "hsl(var(--accent-3))",
+        },
         "accent-2": {
           DEFAULT: "hsl(var(--accent-2))",
           foreground: "hsl(var(--accent-2-foreground))",


### PR DESCRIPTION
## Summary
- expose the accent-3 color in the Tailwind theme so text-accent-3 utilities emit CSS
- add the accent-3 background token to the shared color token list used in demos and tests

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca3ffe4da8832c977dd6e988dcf9fd