### PR TITLE
Fix planner focus hydration and add timezone test

### DIFF
--- a/src/components/planner/plannerStore.ts
+++ b/src/components/planner/plannerStore.ts
@@ -39,6 +39,8 @@ export type Selection = {
   taskId?: string;
 };
 
+const FOCUS_PLACEHOLDER: ISODate = "";
+
 export function todayISO(): ISODate {
   return toISODate(new Date());
 }
@@ -194,7 +196,10 @@ type DaysState = {
   tasksById: TaskIdMap;
 };
 
-type FocusState = { focus: ISODate; setFocus: (iso: ISODate) => void };
+type FocusState = {
+  focus: ISODate;
+  setFocus: React.Dispatch<React.SetStateAction<ISODate>>;
+};
 
 type SelectionState = {
   selected: Record<ISODate, Selection>;
@@ -212,13 +217,21 @@ export function PlannerProvider({ children }: { children: React.ReactNode }) {
   );
   const [focus, setFocus] = usePersistentState<ISODate>(
     "planner:focus",
-    todayISO(),
+    FOCUS_PLACEHOLDER,
   );
   const [selectedState, setSelectedState] = usePersistentState<
     Record<ISODate, Selection>
   >("planner:selected", {});
 
   const days = rawDays;
+
+  React.useEffect(() => {
+    if (focus === FOCUS_PLACEHOLDER) {
+      setFocus((prev) =>
+        prev === FOCUS_PLACEHOLDER ? todayISO() : prev,
+      );
+    }
+  }, [focus, setFocus]);
 
   const selected = React.useMemo(
     () => cleanupSelections(selectedState, days),

--- a/src/components/planner/usePlannerStore.ts
+++ b/src/components/planner/usePlannerStore.ts
@@ -83,6 +83,7 @@ export function usePlannerStore() {
 
   React.useEffect(() => {
     if (!legacyMigrated) {
+      if (!focus) return;
       const projects = readLocal<Project[]>(LEGACY_PROJECTS_KEY);
       const tasks = readLocal<DayTask[]>(LEGACY_TASKS_KEY);
 

--- a/tests/planner/PlannerProvider.timezone.test.tsx
+++ b/tests/planner/PlannerProvider.timezone.test.tsx
@@ -1,0 +1,95 @@
+import * as React from "react";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+import { PlannerProvider, useFocusDate } from "@/components/planner";
+import { toISODate } from "@/lib/date";
+
+const RealDate = Date;
+
+describe("PlannerProvider focus timezone", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    globalThis.Date = RealDate;
+    window.localStorage.clear();
+  });
+
+  it("initializes focus using the client local day", async () => {
+    const offsetMs = 36 * 60 * 60 * 1000;
+
+    class ClientDate extends RealDate {
+      constructor(...args: any[]) {
+        if (args.length === 0) {
+          super(RealDate.now() - offsetMs);
+          return;
+        }
+        switch (args.length) {
+          case 1:
+            super(args[0]);
+            break;
+          case 2:
+            super(args[0], args[1]);
+            break;
+          case 3:
+            super(args[0], args[1], args[2]);
+            break;
+          case 4:
+            super(args[0], args[1], args[2], args[3]);
+            break;
+          case 5:
+            super(args[0], args[1], args[2], args[3], args[4]);
+            break;
+          case 6:
+            super(args[0], args[1], args[2], args[3], args[4], args[5]);
+            break;
+          default:
+            super(
+              args[0],
+              args[1],
+              args[2],
+              args[3],
+              args[4],
+              args[5],
+              args[6],
+            );
+            break;
+        }
+      }
+
+      static override now() {
+        return RealDate.now() - offsetMs;
+      }
+    }
+
+    function ClientTimezone({ children }: { children: React.ReactNode }) {
+      React.useLayoutEffect(() => {
+        globalThis.Date = ClientDate as unknown as typeof Date;
+        return () => {
+          globalThis.Date = RealDate;
+        };
+      }, []);
+      return <>{children}</>;
+    }
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <ClientTimezone>
+        <PlannerProvider>{children}</PlannerProvider>
+      </ClientTimezone>
+    );
+
+    const { result, unmount } = renderHook(() => useFocusDate(), {
+      wrapper,
+    });
+
+    const expected = toISODate(new ClientDate());
+
+    await waitFor(() => {
+      expect(result.current.iso).toBe(expected);
+    });
+
+    unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- initialize the planner focus state with a placeholder and hydrate it after mount so client timezone dates win
- skip legacy planner migrations until the focus day is available
- add a PlannerProvider integration test that verifies clients in different timezones land on their local day

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cbf77f1a98832c83ba80b17775918e