### PR TITLE
Fix navigation active states under GitHub Pages base path

### DIFF
--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { motion, useReducedMotion } from "framer-motion";
-import { cn } from "@/lib/utils";
+import { cn, withoutBasePath } from "@/lib/utils";
 import { NAV_ITEMS, NavItem } from "./nav-items";
 
 type NavBarProps = {
@@ -18,7 +18,8 @@ type NavBarProps = {
 };
 
 export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
-  const path = usePathname() ?? "/";
+  const rawPath = usePathname() ?? "/";
+  const path = withoutBasePath(rawPath);
   const reduceMotion = useReducedMotion();
 
   return (

--- a/src/components/home/BottomNav.tsx
+++ b/src/components/home/BottomNav.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { cn } from "@/lib/utils";
+import { cn, withoutBasePath } from "@/lib/utils";
 import {
   Flag,
   CalendarDays,
@@ -23,7 +23,8 @@ const LINKS = [
 ];
 
 export default function BottomNav() {
-  const pathname = usePathname();
+  const rawPathname = usePathname() ?? "/";
+  const pathname = withoutBasePath(rawPathname);
   return (
     <nav aria-label="Primary" className="border-t border-border pt-[var(--space-4)] md:hidden">
       <ul className="flex justify-around">

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -40,6 +40,29 @@ export function withBasePath(path: string): string {
   return `${NORMALIZED_BASE}${normalizedPath}`;
 }
 
+/** Remove the configured base path prefix from a pathname. */
+export function withoutBasePath(path: string): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+
+  if (!NORMALIZED_BASE) {
+    return normalizedPath;
+  }
+
+  if (
+    normalizedPath === NORMALIZED_BASE ||
+    normalizedPath === `${NORMALIZED_BASE}/`
+  ) {
+    return "/";
+  }
+
+  if (normalizedPath.startsWith(`${NORMALIZED_BASE}/`)) {
+    const remainder = normalizedPath.slice(NORMALIZED_BASE.length);
+    return remainder.length > 0 ? remainder : "/";
+  }
+
+  return normalizedPath;
+}
+
 /** Capitalize first letter (not Unicode-smart on purpose). */
 export function capitalize(s: string): string {
   return s.length ? s[0].toUpperCase() + s.slice(1) : s;

--- a/tests/lib/withBasePath.test.ts
+++ b/tests/lib/withBasePath.test.ts
@@ -2,9 +2,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const ORIGINAL_BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH;
 
-async function importWithBasePath() {
+async function importBasePathUtils() {
   const mod = await import("../../src/lib/utils");
-  return mod.withBasePath;
+  return { withBasePath: mod.withBasePath, withoutBasePath: mod.withoutBasePath };
 }
 
 function restoreBasePathEnv() {
@@ -15,17 +15,18 @@ function restoreBasePathEnv() {
   }
 }
 
+afterEach(() => {
+  restoreBasePathEnv();
+  vi.resetModules();
+});
+
 describe("withBasePath", () => {
-  afterEach(() => {
-    restoreBasePathEnv();
-    vi.resetModules();
-  });
 
   it("normalizes input when NEXT_PUBLIC_BASE_PATH is unset", async () => {
     delete process.env.NEXT_PUBLIC_BASE_PATH;
     vi.resetModules();
 
-    const withBasePath = await importWithBasePath();
+    const { withBasePath } = await importBasePathUtils();
 
     expect(withBasePath("/assets/icon.svg")).toBe("/assets/icon.svg");
     expect(withBasePath("assets/icon.svg")).toBe("/assets/icon.svg");
@@ -35,9 +36,34 @@ describe("withBasePath", () => {
     process.env.NEXT_PUBLIC_BASE_PATH = "/beta/";
     vi.resetModules();
 
-    const withBasePath = await importWithBasePath();
+    const { withBasePath } = await importBasePathUtils();
 
     expect(withBasePath("/assets/icon.svg")).toBe("/beta/assets/icon.svg");
     expect(withBasePath("assets/icon.svg")).toBe("/beta/assets/icon.svg");
+  });
+});
+
+describe("withoutBasePath", () => {
+  it("returns normalized paths when NEXT_PUBLIC_BASE_PATH is unset", async () => {
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+    vi.resetModules();
+
+    const { withoutBasePath } = await importBasePathUtils();
+
+    expect(withoutBasePath("/planner")).toBe("/planner");
+    expect(withoutBasePath("planner")).toBe("/planner");
+  });
+
+  it("strips the configured base path prefix", async () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "/beta/";
+    vi.resetModules();
+
+    const { withoutBasePath } = await importBasePathUtils();
+
+    expect(withoutBasePath("/beta/planner")).toBe("/planner");
+    expect(withoutBasePath("/beta/planner/today")).toBe("/planner/today");
+    expect(withoutBasePath("/beta")).toBe("/");
+    expect(withoutBasePath("/beta/")).toBe("/");
+    expect(withoutBasePath("/other")).toBe("/other");
   });
 });


### PR DESCRIPTION
## Summary
- add a shared helper to strip the configured base path prefix used for GitHub Pages
- normalize the NavBar and BottomNav path comparisons so active state works when the app is served from a sub-path
- extend the base path tests to cover both prefixing and stripping helpers

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca455277d4832cab3afd52b6ec41f8