### PR TITLE
Add hero portrait neumorphic frame

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,6 @@
 import * as React from "react";
 import { Suspense } from "react";
 import { Home } from "lucide-react";
-import Image from "next/image";
 import Link from "next/link";
 import {
   DashboardCard,
@@ -15,6 +14,7 @@ import {
   BottomNav,
   IsometricRoom,
   DashboardList,
+  HeroPortraitFrame,
 } from "@/components/home";
 import { PageHeader, PageShell, Button, ThemeToggle, Spinner } from "@/components/ui";
 import { PlannerProvider } from "@/components/planner";
@@ -96,17 +96,12 @@ function HomePageContent() {
                 children: (
                   <div className="grid grid-cols-12 gap-[var(--space-4)] pt-[var(--space-4)]">
                     <figure className="col-span-12 md:col-start-7 md:col-span-6 lg:col-start-8 lg:col-span-5">
-                      <div className="mx-auto w-full max-w-xl">
-                        <Image
-                          src={heroImage}
-                          alt="Planner dashboard illustration showing widgets for today's focus, goals, and reviews"
-                          className="w-full rounded-[var(--radius-2xl)] border border-[hsl(var(--border))] shadow-neoSoft"
-                          sizes="(min-width: 1280px) 28vw, (min-width: 1024px) 32vw, (min-width: 768px) 45vw, 92vw"
-                          width={1024}
-                          height={1024}
-                          priority
-                        />
-                      </div>
+                      <HeroPortraitFrame
+                        src={heroImage}
+                        alt="Planner dashboard illustration showing widgets for today's focus, goals, and reviews"
+                        sizes="(min-width: 1280px) 28vw, (min-width: 1024px) 32vw, (min-width: 768px) 45vw, 92vw"
+                        priority
+                      />
                     </figure>
                   </div>
                 ),

--- a/src/components/home/HeroPortraitFrame.tsx
+++ b/src/components/home/HeroPortraitFrame.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import * as React from "react";
+import Image, { type ImageProps } from "next/image";
+import { NeomorphicFrameStyles } from "@/components/ui";
+import { cn } from "@/lib/utils";
+
+export interface HeroPortraitFrameProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  src: ImageProps["src"];
+  alt: string;
+  sizes?: ImageProps["sizes"];
+  priority?: ImageProps["priority"];
+  placeholder?: ImageProps["placeholder"];
+  blurDataURL?: ImageProps["blurDataURL"];
+  imageClassName?: string;
+}
+
+const HeroPortraitFrame = React.forwardRef<HTMLDivElement, HeroPortraitFrameProps>(
+  (
+    {
+      src,
+      alt,
+      sizes,
+      priority,
+      placeholder,
+      blurDataURL,
+      imageClassName,
+      className,
+      ...rest
+    },
+    ref,
+  ) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "relative mx-auto flex w-full items-center justify-center",
+          "max-w-[min(92vw,calc(var(--space-8)*6))]",
+          "md:max-w-[min(45vw,calc(var(--space-8)*7))]",
+          "lg:max-w-[min(32vw,calc(var(--space-8)*8))]",
+          className,
+        )}
+        {...rest}
+      >
+        <NeomorphicFrameStyles />
+        <div className="relative aspect-square w-full">
+          <span
+            aria-hidden
+            className="pointer-events-none absolute inset-0 -m-[var(--space-1)] rounded-full opacity-80 shadow-glow-lg"
+          />
+          <span
+            aria-hidden
+            className="pointer-events-none absolute inset-0 -m-[var(--space-0-5)] rounded-full border border-[hsl(var(--accent-3)/0.45)] mix-blend-screen glitch"
+          />
+          <div className="relative flex h-full w-full items-center justify-center">
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-0 rounded-full bg-[var(--edge-iris)] p-[var(--space-0-5)] [mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] [mask-composite:exclude]"
+            />
+            <div className="relative h-full w-full overflow-hidden rounded-full border border-[hsl(var(--border)/0.45)] bg-card/80 hero2-neomorph">
+              <Image
+                src={src}
+                alt={alt}
+                fill
+                sizes={sizes}
+                priority={priority}
+                placeholder={placeholder}
+                blurDataURL={blurDataURL}
+                className={cn(
+                  "h-full w-full object-contain object-center",
+                  "bg-[radial-gradient(circle_at_center,hsl(var(--surface-2))_20%,transparent_75%)]",
+                  imageClassName,
+                )}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  },
+);
+
+HeroPortraitFrame.displayName = "HeroPortraitFrame";
+
+export default HeroPortraitFrame;

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -9,3 +9,4 @@ export { default as TeamPromptsCard } from "./TeamPromptsCard";
 export { default as QuickActionGrid } from "./QuickActionGrid";
 export { default as BottomNav } from "./BottomNav";
 export { default as IsometricRoom } from "./IsometricRoom";
+export { default as HeroPortraitFrame } from "./HeroPortraitFrame";

--- a/src/components/prompts/PromptsDemos.tsx
+++ b/src/components/prompts/PromptsDemos.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import OutlineGlowDemo from "./OutlineGlowDemo";
 import SectionLabel from "@/components/reviews/SectionLabel";
+import { HeroPortraitFrame } from "@/components/home";
 import {
   Card,
   Input,
@@ -37,6 +38,7 @@ import {
   radiusClasses,
   typeRamp,
 } from "./demoData";
+import heroImage from "../../../public/ChatGPT Image Sep 17, 2025, 05_45_34 AM.png";
 
 export default function PromptsDemos() {
   return (
@@ -197,6 +199,19 @@ export default function PromptsDemos() {
           </SectionCard.Header>
           <SectionCard.Body />
         </SectionCard>
+      </Card>
+      <Card className="mt-8 space-y-4">
+        <h3 className="type-title">HeroPortraitFrame</h3>
+        <p className="text-ui text-muted-foreground">
+          Circular neumorphic frame with lavender glow and glitch rim for hero portraits.
+        </p>
+        <div className="grid place-items-center py-[var(--space-4)]">
+          <HeroPortraitFrame
+            src={heroImage}
+            alt="Planner hero portrait frame"
+            sizes="(min-width: 1280px) 16rem, (min-width: 768px) 14rem, 60vw"
+          />
+        </div>
       </Card>
       <Card className="mt-8 space-y-4">
         <h3 className="type-title">Shadows</h3>


### PR DESCRIPTION
## Summary
- create a reusable HeroPortraitFrame that wraps hero portraits in a circular neumorphic shell with semantic glow and glitch accents
- swap the home page hero image to use the new frame for responsive centering
- surface the HeroPortraitFrame in the component gallery for documentation and reuse

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cbdfbbf678832c80f2f1b55d43cf0e