### PR TITLE
Enhance prompts components empty state

### DIFF
--- a/src/app/prompts/PromptsPage.tsx
+++ b/src/app/prompts/PromptsPage.tsx
@@ -140,6 +140,17 @@ function PageContent() {
     void copyText(currentCode);
   }, [currentCode]);
 
+  const handleSuggestionSelect = React.useCallback(
+    (value: string) => {
+      setQuery(value);
+    },
+    [setQuery],
+  );
+
+  const handleResetFilters = React.useCallback(() => {
+    setQuery("");
+  }, [setQuery]);
+
   return (
     <PageShell
       as="main"
@@ -232,6 +243,8 @@ function PageContent() {
                 query={query}
                 section={section}
                 onCurrentCodeChange={handleCurrentCodeChange}
+                onSuggestionSelect={handleSuggestionSelect}
+                onResetFilters={handleResetFilters}
               />
             </div>
             <div

--- a/src/components/comps/CompsPage.tsx
+++ b/src/components/comps/CompsPage.tsx
@@ -170,6 +170,17 @@ export default function CompsPage() {
     panelRef.current?.focus();
   }, [section]);
 
+  const handleSuggestionSelect = React.useCallback(
+    (value: string) => {
+      setQuery(value);
+    },
+    [setQuery],
+  );
+
+  const handleResetFilters = React.useCallback(() => {
+    setQuery("");
+  }, [setQuery]);
+
   return (
     <PageShell
       as="main"
@@ -223,6 +234,8 @@ export default function CompsPage() {
           <ComponentsView
             query={query}
             section={section}
+            onSuggestionSelect={handleSuggestionSelect}
+            onResetFilters={handleResetFilters}
           />
         </div>
       </section>


### PR DESCRIPTION
## Summary
- replace the components view empty card with a neumorphic helper panel that surfaces guidance, popular filter chips, and a reset action
- align the empty state wrapper with populated card grid spans and hook its controls into suggestion and reset callbacks
- thread suggestion/reset handlers through prompts and comps pages so chips immediately update the active search query

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc05b81cb8832cab675e281de303b2