### PR TITLE
feat(planner): share list shell across project and task lists

### DIFF
--- a/src/components/planner/PlannerListPanel.tsx
+++ b/src/components/planner/PlannerListPanel.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type PlannerListPanelProps = {
+  renderComposer?: () => React.ReactNode;
+  renderEmpty: () => React.ReactNode;
+  renderList: () => React.ReactNode;
+  isEmpty: boolean;
+  className?: string;
+  viewportClassName?: string;
+  viewportStyle?: React.CSSProperties;
+  viewportProps?: React.HTMLAttributes<HTMLDivElement>;
+};
+
+export default function PlannerListPanel({
+  renderComposer,
+  renderEmpty,
+  renderList,
+  isEmpty,
+  className,
+  viewportClassName,
+  viewportStyle,
+  viewportProps,
+}: PlannerListPanelProps) {
+  const {
+    className: viewportPropsClassName,
+    style: viewportPropsStyle,
+    ...restViewportProps
+  } = viewportProps ?? {};
+
+  const composer = renderComposer?.();
+  const content = isEmpty ? renderEmpty() : renderList();
+
+  return (
+    <div
+      className={cn(
+        "flex min-w-0 flex-col gap-[var(--space-3)]",
+        className,
+      )}
+    >
+      {composer}
+      <div
+        {...restViewportProps}
+        className={cn(
+          "w-full overflow-y-auto px-[var(--space-2)] py-[var(--space-2)]",
+          viewportPropsClassName,
+          viewportClassName,
+        )}
+        style={{ ...viewportPropsStyle, ...viewportStyle }}
+      >
+        {content}
+      </div>
+    </div>
+  );
+}

