### PR TITLE
Move spec count badge to components grid header

### DIFF
--- a/src/components/comps/CompsPage.tsx
+++ b/src/components/comps/CompsPage.tsx
@@ -3,7 +3,6 @@
 import * as React from "react";
 import { PanelsTopLeft } from "lucide-react";
 import { PageHeader, PageShell } from "@/components/ui";
-import Badge from "@/components/ui/primitives/Badge";
 import ComponentsView from "@/components/prompts/ComponentsView";
 import {
   SECTION_TABS,
@@ -39,9 +38,6 @@ export default function CompsPage() {
     getValidSection(sectionParam),
   );
   const [query, setQuery] = usePersistentState("comps-query", "");
-  const [filteredCount, setFilteredCount] = React.useState(() =>
-    SPEC_DATA[getValidSection(sectionParam)].length,
-  );
   const panelRef = React.useRef<HTMLDivElement>(null);
 
   const heroTabs = React.useMemo(
@@ -63,11 +59,6 @@ export default function CompsPage() {
     () => `Search ${sectionLabel.toLowerCase()} components`,
     [sectionLabel],
   );
-
-  const filteredLabel = React.useMemo(() => {
-    const suffix = filteredCount === 1 ? "component" : "components";
-    return `${filteredCount} ${suffix}`;
-  }, [filteredCount]);
 
   React.useEffect(() => {
     const next = getValidSection(sectionParam);
@@ -146,11 +137,6 @@ export default function CompsPage() {
             round: true,
             "aria-label": searchLabel,
           },
-          actions: (
-            <Badge tone="support" size="sm" className="text-muted-foreground">
-              {filteredLabel}
-            </Badge>
-          ),
         }}
       />
       <section className="grid gap-[var(--space-6)]">
@@ -165,7 +151,6 @@ export default function CompsPage() {
           <ComponentsView
             query={query}
             section={section}
-            onFilteredCountChange={setFilteredCount}
           />
         </div>
       </section>

--- a/src/components/prompts/ComponentsView.tsx
+++ b/src/components/prompts/ComponentsView.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import Fuse from "fuse.js";
 import { Card, CardContent } from "@/components/ui";
+import Badge from "@/components/ui/primitives/Badge";
 import { SPEC_DATA, type Section, type Spec } from "./constants";
 
 type ComponentsViewProps = {
@@ -81,6 +82,7 @@ export default function ComponentsView({
   onCurrentCodeChange,
   onFilteredCountChange,
 }: ComponentsViewProps) {
+  const countDescriptionId = React.useId();
   const [, setActiveSpecId] = React.useState<string | null>(null);
   const handleCodeVisibilityChange = React.useCallback(
     (specId: string, nextCode: string | null, visible: boolean) => {
@@ -124,14 +126,42 @@ export default function ComponentsView({
     return fuse.search(query).map((r) => r.item);
   }, [query, fuse, section]);
 
+  const sectionLabel = React.useMemo(
+    () => section.charAt(0).toUpperCase() + section.slice(1),
+    [section],
+  );
+
+  const filteredCount = specs.length;
+
+  const countLabel = React.useMemo(() => {
+    const suffix = filteredCount === 1 ? "spec" : "specs";
+    return `${filteredCount} ${sectionLabel.toLowerCase()} ${suffix}`;
+  }, [filteredCount, sectionLabel]);
+
   React.useEffect(() => {
     if (!onFilteredCountChange) return;
-    onFilteredCountChange(specs.length);
-  }, [specs, onFilteredCountChange]);
+    onFilteredCountChange(filteredCount);
+  }, [filteredCount, onFilteredCountChange]);
 
   return (
     <div className="space-y-8">
-      <ul className="grid grid-cols-4 gap-6 md:grid-cols-6 lg:grid-cols-12">
+      <header className="flex flex-wrap items-center justify-between gap-[var(--space-3)]">
+        <h2 className="text-ui font-semibold tracking-[-0.01em] text-muted-foreground">
+          {sectionLabel} specs
+        </h2>
+        <Badge
+          id={countDescriptionId}
+          tone="support"
+          size="sm"
+          className="text-muted-foreground"
+        >
+          {countLabel}
+        </Badge>
+      </header>
+      <ul
+        className="grid grid-cols-4 gap-6 md:grid-cols-6 lg:grid-cols-12"
+        aria-describedby={countDescriptionId}
+      >
         {specs.length === 0 ? (
           <li className="col-span-full">
             <Card>


### PR DESCRIPTION
## Summary
- add a grid header inside `ComponentsView` with a support badge that announces the filtered spec count and labels the grid via `aria-describedby`
- remove the hero action badge from `CompsPage` now that the count is rendered beside the components grid header

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cbf617d500832c8d5bcd0e9c8c1f08