### PR TITLE
Fix welcome hero figure visibility and sizing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -487,7 +487,7 @@ function HomePageContent() {
                             </Button>
                           </div>
                           <WelcomeHeroFigure
-                            className="hidden w-full shrink-0 sm:flex sm:max-w-[min(52vw,calc(var(--space-8) * 4))] md:basis-[33%] md:max-w-[34%] lg:basis-[42%] lg:max-w-[44%]"
+                            className="flex w-full shrink-0 sm:max-w-[min(52vw,calc(var(--space-8) * 4))] md:basis-[33%] md:max-w-[34%] lg:basis-[42%] lg:max-w-[44%]"
                           />
                         </div>
                       ),

--- a/src/components/home/WelcomeHeroFigure.tsx
+++ b/src/components/home/WelcomeHeroFigure.tsx
@@ -41,7 +41,7 @@ const haloSecondaryStyle: React.CSSProperties = {
 };
 
 const defaultSizes =
-  "(max-width: 639px) 0px, (max-width: 1023px) 33vw, 40vw";
+  "(max-width: 639px) 100vw, (max-width: 1023px) 33vw, 40vw";
 
 export interface WelcomeHeroFigureProps {
   className?: string;


### PR DESCRIPTION
## Summary
- show the welcome hero illustration at the base breakpoint while preserving existing responsive sizing above `sm`
- update the hero figure responsive sizes so the asset loads on small screens and keeps tablet/desktop allocations

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc1a419e84832ca7913a6c9bdeb754