### PR TITLE
Fix week memo to respond to today changes

### DIFF
--- a/src/components/planner/useFocusDate.ts
+++ b/src/components/planner/useFocusDate.ts
@@ -20,12 +20,12 @@ export function useFocusDate() {
  * @returns Week start/end dates, list of day ISO strings, and today checker.
  */
 export function useWeek(iso: ISODate) {
+  const today = todayISO();
   return React.useMemo(() => {
     const { start, end } = weekRangeFromISO(iso);
     const days: ISODate[] = [];
     for (let i = 0; i < 7; i++) days.push(toISODate(addDays(start, i)));
-    const today = todayISO();
     const isToday = (d: ISODate) => d === today;
     return { start, end, days, isToday } as const;
-  }, [iso]);
+  }, [iso, today]);
 }


### PR DESCRIPTION
## Summary
- capture the current `todayISO()` value outside of the `useWeek` memo
- include the derived `today` value in the memo dependency list so the today marker refreshes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cb0e4855dc832c923454863a0a15b8