### PR TITLE
Use PageShell shell for banner layout

### DIFF
--- a/src/components/chrome/Banner.tsx
+++ b/src/components/chrome/Banner.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import * as React from "react";
+import { PageShell } from "@/components/ui";
 import { cn } from "@/lib/utils";
 
 export type BannerProps = {
@@ -27,22 +28,21 @@ export default function Banner({
   return (
     <header
       className={cn(
-        sticky ? "sticky top-0 z-30 sticky-blur border-b" : "",
+        sticky ? "sticky top-0 z-30 sticky-blur border-b border-border" : "",
         className
       )}
-      style={sticky ? { borderColor: "hsl(var(--border))" } : undefined}
     >
-      <div className="mx-auto max-w-6xl px-2 md:px-4 py-2">
+      <PageShell className="py-[var(--space-3)]">
         {title || actions ? (
-          <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center justify-between gap-[var(--space-4)]">
             <div className="font-mono text-ui text-muted-foreground">
               {title}
             </div>
-            <div className="flex items-center gap-2">{actions}</div>
+            <div className="flex items-center gap-[var(--space-3)]">{actions}</div>
           </div>
         ) : null}
         {children}
-      </div>
+      </PageShell>
     </header>
   );
 }

--- a/tests/chrome/Banner.test.tsx
+++ b/tests/chrome/Banner.test.tsx
@@ -35,10 +35,13 @@ describe("Banner", () => {
 
     const header = screen.getByRole("banner");
 
-    expect(header).toHaveClass("sticky", "top-0", "z-30", "sticky-blur", "border-b");
-    expect(header).toHaveAttribute(
-      "style",
-      expect.stringContaining("border-color: hsl(var(--border))"),
+    expect(header).toHaveClass(
+      "sticky",
+      "top-0",
+      "z-30",
+      "sticky-blur",
+      "border-b",
+      "border-border",
     );
     expect(screen.getByRole("button", { name: "Action" })).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- wrap the banner content with PageShell to use shared spacing primitives
- rely on border-border utility and spacing tokens instead of inline styling and hard-coded gaps
- adjust the banner sticky styling test to assert the new utility classes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cab32831f4832c93b21bf088755f1a