### PR TITLE
Allow Hero to render PageHeader accent row

### DIFF
--- a/src/components/ui/layout/NeomorphicHeroFrame.tsx
+++ b/src/components/ui/layout/NeomorphicHeroFrame.tsx
@@ -105,19 +105,16 @@ const variantMap: Record<Exclude<NeomorphicHeroFrameVariant, "unstyled">, {
 
 const highContrastVariantMap: Record<
   Exclude<NeomorphicHeroFrameVariant, "unstyled">,
-  { container: string; divider: string }
+  { container: string }
 > = {
   default: {
     container: "border-border/70 shadow-neoSoft",
-    divider: "border-border/55",
   },
   compact: {
     container: "border-border/70 shadow-neoSoft",
-    divider: "border-border/55",
   },
   plain: {
     container: "border-border/55 shadow-outline-subtle",
-    divider: "border-border/50",
   },
 };
 
@@ -214,13 +211,16 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
         ? highContrastVariantMap[variant]
         : undefined;
     const slotContrastClass = highContrast ? "text-foreground" : undefined;
-    const actionDividerContrastClass =
-      contrastStyles?.divider ?? (highContrast ? "border-border/55" : undefined);
 
     const hasActionArea = Boolean(
       actionArea &&
         (actionArea.tabs || actionArea.actions || actionArea.search),
     );
+
+    const showDivider = actionArea?.divider ?? true;
+    const actionPaddingClass = showDivider
+      ? variantStyles?.action.pt ?? "pt-[var(--space-4)]"
+      : undefined;
 
     const shouldWrapContent =
       variant !== "unstyled" || hasActionArea || Boolean(contentClassName);
@@ -276,18 +276,24 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
               className={cn(
                 "relative z-[2]",
                 variantStyles?.action.mt ?? "mt-[var(--space-4)]",
-                (actionArea?.divider ?? true)
-                  ? cn(
-                      "border-t border-border/35",
-                      actionDividerContrastClass,
-                      variantStyles?.action.pt ?? "pt-[var(--space-4)]",
-                    )
-                  : null,
+                actionPaddingClass,
                 "grid gap-[var(--space-3)] md:grid-cols-12 md:gap-[var(--space-4)]",
                 variantStyles?.action.gap,
                 actionArea?.className,
               )}
             >
+              {showDivider ? (
+                <>
+                  <span
+                    aria-hidden
+                    className="pointer-events-none absolute inset-x-0 top-0 h-px bg-[hsl(var(--accent))]"
+                  />
+                  <span
+                    aria-hidden
+                    className="pointer-events-none absolute inset-x-0 top-0 h-px bg-[hsl(var(--accent))] blur-[6px] opacity-60"
+                  />
+                </>
+              ) : null}
               {actionArea?.tabs ? (
                 <div
                   data-area="tabs"

--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -156,10 +156,12 @@ const PageHeaderInner = <
   const {
     className: frameClassName,
     variant: frameVariant,
-    actionArea: frameActionArea,
+    actionArea: frameActionAreaProp,
     allowOverflow: frameAllowOverflow,
     ...restFrameProps
   } = frameProps ?? {};
+
+  const frameActionArea = frameActionAreaProp ?? null;
 
   const stickyChildrenPresent = Boolean(headerSticky) || Boolean(heroSticky);
 

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -166,178 +166,184 @@ exports[`ReviewsPage > renders default state 1`] = `
                     </div>
                   </div>
                 </div>
-              </div>
-            </section>
-          </div>
-        </div>
-        <div
-          class="relative z-[2] mt-[var(--space-6)] md:mt-[var(--space-7)] border-t border-border/35 pt-[var(--space-5)] md:pt-[var(--space-6)] grid md:grid-cols-12 md:gap-[var(--space-4)] gap-[var(--space-4)]"
-          role="group"
-        >
-          <div
-            class="flex flex-col gap-[var(--space-2)] md:col-span-7 md:justify-self-stretch"
-            data-area="search"
-          >
-            <form
-              class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-[var(--space-2)] data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"
-              role="search"
-            >
-              <div
-                class="relative min-w-0"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="lucide lucide-search pointer-events-none absolute left-[var(--space-4)] top-1/2 -translate-y-1/2 size-[var(--space-4)] text-muted-foreground"
-                  fill="none"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="m21 21-4.34-4.34"
-                  />
-                  <circle
-                    cx="11"
-                    cy="11"
-                    r="8"
-                  />
-                </svg>
                 <div
-                  class="relative inline-flex items-center border bg-card/60 backdrop-blur-[2px] shadow-control transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-control-hover focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),var(--asset-noise-url,none)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] focus-within:after:opacity-100 w-full hero2-neomorph !border border-[hsl(var(--border)/0.4)] !shadow-neo-inset hover:!shadow-neo-soft active:!shadow-neo-inset focus-within:!shadow-neo-soft [--hover:transparent] [--active:transparent] rounded-full [&>input]:rounded-full overflow-hidden hero2-frame"
-                  style="--control-h: var(--control-h-md);"
-                >
-                  <input
-                    autocapitalize="none"
-                    autocomplete="off"
-                    autocorrect="off"
-                    class="w-full rounded-[inherit] bg-transparent px-[var(--space-3)] text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)] pl-[var(--space-7)]"
-                    id=":r1:"
-                    name=":r1:"
-                    placeholder="Search title, tags, opponent, patch…"
-                    spellcheck="false"
-                    type="search"
-                    value=""
-                  />
-                </div>
-              </div>
-            </form>
-          </div>
-          <div
-            class="flex flex-wrap items-center justify-end gap-[var(--space-2)] md:col-span-5 md:justify-self-end"
-            data-area="actions"
-          >
-            <div
-              class="flex flex-col gap-[var(--space-2)] sm:flex-row sm:items-center sm:gap-[var(--space-3)]"
-            >
-              <label
-                class="flex w-full flex-col gap-[var(--space-1)] sm:w-auto sm:flex-row sm:items-center sm:gap-[var(--space-2)]"
-              >
-                <span
-                  class="text-ui font-medium text-muted-foreground"
-                >
-                  Sort
-                </span>
-                <div
-                  class="glitch-wrap w-full sm:w-auto"
+                  class="relative z-[2] mt-[var(--space-4)] md:mt-[var(--space-5)] flex flex-col gap-[var(--space-4)] md:gap-[var(--space-5)]"
                 >
                   <div
-                    class="group inline-flex rounded-[var(--radius-full)] border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0"
+                    class="relative"
+                    style="--divider: var(--ring);"
                   >
-                    <button
-                      aria-controls=":r2:-listbox"
-                      aria-expanded="false"
-                      aria-haspopup="listbox"
-                      aria-label="Sort reviews"
-                      class="_glitchTrigger_843152 relative flex items-center h-[var(--control-h-sm)] rounded-[var(--radius-full)] px-[var(--space-3)] overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none !h-[var(--control-h-lg)] !px-[var(--space-4)]"
-                      data-lit="true"
-                      data-open="false"
-                      type="button"
+                    <span
+                      aria-hidden="true"
+                      class="block h-px bg-[hsl(var(--divider))/0.28]"
+                    />
+                    <div
+                      class="flex flex-wrap items-start gap-[var(--space-2)] md:flex-nowrap md:items-center md:gap-[var(--space-3)] lg:gap-[var(--space-4)] pt-[var(--space-4)] md:pt-[var(--space-5)]"
                     >
-                      <span
-                        class="font-medium _glitchText_843152 text-foreground group-hover:text-foreground"
+                      <form
+                        class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-[var(--space-2)] data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"
+                        role="search"
                       >
-                        Newest
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        class="lucide lucide-chevron-down _caret_843152 ml-auto size-[var(--space-4)] shrink-0 opacity-75"
-                        fill="none"
-                        height="24"
-                        stroke="currentColor"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          class="relative min-w-0"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="lucide lucide-search pointer-events-none absolute left-[var(--space-4)] top-1/2 -translate-y-1/2 size-[var(--space-4)] text-muted-foreground"
+                            fill="none"
+                            height="24"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="m21 21-4.34-4.34"
+                            />
+                            <circle
+                              cx="11"
+                              cy="11"
+                              r="8"
+                            />
+                          </svg>
+                          <div
+                            class="relative inline-flex items-center border bg-card/60 backdrop-blur-[2px] shadow-control transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-control-hover focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),var(--asset-noise-url,none)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] focus-within:after:opacity-100 w-full hero2-neomorph !border border-[hsl(var(--border)/0.4)] !shadow-neo-inset hover:!shadow-neo-soft active:!shadow-neo-inset focus-within:!shadow-neo-soft [--hover:transparent] [--active:transparent] rounded-full [&>input]:rounded-full overflow-hidden hero2-frame"
+                            style="--control-h: var(--control-h-md);"
+                          >
+                            <input
+                              autocapitalize="none"
+                              autocomplete="off"
+                              autocorrect="off"
+                              class="w-full rounded-[inherit] bg-transparent px-[var(--space-3)] text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)] pl-[var(--space-7)]"
+                              id=":r1:"
+                              name=":r1:"
+                              placeholder="Search title, tags, opponent, patch…"
+                              spellcheck="false"
+                              type="search"
+                              value=""
+                            />
+                          </div>
+                        </div>
+                      </form>
+                      <div
+                        class="flex w-full flex-wrap items-center gap-[var(--space-2)] md:w-auto md:flex-nowrap"
                       >
-                        <path
-                          d="m6 9 6 6 6-6"
-                        />
-                      </svg>
-                      <span
-                        aria-hidden="true"
-                        class="_gbIris_843152"
-                      />
-                      <span
-                        aria-hidden="true"
-                        class="_gbChroma_843152"
-                      />
-                      <span
-                        aria-hidden="true"
-                        class="_gbFlicker_843152"
-                      />
-                      <span
-                        aria-hidden="true"
-                        class="_gbScan_843152"
-                      />
-                    </button>
+                        <div
+                          class="flex flex-col gap-[var(--space-2)] sm:flex-row sm:items-center sm:gap-[var(--space-3)]"
+                        >
+                          <label
+                            class="flex w-full flex-col gap-[var(--space-1)] sm:w-auto sm:flex-row sm:items-center sm:gap-[var(--space-2)]"
+                          >
+                            <span
+                              class="text-ui font-medium text-muted-foreground"
+                            >
+                              Sort
+                            </span>
+                            <div
+                              class="glitch-wrap w-full sm:w-auto"
+                            >
+                              <div
+                                class="group inline-flex rounded-[var(--radius-full)] border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[--theme-ring] focus-within:ring-offset-0"
+                              >
+                                <button
+                                  aria-controls=":r2:-listbox"
+                                  aria-expanded="false"
+                                  aria-haspopup="listbox"
+                                  aria-label="Sort reviews"
+                                  class="_glitchTrigger_843152 relative flex items-center h-[var(--control-h-sm)] rounded-[var(--radius-full)] px-[var(--space-3)] overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none !h-[var(--control-h-lg)] !px-[var(--space-4)]"
+                                  data-lit="true"
+                                  data-open="false"
+                                  type="button"
+                                >
+                                  <span
+                                    class="font-medium _glitchText_843152 text-foreground group-hover:text-foreground"
+                                  >
+                                    Newest
+                                  </span>
+                                  <svg
+                                    aria-hidden="true"
+                                    class="lucide lucide-chevron-down _caret_843152 ml-auto size-[var(--space-4)] shrink-0 opacity-75"
+                                    fill="none"
+                                    height="24"
+                                    stroke="currentColor"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                    viewBox="0 0 24 24"
+                                    width="24"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m6 9 6 6 6-6"
+                                    />
+                                  </svg>
+                                  <span
+                                    aria-hidden="true"
+                                    class="_gbIris_843152"
+                                  />
+                                  <span
+                                    aria-hidden="true"
+                                    class="_gbChroma_843152"
+                                  />
+                                  <span
+                                    aria-hidden="true"
+                                    class="_gbFlicker_843152"
+                                  />
+                                  <span
+                                    aria-hidden="true"
+                                    class="_gbScan_843152"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                          </label>
+                          <button
+                            class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[disabled=true]:opacity-[var(--disabled)] data-[disabled=true]:pointer-events-none h-[var(--control-h-lg)] text-title gap-[var(--space-4)] [&_svg]:size-[var(--space-8)] w-full whitespace-nowrap px-[var(--space-4)] sm:w-auto shadow-glow-sm hover:shadow-glow-md active:translate-y-px active:shadow-btn-primary-active bg-[hsl(var(--primary)/0.12)] border-[hsl(var(--primary)/0.35)] text-[hsl(var(--primary-foreground))] [--hover:theme('colors.interaction.primary.hover')] [--active:theme('colors.interaction.primary.active')]"
+                            style="--glow-active: hsl(var(--primary) / 0.35); --btn-primary-hover-shadow: 0 2px 6px -1px hsl(var(--primary) / 0.25); --btn-primary-active-shadow: inset 0 0 0 1px hsl(var(--primary) / 0.6);"
+                            tabindex="0"
+                            type="button"
+                          >
+                            <span
+                              class="absolute inset-0 pointer-events-none rounded-[inherit] bg-[linear-gradient(90deg,hsl(var(--primary)/.18),hsl(var(--primary)/.18))]"
+                            />
+                            <span
+                              class="relative z-10 inline-flex items-center gap-[var(--space-2)]"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="lucide lucide-plus"
+                                fill="none"
+                                height="24"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                viewBox="0 0 24 24"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5 12h14"
+                                />
+                                <path
+                                  d="M12 5v14"
+                                />
+                              </svg>
+                              <span>
+                                New Review
+                              </span>
+                            </span>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </label>
-              <button
-                class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[--focus] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[disabled=true]:opacity-[var(--disabled)] data-[disabled=true]:pointer-events-none h-[var(--control-h-lg)] text-title gap-[var(--space-4)] [&_svg]:size-[var(--space-8)] w-full whitespace-nowrap px-[var(--space-4)] sm:w-auto shadow-glow-sm hover:shadow-glow-md active:translate-y-px active:shadow-btn-primary-active bg-[hsl(var(--primary)/0.12)] border-[hsl(var(--primary)/0.35)] text-[hsl(var(--primary-foreground))] [--hover:theme('colors.interaction.primary.hover')] [--active:theme('colors.interaction.primary.active')]"
-                style="--glow-active: hsl(var(--primary) / 0.35); --btn-primary-hover-shadow: 0 2px 6px -1px hsl(var(--primary) / 0.25); --btn-primary-active-shadow: inset 0 0 0 1px hsl(var(--primary) / 0.6);"
-                tabindex="0"
-                type="button"
-              >
-                <span
-                  class="absolute inset-0 pointer-events-none rounded-[inherit] bg-[linear-gradient(90deg,hsl(var(--primary)/.18),hsl(var(--primary)/.18))]"
-                />
-                <span
-                  class="relative z-10 inline-flex items-center gap-[var(--space-2)]"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="lucide lucide-plus"
-                    fill="none"
-                    height="24"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M5 12h14"
-                    />
-                    <path
-                      d="M12 5v14"
-                    />
-                  </svg>
-                  <span>
-                    New Review
-                  </span>
-                </span>
-              </button>
-            </div>
+              </div>
+            </section>
           </div>
         </div>
         <div


### PR DESCRIPTION
## Summary
- default the PageHeader frame action area to null so the Hero renders its own utilities and neon divider
- update the NeomorphicHeroFrame action row to use an accent divider when it is rendered by the frame
- refresh the ReviewsPage snapshot for the updated markup

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca476b4d64832c972274e9d85419a1