### PR TITLE
Refine SpecCard surface and primitives

### DIFF
--- a/src/components/ui/primitives/Card.tsx
+++ b/src/components/ui/primitives/Card.tsx
@@ -1,12 +1,17 @@
 import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
 import { cn } from "@/lib/utils";
 
-export type CardProps = React.HTMLAttributes<HTMLDivElement>;
+export type CardProps = React.HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+};
 
-const Card = React.forwardRef<HTMLDivElement, CardProps>(
-  ({ className, ...props }, ref) => {
+const Card = React.forwardRef<React.ElementRef<"div">, CardProps>(
+  ({ className, asChild = false, ...props }, ref) => {
+    const Component = asChild ? Slot : "div";
+
     return (
-      <div
+      <Component
         ref={ref}
         className={cn(
           "rounded-card r-card-lg p-[var(--space-4)] border border-border/25 bg-card/60 text-card-foreground shadow-outline-subtle",

--- a/src/components/ui/primitives/NeoCard.tsx
+++ b/src/components/ui/primitives/NeoCard.tsx
@@ -6,7 +6,7 @@ export type NeoCardProps = CardProps & {
   overlay?: React.ReactNode;
 };
 
-const NeoCard = React.forwardRef<HTMLDivElement, NeoCardProps>(
+const NeoCard = React.forwardRef<React.ElementRef<"div">, NeoCardProps>(
   ({ className, children, overlay, ...props }, ref) => (
     <Card
       ref={ref}


### PR DESCRIPTION
## Summary
- refactor the prompts SpecCard to render a focusable NeoCard surface with semantic hover/press tokens and disabled handling
- add the new inset and glitch treatments for the demo element frame while linking headings/descriptions for accessibility
- extend Card/NeoCard primitives with asChild support and broader ref forwarding so SpecCard can compose them directly

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc1471bab4832cba9ff6b3531aa8fb