### PR TITLE
Adjust review list height handling

### DIFF
--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -167,7 +167,7 @@ export default function ReviewsPage({
                   onSelect(id);
                 }}
                 onCreate={onCreate}
-                className="h-[calc(100vh-var(--header-stack)-var(--space-6))] overflow-auto p-2"
+                className="h-auto overflow-auto p-2 md:h-[calc(100vh-var(--header-stack)-var(--space-6))]"
               />
             </div>
           </div>

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -372,7 +372,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                shown
             </div>
             <div
-              class="rounded-card r-card-lg border border-border/25 bg-card/60 shadow-outline-subtle w-full mx-auto backdrop-blur-sm h-[calc(100vh-var(--header-stack)-var(--space-6))] overflow-auto p-2"
+              class="rounded-card r-card-lg border border-border/25 bg-card/60 shadow-outline-subtle w-full mx-auto backdrop-blur-sm h-auto overflow-auto p-2 md:h-[calc(100vh-var(--header-stack)-var(--space-6))]"
             >
               <ul
                 class="flex flex-col gap-3"


### PR DESCRIPTION
## Summary
- allow the review list to grow naturally at the base breakpoint
- restore the fixed viewport height offset at the md breakpoint

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca5b0e9dc8832c8dfcdd5ef8436f56