### PR TITLE
Soften CTA gradient with card base

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -92,10 +92,11 @@
   ) |
 | seg-active-grad | linear-gradient(
     90deg,
-    hsl(262 83% 58% / 0.95),
-    hsl(292 80% 60% / 0.95),
-    hsl(var(--accent-3) / 0.95)
+    hsl(262 83% 58% / 0.35),
+    hsl(292 80% 60% / 0.35),
+    hsl(var(--accent-3) / 0.35)
   ) |
+| seg-active-base | hsl(var(--card)) |
 | shadow | 0 10px 30px hsl(250 30% 2% / 0.35) |
 | lg-violet | var(--ring) |
 | lg-cyan | var(--accent-2) |

--- a/scripts/themes.ts
+++ b/scripts/themes.ts
@@ -97,9 +97,9 @@ export const themes: ThemeDefinition[] = [
         value: [
           "linear-gradient(",
           "90deg,",
-          "hsl(var(--accent-2) / 0.95),",
-          "hsl(var(--accent) / 0.95),",
-          "hsl(var(--accent-2) / 0.95)",
+          "hsl(var(--accent-2) / 0.35),",
+          "hsl(var(--accent) / 0.35),",
+          "hsl(var(--accent-2) / 0.35)",
           ")",
         ],
       },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -637,7 +637,9 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
   .btn-glitch {
     border-radius: var(--radius-2xl);
     color: hsl(var(--primary-foreground));
-    background: var(--seg-active-grad);
+    background-color: var(--seg-active-base);
+    background-image: var(--seg-active-grad);
+    background-repeat: no-repeat;
     box-shadow:
       0 0 calc(var(--space-5) + var(--space-0-25)) hsl(var(--accent) / 0.6),
       0 0 calc(var(--space-7) + var(--space-0-5)) hsl(var(--accent-2) / 0.4);
@@ -1823,7 +1825,9 @@ textarea:-webkit-autofill {
 
 /* CTA variant */
 .btn-cta {
-  background: var(--seg-active-grad);
+  background-color: var(--seg-active-base);
+  background-image: var(--seg-active-grad);
+  background-repeat: no-repeat;
   color: hsl(var(--primary-foreground));
   border-color: color-mix(
     in oklab,
@@ -1838,7 +1842,9 @@ textarea:-webkit-autofill {
 .btn-cta.is-active,
 .btn-cta[aria-current="page"],
 .btn-cta:hover {
-  background: var(--seg-active-grad);
+  background-color: var(--seg-active-base);
+  background-image: var(--seg-active-grad);
+  background-repeat: no-repeat;
   color: hsl(var(--primary-foreground));
   box-shadow:
     0 0 0 var(--space-0-5) hsl(var(--ring) / 0.38),
@@ -1871,7 +1877,9 @@ a:active .lucide {
   }
 
   .bg-seg-active-grad {
-    background: var(--seg-active-grad);
+    background-color: var(--seg-active-base);
+    background-image: var(--seg-active-grad);
+    background-repeat: no-repeat;
   }
 
   .bg-accent-overlay {

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -99,9 +99,9 @@ html.theme-aurora {
   );
   --seg-active-grad: linear-gradient(
     90deg,
-    hsl(var(--accent-2) / 0.95),
-    hsl(var(--accent) / 0.95),
-    hsl(var(--accent-2) / 0.95)
+    hsl(var(--accent-2) / 0.35),
+    hsl(var(--accent) / 0.35),
+    hsl(var(--accent-2) / 0.35)
   );
   --shadow: 0 10px 30px hsl(var(--shadow-base) / 0.3);
 }

--- a/src/components/home/TeamPromptsCard.tsx
+++ b/src/components/home/TeamPromptsCard.tsx
@@ -42,10 +42,10 @@ export default function TeamPromptsCard() {
           title="Prompts peek"
           cta={{ label: "Explore Prompts", href: "/prompts" }}
         >
-          <div className="relative overflow-hidden rounded-card r-card-md bg-seg-active-grad p-[var(--space-4)] text-center text-ui text-primary-foreground">
+          <div className="relative overflow-hidden rounded-card r-card-md bg-card p-[var(--space-4)] text-center text-ui text-primary-foreground">
             <div
               aria-hidden="true"
-              className="pointer-events-none absolute inset-0 -z-10 rounded-[inherit] bg-[linear-gradient(90deg,hsl(var(--primary)/0.35),hsl(var(--accent)/0.35),hsl(var(--accent-3)/0.35))]"
+              className="pointer-events-none absolute inset-0 -z-10 rounded-[inherit] bg-[var(--seg-active-grad)]"
             />
             <span className="relative z-10 block">Get inspired with curated prompts</span>
           </div>

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -95,10 +95,11 @@
   );
   --seg-active-grad: linear-gradient(
     90deg,
-    hsl(262 83% 58% / 0.95),
-    hsl(292 80% 60% / 0.95),
-    hsl(var(--accent-3) / 0.95)
+    hsl(262 83% 58% / 0.35),
+    hsl(292 80% 60% / 0.35),
+    hsl(var(--accent-3) / 0.35)
   );
+  --seg-active-base: hsl(var(--card));
   --shadow: 0 10px 30px hsl(250 30% 2% / 0.35);
   --lg-violet: var(--ring);
   --lg-cyan: var(--accent-2);

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -88,7 +88,8 @@ export default {
   edgeIris:
     "conic-gradient(\n    from 180deg,\n    hsl(262 83% 58% / 0),\n    hsl(262 83% 58% / 0.7),\n    hsl(var(--accent-3) / 0.7),\n    hsl(320 85% 60% / 0.7),\n    hsl(262 83% 58% / 0)\n  )",
   segActiveGrad:
-    "linear-gradient(\n    90deg,\n    hsl(262 83% 58% / 0.95),\n    hsl(292 80% 60% / 0.95),\n    hsl(var(--accent-3) / 0.95)\n  )",
+    "linear-gradient(\n    90deg,\n    hsl(262 83% 58% / 0.35),\n    hsl(292 80% 60% / 0.35),\n    hsl(var(--accent-3) / 0.35)\n  )",
+  segActiveBase: "hsl(var(--card))",
   shadow: "0 10px 30px hsl(250 30% 2% / 0.35)",
   lgViolet: "var(--ring)",
   lgCyan: "var(--accent-2)",


### PR DESCRIPTION
## Summary
- lower the seg-active gradient alpha and introduce a card-colored base token across tokens, docs, and theme data
- update gradient-backed buttons and utilities to layer the softer blend over the card surface
- anchor the home CTA card on the card background while reusing the shared gradient overlay

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68caa69957a8832ca6df45873c7289ca