### PR TITLE
Adjust ColorsView swatch breakpoints for mobile readability

### DIFF
--- a/src/components/prompts/ColorsView.tsx
+++ b/src/components/prompts/ColorsView.tsx
@@ -20,7 +20,7 @@ type SwatchProps = { token: string };
 
 function Swatch({ token }: SwatchProps) {
   return (
-    <li className="col-span-3 flex flex-col items-center gap-3">
+    <li className="col-span-6 sm:col-span-4 lg:col-span-3 flex flex-col items-center gap-3">
       <div
         className="h-16 w-full rounded-card r-card-md border border-[var(--card-hairline)]"
         style={{ backgroundColor: `hsl(var(--${token}))` }}


### PR DESCRIPTION
## Summary
- widen the color swatch grid items to span six columns on mobile, keeping four-per-row alignment from the small breakpoint upward

## Testing
- npm test -- --run
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cbec1b51b4832c810dbab2b561b9be