### PR TITLE
Add card foreground token and apply to cards

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -4,6 +4,7 @@
 | foreground | 260 20% 96% |
 | text | var(--foreground) |
 | card | 248 30% 10% |
+| card-foreground | var(--foreground) |
 | panel | var(--card) |
 | border | 252 20% 22% |
 | line | var(--border) |

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -287,6 +287,7 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
     background-clip: padding-box;
     position: relative;
     isolation: isolate;
+    color: hsl(var(--card-foreground));
     transition:
       transform var(--dur-quick) var(--ease-out),
       box-shadow var(--dur-quick) var(--ease-out),

--- a/src/components/ui/layout/SectionCard.tsx
+++ b/src/components/ui/layout/SectionCard.tsx
@@ -24,7 +24,7 @@ const Root = React.forwardRef<HTMLElement, RootProps>(
       <section
         ref={ref}
         className={cn(
-          "shadow-neo-strong rounded-card r-card-lg",
+          "shadow-neo-strong rounded-card r-card-lg text-card-foreground",
           variant === "neo" ? "card-neo-soft" : "card-soft",
           className,
         )}

--- a/src/components/ui/primitives/Card.tsx
+++ b/src/components/ui/primitives/Card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
       <div
         ref={ref}
         className={cn(
-          "rounded-card r-card-lg p-[var(--space-4)] border border-border/25 bg-card/60 shadow-outline-subtle",
+          "rounded-card r-card-lg p-[var(--space-4)] border border-border/25 bg-card/60 text-card-foreground shadow-outline-subtle",
           className,
         )}
         {...props}

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ReviewEditor > renders default state 1`] = `
 <div>
   <section
-    class="shadow-neo-strong rounded-card r-card-lg card-soft transition-none shadow-none"
+    class="shadow-neo-strong rounded-card r-card-lg text-card-foreground card-soft transition-none shadow-none"
   >
     <div
       class="section-h sticky"

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -372,7 +372,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                shown
             </div>
             <div
-              class="rounded-card r-card-lg border border-border/25 bg-card/60 shadow-outline-subtle w-full mx-auto backdrop-blur-sm h-auto overflow-auto p-[var(--space-2)] md:h-[calc(100vh-var(--header-stack)-var(--space-6))]"
+              class="rounded-card r-card-lg border border-border/25 bg-card/60 text-card-foreground shadow-outline-subtle w-full mx-auto backdrop-blur-sm h-auto overflow-auto p-[var(--space-2)] md:h-[calc(100vh-var(--header-stack)-var(--space-6))]"
             >
               <ul
                 class="flex flex-col gap-3"

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -7,6 +7,7 @@
   --foreground: 260 20% 96%;
   --text: var(--foreground);
   --card: 248 30% 10%;
+  --card-foreground: var(--foreground);
   --panel: var(--card);
   --border: 252 20% 22%;
   --line: var(--border);

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -7,6 +7,7 @@ export default {
   foreground: "260 20% 96%",
   text: "var(--foreground)",
   card: "248 30% 10%",
+  cardForeground: "var(--foreground)",
   panel: "var(--card)",
   border: "252 20% 22%",
   line: "var(--border)",


### PR DESCRIPTION
## Summary
- declare the card foreground token and refresh generated token outputs
- apply the new text color to Card and SectionCard primitives and card styles
- update snapshots to reflect the additional text color class on review cards

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68caa7217154832cb456a6d553e3210c