### PR TITLE
Adjust solid IconButton info and danger tones

### DIFF
--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -91,9 +91,9 @@ const toneClasses: Record<Variant, Record<Tone, string>> = {
     accent:
       "border-transparent bg-accent/30 text-accent-foreground [--hover:hsl(var(--accent)/0.4)] [--active:hsl(var(--accent)/0.5)]",
     info:
-      "border-transparent bg-accent-2/25 text-accent-2 [--hover:hsl(var(--accent-2)/0.35)] [--active:hsl(var(--accent-2)/0.45)]",
+      "border-transparent bg-accent-2/30 text-accent-2-foreground [--hover:theme('colors.interaction.info.surfaceHover')] [--active:theme('colors.interaction.info.surfaceActive')]",
     danger:
-      "border-transparent bg-danger/15 text-danger-foreground [--hover:hsl(var(--danger)/0.12)] [--active:hsl(var(--danger)/0.1)]",
+      "border-transparent bg-danger/20 text-danger-foreground [--hover:theme('colors.interaction.danger.surfaceHover')] [--active:theme('colors.interaction.danger.surfaceActive')]",
   },
   glow: {
     primary: "border-foreground/35 text-foreground",


### PR DESCRIPTION
## Summary
- update the solid IconButton info tone to use the accent-2 foreground color and interaction surface tokens
- increase the solid IconButton danger fill while hooking hover and active states to the danger interaction surface tokens

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cad2ea4cd0832ca627eac687250152