### PR TITLE
Adjust secondary accent/info hover states

### DIFF
--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -120,9 +120,9 @@ export const toneClasses: Record<
   secondary: {
     primary: "text-muted-foreground bg-panel/60",
     accent:
-      "text-accent-foreground bg-accent/30 [--hover:hsl(var(--accent)/0.4)] [--active:hsl(var(--accent)/0.5)]",
+      "text-accent-foreground bg-accent/30 [--hover:hsl(var(--accent)/0.25)] [--active:hsl(var(--accent)/0.2)]",
     info:
-      "text-accent-2-foreground bg-accent-2/25 [--hover:hsl(var(--accent-2)/0.35)] [--active:hsl(var(--accent-2)/0.45)]",
+      "text-accent-2-foreground bg-accent-2/25 [--hover:hsl(var(--accent-2)/0.2)] [--active:hsl(var(--accent-2)/0.15)]",
     danger:
       "text-danger-foreground bg-danger/15 [--hover:hsl(var(--danger)/0.12)] [--active:hsl(var(--danger)/0.1)]",
   },

--- a/tests/ui/button.test.tsx
+++ b/tests/ui/button.test.tsx
@@ -55,14 +55,14 @@ describe("Button", () => {
       accent: [
         "text-accent-foreground",
         "bg-accent/30",
-        "[--hover:hsl(var(--accent)/0.4)]",
-        "[--active:hsl(var(--accent)/0.5)]",
+        "[--hover:hsl(var(--accent)/0.25)]",
+        "[--active:hsl(var(--accent)/0.2)]",
       ],
       info: [
         "text-accent-2-foreground",
         "bg-accent-2/25",
-        "[--hover:hsl(var(--accent-2)/0.35)]",
-        "[--active:hsl(var(--accent-2)/0.45)]",
+        "[--hover:hsl(var(--accent-2)/0.2)]",
+        "[--active:hsl(var(--accent-2)/0.15)]",
       ],
       danger: [
         "text-danger-foreground",


### PR DESCRIPTION
## Summary
- lower the secondary accent and info hover/active overlays to increase contrast with accent foreground text
- update button snapshot expectations to match the new hover and active token values

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68cb44b7b690832c89b849c8af7e7f02