### PR TITLE
Refactor dashboard cards to share list component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,7 @@ import {
   TeamPromptsCard,
   BottomNav,
   IsometricRoom,
+  DashboardList,
 } from "@/components/home";
 import { PageHeader, PageShell, Button, ThemeToggle, Spinner } from "@/components/ui";
 import { useTheme } from "@/lib/theme-context";
@@ -135,23 +136,25 @@ function HomePageContent() {
             title="Weekly focus"
             cta={{ label: "Open planner", href: "/planner" }}
           >
-            <ul className="divide-y divide-[hsl(var(--border))]">
-              {weeklyHighlights.map((highlight) => (
-                <li key={highlight.id} className="py-3">
-                  <div className="flex flex-col gap-2">
-                    <div className="flex items-baseline justify-between gap-3">
-                      <p className="text-ui font-medium">{highlight.title}</p>
-                      <span className="text-label text-muted-foreground">
-                        {highlight.schedule}
-                      </span>
-                    </div>
-                    <p className="text-body text-muted-foreground">
-                      {highlight.summary}
-                    </p>
+            <DashboardList
+              items={weeklyHighlights}
+              getKey={(highlight) => highlight.id}
+              itemClassName="py-3"
+              empty="No highlights scheduled"
+              renderItem={(highlight) => (
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-baseline justify-between gap-3">
+                    <p className="text-ui font-medium">{highlight.title}</p>
+                    <span className="text-label text-muted-foreground">
+                      {highlight.schedule}
+                    </span>
                   </div>
-                </li>
-              ))}
-            </ul>
+                  <p className="text-body text-muted-foreground">
+                    {highlight.summary}
+                  </p>
+                </div>
+              )}
+            />
           </DashboardCard>
         </div>
         <div className="md:col-span-12">

--- a/src/components/home/DashboardList.tsx
+++ b/src/components/home/DashboardList.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { CircleSlash } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export type DashboardListRenderItem<T> = (
+  item: T,
+  index: number,
+) => React.ReactNode;
+
+export interface DashboardListProps<T> {
+  items: readonly T[];
+  renderItem: DashboardListRenderItem<T>;
+  empty: string;
+  cta?: { label: string; href: string };
+  getKey?: (item: T, index: number) => React.Key;
+  itemClassName?:
+    | string
+    | ((item: T, index: number) => string | undefined | null | false);
+  className?: string;
+}
+
+export default function DashboardList<T>({
+  items,
+  renderItem,
+  empty,
+  cta,
+  getKey,
+  itemClassName,
+  className,
+}: DashboardListProps<T>): React.ReactElement {
+  const hasItems = items.length > 0;
+
+  return (
+    <ul className={cn("divide-y divide-[hsl(var(--border))]", className)}>
+      {hasItems
+        ? items.map((item, index) => {
+            const key = getKey ? getKey(item, index) : index;
+            const itemCls =
+              typeof itemClassName === "function"
+                ? itemClassName(item, index)
+                : itemClassName;
+
+            return (
+              <li
+                key={key}
+                className={cn("py-[var(--space-2)]", itemCls)}
+              >
+                {renderItem(item, index)}
+              </li>
+            );
+          })
+        : (
+            <li
+              className={cn(
+                "py-[var(--space-2)] text-ui text-muted-foreground",
+                cta ? "flex items-center justify-between" : "flex items-center",
+              )}
+            >
+              <span className="flex items-center gap-[var(--space-2)]">
+                <CircleSlash aria-hidden className="size-3" />
+                {empty}
+              </span>
+              {cta ? (
+                <Link
+                  href={cta.href}
+                  className="inline-flex items-center text-label font-medium text-accent-3 underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent-3 active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
+                >
+                  {cta.label}
+                </Link>
+              ) : null}
+            </li>
+          )}
+    </ul>
+  );
+}

--- a/src/components/home/GoalsCard.tsx
+++ b/src/components/home/GoalsCard.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import Link from "next/link";
 import * as React from "react";
 import DashboardCard from "./DashboardCard";
+import DashboardList from "./DashboardList";
 import { usePersistentState } from "@/lib/db";
 import type { Goal } from "@/lib/types";
 import { Progress } from "@/components/ui";
-import { CircleSlash } from "lucide-react";
 
 type GoalProgress = {
   value: number;
@@ -95,14 +94,18 @@ export default function GoalsCard() {
       title="Active goals"
       cta={{ label: "Manage Goals", href: "/goals" }}
     >
-      <ul className="divide-y divide-[hsl(var(--border))]">
-        {activeGoals.map((g) => {
-          const progress = deriveGoalProgress(g);
-          const statusText = getGoalStatus(g);
+      <DashboardList
+        items={activeGoals}
+        getKey={(goal) => goal.id}
+        empty="No active goals"
+        cta={{ label: "Create", href: "/goals" }}
+        renderItem={(goal) => {
+          const progress = deriveGoalProgress(goal);
+          const statusText = getGoalStatus(goal);
 
           return (
-            <li key={g.id} className="py-[var(--space-2)]">
-              <p className="text-ui">{g.title}</p>
+            <div>
+              <p className="text-ui">{goal.title}</p>
               <div className="mt-[var(--space-2)]">
                 {progress ? (
                   <>
@@ -117,24 +120,10 @@ export default function GoalsCard() {
                   <p className="text-label text-muted-foreground">{statusText}</p>
                 )}
               </div>
-            </li>
+            </div>
           );
-        })}
-        {activeGoals.length === 0 && (
-          <li className="flex justify-between py-[var(--space-2)] text-ui text-muted-foreground">
-            <span className="flex items-center gap-[var(--space-2)]">
-              <CircleSlash className="size-3" />
-              No active goals
-            </span>
-            <Link
-              href="/goals"
-              className="inline-flex items-center text-label font-medium text-accent-3 underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent-3 active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
-            >
-              Create
-            </Link>
-          </li>
-        )}
-      </ul>
+        }}
+      />
     </DashboardCard>
   );
 }

--- a/src/components/home/ReviewsCard.tsx
+++ b/src/components/home/ReviewsCard.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import Link from "next/link";
 import * as React from "react";
 import DashboardCard from "./DashboardCard";
+import DashboardList from "./DashboardList";
 import { usePersistentState } from "@/lib/db";
 import type { Review } from "@/lib/types";
 import { LOCALE } from "@/lib/utils";
-import { CircleSlash } from "lucide-react";
 
 export default function ReviewsCard() {
   const [reviews] = usePersistentState<Review[]>("reviews.v1", []);
@@ -20,30 +19,21 @@ export default function ReviewsCard() {
       title="Recent reviews"
       cta={{ label: "Open Reviews", href: "/reviews" }}
     >
-      <ul className="divide-y divide-[hsl(var(--border))]">
-        {recentReviews.map((r) => (
-          <li key={r.id} className="flex justify-between py-[var(--space-2)] text-ui">
-            <span>{r.title || "Untitled"}</span>
+      <DashboardList
+        items={recentReviews}
+        getKey={(review) => review.id}
+        itemClassName="flex justify-between text-ui"
+        empty="No reviews yet"
+        cta={{ label: "Create", href: "/reviews" }}
+        renderItem={(review) => (
+          <>
+            <span>{review.title || "Untitled"}</span>
             <span className="text-label text-muted-foreground">
-              {new Date(r.createdAt).toLocaleDateString(LOCALE)}
+              {new Date(review.createdAt).toLocaleDateString(LOCALE)}
             </span>
-          </li>
-        ))}
-        {recentReviews.length === 0 && (
-          <li className="flex justify-between py-[var(--space-2)] text-ui text-muted-foreground">
-            <span className="flex items-center gap-[var(--space-2)]">
-              <CircleSlash className="size-3" />
-              No reviews yet
-            </span>
-            <Link
-              href="/reviews"
-              className="inline-flex items-center text-label font-medium text-accent-3 underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent-3 active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
-            >
-              Create
-            </Link>
-          </li>
+          </>
         )}
-      </ul>
+      />
     </DashboardCard>
   );
 }

--- a/src/components/home/TodayCard.tsx
+++ b/src/components/home/TodayCard.tsx
@@ -1,15 +1,14 @@
 "use client";
 
-import Link from "next/link";
 import * as React from "react";
 import DashboardCard from "./DashboardCard";
+import DashboardList from "./DashboardList";
 import { usePersistentState } from "@/lib/db";
 import {
   todayISO,
   type DayRecord,
   type ISODate,
 } from "@/components/planner/plannerStore";
-import { CircleSlash } from "lucide-react";
 
 export default function TodayCard() {
   const [days] = usePersistentState<Record<ISODate, DayRecord>>(
@@ -21,28 +20,19 @@ export default function TodayCard() {
 
   return (
     <DashboardCard title="Today" cta={{ label: "Planner", href: "/planner" }}>
-      <ul className="divide-y divide-[hsl(var(--border))]">
-        {topTasks.map((t) => (
-          <li key={t.id} className="flex justify-between py-[var(--space-2)] text-ui">
-            <span>{t.title}</span>
+      <DashboardList
+        items={topTasks}
+        getKey={(task) => task.id}
+        itemClassName="flex justify-between text-ui"
+        empty="No tasks"
+        cta={{ label: "Create", href: "/planner" }}
+        renderItem={(task) => (
+          <>
+            <span>{task.title}</span>
             <span className="text-label text-muted-foreground">Today</span>
-          </li>
-        ))}
-        {topTasks.length === 0 && (
-          <li className="flex justify-between py-[var(--space-2)] text-ui text-muted-foreground">
-            <span className="flex items-center gap-[var(--space-2)]">
-              <CircleSlash className="size-3" />
-              No tasks
-            </span>
-            <Link
-              href="/planner"
-              className="inline-flex items-center text-label font-medium text-accent-3 underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent-3 active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-reduce:transition-none"
-            >
-              Create
-            </Link>
-          </li>
+          </>
         )}
-      </ul>
+      />
     </DashboardCard>
   );
 }

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -1,5 +1,6 @@
 // src/components/home/index.ts
 export { default as DashboardCard } from "./DashboardCard";
+export { default as DashboardList } from "./DashboardList";
 export { default as TodayCard } from "./TodayCard";
 export { default as GoalsCard } from "./GoalsCard";
 export { default as ReviewsCard } from "./ReviewsCard";

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -50,6 +50,7 @@ import PageHeaderDemo from "./PageHeaderDemo";
 import NeomorphicHeroFrameDemo from "./NeomorphicHeroFrameDemo";
 import {
   DashboardCard,
+  DashboardList,
   BottomNav,
   IsometricRoom,
   QuickActionGrid,
@@ -693,6 +694,43 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       element: <DashboardCard title="Demo" />,
       tags: ["dashboard", "card"],
       code: `<DashboardCard title="Demo" />`,
+    },
+    {
+      id: "dashboard-list",
+      name: "DashboardList",
+      element: (
+        <DashboardList
+          items={[
+            { id: "sync", title: "Strategy sync", meta: "Today" },
+            { id: "retro", title: "Retro prep", meta: "Wed" },
+          ]}
+          getKey={(item) => item.id}
+          itemClassName="flex justify-between text-ui"
+          empty="No highlights"
+          renderItem={(item) => (
+            <>
+              <span>{item.title}</span>
+              <span className="text-label text-muted-foreground">{item.meta}</span>
+            </>
+          )}
+        />
+      ),
+      tags: ["dashboard", "list"],
+      code: `<DashboardList
+  items={[
+    { id: "sync", title: "Strategy sync", meta: "Today" },
+    { id: "retro", title: "Retro prep", meta: "Wed" },
+  ]}
+  getKey={(item) => item.id}
+  itemClassName="flex justify-between text-ui"
+  empty="No highlights"
+  renderItem={(item) => (
+    <>
+      <span>{item.title}</span>
+      <span className="text-label text-muted-foreground">{item.meta}</span>
+    </>
+  )}
+/>`,
     },
     {
       id: "card-demo",


### PR DESCRIPTION
## Summary
- add a reusable `DashboardList` component with shared empty state styling
- refactor dashboard cards and weekly focus highlights to render via the new list helper
- document the list in the prompts gallery for component coverage

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca9d6add04832cae3ad617875b5ee7