### PR TITLE
Update hero portrait image references

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -460,8 +460,8 @@ function HomePageContent() {
                 actions: (
                   <>
                     <HeroPortraitFrame
-                      imageSrc="/pixel_cat_yawn.gif"
-                      imageAlt="Planner companion stretching before planning"
+                      imageSrc="/hero_image.png"
+                      imageAlt="Illustration of the Planner hero floating above a holographic dashboard"
                       priority
                       className="max-sm:mx-auto"
                     />

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -1021,15 +1021,15 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       element: (
         <div className="flex justify-center">
           <HeroPortraitFrame
-            imageSrc="/pixel_cat_yawn.gif"
-            imageAlt="Planner companion stretching before planning"
+            imageSrc="/hero_image.png"
+            imageAlt="Illustration of the Planner hero floating above a holographic dashboard"
           />
         </div>
       ),
       tags: ["hero", "portrait", "glitch"],
       code: `<HeroPortraitFrame
-  imageSrc="/pixel_cat_yawn.gif"
-  imageAlt="Planner companion stretching before planning"
+  imageSrc="/hero_image.png"
+  imageAlt="Illustration of the Planner hero floating above a holographic dashboard"
 />`,
     },
     {


### PR DESCRIPTION
## Summary
- point the landing hero portrait frame to the new hero artwork and alt text
- mirror the new image source and description in the HeroPortraitFrame gallery example

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cbe9cfebb8832cb0fe845cde2d1455