### PR TITLE
Link component hero tabs to matching panel

### DIFF
--- a/src/components/comps/CompsPage.tsx
+++ b/src/components/comps/CompsPage.tsx
@@ -200,6 +200,7 @@ export default function CompsPage() {
             value: section,
             onChange: (key) => setSection(key as Section),
             idBase: "comps",
+            linkPanels: true,
           },
           search: {
             id: "comps-search",


### PR DESCRIPTION
## Summary
- enable hero tab links on the components page so tab buttons reference the components panel

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc0cc8152c832c86415d505546f476