### PR TITLE
Align hero frame variants and update demos

### DIFF
--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -993,7 +993,7 @@ export default function ComponentGallery() {
                 Body
               </div>
             </Hero>
-            <NeomorphicHeroFrame variant="plain">
+            <NeomorphicHeroFrame variant="dense">
               <Hero
                 heading="Frame-ready"
                 eyebrow="No padding"
@@ -1006,7 +1006,8 @@ export default function ComponentGallery() {
                 padding="none"
               >
                 <div className="text-ui text-muted-foreground">
-                  Flush to the frame
+                  Dense frame keeps the hero flush while preserving the
+                  neomorphic halo
                 </div>
               </Hero>
             </NeomorphicHeroFrame>

--- a/src/components/prompts/NeomorphicHeroFrameDemo.tsx
+++ b/src/components/prompts/NeomorphicHeroFrameDemo.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import {
   NeomorphicHeroFrame,
+  HeroGrid,
+  HeroCol,
   TabBar,
   SearchBar,
   Button,
@@ -35,7 +37,8 @@ export default function NeomorphicHeroFrameDemo() {
     <div className="space-y-6">
       <NeomorphicHeroFrame
         as="header"
-        actionArea={{
+        label="Mission controls"
+        slots={{
           tabs: (
             <TabBar
               items={missionTabs}
@@ -65,7 +68,7 @@ export default function NeomorphicHeroFrameDemo() {
             />
           ),
           actions: (
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-[var(--space-2)]">
               <ThemeToggle ariaLabel="Toggle theme" className="shrink-0" />
               <Button size="sm" variant="secondary">
                 Draft
@@ -78,11 +81,10 @@ export default function NeomorphicHeroFrameDemo() {
               </Button>
             </div>
           ),
-          "aria-label": "Mission controls",
         }}
       >
-        <div className="grid gap-4 md:grid-cols-12 md:gap-6">
-          <div className="md:col-span-7 space-y-3">
+        <HeroGrid className="gap-[var(--space-4)] md:gap-[var(--space-6)]">
+          <HeroCol span={7} className="space-y-3">
             <h3 className="text-title font-semibold tracking-[-0.01em] text-foreground">
               Default neomorphic frame
             </h3>
@@ -96,28 +98,32 @@ export default function NeomorphicHeroFrameDemo() {
               disabled, and loading states from the design system tokens—interact with
               each control to preview the full range of feedback.
             </p>
-          </div>
-          <dl className="md:col-span-5 grid gap-2 text-label uppercase tracking-[0.08em] text-muted-foreground">
-            <div className="flex items-center justify-between rounded-card r-card-md border border-border/30 bg-card/60 px-3 py-2">
-              <dt className="font-semibold text-foreground">Layer tokens</dt>
-              <dd className="text-label">bg-card/70 · ring-border/55</dd>
-            </div>
-            <div className="flex items-center justify-between rounded-card r-card-md border border-border/30 bg-card/60 px-3 py-2">
-              <dt className="font-semibold text-foreground">Spacing</dt>
-              <dd className="text-label">gap-4 · md:gap-6</dd>
-            </div>
-            <div className="flex items-center justify-between rounded-card r-card-md border border-border/30 bg-card/60 px-3 py-2">
-              <dt className="font-semibold text-foreground">Action grid</dt>
-              <dd className="text-label">md:col-span-5 / 4 / 3</dd>
-            </div>
-          </dl>
-        </div>
+          </HeroCol>
+          <HeroCol span={5}>
+            <dl className="grid gap-[var(--space-2)] text-label uppercase tracking-[0.08em] text-muted-foreground">
+              <div className="flex items-center justify-between rounded-card r-card-md border border-border/30 bg-card/60 px-3 py-2">
+                <dt className="font-semibold text-foreground">Layer tokens</dt>
+                <dd className="text-label">bg-card/70 · ring-border/55</dd>
+              </div>
+              <div className="flex items-center justify-between rounded-card r-card-md border border-border/30 bg-card/60 px-3 py-2">
+                <dt className="font-semibold text-foreground">Spacing</dt>
+                <dd className="text-label">gap-4 · md:gap-6</dd>
+              </div>
+              <div className="flex items-center justify-between rounded-card r-card-md border border-border/30 bg-card/60 px-3 py-2">
+                <dt className="font-semibold text-foreground">Action grid</dt>
+                <dd className="text-label">md:col-span-5 / 4 / 3</dd>
+              </div>
+            </dl>
+          </HeroCol>
+        </HeroGrid>
       </NeomorphicHeroFrame>
 
       <NeomorphicHeroFrame
         as="nav"
         variant="compact"
-        actionArea={{
+        align="between"
+        label="Mission filters"
+        slots={{
           tabs: (
             <TabBar
               items={statusTabs}
@@ -138,7 +144,7 @@ export default function NeomorphicHeroFrameDemo() {
             />
           ),
           actions: (
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-[var(--space-2)]">
               <Button size="sm" variant="secondary">
                 Pin view
               </Button>
@@ -147,12 +153,10 @@ export default function NeomorphicHeroFrameDemo() {
               </Button>
             </div>
           ),
-          align: "between",
-          "aria-label": "Mission filters",
         }}
       >
-        <div className="grid gap-3 md:grid-cols-12 md:gap-4">
-          <div className="md:col-span-6 space-y-2">
+        <HeroGrid className="gap-[var(--space-3)] md:gap-[var(--space-4)]">
+          <HeroCol span={6} className="space-y-2">
             <h3 className="text-ui font-semibold uppercase tracking-[0.08em] text-muted-foreground">
               Compact layout
             </h3>
@@ -161,12 +165,12 @@ export default function NeomorphicHeroFrameDemo() {
               with the <code>r-card-md</code> radius, ideal for utility nav or filter rails.
             </p>
             <p className="text-ui text-muted-foreground">
-              The action row mirrors the grid: tabs span <code>md:col-span-7</code>, search spans
+              The slot grid mirrors the layout: tabs span <code>md:col-span-7</code>, search spans
               <code>md:col-span-3</code>, and button actions anchor on <code>md:col-span-2</code> for
               consistent alignment.
             </p>
-          </div>
-          <div className="md:col-span-6 space-y-2 text-label text-muted-foreground">
+          </HeroCol>
+          <HeroCol span={6} className="space-y-2 text-label text-muted-foreground">
             <p className="font-semibold text-foreground">Interaction checklist</p>
             <ul className="grid grid-cols-2 gap-2">
               <li className="rounded-card r-card-md border border-border/25 bg-card/60 px-3 py-2">
@@ -182,8 +186,8 @@ export default function NeomorphicHeroFrameDemo() {
                 Keyboard focus rings respect the global focus token.
               </li>
             </ul>
-          </div>
-        </div>
+          </HeroCol>
+        </HeroGrid>
       </NeomorphicHeroFrame>
     </div>
   );

--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -214,41 +214,40 @@ export default function PageHeaderDemo() {
         </p>
       </Hero>
 
-      <NeomorphicHeroFrame
-        as="section"
-        variant="plain"
-        contentClassName="space-y-[var(--space-4)]"
-      >
-        <Hero
-          as="section"
-          eyebrow="Frame-ready hero"
-          heading="Flush supportive layout"
-          subtitle="Let the outer frame handle breathing room."
-          sticky={false}
-          topClassName="top-0"
-          tone="supportive"
-          frame={false}
-          rail={false}
-          padding="none"
-          search={{
-            id: "hero-flush-search",
-            value: query,
-            onValueChange: setQuery,
-            debounceMs: 150,
-            placeholder: "Search frame highlights…",
-            "aria-label": "Search frame highlights",
-          }}
-          actions={
-            <Button size="sm" variant="secondary" className="whitespace-nowrap">
-              Assign scout
-            </Button>
-          }
-        >
-          <p className="text-ui text-muted-foreground">
-            When the hero sits inside another shell, drop its padding so the
-            divider and actions align perfectly with the parent grid.
-          </p>
-        </Hero>
+      <NeomorphicHeroFrame as="section" variant="dense">
+        <div className="space-y-[var(--space-4)]">
+          <Hero
+            as="section"
+            eyebrow="Frame-ready hero"
+            heading="Flush supportive layout"
+            subtitle="Let the outer frame handle breathing room."
+            sticky={false}
+            topClassName="top-0"
+            tone="supportive"
+            frame={false}
+            rail={false}
+            padding="none"
+            search={{
+              id: "hero-flush-search",
+              value: query,
+              onValueChange: setQuery,
+              debounceMs: 150,
+              placeholder: "Search frame highlights…",
+              "aria-label": "Search frame highlights",
+            }}
+            actions={
+              <Button size="sm" variant="secondary" className="whitespace-nowrap">
+                Assign scout
+              </Button>
+            }
+          >
+            <p className="text-ui text-muted-foreground">
+              When the hero sits inside another shell, drop its padding so the
+              dense frame keeps dividers and actions aligned with the parent
+              grid.
+            </p>
+          </Hero>
+        </div>
       </NeomorphicHeroFrame>
 
       <PageHeader
@@ -396,7 +395,7 @@ export default function PageHeaderDemo() {
         so the content hugs the frame. Want the Hero divider row instead? Pass
         {" "}
         <code className="ml-1 rounded bg-[hsl(var(--card)/0.6)] px-1.5 py-0.5 font-mono text-[0.75rem] text-foreground/80">
-          {"frameProps={{ actionArea: null }}"}
+          {"frameProps={{ slots: null }}"}
         </code>{" "}
         to hand control back to Hero while keeping tone overrides intact.
       </p>

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -1010,13 +1010,13 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       id: "neomorphic-hero-frame",
       name: "NeomorphicHeroFrame",
       description:
-        "Composable neomorphic frame with semantic wrappers, tokenized spacing, and an action row for tabs, search, and buttons.",
+        "Composable neomorphic frame with semantic wrappers, tokenized spacing, and a slot grid for tabs, search, and buttons.",
       element: <NeomorphicHeroFrameDemo />,
       tags: ["hero", "layout", "tokens"],
       code: `<NeomorphicHeroFrame
   as="header"
-  variant="default"
-  actionArea={{
+  label="Mission controls"
+  slots={{
     tabs: (
       <TabBar
         items={[
@@ -1040,7 +1040,7 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       />
     ),
     actions: (
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-[var(--space-2)]">
         <ThemeToggle ariaLabel="Toggle theme" className="shrink-0" />
         <Button size="sm" variant="primary" loading>
           Deploy
@@ -1052,23 +1052,23 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
     ),
   }}
 >
-  <div className="grid gap-4 md:grid-cols-12">
-    <div className="md:col-span-7 space-y-3">
+  <HeroGrid className="gap-[var(--space-4)] md:gap-[var(--space-6)]">
+    <HeroCol span={7} className="space-y-3">
       <p className="text-ui text-muted-foreground">
         Default variant uses r-card-lg radius with px-6/md:px-7/lg:px-8 tokens and aligns content to the 12-column grid.
       </p>
-    </div>
-  </div>
+    </HeroCol>
+  </HeroGrid>
 </NeomorphicHeroFrame>
 
-<NeomorphicHeroFrame as="nav" variant="compact" actionArea={{ align: "between" }}>
-  <div className="grid gap-3 md:grid-cols-12">
-    <div className="md:col-span-6">
+<NeomorphicHeroFrame as="nav" variant="compact" align="between" label="Mission filters">
+  <HeroGrid className="gap-[var(--space-3)] md:gap-[var(--space-4)]">
+    <HeroCol span={6}>
       <p className="text-ui text-muted-foreground">
         Compact variant swaps to r-card-md radius with px-4/md:px-5/lg:px-6 spacing.
       </p>
-    </div>
-  </div>
+    </HeroCol>
+  </HeroGrid>
 </NeomorphicHeroFrame>`,
     },
     {
@@ -1084,7 +1084,7 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       id: "hero",
       name: "Hero",
       description:
-        "Stacked hero shell with search and actions — default spacing plus frame-ready paddingless variant.",
+        "Stacked hero shell with search and actions — default spacing plus a dense frame-ready variant.",
       element: (
         <div className="space-y-[var(--space-4)]">
           <Hero
@@ -1097,7 +1097,7 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
           >
             <div className="text-ui text-muted-foreground">Body content</div>
           </Hero>
-          <NeomorphicHeroFrame variant="plain">
+          <NeomorphicHeroFrame variant="dense">
             <Hero
               heading="Frame-ready hero"
               eyebrow="No padding"
@@ -1125,7 +1125,7 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
   <div className="text-ui text-muted-foreground">Body content</div>
 </Hero>
 
-<NeomorphicHeroFrame variant="plain">
+<NeomorphicHeroFrame variant="dense">
   <Hero
     heading="Frame-ready hero"
     eyebrow="No padding"

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -452,7 +452,7 @@ export default function TeamCompPage() {
         containerClassName="sticky top-0 md:col-span-12"
         className="rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-4)]"
         contentClassName="space-y-[var(--space-2)]"
-        frameProps={{ variant: "unstyled" }}
+        frameProps={{ variant: "default" }}
         header={{
           id: "teamcomp-header",
           eyebrow: "Comps",

--- a/src/components/ui/layout/NeomorphicHeroFrame.tsx
+++ b/src/components/ui/layout/NeomorphicHeroFrame.tsx
@@ -1,7 +1,7 @@
-// src/components/ui/layout/NeomorphicHeroFrame.tsx
 "use client";
 
 import * as React from "react";
+
 import { cn } from "@/lib/utils";
 import { NeomorphicFrameStyles } from "./NeomorphicFrameStyles";
 
@@ -10,159 +10,163 @@ type FrameElement = Extract<
   "div" | "header" | "section" | "nav" | "article" | "aside" | "main"
 >;
 
-type Align = "start" | "center" | "end" | "between";
+type HeroSpan = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
-export type NeomorphicHeroFrameVariant =
-  | "default"
-  | "compact"
-  | "plain"
-  | "unstyled";
+export type HeroVariant = "default" | "compact" | "dense";
 
-export interface NeomorphicHeroFrameActionAreaProps {
-  /** Optional segmented tabs rendered on the left */
-  tabs?: React.ReactNode;
-  /** Optional primary actions rendered on the right */
-  actions?: React.ReactNode;
-  /** Optional search control rendered inline */
-  search?: React.ReactNode;
-  /** Layout alignment across the action row */
-  align?: Align;
-  /** Adds a top divider when true (default) */
-  divider?: boolean;
-  /**
-   * Additional class for the action row wrapper. Useful for controlling
-   * grid spans when composing with other primitives.
-   */
-  className?: string;
-  tabsClassName?: string;
-  actionsClassName?: string;
-  searchClassName?: string;
-  "aria-label"?: string;
-  "aria-labelledby"?: string;
+export type Align = "start" | "center" | "end" | "between";
+
+export interface HeroSlots {
+  tabs?: React.ReactNode | null;
+  search?: React.ReactNode | null;
+  actions?: React.ReactNode | null;
 }
 
 export interface NeomorphicHeroFrameProps
-  extends React.HTMLAttributes<HTMLElement> {
-  /** Semantic element for the frame */
+  extends Omit<React.HTMLAttributes<HTMLElement>, "children"> {
+  /** Semantic element for the frame. */
   as?: FrameElement;
-  /** Built-in shell styles */
-  variant?: NeomorphicHeroFrameVariant;
-  /** Toggle animated frame layers */
-  frame?: boolean;
-  /** Allow content to overflow the frame while clipping neon backdrops */
-  allowOverflow?: boolean;
-  /** Optional class applied to the inner content wrapper */
-  contentClassName?: string;
-  /** Optional action row (tabs, search, buttons) */
-  actionArea?: NeomorphicHeroFrameActionAreaProps | null;
-  /** Boost surface contrast for accessibility */
-  highContrast?: boolean;
+  /** Built-in surface styling. */
+  variant?: HeroVariant;
+  /** Aligns slot content on md+ viewports. */
+  align?: Align;
+  /** Accessible label for the hero landmark. */
+  label?: string;
+  /** Reference id for an external heading label. */
+  labelledById?: string;
+  /** Optional hero slots (tabs, search, actions). */
+  slots?: HeroSlots | null;
+  /** Hero content rendered inside the frame. */
+  children: React.ReactNode;
+  className?: string;
 }
 
-const variantMap: Record<Exclude<NeomorphicHeroFrameVariant, "unstyled">, {
-  container: string;
-  padding: string;
-  content: string;
-  action: { mt: string; pt: string; gap: string };
-}> = {
+type HeroGridElement = HTMLDivElement;
+
+type HeroGridProps = React.HTMLAttributes<HeroGridElement> & {
+  as?: Extract<keyof React.JSX.IntrinsicElements, "div" | "section" | "ul">;
+};
+
+type HeroColElement = HTMLDivElement;
+
+type HeroColProps = React.HTMLAttributes<HeroColElement> & {
+  as?: Extract<keyof React.JSX.IntrinsicElements, "div" | "li">;
+  span?: HeroSpan;
+};
+
+const HERO_COL_SPANS: Record<HeroSpan, string> = {
+  1: "md:col-span-1",
+  2: "md:col-span-2",
+  3: "md:col-span-3",
+  4: "md:col-span-4",
+  5: "md:col-span-5",
+  6: "md:col-span-6",
+  7: "md:col-span-7",
+  8: "md:col-span-8",
+  9: "md:col-span-9",
+  10: "md:col-span-10",
+  11: "md:col-span-11",
+  12: "md:col-span-12",
+};
+
+export const HeroGrid = React.forwardRef<HeroGridElement, HeroGridProps>(
+  ({ as, className, ...rest }, ref) => {
+    const Component = (as ?? "div") as React.ElementType;
+
+    return (
+      <Component
+        ref={ref}
+        className={cn(
+          "grid gap-[var(--space-3)] md:grid-cols-12 md:gap-[var(--space-4)]",
+          className,
+        )}
+        {...rest}
+      />
+    );
+  },
+);
+
+HeroGrid.displayName = "HeroGrid";
+
+export const HeroCol = React.forwardRef<HeroColElement, HeroColProps>(
+  ({ as, span = 12, className, ...rest }, ref) => {
+    const Component = (as ?? "div") as React.ElementType;
+
+    return (
+      <Component
+        ref={ref}
+        className={cn("col-span-12", HERO_COL_SPANS[span], className)}
+        {...rest}
+      />
+    );
+  },
+);
+
+HeroCol.displayName = "HeroCol";
+
+const VARIANT_STYLES: Record<
+  HeroVariant,
+  {
+    container: string;
+    padding: string;
+    content: string;
+    slots: {
+      mt: string;
+      pt: string;
+      gap: string;
+      wellPadding: string;
+      radius: string;
+    };
+  }
+> = {
   default: {
     container:
-      "rounded-card r-card-lg border border-border/40 bg-card/70 shadow-outline-subtle",
+      "rounded-card r-card-lg border border-[hsl(var(--border)/0.45)] bg-card/70 shadow-outline-subtle",
     padding:
       "px-[var(--space-6)] py-[var(--space-6)] md:px-[var(--space-7)] md:py-[var(--space-7)] lg:px-[var(--space-8)] lg:py-[var(--space-8)]",
     content: "space-y-[var(--space-5)] md:space-y-[var(--space-6)]",
-    action: {
+    slots: {
       mt: "mt-[var(--space-6)] md:mt-[var(--space-7)]",
       pt: "pt-[var(--space-5)] md:pt-[var(--space-6)]",
-      gap: "gap-[var(--space-4)]",
+      gap: "gap-[var(--space-3)] md:gap-[var(--space-4)]",
+      wellPadding: "p-[var(--space-2)] md:p-[var(--space-3)]",
+      radius: "r-card-md",
     },
   },
   compact: {
     container:
-      "rounded-card r-card-md border border-border/35 bg-card/65 shadow-outline-subtle",
+      "rounded-card r-card-md border border-[hsl(var(--border)/0.4)] bg-card/65 shadow-outline-subtle",
     padding:
       "px-[var(--space-4)] py-[var(--space-4)] md:px-[var(--space-5)] md:py-[var(--space-5)] lg:px-[var(--space-6)] lg:py-[var(--space-6)]",
     content: "space-y-[var(--space-4)] md:space-y-[var(--space-5)]",
-    action: {
-      mt: "mt-[var(--space-4)] md:mt-[var(--space-5)]",
+    slots: {
+      mt: "mt-[var(--space-5)] md:mt-[var(--space-6)]",
       pt: "pt-[var(--space-4)] md:pt-[var(--space-5)]",
-      gap: "gap-[var(--space-3)]",
+      gap: "gap-[var(--space-3)] md:gap-[var(--space-3)]",
+      wellPadding: "p-[var(--space-2)]",
+      radius: "r-card-md",
     },
   },
-  plain: {
+  dense: {
     container:
-      "rounded-card r-card-md border border-border/30 bg-card/60 shadow-outline-faint",
+      "rounded-card r-card-sm border border-[hsl(var(--border)/0.35)] bg-card/60 shadow-outline-faint",
     padding:
-      "px-[var(--space-4)] py-[var(--space-4)] md:px-[var(--space-5)] md:py-[var(--space-5)]",
+      "px-[var(--space-3)] py-[var(--space-3)] md:px-[var(--space-4)] md:py-[var(--space-4)]",
     content: "space-y-[var(--space-3)] md:space-y-[var(--space-4)]",
-    action: {
-      mt: "mt-[var(--space-4)]",
-      pt: "pt-[var(--space-3)] md:pt-[var(--space-4)]",
-      gap: "gap-[var(--space-3)]",
+    slots: {
+      mt: "mt-[var(--space-4)] md:mt-[var(--space-4)]",
+      pt: "pt-[var(--space-3)] md:pt-[var(--space-3)]",
+      gap: "gap-[var(--space-2)] md:gap-[var(--space-3)]",
+      wellPadding: "p-[var(--space-1)] md:p-[var(--space-2)]",
+      radius: "r-card-sm",
     },
   },
 };
 
-const highContrastVariantMap: Record<
-  Exclude<NeomorphicHeroFrameVariant, "unstyled">,
-  { container: string }
+const ALIGN_CLASS_MAP: Record<
+  Align,
+  { tabs: string; search: string; actions: string }
 > = {
-  default: {
-    container: "border-border/70 shadow-neoSoft",
-  },
-  compact: {
-    container: "border-border/70 shadow-neoSoft",
-  },
-  plain: {
-    container: "border-border/55 shadow-outline-subtle",
-  },
-};
-
-function slotLayout({
-  hasTabs,
-  hasSearch,
-  hasActions,
-}: {
-  hasTabs: boolean;
-  hasSearch: boolean;
-  hasActions: boolean;
-}) {
-  if (hasTabs && hasSearch && hasActions) {
-    return {
-      tabs: "md:col-span-5",
-      search: "md:col-span-4",
-      actions: "md:col-span-3",
-    };
-  }
-  if (hasTabs && hasSearch) {
-    return {
-      tabs: "md:col-span-6",
-      search: "md:col-span-6",
-      actions: "md:col-span-12",
-    };
-  }
-  if (hasTabs && hasActions) {
-    return {
-      tabs: "md:col-span-7",
-      search: "md:col-span-12",
-      actions: "md:col-span-5",
-    };
-  }
-  if (hasSearch && hasActions) {
-    return {
-      tabs: "md:col-span-12",
-      search: "md:col-span-7",
-      actions: "md:col-span-5",
-    };
-  }
-  return {
-    tabs: "md:col-span-12",
-    search: "md:col-span-12",
-    actions: "md:col-span-12",
-  };
-}
-
-const alignClassMap: Record<Align, { tabs: string; search: string; actions: string }> = {
   start: {
     tabs: "md:justify-self-start",
     search: "md:justify-self-start",
@@ -185,170 +189,324 @@ const alignClassMap: Record<Align, { tabs: string; search: string; actions: stri
   },
 };
 
-const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFrameProps>(
+const SLOT_LAYOUTS: Record<
+  string,
+  { tabs: HeroSpan; search: HeroSpan; actions: HeroSpan }
+> = {
+  "tabs-search-actions": { tabs: 5, search: 4, actions: 3 },
+  "tabs-search": { tabs: 6, search: 6, actions: 12 },
+  "tabs-actions": { tabs: 7, search: 12, actions: 5 },
+  "search-actions": { tabs: 12, search: 7, actions: 5 },
+  tabs: { tabs: 12, search: 12, actions: 12 },
+  search: { tabs: 12, search: 12, actions: 12 },
+  actions: { tabs: 12, search: 12, actions: 12 },
+  none: { tabs: 12, search: 12, actions: 12 },
+};
+
+function getSlotLayout({
+  hasTabs,
+  hasSearch,
+  hasActions,
+}: {
+  hasTabs: boolean;
+  hasSearch: boolean;
+  hasActions: boolean;
+}) {
+  if (hasTabs && hasSearch && hasActions) {
+    return SLOT_LAYOUTS["tabs-search-actions"];
+  }
+  if (hasTabs && hasSearch) {
+    return SLOT_LAYOUTS["tabs-search"];
+  }
+  if (hasTabs && hasActions) {
+    return SLOT_LAYOUTS["tabs-actions"];
+  }
+  if (hasSearch && hasActions) {
+    return SLOT_LAYOUTS["search-actions"];
+  }
+  if (hasTabs) {
+    return SLOT_LAYOUTS.tabs;
+  }
+  if (hasSearch) {
+    return SLOT_LAYOUTS.search;
+  }
+  if (hasActions) {
+    return SLOT_LAYOUTS.actions;
+  }
+  return SLOT_LAYOUTS.none;
+}
+
+function sanitizeLabel(value?: string) {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+const haloStyles = (
+  <style jsx global>{`
+    .neo-hero-frame {
+      position: relative;
+      isolation: isolate;
+    }
+    .neo-hero-frame::before {
+      content: "";
+      position: absolute;
+      inset: calc(var(--hairline-w) * -2);
+      border-radius: inherit;
+      pointer-events: none;
+      opacity: 0;
+      transform: scale(0.98);
+      transition: opacity var(--dur-quick) var(--ease-out),
+        transform var(--dur-quick) var(--ease-out);
+      background: radial-gradient(
+        120% 120% at 50% 50%,
+        hsl(var(--ring) / 0.25),
+        transparent 70%
+      );
+    }
+    .neo-hero-frame:has(:focus-visible)::before,
+    .neo-hero-frame[data-has-focus="true"]::before {
+      opacity: 1;
+      transform: scale(1);
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .neo-hero-frame::before {
+        transition: none;
+      }
+    }
+    .hero-focus {
+      outline: none;
+      position: relative;
+    }
+    .hero-focus:has(:focus-visible) {
+      outline: 2px solid hsl(var(--ring));
+      outline-offset: 2px;
+    }
+    .neo-inset {
+      position: relative;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .hero-focus {
+        transition: none;
+      }
+    }
+  `}</style>
+);
+
+function assignRef<T>(ref: React.ForwardedRef<T>, value: T | null) {
+  if (typeof ref === "function") {
+    ref(value);
+  } else if (ref) {
+    (ref as React.MutableRefObject<T | null>).current = value;
+  }
+}
+
+const NeomorphicHeroFrame = React.forwardRef<
+  HTMLElement,
+  NeomorphicHeroFrameProps
+>(
   (
     {
       as,
       variant = "default",
-      frame = true,
-      className,
-      contentClassName,
+      align = "between",
+      label,
+      labelledById,
+      slots,
       children,
-      actionArea,
-      highContrast,
-      allowOverflow = false,
+      className,
+      onFocusCapture,
+      onBlurCapture,
+      role: roleProp,
       ...rest
     },
-    ref,
+    forwardedRef,
   ) => {
     const Component = (as ?? "div") as FrameElement;
     const Comp = Component as React.ElementType;
-    const showFrame = frame !== false;
-    const variantStyles =
-      variant !== "unstyled" ? variantMap[variant] : undefined;
-    const contrastStyles =
-      highContrast && variant !== "unstyled"
-        ? highContrastVariantMap[variant]
-        : undefined;
-    const slotContrastClass = highContrast ? "text-foreground" : undefined;
+    const variantStyles = VARIANT_STYLES[variant];
+    const slotConfig = variantStyles.slots;
+    const slotAlign = ALIGN_CLASS_MAP[align];
 
-    const hasActionArea = Boolean(
-      actionArea &&
-        (actionArea.tabs || actionArea.actions || actionArea.search),
+    const frameRef = React.useRef<HTMLElement | null>(null);
+
+    const handleRef = React.useCallback(
+      (node: HTMLElement | null) => {
+        frameRef.current = node;
+        assignRef(forwardedRef, node);
+      },
+      [forwardedRef],
     );
 
-    const showDivider = actionArea?.divider ?? true;
-    const actionPaddingClass = showDivider
-      ? variantStyles?.action.pt ?? "pt-[var(--space-4)]"
-      : undefined;
+    const [hasFocusVisible, setHasFocusVisible] = React.useState(false);
 
-    const shouldWrapContent =
-      variant !== "unstyled" || hasActionArea || Boolean(contentClassName);
+    const handleFocusCapture = React.useCallback<
+      NonNullable<React.HTMLAttributes<HTMLElement>["onFocusCapture"]>
+    >(
+      (event) => {
+        onFocusCapture?.(event);
+        if (event.defaultPrevented) return;
 
-    const actionAlign = actionArea?.align ?? "between";
-    const slots = slotLayout({
-      hasTabs: Boolean(actionArea?.tabs),
-      hasSearch: Boolean(actionArea?.search),
-      hasActions: Boolean(actionArea?.actions),
-    });
-    const aligns = alignClassMap[actionAlign];
+        const target = event.target as HTMLElement | null;
+        if (target && typeof target.matches === "function") {
+          if (target.matches(":focus-visible")) {
+            setHasFocusVisible(true);
+            return;
+          }
+        }
 
-    const content = shouldWrapContent ? (
-      <div
-        className={cn(
-          "relative z-[2]",
-          variantStyles?.content,
-          !variantStyles && hasActionArea && "space-y-4 md:space-y-5",
-          contentClassName,
-        )}
-      >
-        {children}
-      </div>
-    ) : (
-      children
+        requestAnimationFrame(() => {
+          const node = frameRef.current;
+          if (!node) return;
+          const active = node.querySelector(":focus-visible");
+          setHasFocusVisible(Boolean(active));
+        });
+      },
+      [onFocusCapture],
     );
+
+    const handleBlurCapture = React.useCallback<
+      NonNullable<React.HTMLAttributes<HTMLElement>["onBlurCapture"]>
+    >(
+      (event) => {
+        onBlurCapture?.(event);
+        if (event.defaultPrevented) return;
+
+        requestAnimationFrame(() => {
+          const node = frameRef.current;
+          if (!node) {
+            setHasFocusVisible(false);
+            return;
+          }
+          const active = node.querySelector(":focus-visible");
+          setHasFocusVisible(Boolean(active));
+        });
+      },
+      [onBlurCapture],
+    );
+
+    const resolvedSlots = slots === null ? null : slots ?? undefined;
+    const hasTabs = Boolean(resolvedSlots?.tabs);
+    const hasSearch = Boolean(resolvedSlots?.search);
+    const hasActions = Boolean(resolvedSlots?.actions);
+    const hasSlotContent =
+      resolvedSlots !== null && (hasTabs || hasSearch || hasActions);
+
+    const layout = React.useMemo(
+      () =>
+        getSlotLayout({
+          hasTabs,
+          hasSearch,
+          hasActions,
+        }),
+      [hasTabs, hasSearch, hasActions],
+    );
+
+    const ariaLabel = sanitizeLabel(label);
+    const ariaLabelledBy = sanitizeLabel(labelledById);
+
+    const computedRole =
+      roleProp ??
+      (Component === "header"
+        ? "banner"
+        : Component === "nav"
+        ? "navigation"
+        : undefined);
 
     return (
       <>
-        {showFrame ? <NeomorphicFrameStyles /> : null}
+        <NeomorphicFrameStyles />
+        {haloStyles}
         <Comp
-          ref={ref}
+          ref={handleRef}
           className={cn(
-            "relative",
-            showFrame &&
-              (allowOverflow
-                ? "overflow-visible hero2-frame hero2-neomorph"
-                : "overflow-hidden hero2-frame hero2-neomorph"),
-            variantStyles?.container,
-            contrastStyles?.container,
-            variantStyles?.padding,
+            "neo-hero-frame relative isolate overflow-visible hero2-frame hero2-neomorph",
+            variantStyles.container,
+            variantStyles.padding,
             className,
           )}
+          data-variant={variant}
+          data-has-focus={hasFocusVisible ? "true" : undefined}
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledBy}
+          role={computedRole}
+          onFocusCapture={handleFocusCapture}
+          onBlurCapture={handleBlurCapture}
           {...rest}
         >
-          {content}
+          <div
+            className={cn(
+              "relative z-[2]",
+              variantStyles.content,
+            )}
+          >
+            {children}
+          </div>
 
-          {hasActionArea ? (
-            <div
-              role="group"
-              aria-label={actionArea?.["aria-label"]}
-              aria-labelledby={actionArea?.["aria-labelledby"]}
+          {hasSlotContent ? (
+            <HeroGrid
               className={cn(
-                "relative z-[2]",
-                variantStyles?.action.mt ?? "mt-[var(--space-4)]",
-                actionPaddingClass,
-                "grid gap-[var(--space-3)] md:grid-cols-12 md:gap-[var(--space-4)]",
-                variantStyles?.action.gap,
-                actionArea?.className,
+                "neo-hero-frame__slots relative z-[2] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-[hsl(var(--card-hairline)/0.55)] before:opacity-80",
+                slotConfig.mt,
+                slotConfig.pt,
+                slotConfig.gap,
               )}
             >
-              {showDivider ? (
-                <>
-                  <span
-                    aria-hidden
-                    className="pointer-events-none absolute inset-x-0 top-0 h-px bg-[hsl(var(--accent))]"
-                  />
-                  <span
-                    aria-hidden
-                    className="pointer-events-none absolute inset-x-0 top-0 h-px bg-[hsl(var(--accent))] blur-[6px] opacity-60"
-                  />
-                </>
-              ) : null}
-              {actionArea?.tabs ? (
-                <div
-                  data-area="tabs"
+              {hasTabs ? (
+                <HeroCol
+                  data-slot="tabs"
+                  span={layout.tabs}
                   className={cn(
                     "flex flex-col gap-[var(--space-2)]",
-                    slotContrastClass,
-                    slots.tabs,
-                    aligns.tabs,
-                    actionArea.tabsClassName,
+                    slotAlign.tabs,
                   )}
                 >
-                  {actionArea.tabs}
-                </div>
+                  <div
+                    className={cn(
+                      "neo-inset hero-focus rounded-card border border-[hsl(var(--card-hairline)/0.55)] bg-panel/80 shadow-neo-inset",
+                      slotConfig.radius,
+                      slotConfig.wellPadding,
+                    )}
+                  >
+                    {resolvedSlots?.tabs}
+                  </div>
+                </HeroCol>
               ) : null}
 
-              {actionArea?.search ? (
-                <div
-                  data-area="search"
+              {hasSearch ? (
+                <HeroCol
+                  data-slot="search"
+                  span={layout.search}
                   className={cn(
                     "flex flex-col gap-[var(--space-2)]",
-                    slotContrastClass,
-                    slots.search,
-                    aligns.search,
-                    actionArea.searchClassName,
+                    slotAlign.search,
                   )}
                 >
-                  {actionArea.search}
-                </div>
+                  <div
+                    className={cn(
+                      "neo-inset hero-focus rounded-card border border-[hsl(var(--card-hairline)/0.55)] bg-panel/80 shadow-neo-inset",
+                      slotConfig.radius,
+                      slotConfig.wellPadding,
+                    )}
+                  >
+                    {resolvedSlots?.search}
+                  </div>
+                </HeroCol>
               ) : null}
 
-              {actionArea?.actions ? (
-                <div
-                  data-area="actions"
+              {hasActions ? (
+                <HeroCol
+                  data-slot="actions"
+                  span={layout.actions}
                   className={cn(
-                    "flex flex-wrap items-center justify-end gap-[var(--space-2)]",
-                    slotContrastClass,
-                    slots.actions,
-                    aligns.actions,
-                    actionArea.actionsClassName,
+                    "hero-focus flex flex-wrap items-center justify-end gap-[var(--space-2)]",
+                    slotAlign.actions,
                   )}
                 >
-                  {actionArea.actions}
-                </div>
+                  {resolvedSlots?.actions}
+                </HeroCol>
               ) : null}
-            </div>
-          ) : null}
-
-          {showFrame ? (
-            <div
-              aria-hidden
-              className={cn(
-                "absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/55",
-                highContrast && "ring-border/70",
-              )}
-            />
+            </HeroGrid>
           ) : null}
         </Comp>
       </>

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -57,8 +57,62 @@ exports[`ReviewsPage > renders default state 1`] = `
       }
     
       </style>
+      <style
+        global="true"
+        jsx="true"
+      >
+        
+    .neo-hero-frame {
+      position: relative;
+      isolation: isolate;
+    }
+    .neo-hero-frame::before {
+      content: "";
+      position: absolute;
+      inset: calc(var(--hairline-w) * -2);
+      border-radius: inherit;
+      pointer-events: none;
+      opacity: 0;
+      transform: scale(0.98);
+      transition: opacity var(--dur-quick) var(--ease-out),
+        transform var(--dur-quick) var(--ease-out);
+      background: radial-gradient(
+        120% 120% at 50% 50%,
+        hsl(var(--ring) / 0.25),
+        transparent 70%
+      );
+    }
+    .neo-hero-frame:has(:focus-visible)::before,
+    .neo-hero-frame[data-has-focus="true"]::before {
+      opacity: 1;
+      transform: scale(1);
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .neo-hero-frame::before {
+        transition: none;
+      }
+    }
+    .hero-focus {
+      outline: none;
+      position: relative;
+    }
+    .hero-focus:has(:focus-visible) {
+      outline: 2px solid hsl(var(--ring));
+      outline-offset: 2px;
+    }
+    .neo-inset {
+      position: relative;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .hero-focus {
+        transition: none;
+      }
+    }
+  
+      </style>
       <div
-        class="relative overflow-hidden hero2-frame hero2-neomorph rounded-card r-card-lg border border-border/40 bg-card/70 shadow-outline-subtle md:px-[var(--space-7)] md:py-[var(--space-7)] lg:px-[var(--space-8)] lg:py-[var(--space-8)] rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-4)]"
+        class="neo-hero-frame relative isolate overflow-visible hero2-frame hero2-neomorph rounded-card r-card-lg border border-[hsl(var(--border)/0.45)] bg-card/70 shadow-outline-subtle md:px-[var(--space-7)] md:py-[var(--space-7)] lg:px-[var(--space-8)] lg:py-[var(--space-8)] rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-4)]"
+        data-variant="default"
       >
         <div
           class="relative z-[2] space-y-[var(--space-5)] md:space-y-[var(--space-6)]"
@@ -164,190 +218,183 @@ exports[`ReviewsPage > renders default state 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  class="relative z-[2] mt-[var(--space-4)] md:mt-[var(--space-5)] flex flex-col gap-[var(--space-4)] md:gap-[var(--space-5)]"
-                >
-                  <div
-                    class="relative"
-                    style="--divider: var(--ring);"
-                  >
-                    <span
-                      aria-hidden="true"
-                      class="block h-px bg-[hsl(var(--divider))/0.28]"
-                    />
-                    <div
-                      class="flex flex-wrap items-start gap-[var(--space-2)] md:flex-nowrap md:items-center md:gap-[var(--space-4)] lg:gap-[var(--space-5)] pt-[var(--space-4)] md:pt-[var(--space-5)]"
-                    >
-                      <form
-                        class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-[var(--space-2)] data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"
-                        role="search"
-                      >
-                        <div
-                          class="relative min-w-0"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="lucide lucide-search pointer-events-none absolute left-[var(--space-4)] top-1/2 -translate-y-1/2 size-[var(--space-4)] text-muted-foreground"
-                            fill="none"
-                            height="24"
-                            stroke="currentColor"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            viewBox="0 0 24 24"
-                            width="24"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="m21 21-4.34-4.34"
-                            />
-                            <circle
-                              cx="11"
-                              cy="11"
-                              r="8"
-                            />
-                          </svg>
-                          <div
-                            class="relative inline-flex items-center border bg-card/60 backdrop-blur-[2px] shadow-control transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-control-hover focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),var(--asset-noise-url,none)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] focus-within:after:opacity-100 w-full hero2-neomorph !border border-[hsl(var(--border)/0.4)] !shadow-neo-inset hover:!shadow-neo-soft active:!shadow-neo-inset focus-within:!shadow-neo-soft [--hover:transparent] [--active:transparent] rounded-full [&>input]:rounded-full overflow-hidden hero2-frame"
-                            style="--control-h: var(--control-h-md);"
-                          >
-                            <input
-                              autocapitalize="none"
-                              autocomplete="off"
-                              autocorrect="off"
-                              class="w-full rounded-[inherit] bg-transparent px-[var(--space-3)] text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)] pl-[var(--space-7)]"
-                              id=":r1:"
-                              name=":r1:"
-                              placeholder="Search title, tags, opponent, patch…"
-                              spellcheck="false"
-                              type="search"
-                              value=""
-                            />
-                          </div>
-                        </div>
-                      </form>
-                      <div
-                        class="flex w-full flex-wrap items-center gap-[var(--space-2)] md:w-auto md:flex-nowrap"
-                      >
-                        <div
-                          class="flex flex-col gap-[var(--space-2)] sm:flex-row sm:items-center sm:gap-[var(--space-3)]"
-                        >
-                          <label
-                            class="flex w-full flex-col gap-[var(--space-1)] sm:w-auto sm:flex-row sm:items-center sm:gap-[var(--space-2)]"
-                          >
-                            <span
-                              class="text-ui font-medium text-muted-foreground"
-                            >
-                              Sort
-                            </span>
-                            <div
-                              class="glitch-wrap w-full sm:w-auto"
-                            >
-                              <div
-                                class="group inline-flex rounded-[var(--radius-full)] border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[var(--theme-ring)] focus-within:ring-offset-0"
-                              >
-                                <button
-                                  aria-controls=":r2:-listbox"
-                                  aria-expanded="false"
-                                  aria-haspopup="listbox"
-                                  aria-label="Sort reviews"
-                                  class="_glitchTrigger_843152 relative flex items-center h-[var(--control-h-sm)] rounded-[var(--radius-full)] px-[var(--space-3)] overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none !h-[var(--control-h-lg)] !px-[var(--space-4)]"
-                                  data-lit="true"
-                                  data-open="false"
-                                  type="button"
-                                >
-                                  <span
-                                    class="font-medium _glitchText_843152 text-foreground group-hover:text-foreground"
-                                  >
-                                    Newest
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    class="lucide lucide-chevron-down _caret_843152 ml-auto size-[var(--space-4)] shrink-0 opacity-75"
-                                    fill="none"
-                                    height="24"
-                                    stroke="currentColor"
-                                    stroke-linecap="round"
-                                    stroke-linejoin="round"
-                                    stroke-width="2"
-                                    viewBox="0 0 24 24"
-                                    width="24"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="m6 9 6 6 6-6"
-                                    />
-                                  </svg>
-                                  <span
-                                    aria-hidden="true"
-                                    class="_gbIris_843152"
-                                  />
-                                  <span
-                                    aria-hidden="true"
-                                    class="_gbChroma_843152"
-                                  />
-                                  <span
-                                    aria-hidden="true"
-                                    class="_gbFlicker_843152"
-                                  />
-                                  <span
-                                    aria-hidden="true"
-                                    class="_gbScan_843152"
-                                  />
-                                </button>
-                              </div>
-                            </div>
-                          </label>
-                          <button
-                            class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[disabled=true]:opacity-[var(--disabled)] data-[disabled=true]:pointer-events-none h-[var(--control-h-lg)] text-title gap-[var(--space-4)] [&_svg]:size-[var(--space-8)] w-full whitespace-nowrap px-[var(--space-4)] sm:w-auto shadow-[var(--btn-primary-shadow-rest)] hover:shadow-[var(--btn-primary-shadow-hover)] active:shadow-[var(--btn-primary-shadow-active)] active:translate-y-px bg-primary-soft border-[hsl(var(--primary)/0.35)] text-[hsl(var(--primary-foreground))] [--hover:theme('colors.interaction.primary.hover')] [--active:theme('colors.interaction.primary.active')]"
-                            style="--glow-active: hsl(var(--primary) / 0.35); --btn-primary-hover-shadow: 0 2px 6px -1px hsl(var(--primary) / 0.25); --btn-primary-active-shadow: inset 0 0 0 1px hsl(var(--primary) / 0.6); --btn-primary-shadow-rest: 0 0 calc(var(--space-4) / 2) var(--glow-active); --btn-primary-shadow-hover: 0 0 var(--space-4) var(--glow-active); --btn-primary-shadow-active: var(--btn-primary-active-shadow);"
-                            tabindex="0"
-                            type="button"
-                          >
-                            <span
-                              class="absolute inset-0 pointer-events-none rounded-[inherit] bg-[linear-gradient(90deg,hsl(var(--primary)/.18),hsl(var(--primary)/.18))]"
-                            />
-                            <span
-                              class="relative z-10 inline-flex items-center gap-[var(--space-2)]"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="lucide lucide-plus"
-                                fill="none"
-                                height="24"
-                                stroke="currentColor"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="2"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M5 12h14"
-                                />
-                                <path
-                                  d="M12 5v14"
-                                />
-                              </svg>
-                              <span>
-                                New Review
-                              </span>
-                            </span>
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
               </div>
             </section>
           </div>
         </div>
         <div
-          aria-hidden="true"
-          class="absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/55"
-        />
+          class="grid md:grid-cols-12 neo-hero-frame__slots relative z-[2] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-[hsl(var(--card-hairline)/0.55)] before:opacity-80 mt-[var(--space-6)] md:mt-[var(--space-7)] pt-[var(--space-5)] md:pt-[var(--space-6)] gap-[var(--space-3)] md:gap-[var(--space-4)]"
+        >
+          <div
+            class="col-span-12 md:col-span-7 flex flex-col gap-[var(--space-2)] md:justify-self-stretch"
+            data-slot="search"
+          >
+            <div
+              class="neo-inset hero-focus rounded-card border border-[hsl(var(--card-hairline)/0.55)] bg-panel/80 shadow-neo-inset r-card-md p-[var(--space-2)] md:p-[var(--space-3)]"
+            >
+              <form
+                class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-[var(--space-2)] data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"
+                role="search"
+              >
+                <div
+                  class="relative min-w-0"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="lucide lucide-search pointer-events-none absolute left-[var(--space-4)] top-1/2 -translate-y-1/2 size-[var(--space-4)] text-muted-foreground"
+                    fill="none"
+                    height="24"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="m21 21-4.34-4.34"
+                    />
+                    <circle
+                      cx="11"
+                      cy="11"
+                      r="8"
+                    />
+                  </svg>
+                  <div
+                    class="relative inline-flex items-center border bg-card/60 backdrop-blur-[2px] shadow-control transition-[box-shadow,transform] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] hover:border-[--border-hover] active:border-[--border-active] [--border-hover:hsl(var(--border)/0.38)] [--border-active:hsl(var(--border)/0.5)] hover:shadow-control-hover focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] data-[loading=true]:opacity-[var(--loading)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:opacity-[0.05] before:bg-[repeating-linear-gradient(0deg,hsl(var(--accent-2)/0.4)_0_1px,transparent_1px_3px),var(--asset-noise-url,none)] after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:p-px after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out after:motion-reduce:transition-none after:bg-[var(--edge-iris,var(--accent))] after:[mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] after:[mask-composite:exclude] focus-within:after:opacity-100 w-full hero2-neomorph !border border-[hsl(var(--border)/0.4)] !shadow-neo-inset hover:!shadow-neo-soft active:!shadow-neo-inset focus-within:!shadow-neo-soft [--hover:transparent] [--active:transparent] rounded-full [&>input]:rounded-full overflow-hidden hero2-frame"
+                    style="--control-h: var(--control-h-md);"
+                  >
+                    <input
+                      autocapitalize="none"
+                      autocomplete="off"
+                      autocorrect="off"
+                      class="w-full rounded-[inherit] bg-transparent px-[var(--space-3)] text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent border-none focus:outline-none focus-visible:outline-none h-[var(--control-h)] hover:bg-[--hover] active:bg-[--active] disabled:opacity-[var(--disabled)] disabled:cursor-not-allowed read-only:cursor-default data-[loading=true]:opacity-[var(--loading)] pl-[var(--space-7)]"
+                      id=":r1:"
+                      name=":r1:"
+                      placeholder="Search title, tags, opponent, patch…"
+                      spellcheck="false"
+                      type="search"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+          <div
+            class="col-span-12 md:col-span-5 hero-focus flex flex-wrap items-center justify-end gap-[var(--space-2)] md:justify-self-end"
+            data-slot="actions"
+          >
+            <div
+              class="flex flex-col gap-[var(--space-2)] sm:flex-row sm:items-center sm:gap-[var(--space-3)]"
+            >
+              <label
+                class="flex w-full flex-col gap-[var(--space-1)] sm:w-auto sm:flex-row sm:items-center sm:gap-[var(--space-2)]"
+              >
+                <span
+                  class="text-ui font-medium text-muted-foreground"
+                >
+                  Sort
+                </span>
+                <div
+                  class="glitch-wrap w-full sm:w-auto"
+                >
+                  <div
+                    class="group inline-flex rounded-[var(--radius-full)] border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[var(--theme-ring)] focus-within:ring-offset-0"
+                  >
+                    <button
+                      aria-controls=":r2:-listbox"
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      aria-label="Sort reviews"
+                      class="_glitchTrigger_843152 relative flex items-center h-[var(--control-h-sm)] rounded-[var(--radius-full)] px-[var(--space-3)] overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none !h-[var(--control-h-lg)] !px-[var(--space-4)]"
+                      data-lit="true"
+                      data-open="false"
+                      type="button"
+                    >
+                      <span
+                        class="font-medium _glitchText_843152 text-foreground group-hover:text-foreground"
+                      >
+                        Newest
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        class="lucide lucide-chevron-down _caret_843152 ml-auto size-[var(--space-4)] shrink-0 opacity-75"
+                        fill="none"
+                        height="24"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="m6 9 6 6 6-6"
+                        />
+                      </svg>
+                      <span
+                        aria-hidden="true"
+                        class="_gbIris_843152"
+                      />
+                      <span
+                        aria-hidden="true"
+                        class="_gbChroma_843152"
+                      />
+                      <span
+                        aria-hidden="true"
+                        class="_gbFlicker_843152"
+                      />
+                      <span
+                        aria-hidden="true"
+                        class="_gbScan_843152"
+                      />
+                    </button>
+                  </div>
+                </div>
+              </label>
+              <button
+                class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[disabled=true]:opacity-[var(--disabled)] data-[disabled=true]:pointer-events-none h-[var(--control-h-lg)] text-title gap-[var(--space-4)] [&_svg]:size-[var(--space-8)] w-full whitespace-nowrap px-[var(--space-4)] sm:w-auto shadow-[var(--btn-primary-shadow-rest)] hover:shadow-[var(--btn-primary-shadow-hover)] active:shadow-[var(--btn-primary-shadow-active)] active:translate-y-px bg-primary-soft border-[hsl(var(--primary)/0.35)] text-[hsl(var(--primary-foreground))] [--hover:theme('colors.interaction.primary.hover')] [--active:theme('colors.interaction.primary.active')]"
+                style="--glow-active: hsl(var(--primary) / 0.35); --btn-primary-hover-shadow: 0 2px 6px -1px hsl(var(--primary) / 0.25); --btn-primary-active-shadow: inset 0 0 0 1px hsl(var(--primary) / 0.6); --btn-primary-shadow-rest: 0 0 calc(var(--space-4) / 2) var(--glow-active); --btn-primary-shadow-hover: 0 0 var(--space-4) var(--glow-active); --btn-primary-shadow-active: var(--btn-primary-active-shadow);"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="absolute inset-0 pointer-events-none rounded-[inherit] bg-[linear-gradient(90deg,hsl(var(--primary)/.18),hsl(var(--primary)/.18))]"
+                />
+                <span
+                  class="relative z-10 inline-flex items-center gap-[var(--space-2)]"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="lucide lucide-plus"
+                    fill="none"
+                    height="24"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M5 12h14"
+                    />
+                    <path
+                      d="M12 5v14"
+                    />
+                  </svg>
+                  <span>
+                    New Review
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </section>
     <div


### PR DESCRIPTION
## Summary
- implement the neomorphic hero frame slot API with variant styling, halo focus states, and 12-column helpers
- migrate PageHeader and demos to the new slots contract, including dense frame usage in gallery/constants
- refresh the reviews snapshot and update TeamCompPage to the supported variants

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc10b0b178832cb13883fcc7c002bd