### PR TITLE
Add pruning helper for planner days

### DIFF
--- a/tests/planner/DayCard.test.tsx
+++ b/tests/planner/DayCard.test.tsx
@@ -6,9 +6,10 @@ import {
   PlannerProvider,
   useDay,
   useSelectedProject,
+  todayISO,
 } from "@/components/planner";
 
-const iso = "2024-01-01";
+const iso = todayISO();
 
 interface TestHandle {
   day: ReturnType<typeof useDay>;

--- a/tests/planner/pruneOldDays.test.ts
+++ b/tests/planner/pruneOldDays.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+
+import { pruneOldDays, type DayRecord } from "@/components/planner";
+
+function createDay(): DayRecord {
+  return {
+    projects: [],
+    tasks: [],
+    tasksById: {},
+    tasksByProject: {},
+    doneCount: 0,
+    totalCount: 0,
+  };
+}
+
+function isoDaysAgo(reference: Date, days: number) {
+  const date = new Date(reference.getTime());
+  date.setDate(date.getDate() - days);
+  return date.toISOString().slice(0, 10);
+}
+
+describe("pruneOldDays", () => {
+  it("drops entries older than the default retention window", () => {
+    const reference = new Date("2024-03-05T12:00:00Z");
+    const withinIso = isoDaysAgo(reference, 200);
+    const expiredIso = isoDaysAgo(reference, 400);
+
+    const map: Record<string, DayRecord> = {
+      [withinIso]: createDay(),
+      [expiredIso]: createDay(),
+    };
+
+    const result = pruneOldDays(map, { now: reference });
+
+    expect(result).not.toBe(map);
+    expect(result[expiredIso]).toBeUndefined();
+    expect(result[withinIso]).toBe(map[withinIso]);
+    expect(map[expiredIso]).toBeDefined();
+  });
+
+  it("returns the original map when no pruning is needed", () => {
+    const reference = new Date("2024-03-05T12:00:00Z");
+    const iso = isoDaysAgo(reference, 10);
+
+    const map: Record<string, DayRecord> = {
+      [iso]: createDay(),
+    };
+
+    const result = pruneOldDays(map, { now: reference });
+
+    expect(result).toBe(map);
+  });
+
+  it("honors a custom retention window", () => {
+    const reference = new Date("2024-03-05T12:00:00Z");
+    const withinIso = isoDaysAgo(reference, 20);
+    const expiredIso = isoDaysAgo(reference, 40);
+
+    const map: Record<string, DayRecord> = {
+      [withinIso]: createDay(),
+      [expiredIso]: createDay(),
+    };
+
+    const result = pruneOldDays(map, { now: reference, maxAgeDays: 30 });
+
+    expect(result[withinIso]).toBe(map[withinIso]);
+    expect(result[expiredIso]).toBeUndefined();
+    expect(map[expiredIso]).toBeDefined();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add a `pruneOldDays` helper to the planner store to drop day entries older than the configured retention window and run it inside `setDays`
- keep selection state in sync with pruned days and extend planner selection coverage to ensure cleanup
- add focused unit tests for the pruning helper and update planner tests to use dynamic dates

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc18ad6374832c9f625053a5013ca4