### PR TITLE
Adjust IconButton info tone colors

### DIFF
--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -82,7 +82,7 @@ const toneClasses: Record<Variant, Record<Tone, string>> = {
   ring: {
     primary: "border-line/35 text-foreground",
     accent: "border-accent/35 text-accent-foreground",
-    info: "border-accent-2/35 text-accent-2",
+    info: "border-accent-2/35 text-accent-2-foreground",
     danger: "border-danger/35 text-danger",
   },
   solid: {
@@ -90,14 +90,15 @@ const toneClasses: Record<Variant, Record<Tone, string>> = {
       "border-transparent bg-foreground/15 text-foreground [--hover:hsl(var(--foreground)/0.25)] [--active:hsl(var(--foreground)/0.35)]",
     accent:
       "border-transparent bg-accent/30 text-accent-foreground [--hover:hsl(var(--accent)/0.4)] [--active:hsl(var(--accent)/0.5)]",
-    info: "border-transparent bg-accent-2/15 text-accent-2 [--hover:hsl(var(--accent-2)/0.25)] [--active:hsl(var(--accent-2)/0.35)]",
+    info:
+      "border-transparent bg-accent-2/25 text-accent-2 [--hover:hsl(var(--accent-2)/0.35)] [--active:hsl(var(--accent-2)/0.45)]",
     danger:
       "border-transparent bg-danger/15 text-danger [--hover:hsl(var(--danger)/0.25)] [--active:hsl(var(--danger)/0.35)]",
   },
   glow: {
     primary: "border-foreground/35 text-foreground",
     accent: "border-accent/35 text-accent-foreground",
-    info: "border-accent-2/35 text-accent-2",
+    info: "border-accent-2/35 text-accent-2-foreground",
     danger: "border-danger/35 text-danger",
   },
 };


### PR DESCRIPTION
## Summary
- use accent-2 foreground color for the info tone of ring and glow icon buttons
- deepen the info solid background so hover and active states retain contrast

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cabb8193f0832ca440d045020c9d51