### PR TITLE
Update review typography tokens

### DIFF
--- a/src/components/reviews/ResultScoreSection.tsx
+++ b/src/components/reviews/ResultScoreSection.tsx
@@ -153,7 +153,7 @@ function ResultScoreSection(
           </div>
         </div>
         <div className="mt-1 flex items-center gap-2 text-ui text-muted-foreground">
-          <span className="pill h-6 px-2 text-label">{score}/10</span>
+          <span className="pill h-6 px-2 text-ui">{score}/10</span>
           <ScoreIcon className={cn("h-4 w-4", scoreIconCls)} />
           <span>{msg}</span>
         </div>

--- a/src/components/reviews/ReviewCard.tsx
+++ b/src/components/reviews/ReviewCard.tsx
@@ -69,7 +69,7 @@ export default function ReviewCard({
             </IconButton>
           </div>
 
-          <div className="mt-1 text-label text-muted-foreground grid grid-cols-2 gap-2">
+          <div className="mt-1 text-ui text-muted-foreground grid grid-cols-2 gap-2">
             <span>Opponent: {review.opponent || "—"}</span>
             <span>Lane: {review.lane || "—"}</span>
             <span>Side: {review.side || "—"}</span>

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -287,7 +287,7 @@ export default function ReviewEditor({
                 </div>
               </div>
               <div className="mt-1 flex items-center gap-2 text-ui text-muted-foreground">
-                <span className="pill h-6 px-2 text-label">{focus}/10</span>
+                <span className="pill h-6 px-2 text-ui">{focus}/10</span>
                 <span>{focusMsg}</span>
               </div>
             </>

--- a/src/components/reviews/ReviewListItem.tsx
+++ b/src/components/reviews/ReviewListItem.tsx
@@ -28,7 +28,7 @@ const itemLoading = cn(
 );
 const loadingLine = "h-3 rounded-card bg-muted";
 const scoreBadge = cn(
-  "px-2 py-1 rounded-full text-label leading-none font-medium",
+  "px-2 py-1 rounded-full text-ui leading-none font-medium",
   "text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2",
   "hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground",
   "focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground",

--- a/src/components/reviews/ReviewSummaryHeader.tsx
+++ b/src/components/reviews/ReviewSummaryHeader.tsx
@@ -47,7 +47,7 @@ export default function ReviewSummaryHeader({
     <div className="section-h sticky">
       <div className="grid w-full grid-cols-[1fr_auto] items-center gap-4">
         <div className="min-w-0">
-          <div className="mb-1 text-label font-medium tracking-[0.02em] text-foreground/25">Title</div>
+          <div className="mb-1 text-ui font-medium tracking-[0.02em] text-foreground/25">Title</div>
           <div className="truncate text-title font-semibold tracking-[-0.01em] leading-7 text-foreground/70">
             {title || "Untitled review"}
           </div>

--- a/src/components/reviews/ReviewSummaryScore.tsx
+++ b/src/components/reviews/ReviewSummaryScore.tsx
@@ -37,7 +37,7 @@ export default function ReviewSummaryScore({
         </div>
       </div>
       <div className="mt-1 flex items-center gap-2 text-ui text-muted-foreground">
-        <span className="pill h-6 px-2 text-label">{score}/10</span>
+        <span className="pill h-6 px-2 text-ui">{score}/10</span>
         <ScoreIcon className={cn("h-4 w-4", scoreIconCls)} />
         <span>{msg}</span>
       </div>
@@ -63,7 +63,7 @@ export default function ReviewSummaryScore({
             </div>
           </div>
           <div className="mt-1 flex items-center gap-2 text-ui text-muted-foreground">
-            <span className="pill h-6 px-2 text-label">{focus}/10</span>
+            <span className="pill h-6 px-2 text-ui">{focus}/10</span>
             <span>{focusMsg}</span>
           </div>
         </div>

--- a/src/components/reviews/ReviewSummaryTimestamps.tsx
+++ b/src/components/reviews/ReviewSummaryTimestamps.tsx
@@ -41,7 +41,7 @@ export default function ReviewSummaryTimestamps({
                     <FileText size={14} className="opacity-80" />
                   </span>
                 ) : (
-                  <span className="pill h-7 px-3 text-label font-mono tabular-nums leading-none">
+                  <span className="pill h-7 px-3 text-ui font-mono tabular-nums leading-none">
                     {m.time ?? "00:00"}
                   </span>
                 )}

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -106,7 +106,7 @@ export default function ReviewsPage({
           actions: (
             <div className="flex flex-col gap-[var(--space-2)] sm:flex-row sm:items-center sm:gap-[var(--space-3)]">
               <label className="flex w-full flex-col gap-[var(--space-1)] sm:w-auto sm:flex-row sm:items-center sm:gap-[var(--space-2)]">
-                <span className="text-label font-medium text-muted-foreground">
+                <span className="text-ui font-medium text-muted-foreground">
                   Sort
                 </span>
                 <Select

--- a/src/components/reviews/SectionLabel.tsx
+++ b/src/components/reviews/SectionLabel.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 export default function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
     <div className="mb-2 flex items-center gap-2">
-      <div className="text-label tracking-wide text-foreground/20">{children}</div>
+      <div className="text-ui tracking-wide text-foreground/20">{children}</div>
       <div className="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
     </div>
   );

--- a/src/components/reviews/TimestampMarkers.tsx
+++ b/src/components/reviews/TimestampMarkers.tsx
@@ -229,7 +229,7 @@ function TimestampMarkers(
           </IconButton>
         </div>
         {timeError && (
-          <p id="tTime-error" className="mt-1 text-label text-danger">
+          <p id="tTime-error" className="mt-1 text-ui text-danger">
             Enter time as mm:ss
           </p>
         )}
@@ -248,7 +248,7 @@ function TimestampMarkers(
                     <FileText size={14} className="opacity-80" />
                   </span>
                 ) : (
-                  <span className="pill h-7 w-16 px-3 text-label font-mono tabular-nums text-center">{m.time}</span>
+                  <span className="pill h-7 w-16 px-3 text-ui font-mono tabular-nums text-center">{m.time}</span>
                 )}
 
                 <span className="truncate text-ui">{m.note}</span>

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`ReviewEditor > renders default state 1`] = `
               class="mb-2 flex items-center gap-2"
             >
               <div
-                class="text-label tracking-wide text-foreground/20"
+                class="text-ui tracking-wide text-foreground/20"
               >
                 Lane
               </div>
@@ -338,7 +338,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 class="mb-2 flex items-center gap-2"
               >
                 <div
-                  class="text-label tracking-wide text-foreground/20"
+                  class="text-ui tracking-wide text-foreground/20"
                 >
                   <span
                     id=":r0:"
@@ -400,7 +400,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           class="mb-2 flex items-center gap-2"
         >
           <div
-            class="text-label tracking-wide text-foreground/20"
+            class="text-ui tracking-wide text-foreground/20"
           >
             Result
           </div>
@@ -441,7 +441,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           class="mb-2 flex items-center gap-2"
         >
           <div
-            class="text-label tracking-wide text-foreground/20"
+            class="text-ui tracking-wide text-foreground/20"
           >
             Score
           </div>
@@ -482,7 +482,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           class="mt-1 flex items-center gap-2 text-ui text-muted-foreground"
         >
           <span
-            class="pill h-6 px-2 text-label"
+            class="pill h-6 px-2 text-ui"
           >
             5
             /10
@@ -725,7 +725,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           class="mb-2 flex items-center gap-2"
         >
           <div
-            class="text-label tracking-wide text-foreground/20"
+            class="text-ui tracking-wide text-foreground/20"
           >
             Pillars
           </div>
@@ -1539,7 +1539,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           class="mb-2 flex items-center gap-2"
         >
           <div
-            class="text-label tracking-wide text-foreground/20"
+            class="text-ui tracking-wide text-foreground/20"
           >
             Timestamps
           </div>
@@ -1913,7 +1913,7 @@ exports[`ReviewEditor > renders default state 1`] = `
             </button>
           </div>
           <p
-            class="mt-1 text-label text-danger"
+            class="mt-1 text-ui text-danger"
             id="tTime-error"
           >
             Enter time as mm:ss
@@ -1930,7 +1930,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           class="mb-2 flex items-center gap-2"
         >
           <div
-            class="text-label tracking-wide text-foreground/20"
+            class="text-ui tracking-wide text-foreground/20"
           >
             Tags
           </div>
@@ -2020,7 +2020,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           class="mb-2 flex items-center gap-2"
         >
           <div
-            class="text-label tracking-wide text-foreground/20"
+            class="text-ui tracking-wide text-foreground/20"
           >
             Notes
           </div>

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`ReviewListItem > renders default state 1`] = `
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-2 py-1 rounded-full text-label leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
+          class="px-2 py-1 rounded-full text-ui leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
         >
           9
           /10
@@ -102,7 +102,7 @@ exports[`ReviewListItem > renders disabled state 1`] = `
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-2 py-1 rounded-full text-label leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
+          class="px-2 py-1 rounded-full text-ui leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
         >
           9
           /10
@@ -176,7 +176,7 @@ exports[`ReviewListItem > renders selected state 1`] = `
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-2 py-1 rounded-full text-label leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
+          class="px-2 py-1 rounded-full text-ui leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
         >
           9
           /10
@@ -233,7 +233,7 @@ exports[`ReviewListItem > renders untitled state 1`] = `
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-2 py-1 rounded-full text-label leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
+          class="px-2 py-1 rounded-full text-ui leading-none font-medium text-background ring-1 ring-accent bg-gradient-to-br from-accent to-accent-2 hover:from-accent-foreground hover:to-accent-foreground hover:ring-accent-foreground focus-visible:from-accent-foreground focus-visible:to-accent-foreground focus-visible:ring-accent-foreground active:from-accent-foreground active:to-accent-foreground active:ring-accent-foreground"
         >
           9
           /10

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -238,7 +238,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                 class="flex w-full flex-col gap-[var(--space-1)] sm:w-auto sm:flex-row sm:items-center sm:gap-[var(--space-2)]"
               >
                 <span
-                  class="text-label font-medium text-muted-foreground"
+                  class="text-ui font-medium text-muted-foreground"
                 >
                   Sort
                 </span>


### PR DESCRIPTION
## Summary
- switch review UI labels and badges from `text-label` to the `text-ui` (14 px) token for consistent readability
- update affected snapshots after the typography token change

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca448541ec832c98c63644539ad385