### PR TITLE
Normalize base path handling

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,11 +12,29 @@ const twMerge = extendTailwindMerge({
   },
 });
 
-const RAW_BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
-const NORMALIZED_BASE =
-  RAW_BASE_PATH && RAW_BASE_PATH !== "/"
-    ? `/${RAW_BASE_PATH.replace(/^\/+|\/+$|\s+/g, "")}`
-    : "";
+function normalizeBasePath(raw: string | undefined): string {
+  if (!raw) {
+    return "";
+  }
+
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed === "/") {
+    return "";
+  }
+
+  const segments = trimmed
+    .split("/")
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+
+  if (segments.length === 0) {
+    return "";
+  }
+
+  return `/${segments.join("/")}`;
+}
+
+const NORMALIZED_BASE = normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH);
 
 const ABSOLUTE_URL_PATTERN = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
 

--- a/tests/lib/withBasePath.test.ts
+++ b/tests/lib/withBasePath.test.ts
@@ -68,6 +68,18 @@ describe("withBasePath", () => {
       }
     }
   });
+
+  it("normalizes duplicate slashes and whitespace in the base path", async () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = " //beta//v1// ";
+    vi.resetModules();
+
+    const { withBasePath, withoutBasePath } = await importBasePathUtils();
+
+    expect(withBasePath("/assets/icon.svg")).toBe(
+      "/beta/v1/assets/icon.svg",
+    );
+    expect(withoutBasePath("/beta/v1/assets/icon.svg")).toBe("/assets/icon.svg");
+  });
 });
 
 describe("withoutBasePath", () => {


### PR DESCRIPTION
## Summary
- normalize NEXT_PUBLIC_BASE_PATH values by trimming whitespace and collapsing duplicate slashes
- update withBasePath/withoutBasePath tests to cover complex base path input

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cac601a0d0832c889822fad47da84f