### PR TITLE
Adjust completed project text style

### DIFF
--- a/src/components/planner/TodayHero.tsx
+++ b/src/components/planner/TodayHero.tsx
@@ -329,7 +329,7 @@ export default function TodayHero({ iso }: Props) {
                       <span
                         className={cn(
                           "truncate",
-                          p.done && "line-through-soft opacity-70",
+                          p.done && "line-through-soft text-muted-foreground",
                         )}
                       >
                         {p.name}


### PR DESCRIPTION
## Summary
- update TodayHero to use the muted foreground color utility when rendering completed project names

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cab9c52290832cbcf05c336e4b64a9