### PR TITLE
Handle absolute URLs when applying base paths

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -18,6 +18,12 @@ const NORMALIZED_BASE =
     ? `/${RAW_BASE_PATH.replace(/^\/+|\/+$|\s+/g, "")}`
     : "";
 
+const ABSOLUTE_URL_PATTERN = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
+
+function isAbsoluteUrl(path: string): boolean {
+  return ABSOLUTE_URL_PATTERN.test(path) || path.startsWith("//");
+}
+
 // Default locale for consistent date/time formatting.
 export const LOCALE = "en-US";
 
@@ -31,6 +37,9 @@ export function cn(...inputs: ClassValue[]): string {
  * Ensures consistent asset URLs for environments served from sub-paths.
  */
 export function withBasePath(path: string): string {
+  if (isAbsoluteUrl(path)) {
+    return path;
+  }
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
 
   if (!NORMALIZED_BASE) {
@@ -42,6 +51,9 @@ export function withBasePath(path: string): string {
 
 /** Remove the configured base path prefix from a pathname. */
 export function withoutBasePath(path: string): string {
+  if (isAbsoluteUrl(path)) {
+    return path;
+  }
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
 
   if (!NORMALIZED_BASE) {

--- a/tests/lib/withBasePath.test.ts
+++ b/tests/lib/withBasePath.test.ts
@@ -41,6 +41,33 @@ describe("withBasePath", () => {
     expect(withBasePath("/assets/icon.svg")).toBe("/beta/assets/icon.svg");
     expect(withBasePath("assets/icon.svg")).toBe("/beta/assets/icon.svg");
   });
+
+  it("returns absolute URLs unchanged regardless of base path", async () => {
+    const urls = [
+      "https://cdn.example.com/assets/icon.svg",
+      "http://cdn.example.com/assets/icon.svg",
+      "//cdn.example.com/assets/icon.svg",
+      "mailto:test@example.com",
+    ];
+
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+    vi.resetModules();
+    {
+      const { withBasePath } = await importBasePathUtils();
+      for (const url of urls) {
+        expect(withBasePath(url)).toBe(url);
+      }
+    }
+
+    process.env.NEXT_PUBLIC_BASE_PATH = "/beta/";
+    vi.resetModules();
+    {
+      const { withBasePath } = await importBasePathUtils();
+      for (const url of urls) {
+        expect(withBasePath(url)).toBe(url);
+      }
+    }
+  });
 });
 
 describe("withoutBasePath", () => {
@@ -65,5 +92,32 @@ describe("withoutBasePath", () => {
     expect(withoutBasePath("/beta")).toBe("/");
     expect(withoutBasePath("/beta/")).toBe("/");
     expect(withoutBasePath("/other")).toBe("/other");
+  });
+
+  it("does not strip prefixes from absolute URLs", async () => {
+    const urls = [
+      "https://cdn.example.com/assets/icon.svg",
+      "http://cdn.example.com/assets/icon.svg",
+      "//cdn.example.com/assets/icon.svg",
+      "mailto:test@example.com",
+    ];
+
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+    vi.resetModules();
+    {
+      const { withoutBasePath } = await importBasePathUtils();
+      for (const url of urls) {
+        expect(withoutBasePath(url)).toBe(url);
+      }
+    }
+
+    process.env.NEXT_PUBLIC_BASE_PATH = "/beta/";
+    vi.resetModules();
+    {
+      const { withoutBasePath } = await importBasePathUtils();
+      for (const url of urls) {
+        expect(withoutBasePath(url)).toBe(url);
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary
- skip adding or stripping the app base path for absolute URLs so external links stay untouched
- cover absolute URL handling with new unit tests for withBasePath and withoutBasePath

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cabbbeb9b4832ca2d563b87fdf0d07