### PR TITLE
Update hero heading weight

### DIFF
--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -148,7 +148,7 @@ function Hero<Key extends string = string>({
     : "flex flex-wrap items-start gap-[var(--space-2)] md:flex-nowrap md:items-center md:gap-[var(--space-3)] lg:gap-[var(--space-4)] pt-[var(--space-4)] md:pt-[var(--space-5)]";
 
   const headingClassName = cx(
-    "font-semibold tracking-[-0.01em] text-balance break-words text-foreground",
+    "font-bold tracking-[-0.01em] text-balance break-words text-foreground",
     isSupportiveTone
       ? "text-title md:text-title"
       : "text-title-lg md:text-title-lg",

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -144,7 +144,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                       class="flex min-w-0 flex-wrap items-baseline gap-x-[var(--space-2)] gap-y-[var(--space-1)]"
                     >
                       <h2
-                        class="font-semibold tracking-[-0.01em] text-balance break-words text-foreground text-title md:text-title"
+                        class="font-bold tracking-[-0.01em] text-balance break-words text-foreground text-title md:text-title"
                         data-text="Browse Reviews"
                       >
                         Browse Reviews


### PR DESCRIPTION
## Summary
- update the Hero heading typography to use the bold weight while keeping existing size tokens
- refresh the ReviewsPage snapshot to capture the new heading weight

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca43a3e300832c9932ec0540fc0edc