### PR TITLE
Add middleware rate limiting

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+import { getSharedRateLimiter } from "@/lib/server/rate-limiter";
+import {
+  createRequestId,
+  deriveRateLimitSubjects,
+} from "@/lib/server/request-identity";
+
+const RATE_LIMIT_PROBLEM_TYPE = "https://planner.noxis.dev/problems/rate-limit";
+
+export const config = {
+  matcher: "/api/:path*",
+};
+
+export async function middleware(
+  request: NextRequest,
+): Promise<Response> {
+  const limiter = getSharedRateLimiter();
+  const timestamp = Date.now();
+
+  const [subjects, requestId] = await Promise.all([
+    deriveRateLimitSubjects(request),
+    createRequestId({
+      method: request.method,
+      pathname: request.nextUrl.pathname,
+      timestamp,
+    }),
+  ]);
+
+  const decision = limiter.check({ subjects, now: timestamp });
+
+  if (decision.ok) {
+    return NextResponse.next();
+  }
+
+  const retryAfterSeconds = Math.max(
+    1,
+    Math.ceil(decision.retryAfterMs / 1000),
+  );
+  const windowSeconds = Math.ceil(decision.limit.windowMs / 1000);
+
+  return NextResponse.json(
+    {
+      type: RATE_LIMIT_PROBLEM_TYPE,
+      title: "Too Many Requests",
+      status: 429,
+      detail: `Exceeded ${decision.limit.limit} requests per ${windowSeconds}s for ${decision.bucket} bucket.`,
+      instance: request.nextUrl.pathname,
+      requestId,
+    },
+    {
+      status: 429,
+      headers: {
+        "Retry-After": retryAfterSeconds.toString(),
+        "RateLimit-Policy": `${decision.bucket};w=${windowSeconds};c=${decision.limit.limit}`,
+        "RateLimit-Remaining": "0",
+      },
+    },
+  );
+}

--- a/src/lib/server/rate-limiter.ts
+++ b/src/lib/server/rate-limiter.ts
@@ -1,0 +1,139 @@
+export type RateLimitBucket = "ip" | "user" | "apiKey";
+
+export type BucketConfig = {
+  /** Maximum number of requests allowed within the window. */
+  limit: number;
+  /** Fixed window duration in milliseconds. */
+  windowMs: number;
+};
+
+export type RateLimitConfig = Record<RateLimitBucket, BucketConfig>;
+
+export type RateLimitSubjects = Partial<Record<RateLimitBucket, string>>;
+
+export type RateLimitSuccess = { ok: true };
+
+export type RateLimitFailure = {
+  ok: false;
+  bucket: RateLimitBucket;
+  retryAfterMs: number;
+  limit: BucketConfig;
+};
+
+export type RateLimitDecision = RateLimitSuccess | RateLimitFailure;
+
+const BUCKET_ORDER: RateLimitBucket[] = ["apiKey", "user", "ip"];
+
+export const DEFAULT_RATE_LIMITS: RateLimitConfig = {
+  ip: { limit: 60, windowMs: 60_000 },
+  user: { limit: 120, windowMs: 60_000 },
+  apiKey: { limit: 300, windowMs: 60_000 },
+};
+
+type BucketState = {
+  count: number;
+  windowStart: number;
+};
+
+type ConsumeResult = { allowed: true } | { allowed: false; retryAfterMs: number };
+
+export type RateLimitCheckInput = {
+  subjects: RateLimitSubjects;
+  now?: number;
+};
+
+export class MultiBucketRateLimiter {
+  private readonly buckets = new Map<string, BucketState>();
+
+  constructor(
+    private readonly config: RateLimitConfig,
+    private readonly getNow: () => number = () => Date.now(),
+  ) {
+    for (const key of Object.keys(config) as RateLimitBucket[]) {
+      const entry = config[key];
+      if (!Number.isFinite(entry.limit) || entry.limit < 0) {
+        throw new Error(`Invalid limit for bucket "${key}"`);
+      }
+      if (!Number.isFinite(entry.windowMs) || entry.windowMs <= 0) {
+        throw new Error(`Invalid window for bucket "${key}"`);
+      }
+    }
+  }
+
+  check(input: RateLimitCheckInput): RateLimitDecision {
+    const timestamp = input.now ?? this.getNow();
+
+    for (const bucket of BUCKET_ORDER) {
+      const identifier = input.subjects[bucket];
+      if (!identifier) {
+        continue;
+      }
+
+      const outcome = this.consume(bucket, identifier, timestamp);
+      if (!outcome.allowed) {
+        const limit = this.config[bucket];
+        return {
+          ok: false,
+          bucket,
+          retryAfterMs: outcome.retryAfterMs,
+          limit,
+        } satisfies RateLimitFailure;
+      }
+    }
+
+    return { ok: true } satisfies RateLimitSuccess;
+  }
+
+  reset(): void {
+    this.buckets.clear();
+  }
+
+  private consume(
+    bucket: RateLimitBucket,
+    identifier: string,
+    timestamp: number,
+  ): ConsumeResult {
+    const config = this.config[bucket];
+    if (config.limit === 0) {
+      return { allowed: false, retryAfterMs: config.windowMs };
+    }
+
+    const key = `${bucket}:${identifier}`;
+    const state = this.buckets.get(key);
+
+    if (!state) {
+      this.buckets.set(key, { count: 1, windowStart: timestamp });
+      return { allowed: true };
+    }
+
+    const windowEnd = state.windowStart + config.windowMs;
+
+    if (timestamp >= windowEnd) {
+      this.buckets.set(key, { count: 1, windowStart: timestamp });
+      return { allowed: true };
+    }
+
+    if (state.count < config.limit) {
+      state.count += 1;
+      return { allowed: true };
+    }
+
+    return {
+      allowed: false,
+      retryAfterMs: Math.max(0, windowEnd - timestamp),
+    } satisfies ConsumeResult;
+  }
+}
+
+declare global {
+  var __plannerRateLimiter: MultiBucketRateLimiter | undefined;
+}
+
+export function getSharedRateLimiter(): MultiBucketRateLimiter {
+  if (!globalThis.__plannerRateLimiter) {
+    globalThis.__plannerRateLimiter = new MultiBucketRateLimiter(DEFAULT_RATE_LIMITS);
+  }
+  return globalThis.__plannerRateLimiter;
+}
+
+export { BUCKET_ORDER };

