### PR TITLE
Adjust nav controls to large token height

### DIFF
--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -34,7 +34,7 @@ export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
                 href={href}
                 aria-current={active ? "page" : undefined}
                 className={cn(
-                  "group relative inline-flex items-center rounded-[var(--radius-2xl)] border px-[var(--space-4)] py-[var(--space-2)] font-mono text-ui transition motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  "group relative inline-flex min-h-[var(--control-h-lg)] items-center rounded-[var(--radius-2xl)] border px-[var(--space-5)] py-[var(--space-3)] font-mono text-ui transition motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                   "bg-[hsl(var(--card)/0.85)]",
                   "supports-[background:color-mix(in_oklab,hsl(var(--card))_85%,transparent)]:bg-[color:color-mix(in_oklab,hsl(var(--card))_85%,transparent)]",
                   active

--- a/src/components/chrome/PageTabs.tsx
+++ b/src/components/chrome/PageTabs.tsx
@@ -93,7 +93,7 @@ export default function PageTabs({
     }: TabRenderContext<string, PageTabBarItem>) => {
       const { className: baseClassName, onClick, ...restProps } = props;
       const mergedClassName = cn(
-        "btn-like-segmented font-mono text-ui",
+        "btn-like-segmented min-h-[var(--control-h-lg)] font-mono text-ui",
         baseClassName,
         active && "btn-glitch is-active",
         disabled && "pointer-events-none opacity-[var(--disabled)]",
@@ -177,6 +177,7 @@ export default function PageTabs({
           ariaLabel={ariaLabel}
           variant="glitch"
           renderItem={renderTab}
+          tablistClassName="data-[variant=glitch]:py-[var(--space-3)]"
         />
       </div>
     </div>

--- a/src/components/home/BottomNav.tsx
+++ b/src/components/home/BottomNav.tsx
@@ -37,7 +37,7 @@ export default function BottomNav() {
                 aria-current={active ? "page" : undefined}
                 data-active={active}
                 className={cn(
-                  "group flex flex-col items-center gap-[var(--space-1)] rounded-xl px-[var(--space-3)] py-[var(--space-2)] text-label font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none",
+                  "group flex min-h-[var(--control-h-lg)] flex-col items-center gap-[var(--space-1)] rounded-xl px-[var(--space-5)] py-[var(--space-3)] text-label font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none",
                   active
                     ? "text-accent-3 ring-2 ring-[--theme-ring]"
                     : "text-muted-foreground hover:text-foreground"


### PR DESCRIPTION
## Summary
- update primary nav links to use large control height and larger spacing tokens
- extend page tabs segmented buttons with the same control height and increase glitch tablist padding
- align bottom mobile nav links with the large control tokens for height and padding

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cab085c140832c838679285d0e7365