### PR TITLE
Adjust accent secondary button contrast

### DIFF
--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -120,7 +120,7 @@ export const toneClasses: Record<
   secondary: {
     primary: "text-foreground",
     accent:
-      "text-accent bg-accent/15 [--hover:theme('colors.interaction.accent.surfaceHover')] [--active:theme('colors.interaction.accent.surfaceActive')]",
+      "text-accent-foreground bg-accent/30 [--hover:hsl(var(--accent)/0.4)] [--active:hsl(var(--accent)/0.5)]",
     info:
       "text-accent-2 bg-accent-2/15 [--hover:theme('colors.interaction.info.surfaceHover')] [--active:theme('colors.interaction.info.surfaceActive')]",
     danger:

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -81,7 +81,7 @@ const variantBase: Record<Variant, string> = {
 const toneClasses: Record<Variant, Record<Tone, string>> = {
   ring: {
     primary: "border-line/35 text-foreground",
-    accent: "border-accent/35 text-accent",
+    accent: "border-accent/35 text-accent-foreground",
     info: "border-accent-2/35 text-accent-2",
     danger: "border-danger/35 text-danger",
   },
@@ -89,14 +89,14 @@ const toneClasses: Record<Variant, Record<Tone, string>> = {
     primary:
       "border-transparent bg-foreground/15 text-foreground [--hover:hsl(var(--foreground)/0.25)] [--active:hsl(var(--foreground)/0.35)]",
     accent:
-      "border-transparent bg-accent/15 text-accent [--hover:hsl(var(--accent)/0.25)] [--active:hsl(var(--accent)/0.35)]",
+      "border-transparent bg-accent/30 text-accent-foreground [--hover:hsl(var(--accent)/0.4)] [--active:hsl(var(--accent)/0.5)]",
     info: "border-transparent bg-accent-2/15 text-accent-2 [--hover:hsl(var(--accent-2)/0.25)] [--active:hsl(var(--accent-2)/0.35)]",
     danger:
       "border-transparent bg-danger/15 text-danger [--hover:hsl(var(--danger)/0.25)] [--active:hsl(var(--danger)/0.35)]",
   },
   glow: {
     primary: "border-foreground/35 text-foreground",
-    accent: "border-accent/35 text-accent",
+    accent: "border-accent/35 text-accent-foreground",
     info: "border-accent-2/35 text-accent-2",
     danger: "border-danger/35 text-danger",
   },

--- a/tests/primitives/icon-button.test.tsx
+++ b/tests/primitives/icon-button.test.tsx
@@ -106,8 +106,11 @@ describe("IconButton", () => {
     );
     const classes = getByRole("button").className;
     expect(classes).toContain("border");
-    expect(classes).toContain("border-transparent bg-accent/15 text-accent");
-    expect(classes).toContain("[--hover:hsl(var(--accent)/0.25)]");
+    expect(classes).toContain(
+      "border-transparent bg-accent/30 text-accent-foreground",
+    );
+    expect(classes).toContain("[--hover:hsl(var(--accent)/0.4)]");
+    expect(classes).toContain("[--active:hsl(var(--accent)/0.5)]");
   });
 
   it("applies glow variant with info tone", () => {

--- a/tests/ui/button.test.tsx
+++ b/tests/ui/button.test.tsx
@@ -52,7 +52,12 @@ describe("Button", () => {
     },
     secondary: {
       primary: ["text-foreground"],
-      accent: ["text-accent", "bg-accent/15"],
+      accent: [
+        "text-accent-foreground",
+        "bg-accent/30",
+        "[--hover:hsl(var(--accent)/0.4)]",
+        "[--active:hsl(var(--accent)/0.5)]",
+      ],
       info: ["text-accent-2", "bg-accent-2/15"],
       danger: ["text-danger", "bg-danger/15"],
     },


### PR DESCRIPTION
## Summary
- darken the secondary accent button surface and switch to the accent foreground token for improved contrast
- mirror the accent foreground/surface updates for IconButton variants and refresh related expectations in tests

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca408d6da0832cb1e257671071a40f