--- a/src/components/planner/ProjectList.tsx
+++ b/src/components/planner/ProjectList.tsx
@@ -7,6 +7,7 @@ import CheckCircle from "@/components/ui/toggles/CheckCircle";
 import { Pencil, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import EmptyRow from "./EmptyRow";
+import PlannerListPanel from "./PlannerListPanel";
 import type { Project } from "./plannerStore";
 
 type Props = {
@@ -37,6 +38,7 @@ export default function ProjectList({
   const [draftProject, setDraftProject] = React.useState("");
   const projectsScrollable = projects.length > 3;
   const multiple = projects.length > 1;
+  const projectListEmpty = projects.length === 0;
 
   function addProjectCommit() {
     const v = draftProject.trim();
@@ -78,148 +80,154 @@ export default function ProjectList({
   );
 
   return (
-    <div className="flex flex-col gap-[var(--space-3)] min-w-0">
-      <div
-        className={cn(
-          "px-0 w-full",
-          projectsScrollable ? "overflow-y-auto" : "overflow-visible",
-        )}
-        style={
-          projectsScrollable
-            ? { maxHeight: "calc(var(--space-8) * 4 + var(--space-1))" }
-            : undefined
-        }
-      >
+    <PlannerListPanel
+      className="gap-[var(--space-2)]"
+      renderComposer={() => (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            addProjectCommit();
+          }}
+        >
+          <Input
+            className="w-full"
+            placeholder="> new project…"
+            value={draftProject}
+            onChange={(e) => setDraftProject(e.target.value)}
+            aria-label="Add project"
+          />
+        </form>
+      )}
+      isEmpty={projectListEmpty}
+      renderEmpty={() => (
         <ul
           className="w-full space-y-[var(--space-2)] py-[var(--space-2)]"
           role="radiogroup"
           aria-label="Projects"
         >
           <li className="w-full">
-            <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                addProjectCommit();
-              }}
-            >
-              <Input
-                className="w-full"
-                placeholder="> new project…"
-                value={draftProject}
-                onChange={(e) => setDraftProject(e.target.value)}
-                aria-label="Add project"
-              />
-            </form>
+            <EmptyRow text="No projects yet." />
           </li>
-          {projects.length === 0 ? (
-            <li>
-              <EmptyRow text="No projects yet." />
-            </li>
-          ) : (
-            projects.map((p, idx) => {
-              const active = p.id === selectedProjectId;
-              const isEditing = editingProjectId === p.id;
-              const handleRowKey = onRowKey(idx, p);
-              return (
-                <li key={p.id} className="w-full">
-                  <div
-                    role="radio"
-                    tabIndex={0}
-                    aria-checked={active}
-                    aria-label={p.name || "Untitled project"}
-                    onKeyDown={isEditing ? undefined : handleRowKey}
-                    onClick={() => {
-                      if (isEditing) return;
-                      setSelectedProjectId(active ? "" : p.id);
-                      if (active) setSelectedTaskId("");
-                    }}
-                    className={cn(
-                      "proj-card group relative [overflow:visible] w-full text-left rounded-card r-card-lg border pl-[var(--space-4)] pr-[var(--space-2)] py-[var(--space-2)]",
-                      "bg-card/55 hover:bg-card/70 transition",
-                      "grid min-h-[var(--space-7)] grid-cols-[auto,1fr,auto] items-center gap-[var(--space-4)]",
-                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                      active && "proj-card--active ring-1 ring-ring",
-                    )}
-                  >
-                    <span
-                      className="shrink-0"
-                      onMouseDown={(e) => e.stopPropagation()}
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <CheckCircle
-                        checked={!!p.done}
-                        onChange={() => toggleProject(p.id)}
-                        aria-label="Toggle project complete"
-                        size="sm"
-                      />
-                    </span>
-
-                    {isEditing ? (
-                      <Input
-                        name={`rename-project-${p.id}`}
-                        autoFocus
-                        value={editingProjectName}
-                        onChange={(e) => setEditingProjectName(e.target.value)}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter") {
-                            commitRename(p.id, p.name);
-                          }
-                          if (e.key === "Escape") {
-                            setEditingProjectId(null);
-                            setEditingProjectName(p.name);
-                          }
-                        }}
-                        onBlur={() => {
-                          commitRename(p.id, p.name);
-                        }}
-                        aria-label={`Rename project ${p.name}`}
-                      />
-                    ) : (
-                      <span className="proj-card__title truncate font-medium">
-                        {p.name || "Untitled"}
-                      </span>
-                    )}
-
-                    <div className="ml-auto flex items-center gap-[var(--space-2)] opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
-                      <IconButton
-                        aria-label="Edit project"
-                        title="Edit"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          setEditingProjectId(p.id);
-                          setEditingProjectName(p.name);
-                        }}
-                        size="sm"
-                        iconSize="xs"
-                        variant="ring"
-                      >
-                        <Pencil />
-                      </IconButton>
-                      <IconButton
-                        aria-label="Delete project"
-                        title="Delete"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          const was = selectedProjectId === p.id;
-                          deleteProject(p.id);
-                          if (was) setSelectedProjectId("");
-                        }}
-                        size="sm"
-                        iconSize="xs"
-                        variant="ring"
-                      >
-                        <Trash2 />
-                      </IconButton>
-                    </div>
-                  </div>
-                </li>
-              );
-            })
-          )}
         </ul>
