### PR TITLE
Use control height token for review tag chips

### DIFF
--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -353,7 +353,7 @@ export default function ReviewEditor({
                 <button
                   key={t}
                   type="button"
-                  className="chip h-9 px-4 text-ui group inline-flex items-center gap-1"
+                  className="chip h-[var(--control-h-lg)] px-4 text-ui group inline-flex items-center gap-1"
                   title="Remove tag"
                   onClick={() => removeTag(t)}
                 >


### PR DESCRIPTION
## Summary
- align removable review tag chips to the large control height token

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca477d8088832cb8b870314af1309d