### PR TITLE
Refine planner selection cleanup

### DIFF
--- a/src/components/planner/plannerStore.ts
+++ b/src/components/planner/plannerStore.ts
@@ -173,11 +173,35 @@ function cleanupSelections(
 
   for (const iso of Object.keys(selected)) {
     const selection = selected[iso];
-    const hasDay = Object.prototype.hasOwnProperty.call(days, iso);
-    const hasProject = Boolean(selection?.projectId);
-    const hasTask = Boolean(selection?.taskId);
+    const day = days[iso];
+    const projectId = selection?.projectId;
+    const taskId = selection?.taskId;
 
-    if (!hasDay || (!hasProject && !hasTask)) {
+    if (!day || (!projectId && !taskId)) {
+      if (!mutated) {
+        mutated = true;
+        result = { ...result };
+      }
+      delete result[iso];
+      continue;
+    }
+
+    if (
+      projectId &&
+      !day.projects.some((project) => project.id === projectId)
+    ) {
+      if (!mutated) {
+        mutated = true;
+        result = { ...result };
+      }
+      delete result[iso];
+      continue;
+    }
+
+    if (
+      taskId &&
+      !(day.tasksById?.[taskId] ?? day.tasks.find((task) => task.id === taskId))
+    ) {
       if (!mutated) {
         mutated = true;
         result = { ...result };
@@ -317,12 +341,10 @@ export function PlannerProvider({ children }: { children: React.ReactNode }) {
         if (Object.is(prev, next)) {
           return prev;
         }
-
-        const cleaned = cleanupSelections(next, days);
-        return Object.is(prev, cleaned) ? prev : cleaned;
+        return next;
       });
     },
-    [days, setSelectedState],
+    [setSelectedState],
   );
   const selectionValue = React.useMemo(
     () => ({ selected, setSelected }),

--- a/tests/planner/useSelection.test.tsx
+++ b/tests/planner/useSelection.test.tsx
@@ -1,13 +1,26 @@
 import * as React from "react";
-import { describe, it, expect, vi } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+const selectionSetSpy = vi.fn<(value: unknown) => void>();
 
 vi.mock("@/lib/db", async () => {
   const actual = await vi.importActual<typeof import("@/lib/db")>("@/lib/db");
   return {
     ...actual,
-    usePersistentState: <T,>(_key: string, initial: T) =>
-      React.useState(initial),
+    usePersistentState: <T,>(key: string, initial: T) => {
+      const [state, setState] = React.useState(initial);
+      const trackedSetState = React.useCallback<typeof setState>(
+        (value) => {
+          if (key === "planner:selected") {
+            selectionSetSpy(value);
+          }
+          setState(value);
+        },
+        [key],
+      );
+      return [state, trackedSetState] as const;
+    },
   };
 });
 
@@ -16,9 +29,15 @@ import {
   usePlannerStore,
   useSelectedProject,
   useSelectedTask,
+  useSelection,
+  useDays,
 } from "@/components/planner";
 
 describe("useSelection hooks", () => {
+  beforeEach(() => {
+    selectionSetSpy.mockClear();
+  });
+
   const wrapper = ({ children }: { children: React.ReactNode }) => (
     <PlannerProvider>{children}</PlannerProvider>
   );
@@ -65,5 +84,121 @@ describe("useSelection hooks", () => {
     act(() => result.current.setSelectedTask(""));
     expect(result.current.selectedTask).toBe("");
     expect(result.current.selectedProject).toBe("");
+  });
+
+  it("clears stale selections once when data disappears", async () => {
+    const iso = "2024-01-02";
+
+    const { result } = renderHook(
+      () => {
+        const planner = usePlannerStore();
+        const { selected } = useSelection();
+        const { setDays } = useDays();
+        const [, setSelectedProject] = useSelectedProject(planner.focus);
+        const [, setSelectedTask] = useSelectedTask(planner.focus);
+
+        return {
+          planner,
+          selected,
+          setSelectedProject,
+          setSelectedTask,
+          setDays,
+        } as const;
+      },
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.planner.setFocus(iso);
+    });
+
+    await waitFor(() => {
+      expect(result.current.planner.focus).toBe(iso);
+    });
+
+    let projectId = "";
+    act(() => {
+      projectId = result.current.planner.addProject("Project");
+    });
+    let taskId = "";
+    act(() => {
+      taskId = result.current.planner.addTask("Task", projectId);
+    });
+
+    await waitFor(() => {
+      expect(result.current.selected[iso]).toBeUndefined();
+    });
+
+    act(() => result.current.setSelectedProject(projectId));
+
+    await waitFor(() => {
+      expect(result.current.selected[iso]?.projectId).toBe(projectId);
+    });
+
+    act(() => result.current.setSelectedTask(taskId));
+
+    await waitFor(() => {
+      expect(result.current.selected[iso]).toEqual({ projectId, taskId });
+    });
+
+    const baseCalls = selectionSetSpy.mock.calls.length;
+
+    act(() => {
+      result.current.planner.removeTask(taskId);
+    });
+
+    await waitFor(() => {
+      expect(result.current.selected[iso]).toBeUndefined();
+    });
+
+    expect(selectionSetSpy.mock.calls.length).toBe(baseCalls + 1);
+
+    act(() => {
+      projectId = result.current.planner.addProject("Next Project");
+    });
+
+    act(() => result.current.setSelectedProject(projectId));
+
+    await waitFor(() => {
+      expect(result.current.selected[iso]?.projectId).toBe(projectId);
+    });
+
+    const projectCleanupCalls = selectionSetSpy.mock.calls.length;
+
+    act(() => {
+      result.current.planner.removeProject(projectId);
+    });
+
+    await waitFor(() => {
+      expect(result.current.selected[iso]).toBeUndefined();
+    });
+
+    expect(selectionSetSpy.mock.calls.length).toBe(projectCleanupCalls + 1);
+
+    act(() => {
+      projectId = result.current.planner.addProject("Final Project");
+    });
+
+    act(() => result.current.setSelectedProject(projectId));
+
+    await waitFor(() => {
+      expect(result.current.selected[iso]?.projectId).toBe(projectId);
+    });
+
+    const dayCleanupCalls = selectionSetSpy.mock.calls.length;
+
+    act(() => {
+      result.current.setDays((prev) => {
+        const next = { ...prev };
+        delete next[iso];
+        return next;
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.selected[iso]).toBeUndefined();
+    });
+
+    expect(selectionSetSpy.mock.calls.length).toBe(dayCleanupCalls + 1);
   });
 });


### PR DESCRIPTION
## Summary
- ensure `cleanupSelections` removes entries for missing days, projects, or tasks and rely on a single normalization path
- simplify the selection setter to trust incoming state without redundant cleanup
- add a regression test that asserts stale selections are cleared once and instruments the persistent state mock for call tracking

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc0e2bdb94832c9bdc1ac73cfb77d2