### PR TITLE
feat: add shared score meter

### DIFF
--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -40,6 +40,7 @@ import PromptsComposePanel from "./PromptsComposePanel";
 import PromptsDemos from "./PromptsDemos";
 import ReviewPanel from "@/components/reviews/ReviewPanel";
 import ReviewListItem from "@/components/reviews/ReviewListItem";
+import ScoreMeter from "@/components/reviews/ScoreMeter";
 import Banner from "@/components/chrome/Banner";
 import NavBar from "@/components/chrome/NavBar";
 import {
@@ -706,6 +707,15 @@ export default function ComponentGallery() {
         element: (
           <div className="w-56">
             <ReviewListItem loading />
+          </div>
+        ),
+      },
+      {
+        label: "ScoreMeter",
+        element: (
+          <div className="w-56 space-y-[var(--space-2)]">
+            <ScoreMeter value={8} label="Score 8 of 10" />
+            <ScoreMeter value={4} label="Focus 4 of 10" tone="accent" />
           </div>
         ),
       },

--- a/src/components/reviews/ResultScoreSection.tsx
+++ b/src/components/reviews/ResultScoreSection.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import SectionLabel from "@/components/reviews/SectionLabel";
+import ScoreMeter from "@/components/reviews/ScoreMeter";
 import { cn } from "@/lib/utils";
 import type { Review } from "@/lib/types";
 import { SCORE_POOLS, pickIndex, scoreIcon } from "@/components/reviews/reviewData";
@@ -117,7 +118,7 @@ function ResultScoreSection(
 
       <div>
         <SectionLabel>Score</SectionLabel>
-        <div className="relative h-12 rounded-card r-card-lg border border-border bg-card px-4 focus-within:ring-2 focus-within:ring-ring">
+        <div className="relative h-[var(--space-7)] rounded-card r-card-lg border border-border bg-card px-[var(--space-4)] focus-within:ring-2 focus-within:ring-ring">
           <input
             ref={scoreRangeRef}
             type="range"
@@ -139,18 +140,11 @@ function ResultScoreSection(
             className="absolute inset-0 z-10 cursor-pointer rounded-card r-card-lg opacity-0 [appearance:none]"
             aria-label="Score from 0 to 10"
           />
-          <div className="absolute left-4 right-4 top-1/2 -translate-y-1/2">
-            <div className="relative h-2 w-full rounded-full bg-muted shadow-neo-inset">
-              <div
-                className="absolute left-0 top-0 h-2 rounded-full bg-gradient-to-r from-primary to-accent shadow-ring [--ring:var(--primary)]"
-                style={{ width: `calc(${(score / 10) * 100}% + var(--space-2) + var(--space-1) / 2)` }}
-              />
-              <div
-                className="absolute top-1/2 h-5 w-5 -translate-y-1/2 rounded-full border border-border bg-card shadow-neoSoft"
-                style={{ left: `calc(${(score / 10) * 100}% - (var(--space-2) + var(--space-1) / 2))` }}
-              />
-            </div>
-          </div>
+          <ScoreMeter
+            value={score}
+            className="absolute left-[var(--space-4)] right-[var(--space-4)] top-1/2 -translate-y-1/2"
+            handleClassName="h-[var(--space-5)] w-[var(--space-5)]"
+          />
         </div>
         <div className="mt-1 flex items-center gap-2 text-ui text-muted-foreground">
           <span className="pill h-6 px-2 text-ui">{score}/10</span>

--- a/src/components/reviews/ReviewSummaryScore.tsx
+++ b/src/components/reviews/ReviewSummaryScore.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 import SectionLabel from "@/components/reviews/SectionLabel";
+import ScoreMeter from "@/components/reviews/ScoreMeter";
 import NeonIcon from "@/components/reviews/NeonIcon";
 
 export type ReviewSummaryScoreProps = {
@@ -26,15 +27,11 @@ export default function ReviewSummaryScore({
     <div>
       <SectionLabel>Score</SectionLabel>
       <div className="relative h-[var(--space-7)] rounded-card r-card-lg border border-border bg-card px-[var(--space-4)]">
-        <div className="absolute left-[var(--space-4)] right-[var(--space-4)] top-1/2 -translate-y-1/2 px-[var(--space-3)]">
-          <div
-            className="relative h-[var(--space-2)] w-full rounded-full bg-muted shadow-neo-inset"
-            style={{ "--progress": `${score * 10}%` } as React.CSSProperties}
-          >
-            <div className="absolute left-0 top-0 h-[var(--space-2)] w-[var(--progress)] rounded-full bg-gradient-to-r from-primary to-accent shadow-ring [--ring:var(--primary)]" />
-            <div className="absolute left-[var(--progress)] top-1/2 h-[calc(var(--space-4)+var(--space-1))] w-[calc(var(--space-4)+var(--space-1))] -translate-y-1/2 -translate-x-1/2 rounded-full border border-border bg-card shadow-neoSoft" />
-          </div>
-        </div>
+        <ScoreMeter
+          value={score}
+          label={`Review score ${score} of 10`}
+          className="absolute left-[var(--space-4)] right-[var(--space-4)] top-1/2 -translate-y-1/2 px-[var(--space-3)]"
+        />
       </div>
       <div className="mt-[var(--space-1)] flex items-center gap-[var(--space-2)] text-ui text-muted-foreground">
         <span className="pill h-[var(--space-5)] px-[var(--space-2)] text-ui">{score}/10</span>
@@ -48,19 +45,12 @@ export default function ReviewSummaryScore({
             <div className="h-[var(--hairline-w)] flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
           </div>
           <div className="relative h-[var(--space-7)] rounded-card r-card-lg border border-border bg-card px-[var(--space-4)]">
-            <div className="absolute left-[var(--space-4)] right-[var(--space-4)] top-1/2 -translate-y-1/2 px-[var(--space-3)]">
-              <div
-                className="relative h-[var(--space-2)] w-full rounded-full bg-muted shadow-neo-inset"
-                style={
-                  {
-                    "--progress": `${(focus / 10) * 100}%`,
-                  } as React.CSSProperties
-                }
-              >
-                <div className="absolute left-0 top-0 h-[var(--space-2)] w-[var(--progress)] rounded-full bg-gradient-to-r from-accent to-primary shadow-ring [--ring:var(--accent)]" />
-                <div className="absolute left-[var(--progress)] top-1/2 h-[calc(var(--space-4)+var(--space-1))] w-[calc(var(--space-4)+var(--space-1))] -translate-y-1/2 -translate-x-1/2 rounded-full border border-border bg-card shadow-neoSoft" />
-              </div>
-            </div>
+            <ScoreMeter
+              value={focus}
+              label={`Focus score ${focus} of 10`}
+              tone="accent"
+              className="absolute left-[var(--space-4)] right-[var(--space-4)] top-1/2 -translate-y-1/2 px-[var(--space-3)]"
+            />
           </div>
           <div className="mt-[var(--space-1)] flex items-center gap-[var(--space-2)] text-ui text-muted-foreground">
             <span className="pill h-[var(--space-5)] px-[var(--space-2)] text-ui">{focus}/10</span>

--- a/src/components/reviews/ScoreMeter.tsx
+++ b/src/components/reviews/ScoreMeter.tsx
@@ -1,0 +1,87 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type ScoreMeterTone = "primary" | "accent";
+
+const toneFillClasses: Record<ScoreMeterTone, string> = {
+  primary: "from-primary to-accent [--ring:var(--primary)]",
+  accent: "from-accent to-primary [--ring:var(--accent)]",
+};
+
+export type ScoreMeterProps = {
+  value: number;
+  max?: number;
+  label?: string;
+  tone?: ScoreMeterTone;
+  trackClassName?: string;
+  fillClassName?: string;
+  handleClassName?: string;
+} & Omit<React.HTMLAttributes<HTMLDivElement>, "children">;
+
+const ScoreMeter = React.forwardRef<HTMLDivElement, ScoreMeterProps>(
+  (
+    {
+      value,
+      max = 10,
+      label,
+      tone = "primary",
+      className,
+      trackClassName,
+      fillClassName,
+      handleClassName,
+      style,
+      ...rest
+    },
+    ref,
+  ) => {
+    const clamped = Math.min(Math.max(value, 0), max);
+    const progress = `${(clamped / max) * 100}%`;
+    const meterStyle = {
+      ...style,
+      "--meter-progress": progress,
+    } as React.CSSProperties;
+
+    return (
+      <div
+        ref={ref}
+        className={cn("w-full", className)}
+        style={meterStyle}
+        role={label ? "img" : undefined}
+        aria-label={label}
+        aria-hidden={label ? undefined : true}
+        {...rest}
+      >
+        <div
+          className={cn(
+            "relative h-[var(--space-2)] w-full rounded-full bg-muted shadow-neo-inset",
+            trackClassName,
+          )}
+        >
+          <div
+            className={cn(
+              "absolute left-0 top-0 h-full rounded-full bg-gradient-to-r shadow-ring",
+              toneFillClasses[tone],
+              fillClassName,
+            )}
+            style={{
+              width: "var(--meter-progress)",
+            }}
+          />
+          <div
+            className={cn(
+              "absolute top-1/2 h-[calc(var(--space-4)+var(--space-1))] w-[calc(var(--space-4)+var(--space-1))] -translate-y-1/2 -translate-x-1/2 rounded-full border border-border bg-card shadow-neoSoft",
+              handleClassName,
+            )}
+            style={{
+              left: "var(--meter-progress)",
+            }}
+          />
+        </div>
+      </div>
+    );
+  },
+);
+
+ScoreMeter.displayName = "ScoreMeter";
+
+export default ScoreMeter;

--- a/src/components/reviews/index.ts
+++ b/src/components/reviews/index.ts
@@ -7,6 +7,7 @@ export { default as ReviewListItem } from "./ReviewListItem";
 export { default as ReviewSummary } from "./ReviewSummary";
 export { default as ReviewSummaryHeader } from "./ReviewSummaryHeader";
 export { default as ReviewSummaryScore } from "./ReviewSummaryScore";
+export { default as ScoreMeter } from "./ScoreMeter";
 export { default as ReviewSummaryPillars } from "./ReviewSummaryPillars";
 export { default as ReviewSummaryTimestamps } from "./ReviewSummaryTimestamps";
 export { default as ReviewSummaryNotes } from "./ReviewSummaryNotes";

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -450,7 +450,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           />
         </div>
         <div
-          class="relative h-12 rounded-card r-card-lg border border-border bg-card px-4 focus-within:ring-2 focus-within:ring-ring"
+          class="relative h-[var(--space-7)] rounded-card r-card-lg border border-border bg-card px-[var(--space-4)] focus-within:ring-2 focus-within:ring-ring"
         >
           <input
             aria-label="Score from 0 to 10"
@@ -462,18 +462,20 @@ exports[`ReviewEditor > renders default state 1`] = `
             value="5"
           />
           <div
-            class="absolute left-4 right-4 top-1/2 -translate-y-1/2"
+            aria-hidden="true"
+            class="w-full absolute left-[var(--space-4)] right-[var(--space-4)] top-1/2 -translate-y-1/2"
+            style="--meter-progress: 50%;"
           >
             <div
-              class="relative h-2 w-full rounded-full bg-muted shadow-neo-inset"
+              class="relative h-[var(--space-2)] w-full rounded-full bg-muted shadow-neo-inset"
             >
               <div
-                class="absolute left-0 top-0 h-2 rounded-full bg-gradient-to-r from-primary to-accent shadow-ring [--ring:var(--primary)]"
-                style="width: calc(50% + var(--space-2) + var(--space-1) / 2);"
+                class="absolute left-0 top-0 h-full rounded-full bg-gradient-to-r shadow-ring from-primary to-accent [--ring:var(--primary)]"
+                style="width: var(--meter-progress);"
               />
               <div
-                class="absolute top-1/2 h-5 w-5 -translate-y-1/2 rounded-full border border-border bg-card shadow-neoSoft"
-                style="left: calc(50% - (var(--space-2) + var(--space-1) / 2));"
+                class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 rounded-full border border-border bg-card shadow-neoSoft h-[var(--space-5)] w-[var(--space-5)]"
+                style="left: var(--meter-progress);"
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add a reusable ScoreMeter component that renders the gradient track, progress fill, and handle
- reuse the shared meter in the review score editor and summary views to remove duplicated markup
- showcase the new meter in the prompts component gallery to keep the catalog current

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68caa4a8e49c832c9de8ad99db485f64