### PR TITLE
Use planner store on TodayCard to reflect planner updates

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,7 @@ import {
   DashboardList,
 } from "@/components/home";
 import { PageHeader, PageShell, Button, ThemeToggle, Spinner } from "@/components/ui";
+import { PlannerProvider } from "@/components/planner";
 import { useTheme } from "@/lib/theme-context";
 import { useThemeQuerySync } from "@/lib/theme-hooks";
 import heroImage from "../../public/ChatGPT Image Sep 17, 2025, 05_45_34 AM.png";
@@ -54,115 +55,117 @@ function HomePageContent() {
   useThemeQuerySync();
 
   return (
-    <PageShell
-      as="main"
-      aria-labelledby="home-header"
-      className="py-6 space-y-6 md:space-y-8 md:pb-8"
-    >
-      <section
-        id="landing-hero"
-        role="region"
-        aria-label="Intro"
-        className="relative grid grid-cols-12 gap-4"
+    <PlannerProvider>
+      <PageShell
+        as="main"
+        aria-labelledby="home-header"
+        className="py-6 space-y-6 md:space-y-8 md:pb-8"
       >
-        <div className="col-span-12">
-          <PageHeader
-            containerClassName="sticky top-0"
-            header={{
-              id: "home-header",
-              heading: "Welcome to Planner",
-              subtitle: "Plan your day, track goals, and review games.",
-              icon: <Home className="opacity-80" />,
-              sticky: true,
-            }}
-            hero={{
-              heading: "Your day at a glance",
-              sticky: false,
-              topClassName: "top-0",
-              actions: (
-                <>
-                  <ThemeToggle className="shrink-0" />
-                  <Button
-                    asChild
-                    variant="primary"
-                    size="sm"
-                    className="px-4 whitespace-nowrap"
-                  >
-                    <Link href="/planner">Plan Week</Link>
-                  </Button>
-                </>
-              ),
-              children: (
-                <div className="grid grid-cols-12 gap-[var(--space-4)] pt-[var(--space-4)]">
-                  <figure className="col-span-12 md:col-start-7 md:col-span-6 lg:col-start-8 lg:col-span-5">
-                    <div className="mx-auto w-full max-w-xl">
-                      <Image
-                        src={heroImage}
-                        alt="Planner dashboard illustration showing widgets for today's focus, goals, and reviews"
-                        className="w-full rounded-[var(--radius-2xl)] border border-[hsl(var(--border))] shadow-neoSoft"
-                        sizes="(min-width: 1280px) 28vw, (min-width: 1024px) 32vw, (min-width: 768px) 45vw, 92vw"
-                        width={1024}
-                        height={1024}
-                        priority
-                      />
-                    </div>
-                  </figure>
-                </div>
-              ),
-            }}
-          />
-        </div>
-      </section>
-      <div className="grid gap-4 md:grid-cols-12 items-start">
-        <div className="md:col-span-6">
-          <QuickActions />
-        </div>
-        <div className="md:col-span-6">
-          <IsometricRoom variant={theme.variant} />
-        </div>
-      </div>
-      <section className="grid grid-cols-1 gap-6 md:grid-cols-12">
-        <div className="md:col-span-4">
-          <TodayCard />
-        </div>
-        <div className="md:col-span-4">
-          <GoalsCard />
-        </div>
-        <div className="md:col-span-4">
-          <ReviewsCard />
-        </div>
-        <div className="md:col-span-4">
-          <DashboardCard
-            title="Weekly focus"
-            cta={{ label: "Open planner", href: "/planner" }}
-          >
-            <DashboardList
-              items={weeklyHighlights}
-              getKey={(highlight) => highlight.id}
-              itemClassName="py-3"
-              empty="No highlights scheduled"
-              renderItem={(highlight) => (
-                <div className="flex flex-col gap-2">
-                  <div className="flex items-baseline justify-between gap-3">
-                    <p className="text-ui font-medium">{highlight.title}</p>
-                    <span className="text-label text-muted-foreground">
-                      {highlight.schedule}
-                    </span>
+        <section
+          id="landing-hero"
+          role="region"
+          aria-label="Intro"
+          className="relative grid grid-cols-12 gap-4"
+        >
+          <div className="col-span-12">
+            <PageHeader
+              containerClassName="sticky top-0"
+              header={{
+                id: "home-header",
+                heading: "Welcome to Planner",
+                subtitle: "Plan your day, track goals, and review games.",
+                icon: <Home className="opacity-80" />,
+                sticky: true,
+              }}
+              hero={{
+                heading: "Your day at a glance",
+                sticky: false,
+                topClassName: "top-0",
+                actions: (
+                  <>
+                    <ThemeToggle className="shrink-0" />
+                    <Button
+                      asChild
+                      variant="primary"
+                      size="sm"
+                      className="px-4 whitespace-nowrap"
+                    >
+                      <Link href="/planner">Plan Week</Link>
+                    </Button>
+                  </>
+                ),
+                children: (
+                  <div className="grid grid-cols-12 gap-[var(--space-4)] pt-[var(--space-4)]">
+                    <figure className="col-span-12 md:col-start-7 md:col-span-6 lg:col-start-8 lg:col-span-5">
+                      <div className="mx-auto w-full max-w-xl">
+                        <Image
+                          src={heroImage}
+                          alt="Planner dashboard illustration showing widgets for today's focus, goals, and reviews"
+                          className="w-full rounded-[var(--radius-2xl)] border border-[hsl(var(--border))] shadow-neoSoft"
+                          sizes="(min-width: 1280px) 28vw, (min-width: 1024px) 32vw, (min-width: 768px) 45vw, 92vw"
+                          width={1024}
+                          height={1024}
+                          priority
+                        />
+                      </div>
+                    </figure>
                   </div>
-                  <p className="text-body text-muted-foreground">
-                    {highlight.summary}
-                  </p>
-                </div>
-              )}
+                ),
+              }}
             />
-          </DashboardCard>
+          </div>
+        </section>
+        <div className="grid gap-4 md:grid-cols-12 items-start">
+          <div className="md:col-span-6">
+            <QuickActions />
+          </div>
+          <div className="md:col-span-6">
+            <IsometricRoom variant={theme.variant} />
+          </div>
         </div>
-        <div className="md:col-span-12">
-          <TeamPromptsCard />
-        </div>
-      </section>
-      <BottomNav />
-    </PageShell>
+        <section className="grid grid-cols-1 gap-6 md:grid-cols-12">
+          <div className="md:col-span-4">
+            <TodayCard />
+          </div>
+          <div className="md:col-span-4">
+            <GoalsCard />
+          </div>
+          <div className="md:col-span-4">
+            <ReviewsCard />
+          </div>
+          <div className="md:col-span-4">
+            <DashboardCard
+              title="Weekly focus"
+              cta={{ label: "Open planner", href: "/planner" }}
+            >
+              <DashboardList
+                items={weeklyHighlights}
+                getKey={(highlight) => highlight.id}
+                itemClassName="py-3"
+                empty="No highlights scheduled"
+                renderItem={(highlight) => (
+                  <div className="flex flex-col gap-2">
+                    <div className="flex items-baseline justify-between gap-3">
+                      <p className="text-ui font-medium">{highlight.title}</p>
+                      <span className="text-label text-muted-foreground">
+                        {highlight.schedule}
+                      </span>
+                    </div>
+                    <p className="text-body text-muted-foreground">
+                      {highlight.summary}
+                    </p>
+                  </div>
+                )}
+              />
+            </DashboardCard>
+          </div>
+          <div className="md:col-span-12">
+            <TeamPromptsCard />
+          </div>
+        </section>
+        <BottomNav />
+      </PageShell>
+    </PlannerProvider>
   );
 }
 

