### PR TITLE
Fix Progress aria label placement

### DIFF
--- a/src/components/ui/feedback/Progress.tsx
+++ b/src/components/ui/feedback/Progress.tsx
@@ -1,13 +1,14 @@
 // src/components/ui/Progress.tsx
 "use client";
 
+import * as React from "react";
+
 /** Simple progress bar (0..100), with SR label */
 export default function Progress({ value, label }: { value: number; label?: string }) {
   const v = Math.max(0, Math.min(100, Math.round(value)));
   return (
     <div
       className="h-[var(--space-2)] w-full rounded-full bg-muted shadow-neo-inset"
-      aria-label={label}
     >
       <div
         className="h-full w-full overflow-hidden rounded-full bg-panel/90 shadow-neo-inset"
@@ -18,6 +19,7 @@ export default function Progress({ value, label }: { value: number; label?: stri
           aria-valuemin={0}
           aria-valuemax={100}
           aria-valuenow={v}
+          aria-label={label}
           role="progressbar"
         >
           <span className="sr-only">{v}%</span>

--- a/tests/ui/progress.test.tsx
+++ b/tests/ui/progress.test.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import Progress from "@/components/ui/feedback/Progress";
+
+describe("Progress", () => {
+  it("exposes its label on the progressbar element", () => {
+    render(<Progress value={42} label="Uploading" />);
+    const progressbar = screen.getByRole("progressbar", { name: "Uploading" });
+    expect(progressbar).toHaveAccessibleName("Uploading");
+    expect(progressbar).toHaveAttribute("aria-valuenow", "42");
+    expect(progressbar).toHaveAttribute("aria-valuemin", "0");
+    expect(progressbar).toHaveAttribute("aria-valuemax", "100");
+  });
+});


### PR DESCRIPTION
## Summary
- move the progress bar label from the decorative wrapper onto the role="progressbar" span
- import React explicitly to satisfy the test environment and keep the wrapper purely presentational
- add a regression test covering the accessible name and value attributes of the progress bar

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cb0e69a6ec832cada96647582cd1e6