-      </div>
-    </div>
+      )}
+      renderList={() => (
+        <ul
+          className="w-full space-y-[var(--space-2)] py-[var(--space-2)]"
+          role="radiogroup"
+          aria-label="Projects"
+        >
+          {projects.map((p, idx) => {
+            const active = p.id === selectedProjectId;
+            const isEditing = editingProjectId === p.id;
+            const handleRowKey = onRowKey(idx, p);
+            return (
+              <li key={p.id} className="w-full">
+                <div
+                  role="radio"
+                  tabIndex={0}
+                  aria-checked={active}
+                  aria-label={p.name || "Untitled project"}
+                  onKeyDown={isEditing ? undefined : handleRowKey}
+                  onClick={() => {
+                    if (isEditing) return;
+                    setSelectedProjectId(active ? "" : p.id);
+                    if (active) setSelectedTaskId("");
+                  }}
+                  className={cn(
+                    "proj-card group relative [overflow:visible] w-full text-left rounded-card r-card-lg border pl-[var(--space-4)] pr-[var(--space-2)] py-[var(--space-2)]",
+                    "bg-card/55 hover:bg-card/70 transition",
+                    "grid min-h-[var(--space-7)] grid-cols-[auto,1fr,auto] items-center gap-[var(--space-4)]",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                    active && "proj-card--active ring-1 ring-ring",
+                  )}
+                >
+                  <span
+                    className="shrink-0"
+                    onMouseDown={(e) => e.stopPropagation()}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <CheckCircle
+                      checked={!!p.done}
+                      onChange={() => toggleProject(p.id)}
+                      aria-label="Toggle project complete"
+                      size="sm"
+                    />
+                  </span>
+
+                  {isEditing ? (
+                    <Input
+                      name={`rename-project-${p.id}`}
+                      autoFocus
+                      value={editingProjectName}
+                      onChange={(e) => setEditingProjectName(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          commitRename(p.id, p.name);
+                        }
+                        if (e.key === "Escape") {
+                          setEditingProjectId(null);
+                          setEditingProjectName(p.name);
+                        }
+                      }}
+                      onBlur={() => {
+                        commitRename(p.id, p.name);
+                      }}
+                      aria-label={`Rename project ${p.name}`}
+                    />
+                  ) : (
+                    <span className="proj-card__title truncate font-medium">
+                      {p.name || "Untitled"}
+                    </span>
+                  )}
+
+                  <div className="ml-auto flex items-center gap-[var(--space-2)] opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+                    <IconButton
+                      aria-label="Edit project"
+                      title="Edit"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        setEditingProjectId(p.id);
+                        setEditingProjectName(p.name);
+                      }}
+                      size="sm"
+                      iconSize="xs"
+                      variant="ring"
+                    >
+                      <Pencil />
+                    </IconButton>
+                    <IconButton
+                      aria-label="Delete project"
+                      title="Delete"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        const was = selectedProjectId === p.id;
+                        deleteProject(p.id);
+                        if (was) setSelectedProjectId("");
+                      }}
+                      size="sm"
+                      iconSize="xs"
+                      variant="ring"
+                    >
+                      <Trash2 />
+                    </IconButton>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+      viewportClassName={cn(
+        "px-0 w-full py-0",
+        projectsScrollable ? undefined : "overflow-visible",
+      )}
+      viewportStyle={
+        projectsScrollable
+          ? { maxHeight: "calc(var(--space-8) * 4 + var(--space-1))" }
+          : undefined
+      }
+    />
   );
 }

--- a/src/components/planner/TaskList.tsx
+++ b/src/components/planner/TaskList.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import Input from "@/components/ui/primitives/Input";
 import EmptyRow from "./EmptyRow";
+import PlannerListPanel from "./PlannerListPanel";
 import TaskRow from "./TaskRow";
 import type { DayTask } from "./plannerStore";
 
@@ -42,6 +43,8 @@ export default function TaskList({
     },
     [selectedProjectId, tasksByProject, tasksById],
   );
