### PR TITLE
Tokenize review summary spacing utilities

### DIFF
--- a/src/components/reviews/ReviewSummaryNotes.tsx
+++ b/src/components/reviews/ReviewSummaryNotes.tsx
@@ -9,7 +9,7 @@ export default function ReviewSummaryNotes({ notes }: ReviewSummaryNotesProps) {
   return (
     <div>
       <SectionLabel>Notes</SectionLabel>
-      <div className="rounded-card r-card-lg border border-border bg-card p-3 text-ui leading-6 text-foreground/70">
+      <div className="rounded-card r-card-lg border border-border bg-card p-[var(--space-3)] text-ui leading-6 text-foreground/70">
         {notes}
       </div>
     </div>

--- a/src/components/reviews/ReviewSummaryPillars.tsx
+++ b/src/components/reviews/ReviewSummaryPillars.tsx
@@ -30,7 +30,7 @@ export default function ReviewSummaryPillars({
     <div>
       <SectionLabel>Pillars</SectionLabel>
       {Array.isArray(pillars) && pillars.length > 0 ? (
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-[var(--space-2)]">
           {pillars.map((p) => (
             <StaticNeonWrap key={p}>
               <PillarBadge pillar={p} size="md" active />

--- a/src/components/reviews/ReviewSummaryScore.tsx
+++ b/src/components/reviews/ReviewSummaryScore.tsx
@@ -25,45 +25,45 @@ export default function ReviewSummaryScore({
   return (
     <div>
       <SectionLabel>Score</SectionLabel>
-      <div className="relative h-12 rounded-card r-card-lg border border-border bg-card px-4">
-        <div className="absolute left-4 right-4 top-1/2 -translate-y-1/2 px-3">
+      <div className="relative h-[var(--space-7)] rounded-card r-card-lg border border-border bg-card px-[var(--space-4)]">
+        <div className="absolute left-[var(--space-4)] right-[var(--space-4)] top-1/2 -translate-y-1/2 px-[var(--space-3)]">
           <div
-            className="relative h-2 w-full rounded-full bg-muted shadow-neo-inset"
+            className="relative h-[var(--space-2)] w-full rounded-full bg-muted shadow-neo-inset"
             style={{ "--progress": `${score * 10}%` } as React.CSSProperties}
           >
-            <div className="absolute left-0 top-0 h-2 w-[var(--progress)] rounded-full bg-gradient-to-r from-primary to-accent shadow-ring [--ring:var(--primary)]" />
-            <div className="absolute left-[var(--progress)] top-1/2 h-5 w-5 -translate-y-1/2 -translate-x-1/2 rounded-full border border-border bg-card shadow-neoSoft" />
+            <div className="absolute left-0 top-0 h-[var(--space-2)] w-[var(--progress)] rounded-full bg-gradient-to-r from-primary to-accent shadow-ring [--ring:var(--primary)]" />
+            <div className="absolute left-[var(--progress)] top-1/2 h-[calc(var(--space-4)+var(--space-1))] w-[calc(var(--space-4)+var(--space-1))] -translate-y-1/2 -translate-x-1/2 rounded-full border border-border bg-card shadow-neoSoft" />
           </div>
         </div>
       </div>
-      <div className="mt-1 flex items-center gap-2 text-ui text-muted-foreground">
-        <span className="pill h-6 px-2 text-ui">{score}/10</span>
-        <ScoreIcon className={cn("h-4 w-4", scoreIconCls)} />
+      <div className="mt-[var(--space-1)] flex items-center gap-[var(--space-2)] text-ui text-muted-foreground">
+        <span className="pill h-[var(--space-5)] px-[var(--space-2)] text-ui">{score}/10</span>
+        <ScoreIcon className={cn("h-[var(--space-4)] w-[var(--space-4)]", scoreIconCls)} />
         <span>{msg}</span>
       </div>
       {focusOn && typeof focus === "number" && focusMsg && (
-        <div className="mt-4 space-y-2">
-          <div className="mb-2 flex items-center gap-2" aria-label="Focus">
+        <div className="mt-[var(--space-4)] space-y-[var(--space-2)]">
+          <div className="mb-[var(--space-2)] flex items-center gap-[var(--space-2)]" aria-label="Focus">
             <NeonIcon kind="brain" on={true} size={32} staticGlow />
-            <div className="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
+            <div className="h-[var(--hairline-w)] flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
           </div>
-          <div className="relative h-12 rounded-card r-card-lg border border-border bg-card px-4">
-            <div className="absolute left-4 right-4 top-1/2 -translate-y-1/2 px-3">
+          <div className="relative h-[var(--space-7)] rounded-card r-card-lg border border-border bg-card px-[var(--space-4)]">
+            <div className="absolute left-[var(--space-4)] right-[var(--space-4)] top-1/2 -translate-y-1/2 px-[var(--space-3)]">
               <div
-                className="relative h-2 w-full rounded-full bg-muted shadow-neo-inset"
+                className="relative h-[var(--space-2)] w-full rounded-full bg-muted shadow-neo-inset"
                 style={
                   {
                     "--progress": `${(focus / 10) * 100}%`,
                   } as React.CSSProperties
                 }
               >
-                <div className="absolute left-0 top-0 h-2 w-[var(--progress)] rounded-full bg-gradient-to-r from-accent to-primary shadow-ring [--ring:var(--accent)]" />
-                <div className="absolute left-[var(--progress)] top-1/2 h-5 w-5 -translate-y-1/2 -translate-x-1/2 rounded-full border border-border bg-card shadow-neoSoft" />
+                <div className="absolute left-0 top-0 h-[var(--space-2)] w-[var(--progress)] rounded-full bg-gradient-to-r from-accent to-primary shadow-ring [--ring:var(--accent)]" />
+                <div className="absolute left-[var(--progress)] top-1/2 h-[calc(var(--space-4)+var(--space-1))] w-[calc(var(--space-4)+var(--space-1))] -translate-y-1/2 -translate-x-1/2 rounded-full border border-border bg-card shadow-neoSoft" />
               </div>
             </div>
           </div>
-          <div className="mt-1 flex items-center gap-2 text-ui text-muted-foreground">
-            <span className="pill h-6 px-2 text-ui">{focus}/10</span>
+          <div className="mt-[var(--space-1)] flex items-center gap-[var(--space-2)] text-ui text-muted-foreground">
+            <span className="pill h-[var(--space-5)] px-[var(--space-2)] text-ui">{focus}/10</span>
             <span>{focusMsg}</span>
           </div>
         </div>

--- a/src/components/reviews/ReviewSummaryTimestamps.tsx
+++ b/src/components/reviews/ReviewSummaryTimestamps.tsx
@@ -16,21 +16,21 @@ export default function ReviewSummaryTimestamps({
 
   return (
     <div>
-      <div className="mb-2 flex items-center gap-2" aria-label="Timestamps">
+      <div className="mb-[var(--space-2)] flex items-center gap-[var(--space-2)]" aria-label="Timestamps">
         <NeonIcon kind="clock" on={!!hasTimed} size={32} staticGlow />
         <NeonIcon kind="file" on={!!hasNoteOnly} size={32} staticGlow />
-        <div className="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
+        <div className="h-[var(--hairline-w)] flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
       </div>
       {!markers.length ? (
         <div className="text-ui text-muted-foreground">No timestamps yet.</div>
       ) : (
-        <ul className="space-y-2">
+        <ul className="space-y-[var(--space-2)]">
           {[...markers]
             .sort((a, b) => a.seconds - b.seconds)
             .map((m) => (
               <li
                 key={m.id}
-                className="grid grid-cols-[auto_1fr] items-center gap-2 rounded-card r-card-lg border border-border bg-card px-3 py-2"
+                className="grid grid-cols-[auto_1fr] items-center gap-[var(--space-2)] rounded-card r-card-lg border border-border bg-card px-[var(--space-3)] py-[var(--space-2)]"
               >
                 {m.noteOnly ? (
                   <span
@@ -41,7 +41,7 @@ export default function ReviewSummaryTimestamps({
                     <FileText size={14} className="opacity-80" />
                   </span>
                 ) : (
-                  <span className="pill h-7 px-3 text-ui font-mono tabular-nums leading-none">
+                  <span className="pill h-7 px-[var(--space-3)] text-ui font-mono tabular-nums leading-none">
                     {m.time ?? "00:00"}
                   </span>
                 )}


### PR DESCRIPTION
## Summary
- replace ReviewSummaryScore layout spacing utilities with theme space tokens
- align ReviewSummaryTimestamps spacing and separators to token-based values
- update ReviewSummaryNotes and ReviewSummaryPillars containers to use shared spacing tokens

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca57ded7c4832cb20a253adb4b393f