### PR TITLE
Align goals progress colors with new tokens

### DIFF
--- a/src/components/goals/GoalsProgress.tsx
+++ b/src/components/goals/GoalsProgress.tsx
@@ -20,7 +20,7 @@ export default function GoalsProgress({
   if (total === 0) {
     return (
       <div className="rounded-card r-card-md border border-border bg-surface-2 p-6 text-center">
-        <p className="mb-4 text-ui font-medium text-muted-foreground">No goals yet.</p>
+        <p className="mb-4 text-muted-foreground text-ui font-medium">No goals yet.</p>
         {onAddFirst && (
           <Button onClick={onAddFirst} size="sm" className="mx-auto">
             Add a first goal

--- a/src/icons/ProgressRingIcon.tsx
+++ b/src/icons/ProgressRingIcon.tsx
@@ -23,7 +23,7 @@ export default function ProgressRingIcon({
         r={radius}
         stroke="currentColor"
         strokeWidth={4}
-        className="text-muted-foreground/30"
+        className="text-foreground/20"
         fill="none"
       />
       <circle


### PR DESCRIPTION
## Summary
- ensure the zero-goal state copy in `GoalsProgress` relies on the `text-muted-foreground` token
- update `ProgressRingIcon` to use the `text-foreground/20` token for the background ring

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cbef1cf2f8832c93ecd48004a96aa9