### PR TITLE
Add review surface primitive for shared card styling

### DIFF
--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -62,6 +62,7 @@ import {
   ResultScoreSection,
   PillarsSelector as ReviewsPillarsSelector,
   TimestampMarkers,
+  ReviewSurface,
 } from "@/components/reviews";
 import type { PromptWithTitle } from "./usePrompts";
 import type { Review, Role } from "@/lib/types";
@@ -723,6 +724,33 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
 >
   <p className="text-ui">Body</p>
 </NeoCard>`,
+    },
+    {
+      id: "review-surface",
+      name: "ReviewSurface",
+      element: (
+        <ReviewSurface padding="sm">
+          <div className="space-y-[var(--space-1)] text-ui">
+            <p className="font-medium text-foreground/80">
+              Shared review shell
+            </p>
+            <p className="text-muted-foreground">
+              Tokenized radius, border, and background for summaries,
+              sliders, and timeline items.
+            </p>
+          </div>
+        </ReviewSurface>
+      ),
+      tags: ["reviews", "card", "tokens"],
+      code: `<ReviewSurface padding="sm">
+  <div className="space-y-[var(--space-1)] text-ui">
+    <p className="font-medium text-foreground/80">Shared review shell</p>
+    <p className="text-muted-foreground">
+      Tokenized radius, border, and background for summaries,
+      sliders, and timeline items.
+    </p>
+  </div>
+</ReviewSurface>`,
     },
     {
       id: "section-card-variants",

--- a/src/components/reviews/ResultScoreSection.tsx
+++ b/src/components/reviews/ResultScoreSection.tsx
@@ -3,6 +3,7 @@ import SectionLabel from "@/components/reviews/SectionLabel";
 import { cn } from "@/lib/utils";
 import type { Review } from "@/lib/types";
 import { SCORE_POOLS, pickIndex, scoreIcon } from "@/components/reviews/reviewData";
+import ReviewSurface from "@/components/reviews/ReviewSurface";
 
 export type ResultScoreSectionHandle = {
   save: () => void;
@@ -54,32 +55,37 @@ function ResultScoreSection(
     <>
       <div>
         <SectionLabel>Result</SectionLabel>
-        <button
-          ref={resultRef}
-          type="button"
-          role="switch"
-          aria-checked={result === "Win"}
-          onClick={() => {
-            const next = result === "Win" ? "Loss" : "Win";
-            setResult(next);
-            commitMeta({ result: next });
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault();
+        <ReviewSurface
+          asChild
+          tone="default"
+          padding="none"
+          className={cn(
+            "relative inline-flex h-10 w-48 select-none items-center overflow-hidden",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          )}
+        >
+          <button
+            ref={resultRef}
+            type="button"
+            role="switch"
+            aria-checked={result === "Win"}
+            onClick={() => {
               const next = result === "Win" ? "Loss" : "Win";
               setResult(next);
               commitMeta({ result: next });
-              scoreRangeRef.current?.focus();
-            }
-          }}
-          className={cn(
-            "relative inline-flex h-10 w-48 select-none items-center overflow-hidden rounded-card r-card-lg",
-            "border border-border bg-card",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-          )}
-          title="Toggle Win/Loss"
-        >
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                const next = result === "Win" ? "Loss" : "Win";
+                setResult(next);
+                commitMeta({ result: next });
+                scoreRangeRef.current?.focus();
+              }
+            }}
+            title="Toggle Win/Loss"
+            className="w-full"
+          >
           <span
             aria-hidden
             className="absolute top-1 bottom-1 left-1 rounded-xl transition-transform duration-300"
@@ -112,12 +118,16 @@ function ResultScoreSection(
               Loss
             </div>
           </div>
-        </button>
+          </button>
+        </ReviewSurface>
       </div>
 
       <div>
         <SectionLabel>Score</SectionLabel>
-        <div className="relative h-12 rounded-card r-card-lg border border-border bg-card px-4 focus-within:ring-2 focus-within:ring-ring">
+        <ReviewSurface
+          paddingX="md"
+          className="relative h-12 focus-within:ring-2 focus-within:ring-ring"
+        >
           <input
             ref={scoreRangeRef}
             type="range"
@@ -151,7 +161,7 @@ function ResultScoreSection(
               />
             </div>
           </div>
-        </div>
+        </ReviewSurface>
         <div className="mt-1 flex items-center gap-2 text-ui text-muted-foreground">
           <span className="pill h-6 px-2 text-ui">{score}/10</span>
           <ScoreIcon className={cn("h-4 w-4", scoreIconCls)} />

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -5,6 +5,7 @@ import { RoleSelector } from "@/components/reviews";
 import SectionLabel from "@/components/reviews/SectionLabel";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import NeonIcon from "@/components/reviews/NeonIcon";
+import ReviewSurface from "@/components/reviews/ReviewSurface";
 
 import * as React from "react";
 import type { Review, Role } from "@/lib/types";
@@ -253,7 +254,10 @@ export default function ReviewEditor({
 
           {focusOn && (
             <>
-              <div className="mt-3 relative h-12 rounded-card r-card-lg border border-border bg-card px-4 focus-within:ring-2 focus-within:ring-ring">
+              <ReviewSurface
+                paddingX="md"
+                className="mt-3 relative h-12 focus-within:ring-2 focus-within:ring-ring"
+              >
                 <input
                   ref={focusRangeRef}
                   type="range"
@@ -285,7 +289,7 @@ export default function ReviewEditor({
                     />
                   </div>
                 </div>
-              </div>
+              </ReviewSurface>
               <div className="mt-1 flex items-center gap-2 text-ui text-muted-foreground">
                 <span className="pill h-6 px-2 text-ui">{focus}/10</span>
                 <span>{focusMsg}</span>

--- a/src/components/reviews/ReviewSummaryNotes.tsx
+++ b/src/components/reviews/ReviewSummaryNotes.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import SectionLabel from "@/components/reviews/SectionLabel";
+import ReviewSurface from "@/components/reviews/ReviewSurface";
 
 export type ReviewSummaryNotesProps = {
   notes: string;
@@ -9,9 +10,12 @@ export default function ReviewSummaryNotes({ notes }: ReviewSummaryNotesProps) {
   return (
     <div>
       <SectionLabel>Notes</SectionLabel>
-      <div className="rounded-card r-card-lg border border-border bg-card p-[var(--space-3)] text-ui leading-6 text-foreground/70">
+      <ReviewSurface
+        padding="sm"
+        className="text-ui leading-6 text-foreground/70"
+      >
         {notes}
-      </div>
+      </ReviewSurface>
     </div>
   );
 }

--- a/src/components/reviews/ReviewSummaryScore.tsx
+++ b/src/components/reviews/ReviewSummaryScore.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 import SectionLabel from "@/components/reviews/SectionLabel";
 import NeonIcon from "@/components/reviews/NeonIcon";
+import ReviewSurface from "@/components/reviews/ReviewSurface";
 
 export type ReviewSummaryScoreProps = {
   score: number;
@@ -25,7 +26,10 @@ export default function ReviewSummaryScore({
   return (
     <div>
       <SectionLabel>Score</SectionLabel>
-      <div className="relative h-[var(--space-7)] rounded-card r-card-lg border border-border bg-card px-[var(--space-4)]">
+      <ReviewSurface
+        paddingX="md"
+        className="relative h-[var(--space-7)]"
+      >
         <div className="absolute left-[var(--space-4)] right-[var(--space-4)] top-1/2 -translate-y-1/2 px-[var(--space-3)]">
           <div
             className="relative h-[var(--space-2)] w-full rounded-full bg-muted shadow-neo-inset"
@@ -35,7 +39,7 @@ export default function ReviewSummaryScore({
             <div className="absolute left-[var(--progress)] top-1/2 h-[calc(var(--space-4)+var(--space-1))] w-[calc(var(--space-4)+var(--space-1))] -translate-y-1/2 -translate-x-1/2 rounded-full border border-border bg-card shadow-neoSoft" />
           </div>
         </div>
-      </div>
+      </ReviewSurface>
       <div className="mt-[var(--space-1)] flex items-center gap-[var(--space-2)] text-ui text-muted-foreground">
         <span className="pill h-[var(--space-5)] px-[var(--space-2)] text-ui">{score}/10</span>
         <ScoreIcon className={cn("h-[var(--space-4)] w-[var(--space-4)]", scoreIconCls)} />
@@ -47,7 +51,10 @@ export default function ReviewSummaryScore({
             <NeonIcon kind="brain" on={true} size={32} staticGlow />
             <div className="h-[var(--hairline-w)] flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
           </div>
-          <div className="relative h-[var(--space-7)] rounded-card r-card-lg border border-border bg-card px-[var(--space-4)]">
+          <ReviewSurface
+            paddingX="md"
+            className="relative h-[var(--space-7)]"
+          >
             <div className="absolute left-[var(--space-4)] right-[var(--space-4)] top-1/2 -translate-y-1/2 px-[var(--space-3)]">
               <div
                 className="relative h-[var(--space-2)] w-full rounded-full bg-muted shadow-neo-inset"
@@ -61,7 +68,7 @@ export default function ReviewSummaryScore({
                 <div className="absolute left-[var(--progress)] top-1/2 h-[calc(var(--space-4)+var(--space-1))] w-[calc(var(--space-4)+var(--space-1))] -translate-y-1/2 -translate-x-1/2 rounded-full border border-border bg-card shadow-neoSoft" />
               </div>
             </div>
-          </div>
+          </ReviewSurface>
           <div className="mt-[var(--space-1)] flex items-center gap-[var(--space-2)] text-ui text-muted-foreground">
             <span className="pill h-[var(--space-5)] px-[var(--space-2)] text-ui">{focus}/10</span>
             <span>{focusMsg}</span>

--- a/src/components/reviews/ReviewSummaryTimestamps.tsx
+++ b/src/components/reviews/ReviewSummaryTimestamps.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import type { ReviewMarker } from "@/lib/types";
 import NeonIcon from "@/components/reviews/NeonIcon";
+import ReviewSurface from "@/components/reviews/ReviewSurface";
 import { FileText } from "lucide-react";
 
 export type ReviewSummaryTimestampsProps = {
@@ -28,25 +29,30 @@ export default function ReviewSummaryTimestamps({
           {[...markers]
             .sort((a, b) => a.seconds - b.seconds)
             .map((m) => (
-              <li
+              <ReviewSurface
                 key={m.id}
-                className="grid grid-cols-[auto_1fr] items-center gap-[var(--space-2)] rounded-card r-card-lg border border-border bg-card px-[var(--space-3)] py-[var(--space-2)]"
+                asChild
+                paddingX="sm"
+                paddingY="xs"
+                className="grid grid-cols-[auto_1fr] items-center gap-[var(--space-2)]"
               >
-                {m.noteOnly ? (
-                  <span
-                    className="pill flex h-7 w-14 items-center justify-center px-0"
-                    title="Note"
-                    aria-label="Note"
-                  >
-                    <FileText size={14} className="opacity-80" />
-                  </span>
-                ) : (
-                  <span className="pill h-7 px-[var(--space-3)] text-ui font-mono tabular-nums leading-none">
-                    {m.time ?? "00:00"}
-                  </span>
-                )}
-                <span className="truncate text-ui">{m.note || "—"}</span>
-              </li>
+                <li>
+                  {m.noteOnly ? (
+                    <span
+                      className="pill flex h-7 w-14 items-center justify-center px-0"
+                      title="Note"
+                      aria-label="Note"
+                    >
+                      <FileText size={14} className="opacity-80" />
+                    </span>
+                  ) : (
+                    <span className="pill h-7 px-[var(--space-3)] text-ui font-mono tabular-nums leading-none">
+                      {m.time ?? "00:00"}
+                    </span>
+                  )}
+                  <span className="truncate text-ui">{m.note || "—"}</span>
+                </li>
+              </ReviewSurface>
             ))}
         </ul>
       )}

--- a/src/components/reviews/ReviewSurface.tsx
+++ b/src/components/reviews/ReviewSurface.tsx
@@ -1,0 +1,106 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { Card, type CardProps } from "@/components/ui";
+import { cn } from "@/lib/utils";
+
+export type ReviewSurfaceTone = "default" | "muted" | "translucent";
+
+const toneVariants: Record<ReviewSurfaceTone, string> = {
+  default: "border-border bg-card",
+  muted: "border-border/70 bg-muted/70",
+  translucent: "border-border/60 bg-card/70",
+};
+
+export type ReviewSurfacePadding = "none" | "xs" | "sm" | "md" | "lg";
+
+const paddingMap: Record<ReviewSurfacePadding, string | undefined> = {
+  none: undefined,
+  xs: "p-[var(--space-2)]",
+  sm: "p-[var(--space-3)]",
+  md: "p-[var(--space-4)]",
+  lg: "p-[var(--space-5)]",
+};
+
+const paddingXMap: Record<ReviewSurfacePadding, string | undefined> = {
+  none: "px-0",
+  xs: "px-[var(--space-2)]",
+  sm: "px-[var(--space-3)]",
+  md: "px-[var(--space-4)]",
+  lg: "px-[var(--space-5)]",
+};
+
+const paddingYMap: Record<ReviewSurfacePadding, string | undefined> = {
+  none: "py-0",
+  xs: "py-[var(--space-2)]",
+  sm: "py-[var(--space-3)]",
+  md: "py-[var(--space-4)]",
+  lg: "py-[var(--space-5)]",
+};
+
+export type ReviewSurfaceProps = CardProps & {
+  asChild?: boolean;
+  tone?: ReviewSurfaceTone;
+  padding?: ReviewSurfacePadding;
+  paddingX?: ReviewSurfacePadding;
+  paddingY?: ReviewSurfacePadding;
+};
+
+const ReviewSurface = React.forwardRef<HTMLDivElement, ReviewSurfaceProps>(
+  (
+    {
+      asChild = false,
+      tone = "default",
+      padding = "none",
+      paddingX,
+      paddingY,
+      className,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const toneClass = toneVariants[tone] ?? toneVariants.default;
+    const spacingClasses = [
+      "p-0",
+      paddingMap[padding],
+      paddingX !== undefined ? paddingXMap[paddingX] : undefined,
+      paddingY !== undefined ? paddingYMap[paddingY] : undefined,
+    ];
+
+    if (asChild) {
+      return (
+        <Slot
+          ref={ref as React.Ref<HTMLElement>}
+          className={cn(
+            "rounded-card r-card-lg border shadow-none",
+            toneClass,
+            spacingClasses,
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </Slot>
+      );
+    }
+
+    return (
+      <Card
+        ref={ref}
+        className={cn(
+          "rounded-card r-card-lg border shadow-none",
+          toneClass,
+          spacingClasses,
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </Card>
+    );
+  },
+);
+
+ReviewSurface.displayName = "ReviewSurface";
+
+export default ReviewSurface;

--- a/src/components/reviews/index.ts
+++ b/src/components/reviews/index.ts
@@ -18,3 +18,4 @@ export { default as LaneOpponentForm } from "./LaneOpponentForm";
 export { default as ResultScoreSection } from "./ResultScoreSection";
 export { default as PillarsSelector } from "./PillarsSelector";
 export { default as TimestampMarkers } from "./TimestampMarkers";
+export { default as ReviewSurface } from "./ReviewSurface";

--- a/storybook/src/components/reviews/ReviewSurface.stories.tsx
+++ b/storybook/src/components/reviews/ReviewSurface.stories.tsx
@@ -1,0 +1,70 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import ReviewSurface from "@/components/reviews/ReviewSurface";
+
+const meta: Meta<typeof ReviewSurface> = {
+  title: "Reviews/ReviewSurface",
+  component: ReviewSurface,
+  args: {
+    tone: "default",
+    padding: "sm",
+    children: (
+      <p className="text-ui text-muted-foreground">
+        ReviewSurface wraps review content in the shared rounded card shell,
+        ensuring consistent tokens for radius, border, and background.
+      </p>
+    ),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ReviewSurface>;
+
+export const Playground: Story = {};
+
+export const SliderShell: Story = {
+  args: {
+    padding: "none",
+    paddingX: "md",
+    children: (
+      <div className="relative h-12">
+        <div className="absolute left-[var(--space-4)] right-[var(--space-4)] top-1/2 -translate-y-1/2">
+          <div className="relative h-2 w-full rounded-full bg-muted shadow-neo-inset">
+            <div
+              className="absolute left-0 top-0 h-2 w-[55%] rounded-full bg-gradient-to-r from-primary to-accent shadow-ring [--ring:var(--primary)]"
+            />
+            <div
+              className="absolute top-1/2 h-5 w-5 -translate-y-1/2 rounded-full border border-border bg-card shadow-neoSoft"
+              style={{ left: "calc(55% - (var(--space-2) + var(--space-1) / 2))" }}
+            />
+          </div>
+        </div>
+      </div>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Combine padding controls with custom slider markup to recreate the score and focus inputs used throughout reviews.",
+      },
+    },
+  },
+};
+
+export const MutedTone: Story = {
+  args: {
+    tone: "muted",
+    padding: "md",
+    children: (
+      <div className="space-y-[var(--space-1)] text-ui">
+        <p className="font-medium text-foreground/80">Muted tone</p>
+        <p className="text-muted-foreground">
+          Muted surfaces lean on the muted token for quieter callouts while keeping
+          the same rounded geometry.
+        </p>
+      </div>
+    ),
+  },
+};

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -410,7 +410,7 @@ exports[`ReviewEditor > renders default state 1`] = `
         </div>
         <button
           aria-checked="true"
-          class="relative inline-flex h-10 w-48 select-none items-center overflow-hidden rounded-card r-card-lg border border-border bg-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          class="rounded-card r-card-lg border shadow-none border-border bg-card p-0 relative inline-flex h-10 w-48 select-none items-center overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring w-full"
           role="switch"
           title="Toggle Win/Loss"
           type="button"
@@ -450,7 +450,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           />
         </div>
         <div
-          class="relative h-12 rounded-card r-card-lg border border-border bg-card px-4 focus-within:ring-2 focus-within:ring-ring"
+          class="rounded-card r-card-lg shadow-outline-subtle rounded-card r-card-lg border shadow-none border-border bg-card p-0 px-[var(--space-4)] relative h-12 focus-within:ring-2 focus-within:ring-ring"
         >
           <input
             aria-label="Score from 0 to 10"


### PR DESCRIPTION
## Summary
- add a ReviewSurface primitive with tone and padding options for review card shells
- refactor review summary, editor, and slider surfaces to reuse the shared component and update snapshots
- document the surface in the prompts gallery and Storybook for reviews

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca9a349a28832c9078c1f737aaf86a