### PR TITLE
Ensure TabBar controls provide accessible labelling

### DIFF
--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -210,6 +210,7 @@ export default function ComponentGallery() {
               { key: "three", label: "Three" },
             ]}
             className="w-56"
+            ariaLabel="Sample tabs"
             linkPanels={false}
           />
         ),
@@ -259,6 +260,7 @@ export default function ComponentGallery() {
             ]}
             defaultValue="tasks"
             variant="glitch"
+            ariaLabel="Glitch demo tabs"
             linkPanels={false}
             renderItem={({ item, active, props, ref, disabled }) => {
               const { className: baseClassName, onClick, ...restProps } = props;
@@ -921,6 +923,7 @@ export default function ComponentGallery() {
                 ],
                 value: headerTab,
                 onChange: setHeaderTab,
+                ariaLabel: "Gallery header tabs",
               }}
             />
           </div>
@@ -943,6 +946,7 @@ export default function ComponentGallery() {
                 ],
                 value: headerTab,
                 onChange: setHeaderTab,
+                ariaLabel: "Gallery hero tabs",
                 linkPanels: false,
               }}
               search={{ value: "", onValueChange: () => {}, round: true }}

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -214,7 +214,12 @@ function HeaderTabsDemo() {
   return (
     <Header
       heading="Header"
-      tabs={{ items: tabs, value: tab, onChange: setTab }}
+      tabs={{
+        items: tabs,
+        value: tab,
+        onChange: setTab,
+        ariaLabel: "Header demo tabs",
+      }}
       sticky={false}
       topClassName="top-0"
     />
@@ -863,7 +868,12 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       tags: ["header", "tabs"],
       code: `<Header
   heading="Header"
-  tabs={{ items: [{ key: "one", label: "One" }, { key: "two", label: "Two" }], value: "one", onChange: () => {} }}
+  tabs={{
+    items: [{ key: "one", label: "One" }, { key: "two", label: "Two" }],
+    value: "one",
+    onChange: () => {},
+    ariaLabel: "Header demo tabs",
+  }}
   sticky={false}
   topClassName="top-0"
 />`,
@@ -1089,10 +1099,15 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
             { key: "b", label: "B" },
           ]}
           defaultValue="a"
+          ariaLabel="Example tabs"
         />
       ),
       tags: ["tabs"],
