### PR TITLE
Adjust review header label emphasis

### DIFF
--- a/src/components/reviews/ReviewSummaryHeader.tsx
+++ b/src/components/reviews/ReviewSummaryHeader.tsx
@@ -47,7 +47,7 @@ export default function ReviewSummaryHeader({
     <div className="section-h sticky">
       <div className="grid w-full grid-cols-[1fr_auto] items-center gap-4">
         <div className="min-w-0">
-          <div className="mb-1 text-ui font-medium tracking-[0.02em] text-muted-foreground">Title</div>
+          <div className="mb-1 text-ui font-medium tracking-[0.02em] text-foreground/60">Title</div>
           <div className="truncate text-title font-semibold tracking-[-0.01em] leading-7 text-foreground/70">
             {title || "Untitled review"}
           </div>


### PR DESCRIPTION
## Summary
- increase the supporting "Title" label contrast in the review summary header by using the `text-foreground/60` token
- keep the primary heading at `text-foreground/70` to maintain the established hierarchy

## Testing
- npm run check


------
https://chatgpt.com/codex/tasks/task_e_68ca9a7ca024832c87697f1e1b3c71fd