+  const hasSelectedProject = Boolean(selectedProjectId);
+  const isEmpty = !hasSelectedProject || tasksForSelected.length === 0;
 
   const onSubmit = React.useCallback(
     (e: React.FormEvent<HTMLFormElement>) => {
@@ -56,49 +59,54 @@ export default function TaskList({
   );
 
   return (
-    <div className="flex flex-col gap-[var(--space-3)] min-w-0">
-      {selectedProjectId && (
-        <form onSubmit={onSubmit}>
-          <Input
-            className="w-full"
-            placeholder="> add task…"
-            value={draftTask}
-            onChange={(e) => setDraftTask(e.target.value)}
-            aria-label="Add task"
-          />
-        </form>
+    <PlannerListPanel
+      renderComposer={
+        hasSelectedProject
+          ? () => (
+              <form onSubmit={onSubmit}>
+                <Input
+                  className="w-full"
+                  placeholder="> add task…"
+                  value={draftTask}
+                  onChange={(e) => setDraftTask(e.target.value)}
+                  aria-label="Add task"
+                />
+              </form>
+            )
+          : undefined
+      }
+      isEmpty={isEmpty}
+      renderEmpty={() => (
+        <EmptyRow
+          text={hasSelectedProject ? "No tasks yet" : "Select a project to view tasks"}
+        />
       )}
-      <div className="min-h-[calc(var(--space-8)*2)] max-h-[calc(var(--space-8)*5)] overflow-y-auto px-[var(--space-2)] py-[var(--space-2)]">
-        {!selectedProjectId ? (
-          <EmptyRow text="Select a project to view tasks" />
-        ) : tasksForSelected.length === 0 ? (
-          <EmptyRow text="No tasks yet" />
-        ) : (
-          <ul
-            className="space-y-[var(--space-2)] [&>li:first-child]:mt-[var(--space-2)] [&>li:last-child]:mb-[var(--space-2)]"
-            aria-label="Tasks"
-          >
-            {tasksForSelected.map((t) => (
-              <TaskRow
-                key={t.id}
-                task={t}
-                onToggle={() => {
-                  toggleTask(t.id);
-                  setSelectedTaskId(t.id);
-                }}
-                onDelete={() => {
-                  deleteTask(t.id);
-                  setSelectedTaskId("");
-                }}
-                onEdit={(title) => renameTask(t.id, title)}
-                onSelect={() => setSelectedTaskId(t.id)}
-                onAddImage={(url) => addTaskImage(t.id, url)}
-                onRemoveImage={(url) => removeTaskImage(t.id, url)}
-              />
-            ))}
-          </ul>
-        )}
-      </div>
-    </div>
+      renderList={() => (
+        <ul
+          className="space-y-[var(--space-2)] [&>li:first-child]:mt-[var(--space-2)] [&>li:last-child]:mb-[var(--space-2)]"
+          aria-label="Tasks"
+        >
+          {tasksForSelected.map((t) => (
+            <TaskRow
+              key={t.id}
+              task={t}
+              onToggle={() => {
+                toggleTask(t.id);
+                setSelectedTaskId(t.id);
+              }}
+              onDelete={() => {
+                deleteTask(t.id);
+                setSelectedTaskId("");
+              }}
+              onEdit={(title) => renameTask(t.id, title)}
+              onSelect={() => setSelectedTaskId(t.id)}
+              onAddImage={(url) => addTaskImage(t.id, url)}
+              onRemoveImage={(url) => removeTaskImage(t.id, url)}
+            />
+          ))}
+        </ul>
+      )}
+      viewportClassName="min-h-[calc(var(--space-8)*2)] max-h-[calc(var(--space-8)*5)]"
+    />
   );
 }

--- a/src/components/planner/index.ts
+++ b/src/components/planner/index.ts
@@ -6,6 +6,7 @@ export { default as DayRow } from "./DayRow";
 export { default as EmptyRow } from "./EmptyRow";
 export { default as FocusPanel } from "./FocusPanel";
 export { default as PlannerPage } from "./PlannerPage";
+export { default as PlannerListPanel } from "./PlannerListPanel";
 export { default as ProjectList } from "./ProjectList";
 export { default as ScrollTopFloatingButton } from "./ScrollTopFloatingButton";
 export { default as TaskList } from "./TaskList";

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -51,6 +51,7 @@ import {
   DayRow,
   ScrollTopFloatingButton,
   PlannerProvider,
+  PlannerListPanel,
 } from "@/components/planner";
 import type { Pillar, Review } from "@/lib/types";
 import type { GameSide } from "@/components/ui/league/SideSelector";
@@ -507,6 +508,37 @@ export default function ComponentGallery() {
             />
           </ul>
         ),
+      },
+      {
+        label: "PlannerListPanel",
+        element: (
+          <PlannerListPanel
+            renderComposer={() => (
+              <form
+                className="w-full"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                }}
+              >
+                <Input className="w-full" placeholder="> add item…" aria-label="Add item" />
+              </form>
+            )}
+            isEmpty={false}
+            renderEmpty={() => <EmptyRow text="All caught up" />}
+            renderList={() => (
+              <ul className="space-y-[var(--space-2)]" aria-label="Demo items">
+                {demoProjects.map((project) => (
+                  <li key={project.id}>
+                    <div className="rounded-card border border-border/40 bg-surface/60 px-[var(--space-4)] py-[var(--space-2)] text-label font-medium">
+                      {project.name}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          />
+        ),
+        className: "sm:col-span-12 md:col-span-12",
       },
       {
         label: "ProjectList",


### PR DESCRIPTION
## Summary
- add a PlannerListPanel wrapper to encapsulate shared composer, viewport, and empty-state scaffolding for planner lists
- refactor ProjectList and TaskList to render through the new panel while preserving their existing behaviors
- surface the PlannerListPanel usage in the prompts gallery for future reuse

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68caa6202b2c832c847aa33d2cb8b588