### PR TITLE
Fix foreground token utility typos

### DIFF
--- a/src/components/goals/GoalsProgress.tsx
+++ b/src/components/goals/GoalsProgress.tsx
@@ -20,7 +20,7 @@ export default function GoalsProgress({
   if (total === 0) {
     return (
       <div className="rounded-card r-card-md border border-border bg-surface-2 p-6 text-center">
-        <p className="mb-4 text-ui font-medium text-fg-muted">No goals yet.</p>
+        <p className="mb-4 text-ui font-medium text-muted-foreground">No goals yet.</p>
         {onAddFirst && (
           <Button onClick={onAddFirst} size="sm" className="mx-auto">
             Add a first goal

--- a/src/icons/ProgressRingIcon.tsx
+++ b/src/icons/ProgressRingIcon.tsx
@@ -23,7 +23,7 @@ export default function ProgressRingIcon({
         r={radius}
         stroke="currentColor"
         strokeWidth={4}
-        className="text-fg/20"
+        className="text-muted-foreground/30"
         fill="none"
       />
       <circle


### PR DESCRIPTION
## Summary
- update GoalsProgress empty state copy to use the muted foreground token
- align ProgressRingIcon base ring color with muted foreground tone
- replace foreground utility typos with the published token names

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cbec285880832c8dcb5c6c74ca0769