### PR TITLE
Adjust segmented gradient for darker palette

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -93,9 +93,9 @@
   ) |
 | seg-active-grad | linear-gradient(
     90deg,
-    hsl(262 83% 58% / 0.35),
-    hsl(292 80% 60% / 0.35),
-    hsl(var(--accent-3) / 0.35)
+    hsl(var(--primary-soft) / 0.85),
+    hsl(var(--accent-soft) / 0.85),
+    hsl(var(--accent-2) / 0.8)
   ) |
 | seg-active-base | hsl(var(--card)) |
 | shadow | 0 10px 30px hsl(250 30% 2% / 0.35) |

--- a/src/components/home/TeamPromptsCard.tsx
+++ b/src/components/home/TeamPromptsCard.tsx
@@ -22,6 +22,11 @@ const teamQuickActions = [
   },
 ];
 
+const promptsOverlayGradient = {
+  "--seg-active-grad":
+    "linear-gradient(90deg, hsl(var(--primary-soft) / 0.85), hsl(var(--accent-soft) / 0.85), hsl(var(--accent-2) / 0.8))",
+} as React.CSSProperties;
+
 export default function TeamPromptsCard() {
   return (
     <div className="grid grid-cols-1 gap-[var(--space-6)] md:grid-cols-12">
@@ -46,6 +51,7 @@ export default function TeamPromptsCard() {
             <div
               aria-hidden="true"
               className="pointer-events-none absolute inset-0 -z-10 rounded-[inherit] bg-[var(--seg-active-grad)]"
+              style={promptsOverlayGradient}
             />
             <span className="relative z-10 block">Get inspired with curated prompts</span>
           </div>

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -96,9 +96,9 @@
   );
   --seg-active-grad: linear-gradient(
     90deg,
-    hsl(262 83% 58% / 0.35),
-    hsl(292 80% 60% / 0.35),
-    hsl(var(--accent-3) / 0.35)
+    hsl(var(--primary-soft) / 0.85),
+    hsl(var(--accent-soft) / 0.85),
+    hsl(var(--accent-2) / 0.8)
   );
   --seg-active-base: hsl(var(--card));
   --shadow: 0 10px 30px hsl(250 30% 2% / 0.35);

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -89,7 +89,7 @@ export default {
   edgeIris:
     "conic-gradient(\n    from 180deg,\n    hsl(262 83% 58% / 0),\n    hsl(262 83% 58% / 0.7),\n    hsl(var(--accent-3) / 0.7),\n    hsl(320 85% 60% / 0.7),\n    hsl(262 83% 58% / 0)\n  )",
   segActiveGrad:
-    "linear-gradient(\n    90deg,\n    hsl(262 83% 58% / 0.35),\n    hsl(292 80% 60% / 0.35),\n    hsl(var(--accent-3) / 0.35)\n  )",
+    "linear-gradient(\n    90deg,\n    hsl(var(--primary-soft) / 0.85),\n    hsl(var(--accent-soft) / 0.85),\n    hsl(var(--accent-2) / 0.8)\n  )",
   segActiveBase: "hsl(var(--card))",
   shadow: "0 10px 30px hsl(250 30% 2% / 0.35)",
   lgViolet: "var(--ring)",


### PR DESCRIPTION
## Summary
- switch the segmented control gradient token to darker primary/accent stops and update generated token artifacts
- align the TeamPromptsCard overlay with the darker gradient palette

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cab0ce8074832c98b85e42145bcea3