### PR TITLE
Allow hero actions to wrap on the prompts page

### DIFF
--- a/src/app/prompts/PromptsPage.tsx
+++ b/src/app/prompts/PromptsPage.tsx
@@ -188,7 +188,7 @@ function PageContent() {
             "aria-label": searchLabel,
           },
           actions: (
-            <div className="flex items-center gap-2">
+            <>
               <Badge
                 tone="accent"
                 size="sm"
@@ -213,7 +213,7 @@ function PageContent() {
               <IconButton size="sm" aria-label="Add">
                 <Plus />
               </IconButton>
-            </div>
+            </>
           ),
         }}
       />


### PR DESCRIPTION
## Summary
- remove the extra flex wrapper around the prompts hero actions so the built-in hero layout can handle wrapping

## Testing
- `npm run check` *(fails: concurrently not found in PATH inside the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbebd1c294832ca62464d6ee8c2fd2