### PR TITLE
Adjust team prompts card gradient overlay

### DIFF
--- a/src/components/home/TeamPromptsCard.tsx
+++ b/src/components/home/TeamPromptsCard.tsx
@@ -31,8 +31,12 @@ export default function TeamPromptsCard() {
           title="Prompts peek"
           cta={{ label: "Explore Prompts", href: "/prompts" }}
         >
-          <div className="rounded-card r-card-md bg-seg-active-grad p-[var(--space-4)] text-center text-ui text-neon-soft">
-            Get inspired with curated prompts
+          <div className="relative overflow-hidden rounded-card r-card-md bg-seg-active-grad p-[var(--space-4)] text-center text-ui text-foreground">
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-0 -z-10 rounded-[inherit] bg-[linear-gradient(90deg,hsl(var(--primary)/0.35),hsl(var(--accent)/0.35),hsl(var(--accent-3)/0.35))]"
+            />
+            <span className="relative z-10 block">Get inspired with curated prompts</span>
           </div>
         </DashboardCard>
       </div>


### PR DESCRIPTION
## Summary
- add a gradient overlay layer to the team prompts highlight card
- keep the prompt text above the overlay and use the semantic foreground color

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca55672040832cbe4be9a2b2427e8a