### PR TITLE
Improve ghost accent/info button contrast

### DIFF
--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -130,9 +130,9 @@ export const toneClasses: Record<
     primary:
       "text-foreground [--hover:theme('colors.interaction.foreground.tintHover')] [--active:theme('colors.interaction.foreground.tintActive')]",
     accent:
-      "text-accent [--hover:theme('colors.interaction.accent.tintHover')] [--active:theme('colors.interaction.accent.tintActive')]",
+      "text-accent-foreground bg-accent/20 [--hover:theme('colors.interaction.accent.surfaceHover')] [--active:theme('colors.interaction.accent.surfaceActive')]",
     info:
-      "text-accent-2 [--hover:theme('colors.interaction.info.tintHover')] [--active:theme('colors.interaction.info.tintActive')]",
+      "text-accent-2-foreground bg-accent-2/20 [--hover:theme('colors.interaction.info.surfaceHover')] [--active:theme('colors.interaction.info.surfaceActive')]",
     danger:
       "text-danger [--hover:theme('colors.interaction.danger.tintHover')] [--active:theme('colors.interaction.danger.tintActive')]",
   },

--- a/tests/ui/button.test.tsx
+++ b/tests/ui/button.test.tsx
@@ -63,8 +63,18 @@ describe("Button", () => {
     },
     ghost: {
       primary: ["text-foreground"],
-      accent: ["text-accent"],
-      info: ["text-accent-2"],
+      accent: [
+        "text-accent-foreground",
+        "bg-accent/20",
+        "[--hover:theme('colors.interaction.accent.surfaceHover')]",
+        "[--active:theme('colors.interaction.accent.surfaceActive')]",
+      ],
+      info: [
+        "text-accent-2-foreground",
+        "bg-accent-2/20",
+        "[--hover:theme('colors.interaction.info.surfaceHover')]",
+        "[--active:theme('colors.interaction.info.surfaceActive')]",
+      ],
       danger: ["text-danger"],
     },
   };


### PR DESCRIPTION
## Summary
- update ghost accent and info tone styling to use foreground tokens with tinted backgrounds and darker hover tokens
- align the button UI tests with the refreshed ghost tone expectations

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca55af62a8832cbeee877fc825726c