### PR TITLE
Fix base path helper double prefix

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -46,6 +46,13 @@ export function withBasePath(path: string): string {
     return normalizedPath;
   }
 
+  if (
+    normalizedPath === NORMALIZED_BASE ||
+    normalizedPath.startsWith(`${NORMALIZED_BASE}/`)
+  ) {
+    return normalizedPath;
+  }
+
   return `${NORMALIZED_BASE}${normalizedPath}`;
 }
 

--- a/tests/lib/withBasePath.test.ts
+++ b/tests/lib/withBasePath.test.ts
@@ -42,6 +42,16 @@ describe("withBasePath", () => {
     expect(withBasePath("assets/icon.svg")).toBe("/beta/assets/icon.svg");
   });
 
+  it("avoids double prefixing when path already includes the base path", async () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "/beta/";
+    vi.resetModules();
+
+    const { withBasePath } = await importBasePathUtils();
+
+    expect(withBasePath("/beta/assets/icon.svg")).toBe("/beta/assets/icon.svg");
+    expect(withBasePath("beta/assets/icon.svg")).toBe("/beta/assets/icon.svg");
+  });
+
   it("returns absolute URLs unchanged regardless of base path", async () => {
     const urls = [
       "https://cdn.example.com/assets/icon.svg",


### PR DESCRIPTION
## Summary
- avoid double-prefixing when withBasePath receives a path that already includes the base path
- add regression coverage for withBasePath double-prefix scenarios

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cac5ff678c832c954a996049b14494