### PR TITLE
Ensure gh-pages deploy checks origin remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,13 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 Run `npm run deploy` from the project root whenever you're ready to publish. The script rebuilds the site with the correct GitHub Pages base path (`GITHUB_PAGES=true` and `BASE_PATH=<repo>`), then calls the [`gh-pages`](https://github.com/tschaub/gh-pages) CLI with `--nojekyll` so the `.nojekyll` marker is always published.
 
+Before building, the script verifies that a Git push target is configured. If `git remote get-url origin` fails and both `GITHUB_REPOSITORY` and `GITHUB_TOKEN` are missing, the deploy exits early and asks you to add an `origin` remote or supply those environment variables before re-running `npm run deploy`.
+
 When the static files are published to `https://<username>.github.io/<repo>/`, the home page is served from `https://<username>.github.io/<repo>/` rather than the domain root. Use that base path whenever you link to or bookmark the deployed site.
 
 For CI (or any environment that should push automatically), export `GITHUB_TOKEN`, `GITHUB_REPOSITORY`, and (optionally) `CI=true` before running the deploy script. When those values are present, the script adds an authenticated remote URL so the push succeeds without additional setup.
 
-Running locally is zero-config in most cases—the script can infer the repository slug from `BASE_PATH`, `GITHUB_REPOSITORY`, your Git remote, or even the folder name if needed. You only need to set `BASE_PATH` manually if none of those sources are available.
+Running locally is zero-config in most cases as long as an `origin` remote exists—the script can infer the repository slug from `BASE_PATH`, `GITHUB_REPOSITORY`, your Git remote, or even the folder name if needed. You only need to set `BASE_PATH` manually if none of those sources are available.
 
 To mirror the GitHub Pages behavior in development, provide the repository slug with `BASE_PATH` while enabling the GitHub Pages flag. For example:
 


### PR DESCRIPTION
## Summary
- add an assertOriginRemote helper to the deploy script to validate the git push target before running gh-pages
- exit early with guidance when origin is missing unless GITHUB_REPOSITORY and GITHUB_TOKEN are provided
- document the new safeguard and the origin/GitHub requirement in the GitHub Pages deployment instructions

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cad31e7d60832c9e5a7ccb9bb27e8b