### PR TITLE
Adjust secondary info button accent styling

### DIFF
--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -122,7 +122,7 @@ export const toneClasses: Record<
     accent:
       "text-accent-foreground bg-accent/30 [--hover:hsl(var(--accent)/0.4)] [--active:hsl(var(--accent)/0.5)]",
     info:
-      "text-accent-2 bg-accent-2/15 [--hover:theme('colors.interaction.info.surfaceHover')] [--active:theme('colors.interaction.info.surfaceActive')]",
+      "text-accent-2-foreground bg-accent-2/25 [--hover:hsl(var(--accent-2)/0.35)] [--active:hsl(var(--accent-2)/0.45)]",
     danger:
       "text-danger bg-danger/15 [--hover:theme('colors.interaction.danger.surfaceHover')] [--active:theme('colors.interaction.danger.surfaceActive')]",
   },

--- a/tests/ui/button.test.tsx
+++ b/tests/ui/button.test.tsx
@@ -58,7 +58,12 @@ describe("Button", () => {
         "[--hover:hsl(var(--accent)/0.4)]",
         "[--active:hsl(var(--accent)/0.5)]",
       ],
-      info: ["text-accent-2", "bg-accent-2/15"],
+      info: [
+        "text-accent-2-foreground",
+        "bg-accent-2/25",
+        "[--hover:hsl(var(--accent-2)/0.35)]",
+        "[--active:hsl(var(--accent-2)/0.45)]",
+      ],
       danger: ["text-danger", "bg-danger/15"],
     },
     ghost: {


### PR DESCRIPTION
## Summary
- update the secondary info tone styling to use the accent-2 foreground text and a deeper accent-2 surface tint with matching hover and active tokens
- refresh the button test expectations to cover the new secondary info tone classes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cab8e61ff4832c884c46da03530f22