### PR TITLE
Ensure TaskRow image keys include index

### DIFF
--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -250,8 +250,11 @@ export default function TaskRow({
       </div>
       {task.images.length > 0 && (
         <ul className="mt-[var(--space-2)] space-y-[var(--space-2)]">
-          {task.images.map((url) => (
-            <li key={url} className="flex items-center gap-[var(--space-2)]">
+          {task.images.map((url, index) => (
+            <li
+              key={`${url}-${index}`}
+              className="flex items-center gap-[var(--space-2)]"
+            >
               <Image
                 src={url}
                 alt={`Task image for ${task.title}`}


### PR DESCRIPTION
## Summary
- include the array index when generating TaskRow image keys so duplicate URLs render reliably

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cbedab7040832c83d3a82327feac9f