### PR TITLE
Sync reminder editor state with updates

### DIFF
--- a/src/components/goals/reminders/ReminderList.tsx
+++ b/src/components/goals/reminders/ReminderList.tsx
@@ -64,6 +64,16 @@ function RemTile({
 
   useAutoFocus({ ref: titleRef, when: editing });
 
+  React.useEffect(() => {
+    if (editing) {
+      return;
+    }
+
+    setTitle(value.title);
+    setBody(value.body ?? "");
+    setTagsText(value.tags.join(", "));
+  }, [editing, value.body, value.tags, value.title]);
+
   const save = React.useCallback(() => {
     const cleanTags = tagsText
       .split(",")


### PR DESCRIPTION
## Summary
- add an effect to sync the reminder editor inputs with the latest reminder value
- reset the local editor state whenever editing is exited so the next edit shows saved content

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cbff69a69c832c8384f1be7cfcb295