### PR TITLE
Adjust prompts peek text color

### DIFF
--- a/src/components/home/TeamPromptsCard.tsx
+++ b/src/components/home/TeamPromptsCard.tsx
@@ -42,7 +42,7 @@ export default function TeamPromptsCard() {
           title="Prompts peek"
           cta={{ label: "Explore Prompts", href: "/prompts" }}
         >
-          <div className="relative overflow-hidden rounded-card r-card-md bg-seg-active-grad p-[var(--space-4)] text-center text-ui text-foreground">
+          <div className="relative overflow-hidden rounded-card r-card-md bg-seg-active-grad p-[var(--space-4)] text-center text-ui text-primary-foreground">
             <div
               aria-hidden="true"
               className="pointer-events-none absolute inset-0 -z-10 rounded-[inherit] bg-[linear-gradient(90deg,hsl(var(--primary)/0.35),hsl(var(--accent)/0.35),hsl(var(--accent-3)/0.35))]"


### PR DESCRIPTION
## Summary
- update the Prompts peek card copy to use the semantic primary foreground color for improved readability against the gradient

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca9a710ed4832c99af445a12ba3ab0