### PR TITLE
Darken segmented gradient palette

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -92,9 +92,9 @@
   ) |
 | seg-active-grad | linear-gradient(
     90deg,
-    hsl(262 83% 58% / 0.95),
-    hsl(292 80% 60% / 0.95),
-    hsl(var(--accent-3) / 0.95)
+    hsl(var(--primary-soft)),
+    hsl(var(--accent-soft)),
+    hsl(var(--accent-2))
   ) |
 | shadow | 0 10px 30px hsl(250 30% 2% / 0.35) |
 | lg-violet | var(--ring) |

--- a/src/components/home/TeamPromptsCard.tsx
+++ b/src/components/home/TeamPromptsCard.tsx
@@ -45,7 +45,7 @@ export default function TeamPromptsCard() {
           <div className="relative overflow-hidden rounded-card r-card-md bg-seg-active-grad p-[var(--space-4)] text-center text-ui text-primary-foreground">
             <div
               aria-hidden="true"
-              className="pointer-events-none absolute inset-0 -z-10 rounded-[inherit] bg-[linear-gradient(90deg,hsl(var(--primary)/0.35),hsl(var(--accent)/0.35),hsl(var(--accent-3)/0.35))]"
+              className="pointer-events-none absolute inset-0 -z-10 rounded-[inherit] bg-[linear-gradient(90deg,hsl(var(--primary-soft)/0.35),hsl(var(--accent-soft)/0.35),hsl(var(--accent-2)/0.35))]"
             />
             <span className="relative z-10 block">Get inspired with curated prompts</span>
           </div>

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -95,9 +95,9 @@
   );
   --seg-active-grad: linear-gradient(
     90deg,
-    hsl(262 83% 58% / 0.95),
-    hsl(292 80% 60% / 0.95),
-    hsl(var(--accent-3) / 0.95)
+    hsl(var(--primary-soft)),
+    hsl(var(--accent-soft)),
+    hsl(var(--accent-2))
   );
   --shadow: 0 10px 30px hsl(250 30% 2% / 0.35);
   --lg-violet: var(--ring);

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -88,7 +88,7 @@ export default {
   edgeIris:
     "conic-gradient(\n    from 180deg,\n    hsl(262 83% 58% / 0),\n    hsl(262 83% 58% / 0.7),\n    hsl(var(--accent-3) / 0.7),\n    hsl(320 85% 60% / 0.7),\n    hsl(262 83% 58% / 0)\n  )",
   segActiveGrad:
-    "linear-gradient(\n    90deg,\n    hsl(262 83% 58% / 0.95),\n    hsl(292 80% 60% / 0.95),\n    hsl(var(--accent-3) / 0.95)\n  )",
+    "linear-gradient(\n    90deg,\n    hsl(var(--primary-soft)),\n    hsl(var(--accent-soft)),\n    hsl(var(--accent-2))\n  )",
   shadow: "0 10px 30px hsl(250 30% 2% / 0.35)",
   lgViolet: "var(--ring)",
   lgCyan: "var(--accent-2)",


### PR DESCRIPTION
## Summary
- update the `--seg-active-grad` token (and generated outputs) to use the darker primary-soft, accent-soft, and accent-2 stops
- align the TeamPromptsCard overlay tint with the refreshed gradient stops so the tile stays in the deeper palette

## Testing
- npm run contrast-report
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68caa793af20832ca90b2e11a30f1f88