--- a/src/components/home/TodayCard.tsx
+++ b/src/components/home/TodayCard.tsx
@@ -3,20 +3,13 @@
 import * as React from "react";
 import DashboardCard from "./DashboardCard";
 import DashboardList from "./DashboardList";
-import { usePersistentState } from "@/lib/db";
-import {
-  todayISO,
-  type DayRecord,
-  type ISODate,
-} from "@/components/planner/plannerStore";
+import { todayISO } from "@/components/planner/plannerStore";
+import { useDay } from "@/components/planner";
 
 export default function TodayCard() {
-  const [days] = usePersistentState<Record<ISODate, DayRecord>>(
-    "planner:days",
-    {},
-  );
-  const tasks = React.useMemo(() => days[todayISO()]?.tasks ?? [], [days]);
-  const topTasks = tasks.slice(0, 3);
+  const iso = todayISO();
+  const { tasks } = useDay(iso);
+  const topTasks = React.useMemo(() => tasks.slice(0, 3), [tasks]);
 
   return (
     <DashboardCard title="Today" cta={{ label: "Planner", href: "/planner" }}>


### PR DESCRIPTION
## Summary
- wrap the home dashboard content in `PlannerProvider` so planner hooks are available to the Today card
- refactor `TodayCard` to read tasks through `useDay(todayISO())`, keeping the widget in sync with normalized planner data

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68caa2a193b0832c9e7c7cdbe99c62a7