### PR TITLE
Add semantic headings to SectionCard header

### DIFF
--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -57,7 +57,8 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
       <SectionCard className="card-neo-soft">
         <SectionCard.Header
           className="flex items-center justify-between"
-          title={<h2 className="text-title font-semibold tracking-[-0.01em]">Add Goal</h2>}
+          title="Add Goal"
+          titleClassName="text-title font-semibold tracking-[-0.01em]"
           actions={
             <Button type="submit" size="sm" disabled={!title.trim()}>
               Add Goal

--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -28,7 +28,10 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
 
   return (
     <SectionCard className="card-neo-soft">
-      <SectionCard.Header title={<h2 className="text-title font-semibold tracking-[-0.01em]">Goal Queue</h2>} />
+      <SectionCard.Header
+        title="Goal Queue"
+        titleClassName="text-title font-semibold tracking-[-0.01em]"
+      />
       <SectionCard.Body className="grid gap-6">
           <ul className="divide-y divide-border/10">
             {items.length === 0 ? (


### PR DESCRIPTION
## Summary
- update SectionCard.Header to emit semantic heading elements, manage heading ids, and wire SectionCard.Body to aria-labelledby automatically
- allow heading-level customization and className overrides, generating ids when consumers do not supply one
- refresh GoalForm and GoalQueue headers to use the new titleClassName helper

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cb0e779cb0832c871afee4bc371275