### PR TITLE
Fix TeamCompPage tab focus effect

### DIFF
--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -203,8 +203,16 @@ export default function TeamCompPage() {
   );
   const active = TABS.find((t) => t.key === tab);
   React.useEffect(() => {
-    TABS.find((t) => t.key === tab)?.ref.current?.focus();
-  }, [tab, TABS]);
+    if (tab === "cheat") {
+      cheatRef.current?.focus();
+      return;
+    }
+    if (tab === "builder") {
+      builderRef.current?.focus();
+      return;
+    }
+    clearsRef.current?.focus();
+  }, [tab]);
 
   const hero = React.useMemo<HeroProps<SubTab>>(() => {
     if (tab === "cheat") {


### PR DESCRIPTION
## Summary
- update the TeamCompPage tab focus effect to target the correct panel ref based solely on the active tab

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca5ad49558832ca7cafd824e2b41b0