### PR TITLE
Adjust secondary primary hover tokens

### DIFF
--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -119,7 +119,8 @@ export const toneClasses: Record<
     danger: toneInteractionTokens.danger,
   },
   secondary: {
-    primary: "text-muted-foreground bg-panel/60",
+    primary:
+      "text-muted-foreground bg-panel/60 [--hover:hsl(var(--primary)/0.25)] [--active:hsl(var(--primary)/0.35)]",
     accent:
       "text-accent-foreground bg-accent/30 [--hover:hsl(var(--accent)/0.25)] [--active:hsl(var(--accent)/0.2)]",
     info:


### PR DESCRIPTION
## Summary
- update the secondary primary tone class to use the new primary hover and active surface tokens while keeping text color unchanged

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cbedc15b98832cb2775ba3a2ad42c0