### PR TITLE
Align planner migration task lookups with runtime helper

### DIFF
--- a/src/components/planner/usePlannerStore.ts
+++ b/src/components/planner/usePlannerStore.ts
@@ -4,6 +4,7 @@ import * as React from "react";
 import {
   ensureDay,
   computeDayCounts,
+  buildTaskLookups,
   useDays,
   useFocus,
   type DayRecord,
@@ -45,13 +46,7 @@ function migrateLegacy(
     updated = { ...updated, projects };
   }
   if (tasks) {
-    const map: Record<string, string[]> = {};
-    const byId: Record<string, DayTask> = {};
-    for (const t of tasks) {
-      byId[t.id] = t;
-      if (t.projectId) (map[t.projectId] ??= []).push(t.id);
-    }
-    updated = { ...updated, tasks, tasksById: byId, tasksByProject: map };
+    updated = { ...updated, tasks, ...buildTaskLookups(tasks) };
   }
   const { doneCount, totalCount } = computeDayCounts(
     updated.projects,

--- a/tests/planner/usePlannerStore.integration.test.tsx
+++ b/tests/planner/usePlannerStore.integration.test.tsx
@@ -68,6 +68,8 @@ describe("usePlannerStore integration", () => {
 
     await waitFor(() => {
       expect(result.current.day.projects[0]?.name).toBe("Legacy");
+      expect(result.current.day.tasksByProject).toEqual({ p1: ["t1"] });
+      expect(result.current.day.tasksById["t1"]?.title).toBe("Old Task");
     });
 
     flushWriteLocal();
@@ -85,12 +87,16 @@ describe("usePlannerStore integration", () => {
       {
         projects?: { name?: string }[];
         tasks?: { title?: string }[];
+        tasksByProject?: Record<string, string[]>;
+        tasksById?: Record<string, { title?: string }>;
       }
     >;
 
     const focus = result.current.focus;
     expect(storedDays[focus]?.projects?.[0]?.name).toBe("Legacy");
     expect(storedDays[focus]?.tasks?.[0]?.title).toBe("Old Task");
+    expect(storedDays[focus]?.tasksByProject).toEqual({ p1: ["t1"] });
+    expect(storedDays[focus]?.tasksById?.["t1"]?.title).toBe("Old Task");
   });
 
   it("persists planner updates across provider instances", async () => {

--- a/tests/planner/usePlannerStore.test.tsx
+++ b/tests/planner/usePlannerStore.test.tsx
@@ -180,9 +180,11 @@ describe("usePlannerStore", () => {
     });
 
     const { result } = renderHook(() => useStore(), { wrapper: localWrapper });
-    await waitFor(() =>
-      expect(result.current.day.projects[0].name).toBe("Legacy"),
-    );
+    await waitFor(() => {
+      expect(result.current.day.projects[0].name).toBe("Legacy");
+      expect(result.current.day.tasksByProject).toEqual({ p1: ["t1"] });
+    });
+    expect(result.current.day.tasksById["t1"]?.title).toBe("Old");
     expect(result.current.day.tasks[0].title).toBe("Old");
     expect(store["planner:projects"]).toBeUndefined();
     expect(store["planner:tasks"]).toBeUndefined();


### PR DESCRIPTION
## Summary
- reuse buildTaskLookups when migrating legacy planner tasks so helper logic is shared
- spread the helper output into migrated DayRecords to align runtime and migration shapes
- extend migration tests to cover task lookup expectations and persisted data

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc0e8204d0832c8d398b91eda08d08