### PR TITLE
Adjust ghost primary button hover tokens

### DIFF
--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -128,7 +128,7 @@ export const toneClasses: Record<
   },
   ghost: {
     primary:
-      "text-foreground [--hover:theme('colors.interaction.foreground.tintHover')] [--active:theme('colors.interaction.foreground.tintActive')]",
+      "text-foreground bg-card/60 [--hover:hsl(var(--background)/0.8)] [--active:hsl(var(--background))]",
     accent:
       "text-accent-foreground bg-accent/20 [--hover:theme('colors.interaction.accent.surfaceHover')] [--active:theme('colors.interaction.accent.surfaceActive')]",
     info:


### PR DESCRIPTION
## Summary
- add the card backdrop class to ghost primary buttons
- darken the hover and active tokens used by the ghost primary tone so quick actions no longer brighten on hover

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cb44b8e698832ca412791ee9e556b9