### PR TITLE
Ensure day note saving state yields UI feedback

### DIFF
--- a/src/components/planner/WeekNotes.tsx
+++ b/src/components/planner/WeekNotes.tsx
@@ -37,7 +37,7 @@ export default function WeekNotes({ iso }: Props) {
         />
         <div className="mt-[var(--space-2)] text-label text-muted-foreground" aria-live="polite">
           {saving
-            ? "Saving changes…"
+            ? "Saving…"
             : isDirty
               ? "Unsaved changes"
               : lastSavedRef.current

--- a/src/components/planner/useDayNotes.ts
+++ b/src/components/planner/useDayNotes.ts
@@ -5,6 +5,15 @@ import * as React from "react";
 import { usePlannerStore } from "./usePlannerStore";
 import type { ISODate } from "./plannerStore";
 
+const scheduleSavingReset = (callback: VoidFunction) => {
+  if (typeof queueMicrotask === "function") {
+    queueMicrotask(callback);
+    return;
+  }
+
+  setTimeout(callback, 0);
+};
+
 export function useDayNotes(iso: ISODate) {
   const { getDay, upsertDay } = usePlannerStore();
   const day = getDay(iso);
@@ -31,7 +40,9 @@ export function useDayNotes(iso: ISODate) {
       setNotesForIso(trimmed);
       lastSavedRef.current = trimmed;
     } finally {
-      setSaving(false);
+      scheduleSavingReset(() => {
+        setSaving(false);
+      });
     }
   }, [isDirty, setNotesForIso, trimmed]);
 


### PR DESCRIPTION
## Summary
- reset the day note saving flag in a microtask so the UI surfaces the transient saving state
- keep error bubbling while scheduling the saving reset asynchronously
- align the WeekNotes status copy with the shorter "Saving…" message

## Testing
- npm run check


------
https://chatgpt.com/codex/tasks/task_e_68cb0e829844832cb8d2f669f37be95c