### PR TITLE
Adjust Hero bar spacing scale

### DIFF
--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -136,8 +136,8 @@ function Hero<Key extends string = string>({
   );
 
   const barSpacingClass = frame
-    ? "relative z-[2] grid grid-cols-1 md:grid-cols-12 items-start md:items-center gap-y-[var(--space-3)] md:gap-y-0 md:gap-x-[var(--space-4)] lg:gap-x-[var(--space-6)] py-[var(--space-6)]"
-    : "relative z-[2] grid grid-cols-1 md:grid-cols-12 items-start md:items-center gap-y-[var(--space-2)] md:gap-y-0 md:gap-x-[var(--space-3)] lg:gap-x-[var(--space-4)] py-[var(--space-4)]";
+    ? "relative z-[2] grid grid-cols-1 md:grid-cols-12 items-start md:items-center gap-y-[var(--space-3)] md:gap-y-0 md:gap-x-[var(--space-4)] lg:gap-x-[var(--space-6)] py-[var(--space-4)] md:py-[var(--space-5)]"
+    : "relative z-[2] grid grid-cols-1 md:grid-cols-12 items-start md:items-center gap-y-[var(--space-2)] md:gap-y-0 md:gap-x-[var(--space-3)] lg:gap-x-[var(--space-4)] py-[var(--space-4)] md:py-[var(--space-5)]";
 
   const labelClusterClass = cx(
     "col-span-full md:col-span-8 flex min-w-0 flex-wrap items-start md:flex-nowrap md:items-center",

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -131,7 +131,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                 class="sticky sticky-blur top-[var(--header-stack)]"
               >
                 <div
-                  class="relative z-[2] grid grid-cols-1 md:grid-cols-12 items-start md:items-center gap-y-[var(--space-2)] md:gap-y-0 md:gap-x-[var(--space-3)] lg:gap-x-[var(--space-4)] py-[var(--space-4)]"
+                  class="relative z-[2] grid grid-cols-1 md:grid-cols-12 items-start md:items-center gap-y-[var(--space-2)] md:gap-y-0 md:gap-x-[var(--space-3)] lg:gap-x-[var(--space-4)] py-[var(--space-4)] md:py-[var(--space-5)]"
                 >
                   <div
                     class="col-span-full md:col-span-8 flex min-w-0 flex-wrap items-start md:flex-nowrap md:items-center gap-[var(--space-2)] md:gap-[var(--space-3)]"


### PR DESCRIPTION
## Summary
- tighten the framed hero bar spacing to stay within the 16–24px range across breakpoints
- align the unframed hero spacing with the same responsive padding and refresh the affected snapshot

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca458b20c0832c94755f506b72f13e