### PR TITLE
Fix project list click selection behavior

### DIFF
--- a/src/components/planner/ProjectList.tsx
+++ b/src/components/planner/ProjectList.tsx
@@ -129,9 +129,9 @@ export default function ProjectList({
                   aria-label={projectLabel}
                   onKeyDown={isEditing ? undefined : handleRowKey}
                   onClick={() => {
-                    if (isEditing) return;
-                    setSelectedProjectId(active ? "" : p.id);
-                    if (active) setSelectedTaskId("");
+                    if (isEditing || active) return;
+                    setSelectedProjectId(p.id);
+                    setSelectedTaskId("");
                   }}
                   className={cn(
                     "proj-card group relative [overflow:visible] w-full text-left rounded-card r-card-lg border pl-[var(--space-4)] pr-[var(--space-2)] py-[var(--space-2)]",


### PR DESCRIPTION
## Summary
- stop clearing the active project selection when its card is clicked again
- clear the selected task whenever a different project is chosen via click

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cabdee0208832c83e9123945e2845e