### PR TITLE
Link WeekNotes textarea to header for accessibility

### DIFF
--- a/src/components/planner/WeekNotes.tsx
+++ b/src/components/planner/WeekNotes.tsx
@@ -18,16 +18,19 @@ type Props = { iso: ISODate };
 export default function WeekNotes({ iso }: Props) {
   const { value, setValue, saving, isDirty, lastSavedRef, commit } =
     useDayNotes(iso);
+  const headerId = React.useMemo(() => `notes-${iso}-header`, [iso]);
 
   return (
     <SectionCard className="card-neo-soft">
-      <SectionCard.Header title="Notes" />
+      <SectionCard.Header id={headerId} title="Notes" />
       <SectionCard.Body>
         <Textarea
           placeholder="Jot down anything related to this day…"
           value={value}
           onChange={(e) => setValue(e.target.value)}
           name={`notes-${iso}`}
+          aria-labelledby={headerId}
+          aria-label="Notes"
           resize="resize-y"
           textareaClassName="min-h-[calc(var(--space-8)*3_-_var(--space-3))] leading-relaxed"
           onBlur={commit}

--- a/src/components/ui/layout/SectionCard.tsx
+++ b/src/components/ui/layout/SectionCard.tsx
@@ -8,10 +8,12 @@ import { cn } from "@/lib/utils";
 type RootProps = React.HTMLAttributes<HTMLElement> & {
   variant?: "neo" | "plain";
 };
-export type SectionCardHeaderProps = {
+export type SectionCardHeaderProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "title"
+> & {
   sticky?: boolean;
   topClassName?: string; // sticky top offset
-  className?: string;
   children?: React.ReactNode; // if provided, we render this and ignore title/actions
   title?: React.ReactNode; // optional convenience API
   actions?: React.ReactNode; // optional convenience API
@@ -44,6 +46,7 @@ function Header({
   children,
   title,
   actions,
+  ...props
 }: SectionCardHeaderProps) {
   return (
     <div
@@ -52,6 +55,7 @@ function Header({
         sticky && clsx("sticky", topClassName),
         className,
       )}
+      {...props}
     >
       {children ?? (
         <div className="flex w-full items-center justify-between">

--- a/src/components/ui/primitives/Textarea.tsx
+++ b/src/components/ui/primitives/Textarea.tsx
@@ -59,6 +59,7 @@ export default React.forwardRef<HTMLTextAreaElement, TextareaProps>(
           ref={ref}
           id={finalId}
           name={finalName}
+          aria-label={ariaLabel}
           className={cn(INNER, resize, textareaClassName)}
           {...props}
         />

--- a/tests/planner/WeekNotes.test.tsx
+++ b/tests/planner/WeekNotes.test.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { PlannerProvider, WeekNotes } from "@/components/planner";
+
+const ISO = "2024-01-03";
+
+describe("WeekNotes", () => {
+  it("associates the textarea with the header text", () => {
+    render(
+      <PlannerProvider>
+        <WeekNotes iso={ISO} />
+      </PlannerProvider>,
+    );
+
+    const textarea = screen.getByRole("textbox", { name: "Notes" });
+
+    expect(textarea).toHaveAttribute("aria-labelledby", `notes-${ISO}-header`);
+    expect(textarea).toHaveAttribute("aria-label", "Notes");
+  });
+});

--- a/tests/ui/__snapshots__/textarea.test.tsx.snap
+++ b/tests/ui/__snapshots__/textarea.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`Textarea > renders default state 1`] = `
   class="relative inline-flex w-full items-center rounded-[var(--control-radius)] overflow-hidden border border-card-hairline bg-card/60 backdrop-blur-[2px] shadow-control transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-control-hover focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),var(--asset-noise-url,none)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] focus-within:after:opacity-100"
 >
   <textarea
+    aria-label="test"
     class="block w-full max-w-full min-h-[var(--space-7)] px-[var(--space-3)] py-[var(--space-3)] text-body bg-transparent text-foreground placeholder:text-muted-foreground/70 focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default"
     id=":r0:"
     name="test"
@@ -17,6 +18,7 @@ exports[`Textarea > renders disabled state 1`] = `
   class="relative inline-flex w-full items-center rounded-[var(--control-radius)] overflow-hidden border border-card-hairline bg-card/60 backdrop-blur-[2px] shadow-control transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-control-hover focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),var(--asset-noise-url,none)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] focus-within:after:opacity-100 opacity-[var(--disabled)] pointer-events-none"
 >
   <textarea
+    aria-label="test"
     class="block w-full max-w-full min-h-[var(--space-7)] px-[var(--space-3)] py-[var(--space-3)] text-body bg-transparent text-foreground placeholder:text-muted-foreground/70 focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default"
     disabled=""
     id=":r2:"
@@ -31,6 +33,7 @@ exports[`Textarea > renders error state 1`] = `
 >
   <textarea
     aria-invalid="true"
+    aria-label="test"
     class="block w-full max-w-full min-h-[var(--space-7)] px-[var(--space-3)] py-[var(--space-3)] text-body bg-transparent text-foreground placeholder:text-muted-foreground/70 focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default"
     id=":r3:"
     name="test"
@@ -43,6 +46,7 @@ exports[`Textarea > renders focus state 1`] = `
   class="relative inline-flex w-full items-center rounded-[var(--control-radius)] overflow-hidden border border-card-hairline bg-card/60 backdrop-blur-[2px] shadow-control transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-control-hover focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),var(--asset-noise-url,none)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] focus-within:after:opacity-100"
 >
   <textarea
+    aria-label="test"
     class="block w-full max-w-full min-h-[var(--space-7)] px-[var(--space-3)] py-[var(--space-3)] text-body bg-transparent text-foreground placeholder:text-muted-foreground/70 focus:[outline:none] focus-visible:[outline:none] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default"
     id=":r1:"
     name="test"


### PR DESCRIPTION
## Summary
- give the WeekNotes section header a stable id and point the textarea at it with aria-labelledby plus an aria-label fallback
- extend SectionCard.Header to accept div attributes so the header id can be set
- ensure the Textarea primitive forwards aria-label and add a WeekNotes accessibility test covering the label hookup

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cad3060154832caae4b2f404eae53b