### PR TITLE
Ensure TimerRingIcon gradients are unique

### DIFF
--- a/src/icons/TimerRingIcon.tsx
+++ b/src/icons/TimerRingIcon.tsx
@@ -7,6 +7,8 @@ interface TimerRingIconProps {
 }
 
 export default function TimerRingIcon({ pct, size = 200 }: TimerRingIconProps) {
+  const uniqueId = React.useId();
+  const gradientId = `timer-ring-grad-${uniqueId}`;
   const radius = size / 2 - 6;
   const circumference = 2 * Math.PI * radius;
   const offset = circumference - (pct / 100) * circumference;
@@ -20,7 +22,7 @@ export default function TimerRingIcon({ pct, size = 200 }: TimerRingIconProps) {
       aria-label={accessibleLabel}
     >
       <defs>
-        <linearGradient id="timer-ring-grad" x1="0%" y1="0%" x2="100%" y2="0%">
+        <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="0%">
           <stop offset="0%" stopColor="hsl(var(--accent))" />
           <stop offset="100%" stopColor="hsl(var(--accent-2))" />
         </linearGradient>
@@ -37,7 +39,7 @@ export default function TimerRingIcon({ pct, size = 200 }: TimerRingIconProps) {
         cx={size / 2}
         cy={size / 2}
         r={radius}
-        stroke="url(#timer-ring-grad)"
+        stroke={`url(#${gradientId})`}
         strokeWidth={4}
         strokeLinecap="round"
         strokeDasharray={circumference}

--- a/storybook/src/components/ui/TimerRingIcon.stories.tsx
+++ b/storybook/src/components/ui/TimerRingIcon.stories.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import TimerRingIcon from "@/icons/TimerRingIcon";
+
+const meta: Meta<typeof TimerRingIcon> = {
+  title: "Icons/TimerRingIcon",
+  component: TimerRingIcon,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "TimerRingIcon visualizes elapsed time with a gradient stroke. Each instance maintains its own gradient definition so multiple rings can render together without conflicts.",
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TimerRingIcon>;
+
+const progressValues = [25, 50, 75];
+
+export const MultipleRings: Story = {
+  render: () => (
+    <div className="flex items-center gap-6">
+      {progressValues.map((pct) => (
+        <div key={pct} className="h-20 w-20">
+          <TimerRingIcon pct={pct} size={80} />
+        </div>
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Rendering multiple TimerRingIcon instances verifies that each ring keeps a distinct gradient.",
+      },
+    },
+  },
+};

--- a/tests/icons/TimerRingIcon.test.tsx
+++ b/tests/icons/TimerRingIcon.test.tsx
@@ -15,4 +15,35 @@ describe("TimerRingIcon", () => {
       screen.getByRole("img", { name: "Timer 72% complete" }),
     ).toBeInTheDocument();
   });
+
+  it("assigns unique gradient ids when rendering multiple icons", () => {
+    const { container } = render(
+      <div>
+        <TimerRingIcon pct={25} size={80} />
+        <TimerRingIcon pct={50} size={80} />
+        <TimerRingIcon pct={75} size={80} />
+      </div>,
+    );
+
+    const gradients = Array.from(
+      container.querySelectorAll("linearGradient[id^='timer-ring-grad-']"),
+    );
+
+    expect(gradients).toHaveLength(3);
+
+    const gradientIds = gradients
+      .map((gradient) => gradient.getAttribute("id"))
+      .filter((id): id is string => Boolean(id));
+
+    expect(gradientIds).toHaveLength(3);
+    expect(new Set(gradientIds).size).toBe(gradientIds.length);
+
+    gradientIds.forEach((id) => {
+      const matchedStrokes = container.querySelectorAll(
+        `circle[stroke="url(#${id})"]`,
+      );
+
+      expect(matchedStrokes).toHaveLength(1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- generate per-instance gradient ids in `TimerRingIcon` so multiple rings can render together
- add a unit test that renders several icons and asserts each keeps its own gradient
- document the behavior with a Storybook example that shows multiple timer rings

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc047a7024832cb295a16951c2699b