### PR TITLE
Update PageHeader sticky defaults

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -72,6 +72,7 @@ function HomePageContent() {
               heading: "Welcome to Planner",
               subtitle: "Plan your day, track goals, and review games.",
               icon: <Home className="opacity-80" />,
+              sticky: true,
             }}
             hero={{
               heading: "Your day at a glance",

--- a/src/app/prompts/PromptsPage.tsx
+++ b/src/app/prompts/PromptsPage.tsx
@@ -159,9 +159,11 @@ function PageContent() {
             onChange: (k) => setView(k as View),
             ariaLabel: "Playground view",
           },
+          sticky: true,
         }}
         hero={{
           frame: false,
+          sticky: true,
           heading:
             view === "components"
               ? "Components"

--- a/src/components/comps/CompsPage.tsx
+++ b/src/components/comps/CompsPage.tsx
@@ -111,9 +111,11 @@ export default function CompsPage() {
           id: "comps-header",
           heading: "Component Gallery",
           subtitle: "Browse Planner UI building blocks by category.",
+          sticky: true,
         }}
         hero={{
           frame: false,
+          sticky: true,
           heading: sectionLabel,
           icon: <PanelsTopLeft aria-hidden className="size-6" />,
           subTabs: {

--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -97,6 +97,7 @@ function Inner() {
             subtitle: "Plan your week",
             icon: <CalendarDays className="opacity-80" />,
             right,
+            sticky: true,
           }}
           hero={{
             frame: false,

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -89,9 +89,11 @@ export default function ReviewsPage({
           icon: <BookOpen className="opacity-80" />,
           topClassName: "top-[var(--header-stack)]",
           underline: true,
+          sticky: true,
         }}
         hero={{
           frame: false,
+          sticky: true,
           topClassName: "top-[var(--header-stack)]",
           heading: "Browse Reviews",
           subtitle: <span className="pill">Total {base.length}</span>,

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -213,6 +213,7 @@ export default function TeamCompPage() {
       return {
         as: "section",
         frame: false,
+        sticky: true,
         topClassName: "top-[var(--header-stack)]",
         eyebrow: active?.label,
         heading: "Comps",
@@ -250,6 +251,7 @@ export default function TeamCompPage() {
       return {
         as: "section",
         frame: false,
+        sticky: true,
         topClassName: "top-[var(--header-stack)]",
         eyebrow: "Comps",
         heading: "Builder",
@@ -371,6 +373,7 @@ export default function TeamCompPage() {
             ariaLabel: "Team comps mode",
           },
           underline: true,
+          sticky: true,
         }}
         hero={hero}
       />

--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -89,16 +89,15 @@ const PageHeaderInner = <
 ) => {
   const Component: PageHeaderElement = as ?? "section";
 
-  const headerSticky = header.sticky ?? true;
-  const heroSticky = hero.sticky ?? true;
-
   const {
+    sticky: headerSticky = false,
     tabs: headerTabs,
     underline: headerUnderline,
     ...headerRest
   } = header;
 
   const {
+    sticky: heroSticky = false,
     subTabs: heroSubTabs,
     search: heroSearch,
     actions: heroActions,
@@ -163,7 +162,7 @@ const PageHeaderInner = <
 
   const frameActionArea = frameActionAreaProp ?? null;
 
-  const stickyChildrenPresent = Boolean(headerSticky) || Boolean(heroSticky);
+  const stickyChildrenPresent = headerSticky || heroSticky;
 
   const heroShouldRenderActionArea = frameActionArea === null;
   const heroShouldRenderTabs = heroShouldRenderActionArea || tabsInHero;
@@ -309,11 +308,13 @@ const PageHeaderInner = <
         >
           <Header
             {...headerRest}
+            sticky={headerSticky}
             tabs={tabsInHero ? undefined : headerTabs}
             underline={headerUnderline ?? false}
           />
           <Hero
             {...heroRest}
+            sticky={heroSticky}
             as={heroAs ?? "section"}
             frame={resolvedHeroFrame}
             topClassName={cn("top-[var(--header-stack)]", heroTopClassName)}


### PR DESCRIPTION
## Summary
- default the PageHeader header/hero sticky flags to false and wire them through to the child components
- ensure allowOverflow only follows when a sticky child is requested
- explicitly opt affected pages back into sticky headers/heroes where desired

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca56db6e60832c80d0753dbebed8f0