### PR TITLE
Add welcome hero figure to home hero and gallery

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ import {
   BottomNav,
   IsometricRoom,
   DashboardList,
-  HeroPortraitFrame,
+  WelcomeHeroFigure,
 } from "@/components/home";
 import {
   PageHeader,
@@ -463,35 +463,38 @@ function HomePageContent() {
                     icon: <Home className="opacity-80" />,
                     sticky: false,
                   }}
-                  hero={{
-                    heading: "Your day at a glance",
-                    sticky: false,
-                    barVariant: "raised",
-                    topClassName: "top-0",
-                    actions: (
-                      <>
-                        <HeroPortraitFrame
-                          imageSrc="/hero_image.png"
-                          imageAlt="Illustration of the Planner hero floating above a holographic dashboard"
-                          priority
-                          className="max-sm:mx-auto"
-                        />
-                        <ThemeToggle className="shrink-0" />
-                        <Button
-                          asChild
-                          variant="primary"
-                          size="sm"
-                          tactile
-                          className="px-4 whitespace-nowrap"
+                    hero={{
+                      heading: "Your day at a glance",
+                      sticky: false,
+                      barVariant: "raised",
+                      topClassName: "top-0",
+                      actions: (
+                        <div
+                          className="flex w-full flex-col gap-[var(--space-3)] sm:flex-row sm:items-center sm:justify-end sm:gap-[var(--space-3)]"
                         >
-                          <Link href="/planner">Plan Week</Link>
-                        </Button>
-                      </>
-                    ),
-                    children: (
-                      <div className="pt-[var(--space-4)]">
-                        <HeroPlannerCards />
-                      </div>
+                          <div
+                            className="flex w-full flex-wrap items-center justify-end gap-[var(--space-2)] sm:w-auto sm:flex-nowrap"
+                          >
+                            <ThemeToggle className="shrink-0" />
+                            <Button
+                              asChild
+                              variant="primary"
+                              size="sm"
+                              tactile
+                              className="whitespace-nowrap px-4"
+                            >
+                              <Link href="/planner">Plan Week</Link>
+                            </Button>
+                          </div>
+                          <WelcomeHeroFigure
+                            className="hidden w-full shrink-0 sm:flex sm:max-w-[min(52vw,calc(var(--space-8) * 4))] md:basis-[33%] md:max-w-[34%] lg:basis-[42%] lg:max-w-[44%]"
+                          />
+                        </div>
+                      ),
+                      children: (
+                        <div className="pt-[var(--space-4)]">
+                          <HeroPlannerCards />
+                        </div>
                     ),
                   }}
                 />

--- a/src/components/home/WelcomeHeroFigure.tsx
+++ b/src/components/home/WelcomeHeroFigure.tsx
@@ -1,0 +1,105 @@
+import * as React from "react";
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+
+type CSSVarStyle = React.CSSProperties & Record<`--${string}`, string>;
+
+const figureVariables: CSSVarStyle = {
+  "--welcome-figure-rim": "calc(var(--space-2) / 1.4)",
+  "--welcome-figure-glow": "calc(var(--space-5) + var(--space-1))",
+  "--welcome-figure-rim-gradient":
+    "conic-gradient(from 125deg at 50% 50%, hsl(var(--accent) / 0.92), hsl(var(--accent-2) / 0.88), hsl(var(--ring) / 0.85), hsl(var(--accent) / 0.92))",
+  "--welcome-figure-surface": "hsl(var(--card) / 0.95)",
+  "--welcome-figure-inner": "hsl(var(--surface) / 0.88)",
+  "--welcome-figure-outline": "0 0 0 var(--hairline-w) hsl(var(--card-hairline) / 0.65)",
+  "--welcome-figure-primary-halo":
+    "radial-gradient(circle at 52% 36%, hsl(var(--accent-2) / 0.5), transparent 72%)",
+  "--welcome-figure-secondary-halo":
+    "radial-gradient(circle at 34% 70%, hsl(var(--accent) / 0.32), transparent 78%)",
+};
+
+const rimStyle: React.CSSProperties = {
+  padding: "var(--welcome-figure-rim)",
+  background: "var(--welcome-figure-rim-gradient)",
+};
+
+const innerStyle: React.CSSProperties = {
+  background: "var(--welcome-figure-surface)",
+  boxShadow: "var(--welcome-figure-outline)",
+};
+
+const overlayStyle: React.CSSProperties = {
+  background: "var(--welcome-figure-inner)",
+};
+
+const haloPrimaryStyle: React.CSSProperties = {
+  background: "var(--welcome-figure-primary-halo)",
+};
+
+const haloSecondaryStyle: React.CSSProperties = {
+  background: "var(--welcome-figure-secondary-halo)",
+};
+
+const defaultSizes =
+  "(max-width: 639px) 0px, (max-width: 1023px) 33vw, 40vw";
+
+export interface WelcomeHeroFigureProps {
+  className?: string;
+  imageSizes?: string;
+}
+
+export default function WelcomeHeroFigure({
+  className,
+  imageSizes = defaultSizes,
+}: WelcomeHeroFigureProps) {
+  return (
+    <figure
+      className={cn(
+        "relative z-10 isolate flex aspect-square w-full items-center justify-center",
+        "rounded-full",
+        className,
+      )}
+      style={figureVariables}
+    >
+      <span
+        aria-hidden
+        className="pointer-events-none absolute -inset-[calc(var(--welcome-figure-rim)*2.3)] rounded-full opacity-80 blur-[var(--welcome-figure-glow)]"
+        style={haloPrimaryStyle}
+      />
+      <span
+        aria-hidden
+        className="pointer-events-none absolute -inset-[calc(var(--welcome-figure-rim)*1.6)] rounded-full opacity-70 blur-[calc(var(--welcome-figure-glow)*0.75)]"
+        style={haloSecondaryStyle}
+      />
+      <span
+        aria-hidden
+        className="glitch-rail pointer-events-none absolute -inset-[calc(var(--welcome-figure-rim)*1.05)] rounded-full mix-blend-screen opacity-75"
+      />
+      <div
+        className="relative flex h-full w-full items-center justify-center rounded-full shadow-neoSoft ring-1 ring-border/50"
+        style={rimStyle}
+      >
+        <div
+          className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-full shadow-neo-inset"
+          style={innerStyle}
+        >
+          <span
+            aria-hidden
+            className="pointer-events-none absolute inset-0 rounded-full"
+            style={overlayStyle}
+          />
+          <Image
+            src="/tryHero.png"
+            alt="Planner assistant reviewing a holographic agenda"
+            fill
+            priority
+            loading="eager"
+            decoding="async"
+            sizes={imageSizes}
+            className="relative z-[1] h-full w-full object-contain object-center"
+          />
+        </div>
+      </div>
+    </figure>
+  );
+}

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -10,3 +10,4 @@ export { default as QuickActionGrid } from "./QuickActionGrid";
 export { default as BottomNav } from "./BottomNav";
 export { default as IsometricRoom } from "./IsometricRoom";
 export { default as HeroPortraitFrame } from "./HeroPortraitFrame";
+export { default as WelcomeHeroFigure } from "./WelcomeHeroFigure";

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -55,6 +55,7 @@ import {
   IsometricRoom,
   QuickActionGrid,
   HeroPortraitFrame,
+  WelcomeHeroFigure,
 } from "@/components/home";
 import ChampListEditor from "@/components/team/ChampListEditor";
 import {
@@ -1164,6 +1165,19 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
   imageSrc="/hero_image.png"
   imageAlt="Illustration of the Planner hero floating above a holographic dashboard"
 />`,
+    },
+    {
+      id: "welcome-hero-figure",
+      name: "WelcomeHeroFigure",
+      description:
+        "Hero automation figure framed in a haloed neumorphic ring with eager loading tuned for the landing experience.",
+      element: (
+        <div className="mx-auto flex w-full max-w-[calc(var(--space-8) * 4.5)] justify-center">
+          <WelcomeHeroFigure />
+        </div>
+      ),
+      tags: ["hero", "figure", "neomorphic"],
+      code: `<WelcomeHeroFigure />`,
     },
   ],
   feedback: [


### PR DESCRIPTION
## Summary
- add a WelcomeHeroFigure primitive with neumorphic frame, halos, and tuned eager image loading
- replace the landing hero action layout to use the new figure alongside existing controls at responsive widths
- export the component and surface it in the prompts gallery for discoverability

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68cc05079fa8832c872ee27083d341b3