### PR TITLE
Add dependency security audit to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,22 @@ jobs:
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund
 
+      - name: Audit dependencies
+        run: |
+          set +e
+          npm audit --audit-level=moderate --json > audit-report.json
+          AUDIT_STATUS=$?
+          node scripts/audit-ci-report.mjs audit-report.json
+          REPORT_STATUS=$?
+
+          if [ "$REPORT_STATUS" -ne 0 ]; then
+            exit "$REPORT_STATUS"
+          fi
+
+          if [ "$AUDIT_STATUS" -ne 0 ]; then
+            echo "npm audit reported issues below the high severity threshold."
+          fi
+
       - name: Run checks
         run: npm run check
 

--- a/docs/dependency-remediation.md
+++ b/docs/dependency-remediation.md
@@ -1,0 +1,30 @@
+# Dependency Vulnerability Remediation
+
+When the CI audit step flags vulnerable packages, follow this playbook to resolve them quickly and keep the dependency tree healthy.
+
+## 1. Inspect the report
+- Review the **Dependency audit** section in the CI logs or job summary.
+- Capture the `audit-report.json` artifact locally with `npm audit --json > audit-report.json` if you need the full dataset for triage.
+- Note each high or critical severity package and the recommended fix guidance from the report.
+
+## 2. Triage the vulnerability
+- Confirm whether the vulnerable package is a direct dependency or a transitive one.
+- Check the upstream advisory to understand exploitability in our context (runtime, tooling only, optional path, etc.).
+- If the vulnerability is not exploitable for us, document the reasoning in the pull request and open a follow-up ticket to revisit when the upstream patch lands.
+
+## 3. Remediate
+- Prefer upgrading the affected package to the patched version suggested by the audit report.
+- If an upgrade requires breaking changes, coordinate the change in the same pull request or create a chore ticket outlining the migration plan.
+- When no fix is available, work with the owning team to evaluate temporary mitigations (pinning to a safe fork, vendor patch, or replacing the dependency).
+- Avoid blanket `npm audit fix --force` runs; update only the packages necessary to resolve the flagged advisory.
+
+## 4. Verify locally
+- Run `npm audit --json` locally to ensure the vulnerability count drops to zero for high and critical severities.
+- Execute `npm run check` to confirm linting, tests, and type-checking still pass with the updated dependencies.
+
+## 5. Document and ship
+- Capture the remediation notes (version bumps, mitigation steps, or acceptance of risk) in the pull request description.
+- Link to any upstream issues or advisories that track remaining work.
+- Merge only after CI reports no high or critical vulnerabilities.
+
+Following this workflow keeps the CI gate meaningful while ensuring we react to security advisories in a predictable, auditable way.

--- a/scripts/audit-ci-report.mjs
+++ b/scripts/audit-ci-report.mjs
@@ -1,0 +1,135 @@
+import fs from "node:fs";
+
+const [reportPath = "audit-report.json"] = process.argv.slice(2);
+
+function readReport(path) {
+  const data = fs.readFileSync(path, "utf8");
+  return JSON.parse(data);
+}
+
+function formatSeverityTable(counts) {
+  const order = [
+    ["critical", "Critical"],
+    ["high", "High"],
+    ["moderate", "Moderate"],
+    ["low", "Low"],
+    ["info", "Info"],
+  ];
+
+  const header = ["| Severity | Count |", "| --- | --- |"];
+  const rows = order.map(([key, label]) => {
+    const value = counts[key] ?? 0;
+    return `| ${label} | ${value} |`;
+  });
+
+  return ["## Dependency audit", "", ...header, ...rows, ""].join("\n");
+}
+
+function formatFinding(name, finding) {
+  const severity = finding.severity ?? "unknown";
+  const version = finding.installedVersion;
+  const range = finding.range;
+  const fix = finding.fixAvailable;
+  const advisories = Array.isArray(finding.via)
+    ? finding.via.filter((item) => typeof item === "object")
+    : [];
+
+  const advisoryText = advisories
+    .map((advisory) => {
+      const id = advisory.id ?? advisory.source;
+      const title = advisory.title ?? advisory.name ?? "Unknown advisory";
+      return `  - ${title}${id ? ` (${id})` : ""}`;
+    })
+    .join("\n");
+
+  const fixLabel = (() => {
+    if (fix === true) {
+      return "Run `npm audit fix`";
+    }
+
+    if (fix && typeof fix === "object") {
+      const target = [fix.name, fix.version].filter(Boolean).join("@");
+      const upgrade = fix.isSemVerMajor ? " (requires major version upgrade)" : "";
+      return target ? `Update to ${target}${upgrade}` : "Apply vendor patch";
+    }
+
+    return "No fix published yet";
+  })();
+
+  const details = [
+    `- **${name}**@${version} (${severity})`,
+    range ? `  - Affected range: ${range}` : null,
+    `  - Recommended fix: ${fixLabel}`,
+    advisoryText ? advisoryText : "  - No advisory metadata provided",
+  ].filter(Boolean);
+
+  return details.join("\n");
+}
+
+function buildSummary(report) {
+  const counts = {
+    info: 0,
+    low: 0,
+    moderate: 0,
+    high: 0,
+    critical: 0,
+  };
+
+  const vulnerabilities = Object.entries(report.vulnerabilities ?? {});
+
+  const metaCounts = report?.metadata?.vulnerabilities;
+  if (metaCounts) {
+    for (const key of Object.keys(counts)) {
+      if (typeof metaCounts[key] === "number") {
+        counts[key] = metaCounts[key];
+      }
+    }
+  }
+
+  if (!metaCounts) {
+    for (const [, finding] of vulnerabilities) {
+      const severity = String(finding.severity ?? "").toLowerCase();
+      if (severity && severity in counts) {
+        counts[severity] += 1;
+      }
+    }
+  }
+
+  const highFindings = vulnerabilities.filter(([, finding]) => {
+    const severity = String(finding.severity ?? "").toLowerCase();
+    return severity === "high" || severity === "critical";
+  });
+
+  const markdownSections = [formatSeverityTable(counts)];
+
+  if (highFindings.length > 0) {
+    const findingsText = highFindings
+      .map(([name, finding]) => formatFinding(name, finding))
+      .join("\n");
+
+    markdownSections.push("### High severity findings", findingsText, "");
+  } else {
+    markdownSections.push("No high severity vulnerabilities detected.", "");
+  }
+
+  return { counts, highFindings, markdown: markdownSections.join("\n") };
+}
+
+try {
+  const report = readReport(reportPath);
+  const { highFindings, markdown } = buildSummary(report);
+
+  console.log(markdown);
+
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) {
+    fs.appendFileSync(summaryPath, `${markdown}\n`);
+  }
+
+  if (highFindings.length > 0) {
+    process.exitCode = 1;
+  }
+} catch (error) {
+  console.error("Failed to parse npm audit report:", error);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- add a CI step that runs `npm audit --audit-level=moderate`, summarizes the report, and only fails the job when high-severity issues are present
- add a reusable script that formats audit findings for GitHub logs and job summaries
- document the remediation workflow for addressing flagged dependencies

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc177ae8e0832c883d802963ed041c