### PR TITLE
Fix empty project list ARIA role

### DIFF
--- a/src/components/planner/ProjectList.tsx
+++ b/src/components/planner/ProjectList.tsx
@@ -102,7 +102,6 @@ export default function ProjectList({
       renderEmpty={() => (
         <ul
           className="w-full space-y-[var(--space-2)] py-[var(--space-2)]"
-          role="radiogroup"
           aria-label="Projects"
         >
           <li className="w-full">


### PR DESCRIPTION
## Summary
- keep the empty projects message outside a radiogroup so the ARIA tree stays valid when no projects exist

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cab5918c84832c99c68168f133fa7c