### PR TITLE
Tokenize spacing on reviews page

### DIFF
--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -76,13 +76,13 @@ export default function ReviewsPage({
   return (
     <PageShell
       as="main"
-      className="py-6 space-y-6"
+      className="py-[var(--space-6)] space-y-[var(--space-6)]"
       aria-labelledby="reviews-header"
     >
       <PageHeader
         containerClassName="sticky top-0"
-        className="rounded-card r-card-lg px-4 py-4"
-        contentClassName="space-y-2"
+        className="rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-4)]"
+        contentClassName="space-y-[var(--space-2)]"
         header={{
           id: "reviews-header",
           heading: "Reviews",
@@ -147,7 +147,7 @@ export default function ReviewsPage({
 
       <div
         className={cn(
-          "grid grid-cols-1 items-start gap-4 sm:gap-6 lg:gap-8 md:grid-cols-6 lg:grid-cols-12",
+          "grid grid-cols-1 items-start gap-[var(--space-4)] sm:gap-[var(--space-6)] lg:gap-[var(--space-8)] md:grid-cols-6 lg:grid-cols-12",
         )}
       >
         <nav
@@ -156,7 +156,7 @@ export default function ReviewsPage({
         >
           <div className="card-neo-soft rounded-card r-card-lg overflow-hidden bg-card/50 shadow-neo-strong">
             <div className="section-b">
-              <div className="mb-2 text-ui text-muted-foreground">
+              <div className="mb-[var(--space-2)] text-ui text-muted-foreground">
                 {filtered.length} shown
               </div>
               <ReviewList
@@ -167,7 +167,7 @@ export default function ReviewsPage({
                   onSelect(id);
                 }}
                 onCreate={onCreate}
-                className="h-auto overflow-auto p-2 md:h-[calc(100vh-var(--header-stack)-var(--space-6))]"
+                className="h-auto overflow-auto p-[var(--space-2)] md:h-[calc(100vh-var(--header-stack)-var(--space-6))]"
               />
             </div>
           </div>
@@ -177,14 +177,14 @@ export default function ReviewsPage({
             <ReviewPanel
               className={cn(
                 panelClass,
-                "flex flex-col items-center justify-center gap-2 py-8 text-ui text-muted-foreground",
+                "flex flex-col items-center justify-center gap-[var(--space-2)] py-[var(--space-8)] text-ui text-muted-foreground",
               )}
             >
               <Ghost className="h-6 w-6 opacity-60" />
               <p>Select a review from the list or create a new one.</p>
             </ReviewPanel>
           ) : (
-            <div className="space-y-4">
+            <div className="space-y-[var(--space-4)]">
               <TabBar<DetailMode>
                 items={[
                   { key: "summary", label: "Summary" },

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`ReviewsPage > renders default state 1`] = `
 <div>
   <main
     aria-labelledby="reviews-header"
-    class="page-shell py-6 space-y-6"
+    class="page-shell py-[var(--space-6)] space-y-[var(--space-6)]"
   >
     <section
       class="sticky top-0"
@@ -60,13 +60,13 @@ exports[`ReviewsPage > renders default state 1`] = `
     
       </style>
       <div
-        class="relative overflow-visible hero2-frame hero2-neomorph rounded-card r-card-lg border border-border/40 bg-card/70 shadow-outline-subtle md:px-[var(--space-7)] md:py-[var(--space-7)] lg:px-[var(--space-8)] lg:py-[var(--space-8)] rounded-card r-card-lg px-4 py-4"
+        class="relative overflow-visible hero2-frame hero2-neomorph rounded-card r-card-lg border border-border/40 bg-card/70 shadow-outline-subtle md:px-[var(--space-7)] md:py-[var(--space-7)] lg:px-[var(--space-8)] lg:py-[var(--space-8)] rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-4)]"
       >
         <div
           class="relative z-[2] space-y-[var(--space-5)] md:space-y-[var(--space-6)]"
         >
           <div
-            class="relative z-[2] space-y-2"
+            class="relative z-[2] space-y-[var(--space-2)]"
           >
             <header
               class="z-[999] relative isolate after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent after:z-[2]"
@@ -353,7 +353,7 @@ exports[`ReviewsPage > renders default state 1`] = `
       </div>
     </section>
     <div
-      class="grid grid-cols-1 items-start gap-4 sm:gap-6 lg:gap-8 md:grid-cols-6 lg:grid-cols-12"
+      class="grid grid-cols-1 items-start gap-[var(--space-4)] sm:gap-[var(--space-6)] lg:gap-[var(--space-8)] md:grid-cols-6 lg:grid-cols-12"
     >
       <nav
         aria-label="Review list"
@@ -366,13 +366,13 @@ exports[`ReviewsPage > renders default state 1`] = `
             class="section-b"
           >
             <div
-              class="mb-2 text-ui text-muted-foreground"
+              class="mb-[var(--space-2)] text-ui text-muted-foreground"
             >
               3
                shown
             </div>
             <div
-              class="rounded-card r-card-lg border border-border/25 bg-card/60 shadow-outline-subtle w-full mx-auto backdrop-blur-sm h-auto overflow-auto p-2 md:h-[calc(100vh-var(--header-stack)-var(--space-6))]"
+              class="rounded-card r-card-lg border border-border/25 bg-card/60 shadow-outline-subtle w-full mx-auto backdrop-blur-sm h-auto overflow-auto p-[var(--space-2)] md:h-[calc(100vh-var(--header-stack)-var(--space-6))]"
             >
               <ul
                 class="flex flex-col gap-3"
@@ -527,7 +527,7 @@ exports[`ReviewsPage > renders default state 1`] = `
       >
         <div
           aria-live="polite"
-          class="rounded-card r-card-lg p-[var(--space-4)] border border-border/25 bg-card/60 shadow-outline-subtle w-full container mx-auto flex flex-col items-center justify-center gap-2 py-8 text-ui text-muted-foreground"
+          class="rounded-card r-card-lg p-[var(--space-4)] border border-border/25 bg-card/60 shadow-outline-subtle w-full container mx-auto flex flex-col items-center justify-center gap-[var(--space-2)] py-[var(--space-8)] text-ui text-muted-foreground"
         >
           <svg
             aria-hidden="true"


### PR DESCRIPTION
## Summary
- replace remaining spacing utilities on the reviews page shell and header with spacing tokens
- align the grid and empty state spacing with design tokens
- update the reviews page snapshot to reflect the new tokenized classes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca9d5f2c40832c83036504e67492c7