### PR TITLE
Adjust native select chevron focus color

### DIFF
--- a/src/components/ui/select/NativeSelect.tsx
+++ b/src/components/ui/select/NativeSelect.tsx
@@ -74,7 +74,7 @@ const NativeSelect = React.forwardRef<HTMLSelectElement, NativeSelectProps>(
               </option>
             ))}
           </select>
-          <ChevronDown className="pointer-events-none absolute right-[var(--space-14)] h-[var(--space-4)] w-[var(--space-4)] text-muted-foreground group-focus-within:text-accent" />
+          <ChevronDown className="pointer-events-none absolute right-[var(--space-14)] h-[var(--space-4)] w-[var(--space-4)] text-muted-foreground group-focus-within:text-accent-foreground" />
         </FieldShell>
         {success && (
           <p

--- a/tests/ui/__snapshots__/select.test.tsx.snap
+++ b/tests/ui/__snapshots__/select.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`Select > renders default state 1`] = `
     </select>
     <svg
       aria-hidden="true"
-      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-[var(--space-4)] w-[var(--space-4)] text-muted-foreground group-focus-within:text-accent"
+      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-[var(--space-4)] w-[var(--space-4)] text-muted-foreground group-focus-within:text-accent-foreground"
       fill="none"
       height="24"
       stroke="currentColor"
@@ -67,7 +67,7 @@ exports[`Select > renders disabled state 1`] = `
     </select>
     <svg
       aria-hidden="true"
-      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-[var(--space-4)] w-[var(--space-4)] text-muted-foreground group-focus-within:text-accent"
+      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-[var(--space-4)] w-[var(--space-4)] text-muted-foreground group-focus-within:text-accent-foreground"
       fill="none"
       height="24"
       stroke="currentColor"
@@ -109,7 +109,7 @@ exports[`Select > renders error state 1`] = `
     </select>
     <svg
       aria-hidden="true"
-      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-[var(--space-4)] w-[var(--space-4)] text-muted-foreground group-focus-within:text-accent"
+      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-[var(--space-4)] w-[var(--space-4)] text-muted-foreground group-focus-within:text-accent-foreground"
       fill="none"
       height="24"
       stroke="currentColor"
@@ -160,7 +160,7 @@ exports[`Select > renders focus state 1`] = `
     </select>
     <svg
       aria-hidden="true"
-      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-[var(--space-4)] w-[var(--space-4)] text-muted-foreground group-focus-within:text-accent"
+      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-[var(--space-4)] w-[var(--space-4)] text-muted-foreground group-focus-within:text-accent-foreground"
       fill="none"
       height="24"
       stroke="currentColor"
@@ -201,7 +201,7 @@ exports[`Select > renders success state 1`] = `
     </select>
     <svg
       aria-hidden="true"
-      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-[var(--space-4)] w-[var(--space-4)] text-muted-foreground group-focus-within:text-accent"
+      class="lucide lucide-chevron-down pointer-events-none absolute right-[var(--space-14)] h-[var(--space-4)] w-[var(--space-4)] text-muted-foreground group-focus-within:text-accent-foreground"
       fill="none"
       height="24"
       stroke="currentColor"


### PR DESCRIPTION
## Summary
- update the native select chevron icon focus style to use the accent foreground token
- refresh select component snapshots to reflect the icon color change

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68cb492a9d70832c8f8165309d675797