### PR TITLE
Adjust SpecCard heading typography

### DIFF
--- a/src/components/prompts/ComponentsView.tsx
+++ b/src/components/prompts/ComponentsView.tsx
@@ -40,7 +40,7 @@ function SpecCard({
   return (
     <div className="flex flex-col gap-4 rounded-card r-card-lg border border-[var(--card-hairline)] bg-card p-6 shadow-[0_0_0_1px_var(--neon-soft)]">
       <header className="flex items-center justify-between">
-        <h3 className="text-body font-semibold tracking-[-0.01em]">{name}</h3>
+        <h3 className="text-title leading-[1.3] font-semibold tracking-[-0.01em]">{name}</h3>
         {code && (
           <button
             type="button"


### PR DESCRIPTION
## Summary
- align SpecCard heading with the title typography ramp by using the text-title token
- add the corresponding 1.3 line-height while keeping the existing tracking class

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca41407f7c832c84a71ce5eec7e332