--- a/src/lib/server/request-identity.ts
+++ b/src/lib/server/request-identity.ts
@@ -1,0 +1,105 @@
+import { Buffer } from "node:buffer";
+
+import type { RateLimitSubjects } from "@/lib/server/rate-limiter";
+
+const encoder = new TextEncoder();
+
+const FALLBACK_IDENTIFIERS = {
+  ip: "unknown-ip",
+  user: "anonymous-user",
+  apiKey: "anonymous-api-key",
+} as const;
+
+export type RequestIdInput = {
+  method: string;
+  pathname: string;
+  timestamp: number;
+};
+
+export type RateLimitRequest = {
+  headers: Headers;
+  ip?: string | null;
+};
+
+export function normalizeIdentifier(
+  value: string | null | undefined,
+  fallback: string,
+): string {
+  if (!value) {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
+export function getClientAddress(request: RateLimitRequest): string | null {
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded) {
+    const [first] = forwarded.split(",");
+    const candidate = first?.trim();
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  const realIp = request.headers.get("x-real-ip");
+  if (realIp) {
+    const trimmed = realIp.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  const cfConnectingIp = request.headers.get("cf-connecting-ip");
+  if (cfConnectingIp) {
+    const trimmed = cfConnectingIp.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  const directIp = typeof request.ip === "string" ? request.ip.trim() : "";
+  return directIp ? directIp : null;
+}
+
+export async function hashIdentifier(value: string): Promise<string> {
+  const data = encoder.encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return Buffer.from(digest).toString("base64url");
+}
+
+export async function createRequestId(input: RequestIdInput): Promise<string> {
+  const payload = `${input.method.toUpperCase()}::${input.pathname}::${input.timestamp}`;
+  const digest = await hashIdentifier(payload);
+  return `req_${digest.slice(0, 16)}`;
+}
+
+export async function deriveRateLimitSubjects(
+  request: RateLimitRequest,
+): Promise<RateLimitSubjects> {
+  const clientIp = normalizeIdentifier(
+    getClientAddress(request),
+    FALLBACK_IDENTIFIERS.ip,
+  );
+  const userId = normalizeIdentifier(
+    request.headers.get("x-user-id"),
+    FALLBACK_IDENTIFIERS.user,
+  );
+  const apiKey = normalizeIdentifier(
+    request.headers.get("x-api-key"),
+    FALLBACK_IDENTIFIERS.apiKey,
+  );
+
+  const [ip, user, apiKeyHash] = await Promise.all([
+    hashIdentifier(clientIp),
+    hashIdentifier(userId),
+    hashIdentifier(apiKey),
+  ]);
+
+  return {
+    ip,
+    user,
+    apiKey: apiKeyHash,
+  } satisfies RateLimitSubjects;
+}

--- a/tests/lib/rate-limiter.test.ts
+++ b/tests/lib/rate-limiter.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MultiBucketRateLimiter,
+  type RateLimitConfig,
+  type RateLimitSubjects,
+} from "@/lib/server/rate-limiter";
+
+const BASE_SUBJECTS: RateLimitSubjects = {
+  ip: "ip-hash",
+  user: "user-hash",
+  apiKey: "api-hash",
+};
+
+const baseConfig: RateLimitConfig = {
+  ip: { limit: 2, windowMs: 1_000 },
+  user: { limit: 2, windowMs: 1_000 },
+  apiKey: { limit: 2, windowMs: 1_000 },
+};
+
+describe("MultiBucketRateLimiter", () => {
+  it("allows requests while buckets have capacity", () => {
+    const limiter = new MultiBucketRateLimiter(baseConfig);
+
+    const first = limiter.check({ subjects: BASE_SUBJECTS, now: 0 });
+    expect(first.ok).toBe(true);
+
+    const second = limiter.check({ subjects: BASE_SUBJECTS, now: 0 });
+    expect(second.ok).toBe(true);
+  });
+
+  it("blocks once the IP bucket is exhausted", () => {
+    const config: RateLimitConfig = {
+      ip: { limit: 1, windowMs: 60_000 },
+      user: { limit: 5, windowMs: 60_000 },
+      apiKey: { limit: 5, windowMs: 60_000 },
+    };
+    const limiter = new MultiBucketRateLimiter(config);
+
+    expect(limiter.check({ subjects: BASE_SUBJECTS, now: 0 }).ok).toBe(true);
+    const blocked = limiter.check({ subjects: BASE_SUBJECTS, now: 0 });
+    expect(blocked.ok).toBe(false);
+    if (!blocked.ok) {
+      expect(blocked.bucket).toBe("ip");
+      expect(blocked.retryAfterMs).toBe(60_000);
+      expect(blocked.limit).toEqual(config.ip);
+    }
+  });
+
+  it("blocks once the user bucket is exhausted", () => {
+    const config: RateLimitConfig = {
+      ip: { limit: 5, windowMs: 60_000 },
+      user: { limit: 1, windowMs: 60_000 },
+      apiKey: { limit: 5, windowMs: 60_000 },
+    };
+    const limiter = new MultiBucketRateLimiter(config);
+
+    expect(limiter.check({ subjects: BASE_SUBJECTS, now: 0 }).ok).toBe(true);
+    const blocked = limiter.check({ subjects: BASE_SUBJECTS, now: 0 });
+    expect(blocked.ok).toBe(false);
+    if (!blocked.ok) {
+      expect(blocked.bucket).toBe("user");
+      expect(blocked.retryAfterMs).toBe(60_000);
+      expect(blocked.limit).toEqual(config.user);
+    }
+  });
+
+  it("blocks once the API key bucket is exhausted", () => {
+    const config: RateLimitConfig = {
+      ip: { limit: 5, windowMs: 60_000 },
+      user: { limit: 5, windowMs: 60_000 },
+      apiKey: { limit: 1, windowMs: 60_000 },
+    };
+    const limiter = new MultiBucketRateLimiter(config);
+
+    expect(limiter.check({ subjects: BASE_SUBJECTS, now: 0 }).ok).toBe(true);
+    const blocked = limiter.check({ subjects: BASE_SUBJECTS, now: 0 });
+    expect(blocked.ok).toBe(false);
+    if (!blocked.ok) {
+      expect(blocked.bucket).toBe("apiKey");
+      expect(blocked.retryAfterMs).toBe(60_000);
+      expect(blocked.limit).toEqual(config.apiKey);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add Next.js middleware that limits /api traffic per IP, user, and API key while returning RFC 7807 errors
- share deterministic helpers for hashing identifiers and generating request IDs used by the middleware
- cover rate limiter scenarios with unit tests for successful passes and each exhausted bucket

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc1441d388832caa38adbeeddaf77c