-      code: `<TabBar items={[{ key: "a", label: "A" }, { key: "b", label: "B" }]} defaultValue="a" />`,
+      code: `<TabBar
+  items={[{ key: "a", label: "A" }, { key: "b", label: "B" }]}
+  defaultValue="a"
+  ariaLabel="Example tabs"
+/>`,
     },
     {
       id: "tab-bar-app-nav",

--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -11,7 +11,11 @@
  */
 
 import * as React from "react";
-import TabBar, { type TabBarProps, type TabItem } from "./TabBar";
+import TabBar, {
+  type TabBarA11yProps,
+  type TabBarProps,
+  type TabItem,
+} from "./TabBar";
 import { NeomorphicFrameStyles } from "./NeomorphicFrameStyles";
 
 function cx(...parts: Array<string | false | null | undefined>) {
@@ -22,16 +26,14 @@ export interface HeaderTab<Key extends string = string> extends TabItem<Key> {
   hint?: string;
 }
 
-export interface HeaderTabsProps<Key extends string = string>
-  extends Omit<
-    TabBarProps<Key>,
-    "items" | "value" | "defaultValue" | "onValueChange"
-  > {
+export type HeaderTabsProps<Key extends string = string> = Omit<
+  TabBarProps<Key>,
+  "items" | "value" | "defaultValue" | "onValueChange"
+> & {
   items: HeaderTab<Key>[];
   value: Key;
   onChange: (key: Key) => void;
-  ariaLabel?: string;
-}
+};
 
 export interface HeaderProps<Key extends string = string>
   extends Omit<React.HTMLAttributes<HTMLElement>, "title"> {
@@ -94,23 +96,40 @@ export default function Header<Key extends string = string>({
       value: tabValue,
       onChange: tabOnChange,
       ariaLabel: tabAriaLabel,
+      ariaLabelledBy: tabAriaLabelledBy,
       size: tabSize,
       align: tabAlign,
       className: tabClassName,
       variant: tabVariant,
       ...tabBarRest
     } = tabs;
+    const sanitizedTabAriaLabel =
+      typeof tabAriaLabel === "string" && tabAriaLabel.trim().length > 0
+        ? tabAriaLabel.trim()
+        : undefined;
+    const sanitizedTabAriaLabelledBy =
+      typeof tabAriaLabelledBy === "string" && tabAriaLabelledBy.trim().length > 0
+        ? tabAriaLabelledBy.trim()
+        : undefined;
+    const accessibilityProps: TabBarA11yProps = sanitizedTabAriaLabelledBy
+      ? {
+          ariaLabelledBy: sanitizedTabAriaLabelledBy,
+          ...(sanitizedTabAriaLabel ? { ariaLabel: sanitizedTabAriaLabel } : {}),
+        }
+      : {
+          ariaLabel: sanitizedTabAriaLabel ?? "Header tabs",
+        };
 
     tabControl = (
       <TabBar
         items={tabItems}
         value={tabValue}
         onValueChange={tabOnChange}
-        ariaLabel={tabAriaLabel}
         size={tabSize ?? "sm"}
         align={tabAlign ?? "end"}
         className={cx("w-auto max-w-full shrink-0", tabClassName)}
         variant={tabVariant ?? (isNeo ? "neo" : "default")}
+        {...accessibilityProps}
         {...tabBarRest}
       />
     );
@@ -265,23 +284,40 @@ export function HeaderTabs<Key extends string = string>({
   activeKey,
   onChange,
   ariaLabel,
+  ariaLabelledBy,
   variant,
 }: {
   tabs: HeaderTab<Key>[];
   activeKey: Key;
   onChange: (key: Key) => void;
-  ariaLabel?: string;
   variant?: TabBarProps["variant"];
-}) {
+} & TabBarA11yProps) {
+  const sanitizedAriaLabel =
+    typeof ariaLabel === "string" && ariaLabel.trim().length > 0
+      ? ariaLabel.trim()
+      : undefined;
+  const sanitizedAriaLabelledBy =
+    typeof ariaLabelledBy === "string" && ariaLabelledBy.trim().length > 0
+      ? ariaLabelledBy.trim()
+      : undefined;
+  const accessibilityProps: TabBarA11yProps = sanitizedAriaLabelledBy
+    ? {
+        ariaLabelledBy: sanitizedAriaLabelledBy,
+        ...(sanitizedAriaLabel ? { ariaLabel: sanitizedAriaLabel } : {}),
+      }
+    : {
+        ariaLabel: sanitizedAriaLabel ?? "Header tabs",
+      };
+
   return (
     <TabBar
       items={tabs}
       value={activeKey}
       onValueChange={onChange}
-      ariaLabel={ariaLabel}
       align="end"
       size="sm"
       variant={variant}
+      {...accessibilityProps}
     />
   );
 }

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -11,7 +11,11 @@
  */
 
 import * as React from "react";
-import TabBar, { type TabBarProps, type TabItem } from "./TabBar";
+import TabBar, {
+  type TabBarA11yProps,
+  type TabBarProps,
+  type TabItem,
+} from "./TabBar";
 import type { HeaderTabsProps } from "@/components/ui/layout/Header";
 import SearchBar, {
   type SearchBarProps,
@@ -172,29 +176,51 @@ function Hero<Key extends string = string>({
   );
 
   // Compose right area: prefer built-in sub-tabs if provided.
-  const subTabsNode = subTabs ? (
-    <TabBar
-      items={subTabs.items.map(({ hint, ...item }) => {
-        void hint;
-        return item;
-      })}
-      value={String(subTabs.value)}
-      onValueChange={(k) => subTabs.onChange(k as Key)}
-      size={subTabs.size ?? "md"}
-      align={subTabs.align ?? "end"}
-      right={subTabs.right}
-      showBaseline={subTabs.showBaseline ?? true}
-      variant={subTabs.variant ?? heroVariant}
-      className={cx("justify-end", subTabs.className)}
-      ariaLabel={subTabs.ariaLabel ?? "Hero sub-tabs"}
-      linkPanels={subTabs.linkPanels}
-    />
-  ) : tabs ? (
-    <TabBar
-      items={tabs.items}
-      value={tabs.value}
-      onValueChange={tabs.onChange}
-      size={tabs.size ?? "md"}
+  const subTabsNode = subTabs
+    ? (() => {
+        const sanitizedLabel =
+          typeof subTabs.ariaLabel === "string" && subTabs.ariaLabel.trim().length > 0
+            ? subTabs.ariaLabel.trim()
+            : undefined;
+        const sanitizedLabelledBy =
+          typeof subTabs.ariaLabelledBy === "string" &&
+          subTabs.ariaLabelledBy.trim().length > 0
+            ? subTabs.ariaLabelledBy.trim()
+            : undefined;
+        const accessibilityProps: TabBarA11yProps = sanitizedLabelledBy
+          ? {
+              ariaLabelledBy: sanitizedLabelledBy,
+              ...(sanitizedLabel ? { ariaLabel: sanitizedLabel } : {}),
+            }
+          : {
+              ariaLabel: sanitizedLabel ?? "Hero sub-tabs",
+            };
+
+        return (
+          <TabBar
+            items={subTabs.items.map(({ hint, ...item }) => {
+              void hint;
+              return item;
+            })}
+            value={String(subTabs.value)}
+            onValueChange={(k) => subTabs.onChange(k as Key)}
+            size={subTabs.size ?? "md"}
+            align={subTabs.align ?? "end"}
+            right={subTabs.right}
+            showBaseline={subTabs.showBaseline ?? true}
+            variant={subTabs.variant ?? heroVariant}
+            className={cx("justify-end", subTabs.className)}
+            {...accessibilityProps}
+            linkPanels={subTabs.linkPanels}
+          />
+        );
+      })()
+    : tabs ? (
+      <TabBar
+        items={tabs.items}
+        value={tabs.value}
+        onValueChange={tabs.onChange}
+        size={tabs.size ?? "md"}
       align={tabs.align ?? "end"}
       showBaseline={tabs.showBaseline ?? true}
       variant={tabs.variant ?? heroVariant}
@@ -308,7 +334,6 @@ export function HeroTabs<K extends string>(props: {
   tabs: Array<HeroTab<K>>;
   activeKey: K;
   onChange: (k: K) => void;
-  ariaLabel?: string;
   className?: string;
   align?: TabBarProps["align"];
   size?: TabBarProps["size"];
@@ -316,12 +341,13 @@ export function HeroTabs<K extends string>(props: {
   showBaseline?: boolean;
   variant?: TabBarProps["variant"];
   linkPanels?: boolean;
-}) {
+} & TabBarA11yProps) {
   const {
     tabs,
     activeKey,
     onChange,
     ariaLabel,
+    ariaLabelledBy,
     className,
     align = "end",
     size = "md",
@@ -330,6 +356,23 @@ export function HeroTabs<K extends string>(props: {
     variant,
     linkPanels = false,
   } = props;
+
+  const sanitizedAriaLabel =
+    typeof ariaLabel === "string" && ariaLabel.trim().length > 0
+      ? ariaLabel.trim()
+      : undefined;
+  const sanitizedAriaLabelledBy =
+    typeof ariaLabelledBy === "string" && ariaLabelledBy.trim().length > 0
+      ? ariaLabelledBy.trim()
+      : undefined;
+  const accessibilityProps: TabBarA11yProps = sanitizedAriaLabelledBy
+    ? {
+        ariaLabelledBy: sanitizedAriaLabelledBy,
+        ...(sanitizedAriaLabel ? { ariaLabel: sanitizedAriaLabel } : {}),
+      }
+    : {
+        ariaLabel: sanitizedAriaLabel ?? "Hero tabs",
+      };
 
   const items: TabItem[] = React.useMemo(
     () =>
@@ -352,7 +395,7 @@ export function HeroTabs<K extends string>(props: {
       align={align}
       size={size}
       right={right}
-      ariaLabel={ariaLabel ?? "Hero tabs"}
+      {...accessibilityProps}
       className={className}
       showBaseline={showBaseline}
       variant={variant}

--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -8,7 +8,7 @@ import NeomorphicHeroFrame, {
   type NeomorphicHeroFrameProps,
   type NeomorphicHeroFrameActionAreaProps,
 } from "./NeomorphicHeroFrame";
-import TabBar, { type TabBarProps } from "./TabBar";
+import TabBar, { type TabBarA11yProps, type TabBarProps } from "./TabBar";
 import { cn } from "@/lib/utils";
 
 type PageHeaderElement = Extract<
@@ -188,6 +188,7 @@ const PageHeaderInner = <
       showBaseline,
       right: subTabsRight,
       ariaLabel,
+      ariaLabelledBy: subTabsAriaLabelledBy,
       variant: subTabsVariant,
       linkPanels,
       idBase,
@@ -197,6 +198,24 @@ const PageHeaderInner = <
       void hint;
       return item;
     });
+
+    const sanitizedAriaLabel =
+      typeof ariaLabel === "string" && ariaLabel.trim().length > 0
+        ? ariaLabel.trim()
+        : undefined;
+    const sanitizedAriaLabelledBy =
+      typeof subTabsAriaLabelledBy === "string" &&
+      subTabsAriaLabelledBy.trim().length > 0
+        ? subTabsAriaLabelledBy.trim()
+        : undefined;
+    const accessibilityProps: TabBarA11yProps = sanitizedAriaLabelledBy
+      ? {
+          ariaLabelledBy: sanitizedAriaLabelledBy,
+          ...(sanitizedAriaLabel ? { ariaLabel: sanitizedAriaLabel } : {}),
+        }
+      : {
+          ariaLabel: sanitizedAriaLabel ?? "Hero sub-tabs",
+        };
 
     return (
       <TabBar<HeroKey>
@@ -209,7 +228,7 @@ const PageHeaderInner = <
         showBaseline={showBaseline ?? true}
         right={subTabsRight}
         variant={subTabsVariant ?? heroTabVariant}
-        ariaLabel={ariaLabel ?? "Hero sub-tabs"}
+        {...accessibilityProps}
         linkPanels={linkPanels}
         idBase={idBase}
       />

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -62,7 +62,17 @@ export type TabRenderContext<
   variant: Variant;
 };
 
-export type TabBarProps<
+export type TabBarA11yProps =
+  | {
+      ariaLabel: string;
+      ariaLabelledBy?: string;
+    }
+  | {
+      ariaLabel?: string;
+      ariaLabelledBy: string;
+    };
+
+type TabBarBaseProps<
   K extends string = string,
   Extra extends Record<string, unknown> | undefined = undefined,
 > = {
@@ -74,7 +84,6 @@ export type TabBarProps<
   align?: Align;
   className?: string;
   right?: React.ReactNode;
-  ariaLabel?: string;
   showBaseline?: boolean;
   linkPanels?: boolean;
   variant?: Variant;
@@ -88,6 +97,11 @@ export type TabBarProps<
    */
   idBase?: string;
 };
+
+export type TabBarProps<
+  K extends string = string,
+  Extra extends Record<string, unknown> | undefined = undefined,
+> = TabBarBaseProps<K, Extra> & TabBarA11yProps;
 
 const sizeMap: Record<Size, { h: string; px: string; text: string }> = {
   sm: {
@@ -120,6 +134,7 @@ export default function TabBar<
   className,
   right,
   ariaLabel,
+  ariaLabelledBy,
   showBaseline = false,
   linkPanels = true,
   variant = "default",
@@ -127,6 +142,25 @@ export default function TabBar<
   renderItem,
   idBase,
 }: TabBarProps<K, Extra>) {
+  const ariaLabelAttr =
+    typeof ariaLabel === "string" && ariaLabel.trim().length > 0
+      ? ariaLabel.trim()
+      : undefined;
+  const ariaLabelledByAttr =
+    typeof ariaLabelledBy === "string" && ariaLabelledBy.trim().length > 0
+      ? ariaLabelledBy.trim()
+      : undefined;
+
+  React.useEffect(() => {
+    if (process.env.NODE_ENV !== "production") {
+      if (!ariaLabelAttr && !ariaLabelledByAttr) {
+        console.warn(
+          "TabBar requires an ariaLabel or ariaLabelledBy prop to describe the tablist.",
+        );
+      }
+    }
+  }, [ariaLabelAttr, ariaLabelledByAttr]);
+
   const uid = useId();
   const baseId = idBase ?? uid;
   const isControlled = value !== undefined;
@@ -243,7 +277,8 @@ export default function TabBar<
         {/* Tabs group */}
         <div
           role="tablist"
-          aria-label={ariaLabel}
+          aria-label={ariaLabelAttr}
+          aria-labelledby={ariaLabelledByAttr}
           aria-orientation="horizontal"
           onKeyDown={onKeyDown}
           data-variant={variant}

--- a/tests/ui/hero-tabs.test.tsx
+++ b/tests/ui/hero-tabs.test.tsx
@@ -12,6 +12,7 @@ describe("HeroTabs", () => {
         activeKey="overview"
         onChange={() => {}}
         linkPanels
+        ariaLabel="Hero tabs demo"
         tabs={[
           {
             key: "overview",


### PR DESCRIPTION
## Summary
- add TabBarA11yProps to require aria-label or aria-labelledby metadata and warn during development when missing
- normalize TabBar consumers (Header, Hero, PageHeader, demos, and tests) to sanitize and provide accessible labels

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cad28b9238832cbebe0c450aa85e7b