### PR TITLE
Keep task tile active text color on foreground

### DIFF
--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -138,7 +138,7 @@
     hsl(var(--accent) / 0.18);
 }
 .task-tile__text:active {
-  color: hsl(var(--accent));
+  color: hsl(var(--primary-foreground));
   cursor: pointer;
   text-shadow: 0 0 calc(var(--space-3) - var(--space-1) / 2)
     hsl(var(--accent) / 0.28);


### PR DESCRIPTION
## Summary
- ensure task tile active state retains the primary foreground color while keeping accent feedback

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cb492f4b40832c9339af85e3b05b7f