### PR TITLE
Include task title in TaskRow toggle label

### DIFF
--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -148,7 +148,7 @@ export default function TaskRow({
               onChange={() => {
                 if (!editing) onToggle();
               }}
-              aria-label="Toggle task done"
+              aria-label={`Toggle ${task.title} done`}
               size="sm"
             />
           </div>

--- a/tests/planner/TaskRow.test.tsx
+++ b/tests/planner/TaskRow.test.tsx
@@ -53,7 +53,7 @@ describe("TaskRow", () => {
         onRemoveImage={noop}
       />,
     );
-    fireEvent.click(screen.getAllByLabelText("Toggle task done")[0]);
+    fireEvent.click(screen.getAllByLabelText("Toggle Test task done")[0]);
     fireEvent.click(screen.getAllByLabelText("Edit task")[0]);
     fireEvent.click(screen.getAllByLabelText("Delete task")[0]);
     expect(onSelect).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- update the TaskRow toggle to include the task title in its aria-label for better accessibility
- align the TaskRow test with the new accessible label

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cab71d2750832caaf8f2f9ee2e8f8c