### PR TITLE
Default interactive badges to button semantics

### DIFF
--- a/src/components/ui/primitives/Badge.tsx
+++ b/src/components/ui/primitives/Badge.tsx
@@ -95,7 +95,10 @@ export default function Badge<T extends React.ElementType = "span">({
         sizeMap[size],
         toneBorder[tone],
         interactive &&
-          "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--surface-2))] hover:bg-muted/28 active:bg-muted/36 active:translate-y-[var(--space-1)] motion-reduce:active:translate-y-0 data-[disabled=true]:opacity-[var(--disabled)] data-[disabled=true]:cursor-default",
+          cn(
+            "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--surface-2))] hover:bg-muted/28 active:bg-muted/36 active:translate-y-[var(--space-1)] motion-reduce:active:translate-y-0 data-[disabled=true]:opacity-[var(--disabled)] data-[disabled=true]:cursor-default",
+            !isButtonElement && "data-[disabled=true]:pointer-events-none",
+          ),
         selected &&
           "bg-primary-soft/36 border-[var(--ring-contrast)] shadow-inset-contrast shadow-glow-xl text-[var(--text-on-accent)]",
         glitch &&


### PR DESCRIPTION
## Summary
- default interactive badges to render as buttons and apply semantic fallbacks when overriding the element type
- forward disabled and type props while removing redundant pointer-event suppression for disabled badges
- restore synthetic pointer-event suppression for disabled interactive badges rendered as non-button elements

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cbd80a1f20832ca1de4b4cd167dbf4