### PR TITLE
Fix Next config JSON import for deploy compatibility

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,10 @@
 import path from "path";
 import { fileURLToPath } from "url";
-import securityHeadersMap from "./security-headers.json" assert { type: "json" };
+import { readFileSync } from "node:fs";
+
+const securityHeadersMap = JSON.parse(
+  readFileSync(new URL("./security-headers.json", import.meta.url), "utf8"),
+);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 


### PR DESCRIPTION
## Summary
- read the security headers JSON via fs utilities to avoid module import assertions that break Next build

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc1e108a4c832cbd361ce0a25c96dd