### PR TITLE
Adjust CheckCircle inactive contrast

### DIFF
--- a/src/components/ui/toggles/CheckCircle.tsx
+++ b/src/components/ui/toggles/CheckCircle.tsx
@@ -263,11 +263,11 @@ export default function CheckCircle({
           {/* Tick glyph */}
           <Check
             aria-hidden
-            className={cn(
+              className={cn(
               "relative z-[1] transition-all duration-200",
               lit
                 ? "[color:var(--cc-color)] [filter:drop-shadow(0_0_var(--space-2)_var(--cc-glow))] opacity-100"
-                : "text-muted-foreground/60 opacity-80",
+                : "text-muted-foreground",
             )}
             style={ccStyle}
             strokeWidth={2.5}


### PR DESCRIPTION
## Summary
- raise the CheckCircle inactive checkmark contrast by using the stronger `text-muted-foreground` token instead of stacking translucency classes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cbe05bd0b8832c98bff40365b47900