### PR TITLE
Sync task row title state with task props

### DIFF
--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -47,6 +47,12 @@ export default function TaskRow({
 
   useAutoFocus({ ref: inputRef, when: editing });
 
+  React.useEffect(() => {
+    if (!editing) {
+      setTitle(task.title);
+    }
+  }, [editing, task.title]);
+
   const handleFocusWithin = React.useCallback(() => {
     setHasFocusWithin(true);
   }, []);
@@ -99,7 +105,11 @@ export default function TaskRow({
   function commit() {
     const v = title.trim();
     setEditing(false);
-    if (v && v !== task.title) onEdit(v);
+    if (!v) {
+      setTitle(task.title);
+      return;
+    }
+    if (v !== task.title) onEdit(v);
   }
   function cancel() {
     setEditing(false);


### PR DESCRIPTION
## Summary
- sync the TaskRow title state with task title updates whenever the row is not actively editing
- ensure committing an empty title restores the current task name for the next edit session

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cbdc8c4de4832c88e2ddcb37e0d019