### PR TITLE
Adjust slow fade demo hover contrast

### DIFF
--- a/src/components/prompts/PromptsDemos.tsx
+++ b/src/components/prompts/PromptsDemos.tsx
@@ -261,7 +261,7 @@ export default function PromptsDemos() {
         <div className="flex gap-2">
           <button
             type="button"
-            className="px-3 py-1 rounded-md bg-accent/20 transition-opacity duration-420 hover:opacity-60"
+            className="px-3 py-1 rounded-md bg-accent/20 text-foreground transition-colors duration-420 hover:bg-accent/30 hover:text-foreground"
           >
             Slow fade
           </button>


### PR DESCRIPTION
## Summary
- replace the slow fade motion demo hover opacity drop with a token-based accent background
- ensure the demo keeps readable foreground text while still signaling hover motion with color transitions

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca5950abf0832cb278160c570ecb1d