### PR TITLE
Remove focusability from week summary tiles

### DIFF
--- a/src/components/planner/WeekSummary.tsx
+++ b/src/components/planner/WeekSummary.tsx
@@ -104,7 +104,6 @@ export default function WeekSummary({
               empty && "ws-tile--empty",
             )}
             data-today={today || undefined}
-            tabIndex={0}
             aria-label={`${friendlyDay}: ${countsLabel}`}
           >
             <div className="ws-tile__date">{friendlyDay}</div>


### PR DESCRIPTION
## Summary
- remove the explicit `tabIndex` from week summary tiles so passive tiles are no longer in the keyboard focus order
- keep aria labels for screen reader context while leaving the tiles non-interactive

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68ca5acab5b4832c925f73b39b90d0bf