### PR TITLE
Update GitHub Pages deployment documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,15 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## GitHub Pages Deployment
 
-Export the site for GitHub Pages by building with the flag `GITHUB_PAGES=true` (the `npm run deploy` script already sets it). This enables the GitHub Pages configuration and generates an export that expects to live at the repository base path (`/<repo>/`).
+Run `npm run deploy` from the project root whenever you're ready to publish. The script rebuilds the site with the correct GitHub Pages base path (`GITHUB_PAGES=true` and `BASE_PATH=<repo>`), then calls the [`gh-pages`](https://github.com/tschaub/gh-pages) CLI with `--nojekyll` so the `.nojekyll` marker is always published.
 
 When the static files are published to `https://<username>.github.io/<repo>/`, the home page is served from `https://<username>.github.io/<repo>/` rather than the domain root. Use that base path whenever you link to or bookmark the deployed site.
 
-To mirror the GitHub Pages behavior locally, provide the repository slug with `BASE_PATH` while enabling the GitHub Pages flag. For example:
+For CI (or any environment that should push automatically), export `GITHUB_TOKEN`, `GITHUB_REPOSITORY`, and (optionally) `CI=true` before running the deploy script. When those values are present, the script adds an authenticated remote URL so the push succeeds without additional setup.
+
+Running locally is zero-config in most cases—the script can infer the repository slug from `BASE_PATH`, `GITHUB_REPOSITORY`, your Git remote, or even the folder name if needed. You only need to set `BASE_PATH` manually if none of those sources are available.
+
+To mirror the GitHub Pages behavior in development, provide the repository slug with `BASE_PATH` while enabling the GitHub Pages flag. For example:
 
 ```bash
 GITHUB_PAGES=true BASE_PATH=<repo> npm run dev


### PR DESCRIPTION
## Summary
- document how the GitHub Pages deploy script rebuilds with the repository base path and publishes with gh-pages
- add guidance for CI authentication and automatic repository slug detection when running the deploy script

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cab366f6a0832caa95381a56f0f2b1