### PR TITLE
Adjust info solid IconButton hover states

### DIFF
--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -91,7 +91,7 @@ const toneClasses: Record<Variant, Record<Tone, string>> = {
     accent:
       "border-transparent bg-accent/30 text-accent-foreground [--hover:hsl(var(--accent)/0.4)] [--active:hsl(var(--accent)/0.5)]",
     info:
-      "border-transparent bg-accent-2/30 text-accent-2-foreground [--hover:theme('colors.interaction.info.surfaceHover')] [--active:theme('colors.interaction.info.surfaceActive')]",
+      "border-transparent bg-accent-2/30 text-accent-2-foreground [--hover:hsl(var(--accent-2)/0.2)] [--active:hsl(var(--accent-2)/0.15)]",
     danger:
       "border-transparent bg-danger/20 text-danger-foreground [--hover:theme('colors.interaction.danger.surfaceHover')] [--active:theme('colors.interaction.danger.surfaceActive')]",
   },


### PR DESCRIPTION
## Summary
- align the solid info IconButton to accent-2 foreground tokens and updated hover/active overlays for improved contrast

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cb0d4f15fc832ca1b0fe02cdca226a