### PR TITLE
Handle missing IntersectionObserver in scroll button

### DIFF
--- a/src/components/planner/ScrollTopFloatingButton.tsx
+++ b/src/components/planner/ScrollTopFloatingButton.tsx
@@ -21,6 +21,9 @@ export default function ScrollTopFloatingButton({
     () => watchRef.current,
   );
 
+  const supportsIntersectionObserver =
+    typeof window !== "undefined" && "IntersectionObserver" in window;
+
   React.useEffect(() => {
     if (watchRef.current !== target) {
       setTarget(watchRef.current ?? null);
@@ -28,6 +31,11 @@ export default function ScrollTopFloatingButton({
   }, [watchRef, target]);
 
   React.useEffect(() => {
+    if (!supportsIntersectionObserver) {
+      setVisible(true);
+      return undefined;
+    }
+
     if (!target) {
       return undefined;
     }
@@ -42,7 +50,7 @@ export default function ScrollTopFloatingButton({
       obs.unobserve(target);
       obs.disconnect();
     };
-  }, [target]);
+  }, [supportsIntersectionObserver, target]);
 
   const scrollTop = () => {
     if (typeof window !== "undefined") {

--- a/tests/planner/ScrollTopFloatingButton.test.tsx
+++ b/tests/planner/ScrollTopFloatingButton.test.tsx
@@ -3,6 +3,8 @@ import { render, fireEvent, cleanup, act } from "@testing-library/react";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import ScrollTopFloatingButton from "@/components/planner/ScrollTopFloatingButton";
 
+const originalIntersectionObserver = window.IntersectionObserver;
+
 describe("ScrollTopFloatingButton", () => {
   let observerCallback: IntersectionObserverCallback;
   beforeEach(() => {
@@ -21,6 +23,11 @@ describe("ScrollTopFloatingButton", () => {
 
   afterEach(() => {
     cleanup();
+    if (originalIntersectionObserver) {
+      window.IntersectionObserver = originalIntersectionObserver;
+    } else {
+      Reflect.deleteProperty(window, "IntersectionObserver");
+    }
   });
 
   it("scrolls to top when clicked", () => {
@@ -68,5 +75,14 @@ describe("ScrollTopFloatingButton", () => {
       observerCallback([entry], {} as IntersectionObserver);
     });
     expect(queryByRole("button")).not.toBeNull();
+  });
+
+  it("falls back gracefully when IntersectionObserver is unavailable", async () => {
+    Reflect.deleteProperty(window, "IntersectionObserver");
+
+    const ref = React.createRef<HTMLElement>();
+    const { findByRole } = render(<ScrollTopFloatingButton watchRef={ref} />);
+
+    await findByRole("button", { name: "Scroll to top" });
   });
 });


### PR DESCRIPTION
## Summary
- guard the scroll-to-top floating button against missing `IntersectionObserver`
- default to showing the control when observation is unavailable while keeping the SSR path safe
- cover the fallback with a unit test that removes `IntersectionObserver`

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc0986c688832ca7cc358c72942360