### PR TITLE
Add shared security headers

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import securityHeadersMap from "./security-headers.json" assert { type: "json" };
+
+const securityHeaders = Object.entries(securityHeadersMap);
+
+export function middleware(_request: NextRequest) {
+  const response = NextResponse.next();
+  for (const [key, value] of securityHeaders) {
+    response.headers.set(key, value);
+  }
+  return response;
+}
+
+export const config = {
+  matcher: "/:path*",
+};

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,6 @@
 import path from "path";
 import { fileURLToPath } from "url";
+import securityHeadersMap from "./security-headers.json" assert { type: "json" };
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -23,6 +24,10 @@ const normalizedBasePath = slug ? `/${slug}` : undefined;
 const isUserOrOrgGitHubPage = (repositorySlug ?? slug)?.endsWith(".github.io") ?? false;
 const shouldApplyBasePath = Boolean(isGitHubPages && normalizedBasePath && !isUserOrOrgGitHubPage);
 
+const securityHeaders = Object.entries(securityHeadersMap).map(
+  ([key, value]) => ({ key, value }),
+);
+
 const nextConfig = {
   reactStrictMode: true,
   output: isGitHubPages ? "export" : undefined,
@@ -43,6 +48,14 @@ const nextConfig = {
   },
   env: {
     NEXT_PUBLIC_BASE_PATH: shouldApplyBasePath ? normalizedBasePath : "",
+  },
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders.map((header) => ({ ...header })),
+      },
+    ];
   },
   webpack: (config) => {
     config.resolve.alias["@"] = path.resolve(__dirname, "src");

--- a/security-headers.json
+++ b/security-headers.json
@@ -1,0 +1,8 @@
+{
+  "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; media-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; manifest-src 'self'; worker-src 'self' blob:; frame-src 'none'",
+  "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "X-Frame-Options": "DENY",
+  "X-Content-Type-Options": "nosniff",
+  "Permissions-Policy": "accelerometer=(), autoplay=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), usb=(), xr-spatial-tracking=()"
+}


### PR DESCRIPTION
## Summary
- add a shared security header map and apply it through `headers()` in the Next config so every route receives CSP, HSTS, and related protections
- mirror the same header set from middleware responses to keep framework-generated replies aligned

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc13ab0d50832c9090e512e20aa8fb