### PR TITLE
Align Hero layout spacing to 8px grid

### DIFF
--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -139,17 +139,17 @@ function Hero<Key extends string = string>({
         ? "px-[var(--space-6)]"
         : undefined
       : padding === "default"
-        ? "px-[var(--space-3)] sm:px-[var(--space-4)] lg:px-[var(--space-5)]"
+        ? "px-[var(--space-2)] sm:px-[var(--space-4)] lg:px-[var(--space-5)]"
         : undefined,
   );
 
   const barSpacingClass = frame
-    ? "relative z-[2] grid grid-cols-1 md:grid-cols-12 items-start md:items-center gap-y-[var(--space-3)] md:gap-y-0 md:gap-x-[var(--space-4)] lg:gap-x-[var(--space-6)] py-[var(--space-4)] md:py-[var(--space-5)]"
-    : "relative z-[2] grid grid-cols-1 md:grid-cols-12 items-start md:items-center gap-y-[var(--space-2)] md:gap-y-0 md:gap-x-[var(--space-3)] lg:gap-x-[var(--space-4)] py-[var(--space-4)] md:py-[var(--space-5)]";
+    ? "relative z-[2] grid grid-cols-1 md:grid-cols-12 items-start md:items-center gap-y-[var(--space-4)] md:gap-y-0 md:gap-x-[var(--space-4)] lg:gap-x-[var(--space-6)] py-[var(--space-4)] md:py-[var(--space-5)]"
+    : "relative z-[2] grid grid-cols-1 md:grid-cols-12 items-start md:items-center gap-y-[var(--space-2)] md:gap-y-0 md:gap-x-[var(--space-4)] lg:gap-x-[var(--space-5)] py-[var(--space-4)] md:py-[var(--space-5)]";
 
   const clusterGapClass = frame
-    ? "gap-[var(--space-3)] md:gap-[var(--space-4)]"
-    : "gap-[var(--space-2)] md:gap-[var(--space-3)]";
+    ? "gap-[var(--space-4)] md:gap-[var(--space-5)]"
+    : "gap-[var(--space-2)] md:gap-[var(--space-4)]";
 
   const labelClusterClass = cx(
     "col-span-full md:col-span-8 flex min-w-0 flex-wrap items-start md:flex-nowrap",
@@ -160,7 +160,7 @@ function Hero<Key extends string = string>({
   const raisedLabelBarClass = cx(
     "flex w-full min-w-0 flex-wrap items-start md:flex-nowrap md:items-center",
     clusterGapClass,
-    "overflow-hidden rounded-card r-card-lg border border-[hsl(var(--border))/0.45] bg-card/70 px-[var(--space-3)] py-[var(--space-3)] md:px-[var(--space-4)] shadow-neoSoft backdrop-blur-md hero2-frame hero2-neomorph",
+    "overflow-hidden rounded-card r-card-lg border border-[hsl(var(--border))/0.45] bg-card/70 px-[var(--space-4)] py-[var(--space-4)] md:px-[var(--space-4)] shadow-neoSoft backdrop-blur-md hero2-frame hero2-neomorph",
   );
 
   const utilitiesClass = cx(
@@ -173,8 +173,8 @@ function Hero<Key extends string = string>({
     : "relative z-[2] mt-[var(--space-4)] md:mt-[var(--space-5)] flex flex-col gap-[var(--space-4)] md:gap-[var(--space-5)]";
 
   const actionRowClass = frame
-    ? "flex flex-wrap items-start gap-[var(--space-3)] md:flex-nowrap md:items-center md:gap-[var(--space-4)] lg:gap-[var(--space-6)] pt-[var(--space-5)] md:pt-[var(--space-6)]"
-    : "flex flex-wrap items-start gap-[var(--space-2)] md:flex-nowrap md:items-center md:gap-[var(--space-3)] lg:gap-[var(--space-4)] pt-[var(--space-4)] md:pt-[var(--space-5)]";
+    ? "flex flex-wrap items-start gap-[var(--space-4)] md:flex-nowrap md:items-center md:gap-[var(--space-5)] lg:gap-[var(--space-6)] pt-[var(--space-5)] md:pt-[var(--space-6)]"
+    : "flex flex-wrap items-start gap-[var(--space-2)] md:flex-nowrap md:items-center md:gap-[var(--space-4)] lg:gap-[var(--space-5)] pt-[var(--space-4)] md:pt-[var(--space-5)]";
 
   const headingClassName = cx(
     "font-semibold tracking-[-0.01em] text-balance break-words text-foreground",

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -129,10 +129,10 @@ exports[`ReviewsPage > renders default state 1`] = `
                 class=""
               >
                 <div
-                  class="relative z-[2] grid grid-cols-1 md:grid-cols-12 items-start md:items-center gap-y-[var(--space-2)] md:gap-y-0 md:gap-x-[var(--space-3)] lg:gap-x-[var(--space-4)] py-[var(--space-4)] md:py-[var(--space-5)]"
+                  class="relative z-[2] grid grid-cols-1 md:grid-cols-12 items-start md:items-center gap-y-[var(--space-2)] md:gap-y-0 md:gap-x-[var(--space-4)] lg:gap-x-[var(--space-5)] py-[var(--space-4)] md:py-[var(--space-5)]"
                 >
                   <div
-                    class="col-span-full md:col-span-8 flex min-w-0 flex-wrap items-start md:flex-nowrap md:items-center gap-[var(--space-2)] md:gap-[var(--space-3)]"
+                    class="col-span-full md:col-span-8 flex min-w-0 flex-wrap items-start md:flex-nowrap md:items-center gap-[var(--space-2)] md:gap-[var(--space-4)]"
                   >
                     <span
                       aria-hidden="true"
@@ -176,7 +176,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                       class="block h-px bg-[hsl(var(--divider))/0.28]"
                     />
                     <div
-                      class="flex flex-wrap items-start gap-[var(--space-2)] md:flex-nowrap md:items-center md:gap-[var(--space-3)] lg:gap-[var(--space-4)] pt-[var(--space-4)] md:pt-[var(--space-5)]"
+                      class="flex flex-wrap items-start gap-[var(--space-2)] md:flex-nowrap md:items-center md:gap-[var(--space-4)] lg:gap-[var(--space-5)] pt-[var(--space-4)] md:pt-[var(--space-5)]"
                     >
                       <form
                         class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-[var(--space-2)] data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"


### PR DESCRIPTION
## Summary
- update Hero layout spacing to use 8px token multiples and adjust responsive gaps to keep layout proportions
- increase raised label bar padding to the new spacing scale and refresh the Reviews page snapshot

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cbf8a628a4832c9b5338b8535d4a05