### PR TITLE
Harden planner persistence decoding

### DIFF
--- a/tests/planner/WeekPicker.test.tsx
+++ b/tests/planner/WeekPicker.test.tsx
@@ -13,7 +13,7 @@ vi.mock("@/lib/db", async () => {
   const initialFocus = "2024-01-01";
   return {
     ...actual,
-    usePersistentState: <T,>(key: string, initial: T) => {
+    usePersistentState: <T,>(key: string, initial: T, _options?: unknown) => {
       if (key === "planner:focus") {
         return React.useState(initialFocus) as unknown as [
           T,

--- a/tests/planner/decodePlannerDays.test.ts
+++ b/tests/planner/decodePlannerDays.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+
+import { decodePlannerDays } from "@/components/planner";
+
+describe("decodePlannerDays", () => {
+  it("returns an empty object for invalid input", () => {
+    expect(decodePlannerDays(null)).toEqual({});
+    expect(decodePlannerDays(undefined)).toEqual({});
+    expect(decodePlannerDays([])).toEqual({});
+  });
+
+  it("repairs planner day records and filters invalid entries", () => {
+    const decoded = decodePlannerDays({
+      "2024-05-10": {
+        projects: [
+          { id: "p1", name: "Alpha", done: true, createdAt: 1 },
+          { id: 2, name: "Bad", done: false, createdAt: 3 },
+        ],
+        tasks: [
+          {
+            id: "t1",
+            title: "Task",
+            done: true,
+            createdAt: 5,
+            projectId: "p1",
+            images: ["one", 2, "two"],
+          },
+          {
+            id: "bad",
+            title: 12,
+            done: false,
+            createdAt: "oops",
+            projectId: "p1",
+            images: "nope",
+          },
+        ],
+        tasksById: { stale: { id: "stale" } },
+        tasksByProject: { p1: ["stale"] },
+        doneCount: 99,
+        totalCount: 5,
+        focus: "t1",
+        notes: "Keep me",
+      },
+      "2024-05-11": {
+        projects: "invalid",
+        tasks: [
+          {
+            id: "t2",
+            title: "Loose",
+            done: false,
+            createdAt: 2,
+            projectId: 7,
+            images: null,
+          },
+        ],
+        focus: 42,
+        notes: ["no"],
+      },
+      "2024-05-12": "nope",
+    });
+
+    expect(Object.keys(decoded)).toEqual(["2024-05-10", "2024-05-11"]);
+
+    const first = decoded["2024-05-10"];
+    expect(first.projects).toHaveLength(1);
+    expect(first.projects[0]).toEqual({
+      id: "p1",
+      name: "Alpha",
+      done: true,
+      createdAt: 1,
+    });
+    expect(first.tasks).toHaveLength(1);
+    expect(first.tasks[0]).toEqual({
+      id: "t1",
+      title: "Task",
+      done: true,
+      createdAt: 5,
+      projectId: "p1",
+      images: ["one", "two"],
+    });
+    expect(first.tasksById["t1"]).toBe(first.tasks[0]);
+    expect(first.tasksByProject).toEqual({ p1: ["t1"] });
+    expect(first.doneCount).toBe(2);
+    expect(first.totalCount).toBe(2);
+    expect(first.focus).toBe("t1");
+    expect(first.notes).toBe("Keep me");
+
+    const second = decoded["2024-05-11"];
+    expect(second.projects).toEqual([]);
+    expect(second.tasks).toHaveLength(1);
+    expect(second.tasks[0]).toEqual({
+      id: "t2",
+      title: "Loose",
+      done: false,
+      createdAt: 2,
+      images: [],
+    });
+    expect(second.tasks[0].projectId).toBeUndefined();
+    expect(second.tasksById["t2"]).toBe(second.tasks[0]);
+    expect(second.tasksByProject).toEqual({});
+    expect(second.doneCount).toBe(0);
+    expect(second.totalCount).toBe(1);
+    expect(second.focus).toBeUndefined();
+    expect(second.notes).toBeUndefined();
+  });
+});

--- a/tests/planner/useFocusDate.test.tsx
+++ b/tests/planner/useFocusDate.test.tsx
@@ -6,7 +6,7 @@ vi.mock("@/lib/db", async () => {
   const actual = await vi.importActual<typeof import("@/lib/db")>("@/lib/db");
   return {
     ...actual,
-    usePersistentState: <T,>(_key: string, initial: T) =>
+    usePersistentState: <T,>(_key: string, initial: T, _options?: unknown) =>
       React.useState(initial),
   };
 });

--- a/tests/planner/usePlannerStore.test.tsx
+++ b/tests/planner/usePlannerStore.test.tsx
@@ -6,7 +6,7 @@ vi.mock("@/lib/db", async () => {
   const actual = await vi.importActual<typeof import("@/lib/db")>("@/lib/db");
   return {
     ...actual,
-    usePersistentState: <T,>(_key: string, initial: T) =>
+    usePersistentState: <T,>(_key: string, initial: T, _options?: unknown) =>
       React.useState(initial),
   };
 });

--- a/tests/planner/useSelection.test.tsx
+++ b/tests/planner/useSelection.test.tsx
@@ -8,7 +8,7 @@ vi.mock("@/lib/db", async () => {
   const actual = await vi.importActual<typeof import("@/lib/db")>("@/lib/db");
   return {
     ...actual,
-    usePersistentState: <T,>(key: string, initial: T) => {
+    usePersistentState: <T,>(key: string, initial: T, _options?: unknown) => {
       const [state, setState] = React.useState(initial);
       const trackedSetState = React.useCallback<typeof setState>(
         (value) => {

--- a/tests/prompts/use-prompts.test.ts
+++ b/tests/prompts/use-prompts.test.ts
@@ -9,7 +9,7 @@ vi.mock("@/lib/db", async () => {
   const actual = await vi.importActual<typeof import("@/lib/db")>("@/lib/db");
   return {
     ...actual,
-    usePersistentState: <T>(_key: string, _initial: T) =>
+    usePersistentState: <T>(_key: string, _initial: T, _options?: unknown) =>
       React.useState(mockInitialPrompts as T),
   };
 });


### PR DESCRIPTION
## Summary
- add optional encode/decode hooks to `usePersistentState` and wire the planner provider to use them
- decode planner day blobs defensively, rebuilding lookups/counts and dropping invalid entries
- extend tests to cover decoding behaviour and corrupted planner storage repair

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc13562908832caad6718a7d897c84