### PR TITLE
Fix team nav label

### DIFF
--- a/src/components/chrome/nav-items.ts
+++ b/src/components/chrome/nav-items.ts
@@ -10,7 +10,7 @@ export const NAV_ITEMS = [
   { href: "/reviews", label: "Reviews" },
   { href: "/planner", label: "Planner" },
   { href: "/goals", label: "Goals" },
-  { href: "/team", label: "Comps" },
+  { href: "/team", label: "Team" },
   { href: "/comps", label: "Components" },
   { href: "/prompts", label: "Prompts" },
 ] as const satisfies readonly NavItem[];


### PR DESCRIPTION
## Summary
- update the desktop navigation items so /team displays the "Team" label

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cac612e400832c9096fc04ca62725e