### PR TITLE
Add listbox semantics to week day chips

### DIFF
--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -390,7 +390,11 @@ export default function WeekPicker() {
         </div>
 
         {/* Day chips */}
-        <div className="flex gap-[var(--space-3)] overflow-x-auto snap-x snap-mandatory lg:overflow-visible">
+        <div
+          role="listbox"
+          aria-label={`Select a focus day between ${rangeLabel}`}
+          className="flex gap-[var(--space-3)] overflow-x-auto snap-x snap-mandatory lg:overflow-visible"
+        >
           {days.map((d, i) => (
             <DayChip
               key={d}


### PR DESCRIPTION
## Summary
- wrap the week picker chip row in a listbox container with an accessible label so option roles have the correct parent

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cac67ebf04832c8ad0cff1ef333037