### PR TITLE
Adjust reviews grid layout columns

### DIFF
--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -145,10 +145,13 @@ export default function ReviewsPage({
 
       <div
         className={cn(
-          "grid grid-cols-1 items-start gap-4 sm:gap-6 lg:gap-8 md:grid-cols-12",
+          "grid grid-cols-1 items-start gap-4 sm:gap-6 lg:gap-8 md:grid-cols-6 lg:grid-cols-12",
         )}
       >
-        <nav aria-label="Review list" className="md:col-span-4">
+        <nav
+          aria-label="Review list"
+          className="md:col-span-2 lg:col-span-4"
+        >
           <div className="card-neo-soft rounded-card r-card-lg overflow-hidden bg-card/50 shadow-neo-strong">
             <div className="section-b">
               <div className="mb-2 text-ui text-muted-foreground">
@@ -167,7 +170,7 @@ export default function ReviewsPage({
             </div>
           </div>
         </nav>
-        <div aria-live="polite" className="md:col-span-8">
+        <div aria-live="polite" className="md:col-span-4 lg:col-span-8">
           {!active ? (
             <ReviewPanel
               className={cn(

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -353,11 +353,11 @@ exports[`ReviewsPage > renders default state 1`] = `
       </div>
     </section>
     <div
-      class="grid grid-cols-1 items-start gap-4 sm:gap-6 lg:gap-8 md:grid-cols-12"
+      class="grid grid-cols-1 items-start gap-4 sm:gap-6 lg:gap-8 md:grid-cols-6 lg:grid-cols-12"
     >
       <nav
         aria-label="Review list"
-        class="md:col-span-4"
+        class="md:col-span-2 lg:col-span-4"
       >
         <div
           class="card-neo-soft rounded-card r-card-lg overflow-hidden bg-card/50 shadow-neo-strong"
@@ -523,7 +523,7 @@ exports[`ReviewsPage > renders default state 1`] = `
       </nav>
       <div
         aria-live="polite"
-        class="md:col-span-8"
+        class="md:col-span-4 lg:col-span-8"
       >
         <div
           aria-live="polite"


### PR DESCRIPTION
## Summary
- tune the reviews page grid to use six columns on medium screens and twelve on large layouts
- resize the list and detail columns to span two/four and four/eight columns respectively so the 12-column grid stays balanced
- refresh the ReviewsPage snapshot to capture the updated responsive classes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca50f37660832c94b25ce09ed69de2