### PR TITLE
Align bottom nav styling tokens

### DIFF
--- a/src/components/home/BottomNav.tsx
+++ b/src/components/home/BottomNav.tsx
@@ -37,13 +37,15 @@ export default function BottomNav() {
                 aria-current={active ? "page" : undefined}
                 data-active={active}
                 className={cn(
-                  "group flex min-h-[var(--control-h-lg)] flex-col items-center gap-[var(--space-1)] rounded-xl px-[var(--space-5)] py-[var(--space-3)] text-label font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none",
+                  "group flex min-h-[var(--control-h-lg)] flex-col items-center gap-[var(--space-1)] rounded-card r-card-md px-[var(--space-5)] py-[var(--space-3)] text-label font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none",
                   active
                     ? "text-accent-3 ring-2 ring-[--theme-ring]"
                     : "text-muted-foreground hover:text-foreground"
                 )}
               >
-                <Icon aria-hidden="true" className="size-5" />
+                <span className="[&_svg]:size-[var(--space-4)]">
+                  <Icon aria-hidden="true" />
+                </span>
                 <span>{label}</span>
               </Link>
             </li>


### PR DESCRIPTION
## Summary
- swap the bottom nav item radius to the card token utilities for consistency with the design system
- wrap nav icons with a span that applies the SVG size token instead of the hard-coded utility

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cab2c045bc832cb30783461bbe3e83