### PR TITLE
Add QuickActionGrid primitive for home quick actions

### DIFF
--- a/src/components/home/QuickActionGrid.tsx
+++ b/src/components/home/QuickActionGrid.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import Button, { type ButtonProps } from "@/components/ui/primitives/Button";
+import { cn } from "@/lib/utils";
+
+type QuickActionLayout = "stacked" | "grid";
+
+const layoutClassNames: Record<QuickActionLayout, string> = {
+  stacked: "flex flex-col gap-[var(--space-4)]",
+  grid: "grid gap-[var(--space-4)]",
+};
+
+const buttonBaseClassName =
+  "rounded-[var(--radius-2xl)] [--focus:var(--theme-ring)] focus-visible:ring-offset-0";
+
+type QuickActionDefinition = {
+  href: string;
+  label: React.ReactNode;
+  tone?: ButtonProps["tone"];
+  asChild?: boolean;
+  className?: string;
+  size?: ButtonProps["size"];
+  variant?: ButtonProps["variant"];
+  linkProps?: Omit<React.ComponentProps<typeof Link>, "href" | "children">;
+};
+
+type QuickActionGridProps = {
+  actions: QuickActionDefinition[];
+  layout?: QuickActionLayout;
+  className?: string;
+  buttonClassName?: string;
+  buttonSize?: ButtonProps["size"];
+  buttonTone?: ButtonProps["tone"];
+  buttonVariant?: ButtonProps["variant"];
+};
+
+export default function QuickActionGrid({
+  actions,
+  layout = "stacked",
+  className,
+  buttonClassName,
+  buttonSize = "md",
+  buttonTone = "primary",
+  buttonVariant = "secondary",
+}: QuickActionGridProps) {
+  return (
+    <div className={cn(layoutClassNames[layout], className)}>
+      {actions.map((action, index) => {
+        const {
+          href,
+          label,
+          tone,
+          asChild,
+          className: actionClassName,
+          size,
+          variant,
+          linkProps,
+        } = action;
+        const key = `${href}-${index}`;
+        const resolvedTone = tone ?? buttonTone;
+        const resolvedSize = size ?? buttonSize;
+        const resolvedVariant = variant ?? buttonVariant;
+        const mergedClassName = cn(
+          buttonBaseClassName,
+          buttonClassName,
+          actionClassName,
+        );
+
+        if (asChild) {
+          return (
+            <Button
+              key={key}
+              asChild
+              tone={resolvedTone}
+              size={resolvedSize}
+              variant={resolvedVariant}
+              className={mergedClassName}
+            >
+              <Link href={href} {...linkProps}>
+                {label}
+              </Link>
+            </Button>
+          );
+        }
+
+        const target = linkProps?.target;
+        const rel = linkProps?.rel;
+
+        return (
+          <Button
+            key={key}
+            href={href}
+            tone={resolvedTone}
+            size={resolvedSize}
+            variant={resolvedVariant}
+            className={mergedClassName}
+            target={target}
+            rel={rel}
+          >
+            {label}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/home/QuickActions.tsx
+++ b/src/components/home/QuickActions.tsx
@@ -1,25 +1,33 @@
 "use client";
 
 import * as React from "react";
-import Button from "@/components/ui/primitives/Button";
+import QuickActionGrid from "./QuickActionGrid";
 
-const quickActionButtonClassName =
-  "rounded-[var(--radius-2xl)] [--focus:var(--theme-ring)] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none";
+const actions = [
+  {
+    href: "/planner",
+    label: "Planner Today",
+  },
+  {
+    href: "/goals",
+    label: "New Goal",
+    tone: "accent" as const,
+  },
+  {
+    href: "/reviews",
+    label: "New Review",
+    tone: "accent" as const,
+  },
+];
 
 export default function QuickActions() {
   return (
     <section aria-label="Quick actions" className="grid gap-[var(--space-4)]">
-      <div className="flex flex-col gap-[var(--space-4)] md:flex-row md:items-center md:justify-between">
-        <Button href="/planner" className={quickActionButtonClassName}>
-          Planner Today
-        </Button>
-        <Button href="/goals" className={quickActionButtonClassName} tone="accent">
-          New Goal
-        </Button>
-        <Button href="/reviews" className={quickActionButtonClassName} tone="accent">
-          New Review
-        </Button>
-      </div>
+      <QuickActionGrid
+        actions={actions}
+        className="md:flex-row md:items-center md:justify-between"
+        buttonClassName="motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
+      />
     </section>
   );
 }

--- a/src/components/home/TeamPromptsCard.tsx
+++ b/src/components/home/TeamPromptsCard.tsx
@@ -1,29 +1,40 @@
 "use client";
 
 import * as React from "react";
-import Link from "next/link";
-import Button from "@/components/ui/primitives/Button";
 import DashboardCard from "./DashboardCard";
+import QuickActionGrid from "./QuickActionGrid";
 
-const quickActionClassName =
-  "col-span-12 w-full justify-start text-left border-border bg-card/60 [--focus:var(--theme-ring)] focus-visible:ring-offset-0 sm:col-span-6 lg:col-span-4";
+const teamQuickActions = [
+  {
+    href: "/team",
+    label: "Archetypes",
+    asChild: true,
+  },
+  {
+    href: "/team",
+    label: "Team Builder",
+    asChild: true,
+  },
+  {
+    href: "/team",
+    label: "Jungle Clears",
+    asChild: true,
+  },
+];
 
 export default function TeamPromptsCard() {
   return (
     <div className="grid grid-cols-1 gap-[var(--space-6)] md:grid-cols-12">
       <div className="md:col-span-6">
         <DashboardCard title="Team quick actions">
-          <div className="grid grid-cols-12 gap-[var(--space-4)]">
-            <Button asChild size="sm" variant="ghost" className={quickActionClassName}>
-              <Link href="/team">Archetypes</Link>
-            </Button>
-            <Button asChild size="sm" variant="ghost" className={quickActionClassName}>
-              <Link href="/team">Team Builder</Link>
-            </Button>
-            <Button asChild size="sm" variant="ghost" className={quickActionClassName}>
-              <Link href="/team">Jungle Clears</Link>
-            </Button>
-          </div>
+          <QuickActionGrid
+            actions={teamQuickActions}
+            layout="grid"
+            className="grid-cols-12"
+            buttonVariant="ghost"
+            buttonSize="sm"
+            buttonClassName="col-span-12 w-full justify-start text-left border-border bg-card/60 sm:col-span-6 lg:col-span-4"
+          />
         </DashboardCard>
       </div>
       <div className="md:col-span-6">

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -5,5 +5,6 @@ export { default as GoalsCard } from "./GoalsCard";
 export { default as ReviewsCard } from "./ReviewsCard";
 export { default as QuickActions } from "./QuickActions";
 export { default as TeamPromptsCard } from "./TeamPromptsCard";
+export { default as QuickActionGrid } from "./QuickActionGrid";
 export { default as BottomNav } from "./BottomNav";
 export { default as IsometricRoom } from "./IsometricRoom";

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -48,7 +48,12 @@ import SkeletonShowcase from "./SkeletonShowcase";
 import ToggleShowcase from "./ToggleShowcase";
 import PageHeaderDemo from "./PageHeaderDemo";
 import NeomorphicHeroFrameDemo from "./NeomorphicHeroFrameDemo";
-import { DashboardCard, BottomNav, IsometricRoom } from "@/components/home";
+import {
+  DashboardCard,
+  BottomNav,
+  IsometricRoom,
+  QuickActionGrid,
+} from "@/components/home";
 import ChampListEditor from "@/components/team/ChampListEditor";
 import {
   RoleSelector,
@@ -381,6 +386,32 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
   ]}
   defaultValue="active"
   ariaLabel="Show active goals"
+/>`,
+    },
+    {
+      id: "quick-action-grid",
+      name: "QuickActionGrid",
+      description: "Maps quick action configs to styled buttons",
+      element: (
+        <QuickActionGrid
+          actions={[
+            { href: "/planner", label: "Planner Today" },
+            { href: "/goals", label: "New Goal", tone: "accent" },
+            { href: "/reviews", label: "New Review", tone: "accent" },
+          ]}
+          className="md:flex-row md:items-center md:justify-between"
+          buttonClassName="motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
+        />
+      ),
+      tags: ["button", "layout"],
+      code: `<QuickActionGrid
+  actions={[
+    { href: "/planner", label: "Planner Today" },
+    { href: "/goals", label: "New Goal", tone: "accent" },
+    { href: "/reviews", label: "New Review", tone: "accent" },
+  ]}
+  className="md:flex-row md:items-center md:justify-between"
+  buttonClassName="motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
 />`,
     },
     {


### PR DESCRIPTION
## Summary
- add a reusable QuickActionGrid that maps action definitions to the shared quick-action button layout
- refactor QuickActions and TeamPromptsCard to consume the new primitive and centralize styling
- export QuickActionGrid and document it in the component gallery for future reference

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca5a2fb1d4832c90d458f89d3da003