### PR TITLE
feat: surface filtered component count

### DIFF
--- a/src/components/comps/CompsPage.tsx
+++ b/src/components/comps/CompsPage.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { PanelsTopLeft } from "lucide-react";
 import { PageHeader, PageShell } from "@/components/ui";
+import Badge from "@/components/ui/primitives/Badge";
 import ComponentsView from "@/components/prompts/ComponentsView";
 import {
   SECTION_TABS,
@@ -38,6 +39,9 @@ export default function CompsPage() {
     getValidSection(sectionParam),
   );
   const [query, setQuery] = usePersistentState("comps-query", "");
+  const [filteredCount, setFilteredCount] = React.useState(() =>
+    SPEC_DATA[getValidSection(sectionParam)].length,
+  );
   const panelRef = React.useRef<HTMLDivElement>(null);
 
   const heroTabs = React.useMemo(
@@ -59,6 +63,11 @@ export default function CompsPage() {
     () => `Search ${sectionLabel.toLowerCase()} components`,
     [sectionLabel],
   );
+
+  const filteredLabel = React.useMemo(() => {
+    const suffix = filteredCount === 1 ? "component" : "components";
+    return `${filteredCount} ${suffix}`;
+  }, [filteredCount]);
 
   React.useEffect(() => {
     const next = getValidSection(sectionParam);
@@ -137,6 +146,11 @@ export default function CompsPage() {
             round: true,
             "aria-label": searchLabel,
           },
+          actions: (
+            <Badge tone="support" size="sm" className="text-muted-foreground">
+              {filteredLabel}
+            </Badge>
+          ),
         }}
       />
       <section className="grid gap-[var(--space-6)]">
@@ -148,7 +162,11 @@ export default function CompsPage() {
           ref={panelRef}
           className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
-          <ComponentsView query={query} section={section} />
+          <ComponentsView
+            query={query}
+            section={section}
+            onFilteredCountChange={setFilteredCount}
+          />
         </div>
       </section>
     </PageShell>

--- a/src/components/prompts/ComponentsView.tsx
+++ b/src/components/prompts/ComponentsView.tsx
@@ -7,6 +7,7 @@ type ComponentsViewProps = {
   query: string;
   section: Section;
   onCurrentCodeChange?: (code: string | null) => void;
+  onFilteredCountChange?: (count: number) => void;
 };
 
 type SpecCardProps = Spec & {
@@ -78,6 +79,7 @@ export default function ComponentsView({
   query,
   section,
   onCurrentCodeChange,
+  onFilteredCountChange,
 }: ComponentsViewProps) {
   const [, setActiveSpecId] = React.useState<string | null>(null);
   const handleCodeVisibilityChange = React.useCallback(
@@ -121,6 +123,11 @@ export default function ComponentsView({
     if (!query) return SPEC_DATA[section];
     return fuse.search(query).map((r) => r.item);
   }, [query, fuse, section]);
+
+  React.useEffect(() => {
+    if (!onFilteredCountChange) return;
+    onFilteredCountChange(specs.length);
+  }, [specs, onFilteredCountChange]);
 
   return (
     <div className="space-y-8">


### PR DESCRIPTION
## Summary
- add an optional onFilteredCountChange callback to ComponentsView and fire it after specs are filtered
- track the filtered component count on the Comps page and show a supportive badge in the hero actions

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cbe9bc4788832c8ca52bb4dc87f9ed