### PR TITLE
Improve duration selector radio semantics

### DIFF
--- a/src/components/goals/DurationSelector.tsx
+++ b/src/components/goals/DurationSelector.tsx
@@ -22,7 +22,11 @@ export default function DurationSelector({
   className,
 }: DurationSelectorProps) {
   return (
-    <div className={cn("flex flex-row gap-3", className)}>
+    <div
+      role="radiogroup"
+      aria-disabled={disabled || undefined}
+      className={cn("flex flex-row gap-3", className)}
+    >
       {options.map((m) => {
         const active = value === m;
         return (
@@ -31,6 +35,9 @@ export default function DurationSelector({
             type="button"
             disabled={disabled}
             onClick={() => !disabled && onChange?.(m)}
+            role="radio"
+            aria-checked={active}
+            aria-disabled={disabled || undefined}
             className={cn(
               "inline-flex items-center justify-center h-9 px-3 rounded-full text-center text-ui font-medium",
               "border transition-colors",


### PR DESCRIPTION
## Summary
- wrap the duration selector buttons in a radiogroup container for clearer assistive technology semantics
- mark each option button as a radio and expose its checked state via aria-checked while keeping disabled handling intact

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cab567db7c832cbaf710a4f3c1a9dd