### PR TITLE
chore: update goal progress color tokens

### DIFF
--- a/src/components/goals/GoalsProgress.tsx
+++ b/src/components/goals/GoalsProgress.tsx
@@ -20,7 +20,7 @@ export default function GoalsProgress({
   if (total === 0) {
     return (
       <div className="rounded-card r-card-md border border-border bg-surface-2 p-6 text-center">
-        <p className="mb-4 text-ui font-medium text-fg-muted">No goals yet.</p>
+        <p className="mb-4 text-ui font-medium text-muted-foreground">No goals yet.</p>
         {onAddFirst && (
           <Button onClick={onAddFirst} size="sm" className="mx-auto">
             Add a first goal

--- a/src/icons/ProgressRingIcon.tsx
+++ b/src/icons/ProgressRingIcon.tsx
@@ -23,7 +23,7 @@ export default function ProgressRingIcon({
         r={radius}
         stroke="currentColor"
         strokeWidth={4}
-        className="text-fg/20"
+        className="text-foreground/20"
         fill="none"
       />
       <circle


### PR DESCRIPTION
## Summary
- swap GoalProgress empty state copy to use the muted foreground text token
- align ProgressRingIcon background stroke with the foreground color token naming

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cbed253174832c9691d8459ab4c67a