### PR TITLE
Add colors view tab to components gallery

### DIFF
--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -1417,3 +1417,10 @@ export const SECTION_TABS: HeaderTab<Section>[] = (
   key,
   label: formatSectionLabel(key),
 }));
+
+export type CompsView = "components" | "colors";
+
+export const COMPS_VIEW_TABS: HeaderTab<CompsView>[] = [
+  { key: "components", label: "Components", controls: "components-panel" },
+  { key: "colors", label: "Colors", controls: "colors-panel" },
+];


### PR DESCRIPTION
## Summary
- add a top-level view tab on the component gallery that syncs with the `view` search param
- render the colors palette as a second tab panel with matching focus management and hide section controls when it’s active
- co-locate the component gallery view metadata with the existing section tabs exports

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc0fc705dc832c9f207b3995f95d19