### PR TITLE
Adjust timer completion badge contrast

### DIFF
--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -516,7 +516,7 @@ export default function TimerTab() {
             {/* Complete state */}
             {finished && (
               <div className="mt-6 grid place-items-center">
-                <div className="rounded-full bg-[linear-gradient(90deg,hsl(var(--accent)),hsl(var(--accent-2)))] px-3 py-1 text-ui font-medium text-foreground shadow-glow animate-pulse">
+                <div className="rounded-full bg-[linear-gradient(90deg,hsl(var(--accent)/0.35),hsl(var(--accent-2)/0.35)))] px-3 py-1 text-ui font-medium text-foreground shadow-glow ring-1 ring-inset ring-border/50 motion-safe:animate-pulse motion-reduce:animate-none">
                   Complete
                 </div>
                 <div className="mt-2 text-label font-medium tracking-[0.02em] text-muted-foreground">


### PR DESCRIPTION
## Summary
- soften the timer completion badge gradient with a semi-transparent accent overlay and add a subtle ring to keep the label legible during pulse states

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca5b19ce30832cb70e71f8513949bb