### PR TITLE
Add recessed dashboard background panel

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,113 +56,119 @@ function HomePageContent() {
 
   return (
     <PlannerProvider>
-      <PageShell
-        as="main"
-        aria-labelledby="home-header"
-        className="py-6 space-y-6 md:space-y-8 md:pb-8"
-      >
-        <section
-          id="landing-hero"
-          role="region"
-          aria-label="Intro"
-          className="relative grid grid-cols-12 gap-4"
+      <PageShell as="main" aria-labelledby="home-header" className="relative isolate">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 -z-10"
         >
-          <div className="col-span-12">
-            <PageHeader
-              header={{
-                id: "home-header",
-                heading: "Welcome to Planner",
-                subtitle: "Plan your day, track goals, and review games.",
-                icon: <Home className="opacity-80" />,
-                sticky: false,
-              }}
-              hero={{
-                heading: "Your day at a glance",
-                sticky: false,
-                topClassName: "top-0",
-                actions: (
-                  <>
-                    <ThemeToggle className="shrink-0" />
-                    <Button
-                      asChild
-                      variant="primary"
-                      size="sm"
-                      className="px-4 whitespace-nowrap"
-                    >
-                      <Link href="/planner">Plan Week</Link>
-                    </Button>
-                  </>
-                ),
-                children: (
-                  <div className="grid grid-cols-12 gap-[var(--space-4)] pt-[var(--space-4)]">
-                    <figure className="col-span-12 md:col-start-7 md:col-span-6 lg:col-start-8 lg:col-span-5">
-                      <div className="mx-auto w-full max-w-xl">
-                        <Image
-                          src={heroImage}
-                          alt="Planner dashboard illustration showing widgets for today's focus, goals, and reviews"
-                          className="w-full rounded-[var(--radius-2xl)] border border-[hsl(var(--border))] shadow-neoSoft"
-                          sizes="(min-width: 1280px) 28vw, (min-width: 1024px) 32vw, (min-width: 768px) 45vw, 92vw"
-                          width={1024}
-                          height={1024}
-                          priority
-                        />
-                      </div>
-                    </figure>
-                  </div>
-                ),
-              }}
-            />
-          </div>
-        </section>
-        <div className="grid gap-4 md:grid-cols-12 items-start">
-          <div className="md:col-span-6">
-            <QuickActions />
-          </div>
-          <div className="md:col-span-6">
-            <IsometricRoom variant={theme.variant} />
-          </div>
+          <div
+            className="h-full w-full rounded-card r-card-lg border border-border/40 bg-[hsl(var(--panel)/0.88)] shadow-neo-inset"
+          />
         </div>
-        <section className="grid grid-cols-1 gap-6 md:grid-cols-12">
-          <div className="md:col-span-4">
-            <TodayCard />
-          </div>
-          <div className="md:col-span-4">
-            <GoalsCard />
-          </div>
-          <div className="md:col-span-4">
-            <ReviewsCard />
-          </div>
-          <div className="md:col-span-4">
-            <DashboardCard
-              title="Weekly focus"
-              cta={{ label: "Open planner", href: "/planner" }}
-            >
-              <DashboardList
-                items={weeklyHighlights}
-                getKey={(highlight) => highlight.id}
-                itemClassName="py-3"
-                empty="No highlights scheduled"
-                renderItem={(highlight) => (
-                  <div className="flex flex-col gap-2">
-                    <div className="flex items-baseline justify-between gap-3">
-                      <p className="text-ui font-medium">{highlight.title}</p>
-                      <span className="text-label text-muted-foreground">
-                        {highlight.schedule}
-                      </span>
+        <div className="relative z-10 py-6 space-y-6 md:space-y-8 md:pb-8">
+          <section
+            id="landing-hero"
+            role="region"
+            aria-label="Intro"
+            className="relative grid grid-cols-12 gap-[var(--space-4)] rounded-card r-card-lg border border-border/40 bg-[hsl(var(--surface)/0.78)] p-[var(--space-4)] shadow-neoSoft backdrop-blur-md md:p-[var(--space-6)]"
+          >
+            <div className="col-span-12">
+              <PageHeader
+                header={{
+                  id: "home-header",
+                  heading: "Welcome to Planner",
+                  subtitle: "Plan your day, track goals, and review games.",
+                  icon: <Home className="opacity-80" />,
+                  sticky: false,
+                }}
+                hero={{
+                  heading: "Your day at a glance",
+                  sticky: false,
+                  topClassName: "top-0",
+                  actions: (
+                    <>
+                      <ThemeToggle className="shrink-0" />
+                      <Button
+                        asChild
+                        variant="primary"
+                        size="sm"
+                        className="px-4 whitespace-nowrap"
+                      >
+                        <Link href="/planner">Plan Week</Link>
+                      </Button>
+                    </>
+                  ),
+                  children: (
+                    <div className="grid grid-cols-12 gap-[var(--space-4)] pt-[var(--space-4)]">
+                      <figure className="col-span-12 md:col-start-7 md:col-span-6 lg:col-start-8 lg:col-span-5">
+                        <div className="mx-auto w-full max-w-xl">
+                          <Image
+                            src={heroImage}
+                            alt="Planner dashboard illustration showing widgets for today's focus, goals, and reviews"
+                            className="w-full rounded-[var(--radius-2xl)] border border-[hsl(var(--border))] shadow-neoSoft"
+                            sizes="(min-width: 1280px) 28vw, (min-width: 1024px) 32vw, (min-width: 768px) 45vw, 92vw"
+                            width={1024}
+                            height={1024}
+                            priority
+                          />
+                        </div>
+                      </figure>
                     </div>
-                    <p className="text-body text-muted-foreground">
-                      {highlight.summary}
-                    </p>
-                  </div>
-                )}
+                  ),
+                }}
               />
-            </DashboardCard>
+            </div>
+          </section>
+          <div className="relative grid items-start gap-[var(--space-4)] md:grid-cols-12">
+            <div className="md:col-span-6">
+              <QuickActions />
+            </div>
+            <div className="md:col-span-6">
+              <IsometricRoom variant={theme.variant} />
+            </div>
           </div>
-          <div className="md:col-span-12">
-            <TeamPromptsCard />
-          </div>
-        </section>
-        <BottomNav />
+          <section className="relative grid grid-cols-1 gap-[var(--space-6)] md:grid-cols-12">
+            <div className="md:col-span-4">
+              <TodayCard />
+            </div>
+            <div className="md:col-span-4">
+              <GoalsCard />
+            </div>
+            <div className="md:col-span-4">
+              <ReviewsCard />
+            </div>
+            <div className="md:col-span-4">
+              <DashboardCard
+                title="Weekly focus"
+                cta={{ label: "Open planner", href: "/planner" }}
+              >
+                <DashboardList
+                  items={weeklyHighlights}
+                  getKey={(highlight) => highlight.id}
+                  itemClassName="py-3"
+                  empty="No highlights scheduled"
+                  renderItem={(highlight) => (
+                    <div className="flex flex-col gap-2">
+                      <div className="flex items-baseline justify-between gap-3">
+                        <p className="text-ui font-medium">{highlight.title}</p>
+                        <span className="text-label text-muted-foreground">
+                          {highlight.schedule}
+                        </span>
+                      </div>
+                      <p className="text-body text-muted-foreground">
+                        {highlight.summary}
+                      </p>
+                    </div>
+                  )}
+                />
+              </DashboardCard>
+            </div>
+            <div className="md:col-span-12">
+              <TeamPromptsCard />
+            </div>
+          </section>
+          <BottomNav />
+        </div>
       </PageShell>
     </PlannerProvider>
   );

--- a/src/components/home/QuickActions.tsx
+++ b/src/components/home/QuickActions.tsx
@@ -22,7 +22,10 @@ const actions = [
 
 export default function QuickActions() {
   return (
-    <section aria-label="Quick actions" className="grid gap-[var(--space-4)]">
+    <section
+      aria-label="Quick actions"
+      className="relative overflow-hidden rounded-card r-card-lg border border-border/40 bg-[hsl(var(--surface)/0.72)] p-[var(--space-4)] shadow-neoSoft backdrop-blur-md md:p-[var(--space-6)]"
+    >
       <QuickActionGrid
         actions={actions}
         className="md:flex-row md:items-center md:justify-between"


### PR DESCRIPTION
## Summary
- add a recessed panel background beneath the home page shell using neumorphic inset shadows tied to the design tokens
- apply glassy elevation styling to the hero cluster and quick actions so primary cards sit above the panel without affecting the grid

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cbe067cbc4832ca19b011a68e651f7