### PR TITLE
feat: finalize hero frame slots and demos

### DIFF
--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -19,6 +19,8 @@ import {
   Header,
   Hero,
   NeomorphicHeroFrame,
+  HeroGrid,
+  HeroCol,
   PageShell,
   SearchBar,
   Snackbar,
@@ -991,7 +993,27 @@ export default function ComponentGallery() {
                 Body
               </div>
             </Hero>
-            <NeomorphicHeroFrame variant="plain">
+            <NeomorphicHeroFrame
+              variant="dense"
+              align="end"
+              label="Hero frame demo"
+              slots={{
+                search: (
+                  <SearchBar
+                    value={query}
+                    onValueChange={setQuery}
+                    placeholder="Search layout patterns…"
+                    aria-label="Search layout patterns"
+                    className="w-full"
+                  />
+                ),
+                actions: (
+                  <Button size="sm" variant="secondary" className="whitespace-nowrap">
+                    Assign scout
+                  </Button>
+                ),
+              }}
+            >
               <Hero
                 heading="Frame-ready"
                 eyebrow="No padding"
@@ -1003,9 +1025,25 @@ export default function ComponentGallery() {
                 rail={false}
                 padding="none"
               >
-                <div className="text-ui text-muted-foreground">
-                  Flush to the frame
-                </div>
+                <HeroGrid variant="dense">
+                  <HeroCol span={7} className="space-y-2 text-ui text-muted-foreground">
+                    <p className="font-semibold text-foreground">Flush to the frame</p>
+                    <p>
+                      Dense spacing trims the padding while the slot row keeps
+                      search and quick actions aligned with the hero copy.
+                    </p>
+                  </HeroCol>
+                  <HeroCol span={5} className="space-y-2 text-label text-muted-foreground">
+                    <div className="rounded-card r-card-md border border-border/25 bg-card/60 px-3 py-2">
+                      <span className="font-semibold text-foreground">Slot order</span>
+                      <div>Tabs → Search → Actions</div>
+                    </div>
+                    <div className="rounded-card r-card-md border border-border/25 bg-card/60 px-3 py-2">
+                      <span className="font-semibold text-foreground">Grid helpers</span>
+                      <div>HeroGrid + HeroCol</div>
+                    </div>
+                  </HeroCol>
+                </HeroGrid>
               </Hero>
             </NeomorphicHeroFrame>
           </div>
@@ -1108,7 +1146,7 @@ export default function ComponentGallery() {
         className: "sm:col-span-12 md:col-span-12",
       },
     ],
-    [headerTab],
+    [headerTab, query],
   );
 
   const itemsMap: Record<

--- a/src/components/prompts/NeomorphicHeroFrameDemo.tsx
+++ b/src/components/prompts/NeomorphicHeroFrameDemo.tsx
@@ -5,6 +5,8 @@ import {
   SearchBar,
   Button,
   ThemeToggle,
+  HeroGrid,
+  HeroCol,
   type TabItem,
 } from "@/components/ui";
 
@@ -35,7 +37,8 @@ export default function NeomorphicHeroFrameDemo() {
     <div className="space-y-6">
       <NeomorphicHeroFrame
         as="header"
-        actionArea={{
+        label="Mission controls"
+        slots={{
           tabs: (
             <TabBar
               items={missionTabs}
@@ -78,46 +81,48 @@ export default function NeomorphicHeroFrameDemo() {
               </Button>
             </div>
           ),
-          "aria-label": "Mission controls",
         }}
       >
-        <div className="grid gap-4 md:grid-cols-12 md:gap-6">
-          <div className="md:col-span-7 space-y-3">
+        <HeroGrid variant="default">
+          <HeroCol span={7} className="space-y-3">
             <h3 className="text-title font-semibold tracking-[-0.01em] text-foreground">
               Default neomorphic frame
             </h3>
             <p className="text-ui text-muted-foreground">
               The default variant applies the <code>r-card-lg</code> radius, border tint
               from <code>border-border/40</code>, and responsive padding tokens
-              (<code>px-6</code>, <code>md:px-7</code>, <code>lg:px-8</code>) to stay aligned with the 12-column grid.
+              (<code>px-6</code>, <code>md:px-7</code>, <code>lg:px-8</code>) while the <code>HeroGrid</code>
+              keeps content aligned to the 12-column layout.
             </p>
             <p className="text-ui text-muted-foreground">
               Tabs, search, and button actions all inherit hover, focus, active,
               disabled, and loading states from the design system tokens—interact with
               each control to preview the full range of feedback.
             </p>
-          </div>
-          <dl className="md:col-span-5 grid gap-2 text-label uppercase tracking-[0.08em] text-muted-foreground">
+          </HeroCol>
+          <HeroCol span={5} className="grid gap-2 text-label uppercase tracking-[0.08em] text-muted-foreground">
             <div className="flex items-center justify-between rounded-card r-card-md border border-border/30 bg-card/60 px-3 py-2">
               <dt className="font-semibold text-foreground">Layer tokens</dt>
               <dd className="text-label">bg-card/70 · ring-border/55</dd>
             </div>
             <div className="flex items-center justify-between rounded-card r-card-md border border-border/30 bg-card/60 px-3 py-2">
-              <dt className="font-semibold text-foreground">Spacing</dt>
-              <dd className="text-label">gap-4 · md:gap-6</dd>
+              <dt className="font-semibold text-foreground">Grid rhythm</dt>
+              <dd className="text-label">HeroGrid gap-4 · md:gap-6</dd>
             </div>
             <div className="flex items-center justify-between rounded-card r-card-md border border-border/30 bg-card/60 px-3 py-2">
-              <dt className="font-semibold text-foreground">Action grid</dt>
-              <dd className="text-label">md:col-span-5 / 4 / 3</dd>
+              <dt className="font-semibold text-foreground">Slot spans</dt>
+              <dd className="text-label">HeroCol 7 / 5 alignment</dd>
             </div>
-          </dl>
-        </div>
+          </HeroCol>
+        </HeroGrid>
       </NeomorphicHeroFrame>
 
       <NeomorphicHeroFrame
         as="nav"
         variant="compact"
-        actionArea={{
+        align="between"
+        label="Mission filters"
+        slots={{
           tabs: (
             <TabBar
               items={statusTabs}
@@ -147,12 +152,10 @@ export default function NeomorphicHeroFrameDemo() {
               </Button>
             </div>
           ),
-          align: "between",
-          "aria-label": "Mission filters",
         }}
       >
-        <div className="grid gap-3 md:grid-cols-12 md:gap-4">
-          <div className="md:col-span-6 space-y-2">
+        <HeroGrid variant="compact">
+          <HeroCol span={6} className="space-y-2">
             <h3 className="text-ui font-semibold uppercase tracking-[0.08em] text-muted-foreground">
               Compact layout
             </h3>
@@ -161,12 +164,11 @@ export default function NeomorphicHeroFrameDemo() {
               with the <code>r-card-md</code> radius, ideal for utility nav or filter rails.
             </p>
             <p className="text-ui text-muted-foreground">
-              The action row mirrors the grid: tabs span <code>md:col-span-7</code>, search spans
-              <code>md:col-span-3</code>, and button actions anchor on <code>md:col-span-2</code> for
-              consistent alignment.
+              Slots span <code>HeroCol 7 / 3 / 2</code> at the medium breakpoint so tabs, search,
+              and quick actions stay aligned with adjacent content.
             </p>
-          </div>
-          <div className="md:col-span-6 space-y-2 text-label text-muted-foreground">
+          </HeroCol>
+          <HeroCol span={6} className="space-y-2 text-label text-muted-foreground">
             <p className="font-semibold text-foreground">Interaction checklist</p>
             <ul className="grid grid-cols-2 gap-2">
               <li className="rounded-card r-card-md border border-border/25 bg-card/60 px-3 py-2">
@@ -182,8 +184,8 @@ export default function NeomorphicHeroFrameDemo() {
                 Keyboard focus rings respect the global focus token.
               </li>
             </ul>
-          </div>
-        </div>
+          </HeroCol>
+        </HeroGrid>
       </NeomorphicHeroFrame>
     </div>
   );

--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   ThemeToggle,
   IconButton,
+  SearchBar,
   type HeaderTab,
 } from "@/components/ui";
 import { Bell, CircleUser } from "lucide-react";
@@ -216,39 +217,46 @@ export default function PageHeaderDemo() {
 
       <NeomorphicHeroFrame
         as="section"
-        variant="plain"
-        contentClassName="space-y-[var(--space-4)]"
-      >
-        <Hero
-          as="section"
-          eyebrow="Frame-ready hero"
-          heading="Flush supportive layout"
-          subtitle="Let the outer frame handle breathing room."
-          sticky={false}
-          topClassName="top-0"
-          tone="supportive"
-          frame={false}
-          rail={false}
-          padding="none"
-          search={{
-            id: "hero-flush-search",
-            value: query,
-            onValueChange: setQuery,
-            debounceMs: 150,
-            placeholder: "Search frame highlights…",
-            "aria-label": "Search frame highlights",
-          }}
-          actions={
+        variant="dense"
+        align="end"
+        label="Frame-ready hero"
+        slots={{
+          search: (
+            <SearchBar
+              id="hero-flush-search"
+              value={query}
+              onValueChange={setQuery}
+              debounceMs={150}
+              placeholder="Search frame highlights…"
+              aria-label="Search frame highlights"
+            />
+          ),
+          actions: (
             <Button size="sm" variant="secondary" className="whitespace-nowrap">
               Assign scout
             </Button>
-          }
-        >
-          <p className="text-ui text-muted-foreground">
-            When the hero sits inside another shell, drop its padding so the
-            divider and actions align perfectly with the parent grid.
-          </p>
-        </Hero>
+          ),
+        }}
+      >
+        <div className="space-y-[var(--space-4)]">
+          <Hero
+            as="section"
+            eyebrow="Frame-ready hero"
+            heading="Flush supportive layout"
+            subtitle="Let the outer frame handle breathing room."
+            sticky={false}
+            topClassName="top-0"
+            tone="supportive"
+            frame={false}
+            rail={false}
+            padding="none"
+          >
+            <p className="text-ui text-muted-foreground">
+              When the hero sits inside another shell, drop its padding so the
+              divider and actions align perfectly with the parent grid.
+            </p>
+          </Hero>
+        </div>
       </NeomorphicHeroFrame>
 
       <PageHeader
@@ -396,7 +404,7 @@ export default function PageHeaderDemo() {
         so the content hugs the frame. Want the Hero divider row instead? Pass
         {" "}
         <code className="ml-1 rounded bg-[hsl(var(--card)/0.6)] px-1.5 py-0.5 font-mono text-[0.75rem] text-foreground/80">
-          {"frameProps={{ actionArea: null }}"}
+          {"frameProps={{ slots: null }}"}
         </code>{" "}
         to hand control back to Hero while keeping tone overrides intact.
       </p>

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -1011,8 +1011,7 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       tags: ["hero", "layout", "tokens"],
       code: `<NeomorphicHeroFrame
   as="header"
-  variant="default"
-  actionArea={{
+  slots={{
     tabs: (
       <TabBar
         items={[
@@ -1048,23 +1047,23 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
     ),
   }}
 >
-  <div className="grid gap-4 md:grid-cols-12">
-    <div className="md:col-span-7 space-y-3">
+  <HeroGrid>
+    <HeroCol span={7} className="space-y-3">
       <p className="text-ui text-muted-foreground">
         Default variant uses r-card-lg radius with px-6/md:px-7/lg:px-8 tokens and aligns content to the 12-column grid.
       </p>
-    </div>
-  </div>
+    </HeroCol>
+  </HeroGrid>
 </NeomorphicHeroFrame>
 
-<NeomorphicHeroFrame as="nav" variant="compact" actionArea={{ align: "between" }}>
-  <div className="grid gap-3 md:grid-cols-12">
-    <div className="md:col-span-6">
+<NeomorphicHeroFrame as="nav" variant="compact" align="between">
+  <HeroGrid variant="compact">
+    <HeroCol span={6}>
       <p className="text-ui text-muted-foreground">
         Compact variant swaps to r-card-md radius with px-4/md:px-5/lg:px-6 spacing.
       </p>
-    </div>
-  </div>
+    </HeroCol>
+  </HeroGrid>
 </NeomorphicHeroFrame>`,
     },
     {
@@ -1093,7 +1092,7 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
           >
             <div className="text-ui text-muted-foreground">Body content</div>
           </Hero>
-          <NeomorphicHeroFrame variant="plain">
+          <NeomorphicHeroFrame variant="dense">
             <Hero
               heading="Frame-ready hero"
               eyebrow="No padding"
@@ -1121,7 +1120,7 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
   <div className="text-ui text-muted-foreground">Body content</div>
 </Hero>
 
-<NeomorphicHeroFrame variant="plain">
+<NeomorphicHeroFrame variant="dense">
   <Hero
     heading="Frame-ready hero"
     eyebrow="No padding"

--- a/src/components/ui/layout/NeomorphicHeroFrame.tsx
+++ b/src/components/ui/layout/NeomorphicHeroFrame.tsx
@@ -2,7 +2,9 @@
 "use client";
 
 import * as React from "react";
+
 import { cn } from "@/lib/utils";
+
 import { NeomorphicFrameStyles } from "./NeomorphicFrameStyles";
 
 type FrameElement = Extract<
@@ -10,157 +12,85 @@ type FrameElement = Extract<
   "div" | "header" | "section" | "nav" | "article" | "aside" | "main"
 >;
 
-type Align = "start" | "center" | "end" | "between";
+export type HeroVariant = "default" | "compact" | "dense" | "unstyled";
+export type Align = "start" | "center" | "end" | "between";
 
-export type NeomorphicHeroFrameVariant =
-  | "default"
-  | "compact"
-  | "plain"
-  | "unstyled";
+const heroSlotOrder = ["tabs", "search", "actions"] as const;
+type HeroSlotKey = (typeof heroSlotOrder)[number];
 
-export interface NeomorphicHeroFrameActionAreaProps {
-  /** Optional segmented tabs rendered on the left */
-  tabs?: React.ReactNode;
-  /** Optional primary actions rendered on the right */
-  actions?: React.ReactNode;
-  /** Optional search control rendered inline */
-  search?: React.ReactNode;
-  /** Layout alignment across the action row */
-  align?: Align;
-  /** Adds a top divider when true (default) */
-  divider?: boolean;
-  /**
-   * Additional class for the action row wrapper. Useful for controlling
-   * grid spans when composing with other primitives.
-   */
+export interface HeroSlot {
+  node: React.ReactNode;
   className?: string;
-  tabsClassName?: string;
-  actionsClassName?: string;
-  searchClassName?: string;
-  "aria-label"?: string;
-  "aria-labelledby"?: string;
 }
+
+export type HeroSlotInput = React.ReactNode | HeroSlot;
+
+export type HeroSlots = Partial<Record<HeroSlotKey, HeroSlotInput>>;
 
 export interface NeomorphicHeroFrameProps
   extends React.HTMLAttributes<HTMLElement> {
-  /** Semantic element for the frame */
   as?: FrameElement;
-  /** Built-in shell styles */
-  variant?: NeomorphicHeroFrameVariant;
-  /** Toggle animated frame layers */
-  frame?: boolean;
-  /** Allow content to overflow the frame while clipping neon backdrops */
-  allowOverflow?: boolean;
-  /** Optional class applied to the inner content wrapper */
-  contentClassName?: string;
-  /** Optional action row (tabs, search, buttons) */
-  actionArea?: NeomorphicHeroFrameActionAreaProps | null;
-  /** Boost surface contrast for accessibility */
-  highContrast?: boolean;
+  variant?: HeroVariant;
+  align?: Align;
+  label?: string;
+  labelledById?: string;
+  slots?: HeroSlots | null;
+  children?: React.ReactNode;
 }
 
-const variantMap: Record<Exclude<NeomorphicHeroFrameVariant, "unstyled">, {
-  container: string;
+type VariantConfig = {
+  radius: string;
   padding: string;
-  content: string;
-  action: { mt: string; pt: string; gap: string };
-}> = {
+  contentSpacing: string;
+  slot: {
+    marginTop: string;
+    paddingTop: string;
+    gapY: string;
+    gapMd: string;
+  };
+};
+
+const variantMap: Record<Exclude<HeroVariant, "unstyled">, VariantConfig> = {
   default: {
-    container:
-      "rounded-card r-card-lg border border-border/40 bg-card/70 shadow-outline-subtle",
+    radius: "rounded-card r-card-lg",
     padding:
       "px-[var(--space-6)] py-[var(--space-6)] md:px-[var(--space-7)] md:py-[var(--space-7)] lg:px-[var(--space-8)] lg:py-[var(--space-8)]",
-    content: "space-y-[var(--space-5)] md:space-y-[var(--space-6)]",
-    action: {
-      mt: "mt-[var(--space-6)] md:mt-[var(--space-7)]",
-      pt: "pt-[var(--space-5)] md:pt-[var(--space-6)]",
-      gap: "gap-[var(--space-4)]",
+    contentSpacing:
+      "space-y-[var(--space-5)] md:space-y-[var(--space-6)]",
+    slot: {
+      marginTop: "mt-[var(--space-6)] md:mt-[var(--space-7)]",
+      paddingTop: "pt-[var(--space-5)] md:pt-[var(--space-6)]",
+      gapY: "gap-[var(--space-3)]",
+      gapMd: "md:gap-[var(--space-4)]",
     },
   },
   compact: {
-    container:
-      "rounded-card r-card-md border border-border/35 bg-card/65 shadow-outline-subtle",
+    radius: "rounded-card r-card-md",
     padding:
       "px-[var(--space-4)] py-[var(--space-4)] md:px-[var(--space-5)] md:py-[var(--space-5)] lg:px-[var(--space-6)] lg:py-[var(--space-6)]",
-    content: "space-y-[var(--space-4)] md:space-y-[var(--space-5)]",
-    action: {
-      mt: "mt-[var(--space-4)] md:mt-[var(--space-5)]",
-      pt: "pt-[var(--space-4)] md:pt-[var(--space-5)]",
-      gap: "gap-[var(--space-3)]",
+    contentSpacing:
+      "space-y-[var(--space-4)] md:space-y-[var(--space-5)]",
+    slot: {
+      marginTop: "mt-[var(--space-5)]",
+      paddingTop: "pt-[var(--space-4)] md:pt-[var(--space-5)]",
+      gapY: "gap-[var(--space-3)]",
+      gapMd: "md:gap-[var(--space-3)]",
     },
   },
-  plain: {
-    container:
-      "rounded-card r-card-md border border-border/30 bg-card/60 shadow-outline-faint",
+  dense: {
+    radius: "rounded-card r-card-md",
     padding:
-      "px-[var(--space-4)] py-[var(--space-4)] md:px-[var(--space-5)] md:py-[var(--space-5)]",
-    content: "space-y-[var(--space-3)] md:space-y-[var(--space-4)]",
-    action: {
-      mt: "mt-[var(--space-4)]",
-      pt: "pt-[var(--space-3)] md:pt-[var(--space-4)]",
-      gap: "gap-[var(--space-3)]",
+      "px-[var(--space-3)] py-[var(--space-3)] md:px-[var(--space-4)] md:py-[var(--space-4)] lg:px-[var(--space-5)] lg:py-[var(--space-5)]",
+    contentSpacing:
+      "space-y-[var(--space-3)] md:space-y-[var(--space-4)]",
+    slot: {
+      marginTop: "mt-[var(--space-4)]",
+      paddingTop: "pt-[var(--space-3)] md:pt-[var(--space-4)]",
+      gapY: "gap-[var(--space-2)]",
+      gapMd: "md:gap-[var(--space-3)]",
     },
   },
 };
-
-const highContrastVariantMap: Record<
-  Exclude<NeomorphicHeroFrameVariant, "unstyled">,
-  { container: string }
-> = {
-  default: {
-    container: "border-border/70 shadow-neoSoft",
-  },
-  compact: {
-    container: "border-border/70 shadow-neoSoft",
-  },
-  plain: {
-    container: "border-border/55 shadow-outline-subtle",
-  },
-};
-
-function slotLayout({
-  hasTabs,
-  hasSearch,
-  hasActions,
-}: {
-  hasTabs: boolean;
-  hasSearch: boolean;
-  hasActions: boolean;
-}) {
-  if (hasTabs && hasSearch && hasActions) {
-    return {
-      tabs: "md:col-span-5",
-      search: "md:col-span-4",
-      actions: "md:col-span-3",
-    };
-  }
-  if (hasTabs && hasSearch) {
-    return {
-      tabs: "md:col-span-6",
-      search: "md:col-span-6",
-      actions: "md:col-span-12",
-    };
-  }
-  if (hasTabs && hasActions) {
-    return {
-      tabs: "md:col-span-7",
-      search: "md:col-span-12",
-      actions: "md:col-span-5",
-    };
-  }
-  if (hasSearch && hasActions) {
-    return {
-      tabs: "md:col-span-12",
-      search: "md:col-span-7",
-      actions: "md:col-span-5",
-    };
-  }
-  return {
-    tabs: "md:col-span-12",
-    search: "md:col-span-12",
-    actions: "md:col-span-12",
-  };
-}
 
 const alignClassMap: Record<Align, { tabs: string; search: string; actions: string }> = {
   start: {
@@ -185,61 +115,271 @@ const alignClassMap: Record<Align, { tabs: string; search: string; actions: stri
   },
 };
 
+const spanClassMap = {
+  tabs: {
+    three: "md:col-span-5",
+    twoWithActions: "md:col-span-7",
+    two: "md:col-span-6",
+    solo: "md:col-span-12",
+  },
+  search: {
+    three: "md:col-span-4",
+    twoWithActions: "md:col-span-7",
+    two: "md:col-span-6",
+    solo: "md:col-span-12",
+  },
+  actions: {
+    three: "md:col-span-3",
+    twoWithTabs: "md:col-span-5",
+    two: "md:col-span-5",
+    solo: "md:col-span-12",
+  },
+} as const satisfies Record<HeroSlotKey, Record<string, string>>;
+
+type LayoutState = {
+  tabs?: string;
+  search?: string;
+  actions?: string;
+};
+
+function getSlotLayout(
+  present: Record<HeroSlotKey, boolean>,
+): LayoutState {
+  const { tabs, search, actions } = present;
+  if (tabs && search && actions) {
+    return {
+      tabs: spanClassMap.tabs.three,
+      search: spanClassMap.search.three,
+      actions: spanClassMap.actions.three,
+    };
+  }
+  if (tabs && search) {
+    return {
+      tabs: spanClassMap.tabs.two,
+      search: spanClassMap.search.two,
+      actions: spanClassMap.actions.solo,
+    };
+  }
+  if (tabs && actions) {
+    return {
+      tabs: spanClassMap.tabs.twoWithActions,
+      search: spanClassMap.search.solo,
+      actions: spanClassMap.actions.twoWithTabs,
+    };
+  }
+  if (search && actions) {
+    return {
+      tabs: spanClassMap.tabs.solo,
+      search: spanClassMap.search.twoWithActions,
+      actions: spanClassMap.actions.two,
+    };
+  }
+  return {
+    tabs: spanClassMap.tabs.solo,
+    search: spanClassMap.search.solo,
+    actions: spanClassMap.actions.solo,
+  };
+}
+
+function isSlotConfig(value: HeroSlotInput | undefined): value is HeroSlot {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !React.isValidElement(value) &&
+    Object.prototype.hasOwnProperty.call(value, "node")
+  );
+}
+
+function normalizeSlot(value: HeroSlotInput | undefined): HeroSlot | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (isSlotConfig(value)) {
+    return value.node === null || value.node === undefined
+      ? null
+      : value;
+  }
+  return { node: value };
+}
+
+const slotWellBaseClass =
+  "group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md border border-border/45 bg-card/75 px-[var(--space-3)] py-[var(--space-2)] neo-inset hero-focus shadow-neo-inset transition-shadow focus-within:shadow-neoSoft focus-within:ring-1 focus-within:ring-ring/60";
+
+const slotContentClass = "relative z-[1] flex w-full min-w-0 flex-col";
+
+const heroGridGaps: Record<Exclude<HeroVariant, "unstyled">, string> = {
+  default: "gap-[var(--space-4)] md:gap-[var(--space-6)]",
+  compact: "gap-[var(--space-3)] md:gap-[var(--space-4)]",
+  dense: "gap-[var(--space-2)] md:gap-[var(--space-3)]",
+};
+
+export interface HeroGridProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: Exclude<HeroVariant, "unstyled">;
+}
+
+export const HeroGrid = React.forwardRef<HTMLDivElement, HeroGridProps>(
+  ({ variant = "default", className, ...rest }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "grid grid-cols-1 md:grid-cols-12",
+          heroGridGaps[variant],
+          className,
+        )}
+        {...rest}
+      />
+    );
+  },
+);
+
+HeroGrid.displayName = "HeroGrid";
+
+const heroColSpanClasses = {
+  1: "md:col-span-1",
+  2: "md:col-span-2",
+  3: "md:col-span-3",
+  4: "md:col-span-4",
+  5: "md:col-span-5",
+  6: "md:col-span-6",
+  7: "md:col-span-7",
+  8: "md:col-span-8",
+  9: "md:col-span-9",
+  10: "md:col-span-10",
+  11: "md:col-span-11",
+  12: "md:col-span-12",
+} as const;
+
+const heroColSpanLgClasses = {
+  1: "lg:col-span-1",
+  2: "lg:col-span-2",
+  3: "lg:col-span-3",
+  4: "lg:col-span-4",
+  5: "lg:col-span-5",
+  6: "lg:col-span-6",
+  7: "lg:col-span-7",
+  8: "lg:col-span-8",
+  9: "lg:col-span-9",
+  10: "lg:col-span-10",
+  11: "lg:col-span-11",
+  12: "lg:col-span-12",
+} as const;
+
+export interface HeroColProps extends React.HTMLAttributes<HTMLDivElement> {
+  span?: keyof typeof heroColSpanClasses;
+  spanLg?: keyof typeof heroColSpanLgClasses;
+}
+
+export const HeroCol = React.forwardRef<HTMLDivElement, HeroColProps>(
+  ({ span = 12, spanLg, className, ...rest }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "col-span-full min-w-0",
+          heroColSpanClasses[span],
+          spanLg ? heroColSpanLgClasses[spanLg] : undefined,
+          className,
+        )}
+        {...rest}
+      />
+    );
+  },
+);
+
+HeroCol.displayName = "HeroCol";
+
 const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFrameProps>(
   (
     {
       as,
       variant = "default",
-      frame = true,
-      className,
-      contentClassName,
+      align = "between",
+      label,
+      labelledById,
+      slots,
       children,
-      actionArea,
-      highContrast,
-      allowOverflow = false,
+      className,
+      role: roleProp,
+      tabIndex,
+      onFocusCapture,
+      onBlurCapture,
       ...rest
     },
     ref,
   ) => {
     const Component = (as ?? "div") as FrameElement;
     const Comp = Component as React.ElementType;
-    const showFrame = frame !== false;
     const variantStyles =
       variant !== "unstyled" ? variantMap[variant] : undefined;
-    const contrastStyles =
-      highContrast && variant !== "unstyled"
-        ? highContrastVariantMap[variant]
-        : undefined;
-    const slotContrastClass = highContrast ? "text-foreground" : undefined;
+    const [hasFocus, setHasFocus] = React.useState(false);
 
-    const hasActionArea = Boolean(
-      actionArea &&
-        (actionArea.tabs || actionArea.actions || actionArea.search),
+    const normalizedSlots = React.useMemo(() => {
+      if (slots === null) return null;
+      if (!slots) return undefined;
+      const entries: Partial<Record<HeroSlotKey, HeroSlot>> = {};
+      let any = false;
+      for (const key of heroSlotOrder) {
+        const normalized = normalizeSlot(slots[key]);
+        if (normalized) {
+          entries[key] = normalized;
+          any = true;
+        }
+      }
+      return any ? entries : undefined;
+    }, [slots]);
+
+    const hasTabs = Boolean(normalizedSlots?.tabs);
+    const hasSearch = Boolean(normalizedSlots?.search);
+    const hasActions = Boolean(normalizedSlots?.actions);
+
+    const layout = React.useMemo(
+      () =>
+        normalizedSlots
+          ? getSlotLayout({
+              tabs: hasTabs,
+              search: hasSearch,
+              actions: hasActions,
+            })
+          : ({} as LayoutState),
+      [normalizedSlots, hasTabs, hasSearch, hasActions],
     );
 
-    const showDivider = actionArea?.divider ?? true;
-    const actionPaddingClass = showDivider
-      ? variantStyles?.action.pt ?? "pt-[var(--space-4)]"
-      : undefined;
+    const aligns = alignClassMap[align];
 
-    const shouldWrapContent =
-      variant !== "unstyled" || hasActionArea || Boolean(contentClassName);
+    const handleFocusCapture = React.useCallback(
+      (event: React.FocusEvent<HTMLElement>) => {
+        setHasFocus(true);
+        onFocusCapture?.(event);
+      },
+      [onFocusCapture],
+    );
 
-    const actionAlign = actionArea?.align ?? "between";
-    const slots = slotLayout({
-      hasTabs: Boolean(actionArea?.tabs),
-      hasSearch: Boolean(actionArea?.search),
-      hasActions: Boolean(actionArea?.actions),
-    });
-    const aligns = alignClassMap[actionAlign];
+    const handleBlurCapture = React.useCallback(
+      (event: React.FocusEvent<HTMLElement>) => {
+        const nextTarget = event.relatedTarget as Node | null;
+        if (nextTarget && event.currentTarget.contains(nextTarget)) {
+          onBlurCapture?.(event);
+          return;
+        }
+        setHasFocus(false);
+        onBlurCapture?.(event);
+      },
+      [onBlurCapture],
+    );
 
-    const content = shouldWrapContent ? (
+    const roleFromElement =
+      as === "header"
+        ? "banner"
+        : as === "nav"
+        ? "navigation"
+        : undefined;
+
+    const resolvedChildren = variantStyles ? (
       <div
         className={cn(
-          "relative z-[2]",
-          variantStyles?.content,
-          !variantStyles && hasActionArea && "space-y-4 md:space-y-5",
-          contentClassName,
+          "relative z-[1]",
+          variantStyles.contentSpacing,
         )}
       >
         {children}
@@ -248,108 +388,76 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
       children
     );
 
-    return (
-      <>
-        {showFrame ? <NeomorphicFrameStyles /> : null}
-        <Comp
-          ref={ref}
-          className={cn(
-            "relative",
-            showFrame &&
-              (allowOverflow
-                ? "overflow-visible hero2-frame hero2-neomorph"
-                : "overflow-hidden hero2-frame hero2-neomorph"),
-            variantStyles?.container,
-            contrastStyles?.container,
-            variantStyles?.padding,
-            className,
-          )}
-          {...rest}
-        >
-          {content}
-
-          {hasActionArea ? (
+    const slotArea = normalizedSlots ? (
+      <div
+        role="group"
+        className={cn(
+          "group/hero-slots relative z-[1] isolate w-full grid grid-cols-1",
+          variantStyles?.slot.marginTop,
+          variantStyles?.slot.paddingTop,
+          variantStyles?.slot.gapY,
+          variantStyles?.slot.gapMd,
+          "md:grid-cols-12",
+          "before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-[hsl(var(--accent))] before:opacity-60 before:content-['']",
+          "after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-px after:bg-[hsl(var(--accent))] after:opacity-40 after:blur-sm after:content-['']",
+        )}
+        data-align={align}
+      >
+        {heroSlotOrder.map((key) => {
+          const slot = normalizedSlots[key];
+          if (!slot) return null;
+          return (
             <div
-              role="group"
-              aria-label={actionArea?.["aria-label"]}
-              aria-labelledby={actionArea?.["aria-labelledby"]}
+              key={key}
+              data-slot={key}
               className={cn(
-                "relative z-[2]",
-                variantStyles?.action.mt ?? "mt-[var(--space-4)]",
-                actionPaddingClass,
-                "grid gap-[var(--space-3)] md:grid-cols-12 md:gap-[var(--space-4)]",
-                variantStyles?.action.gap,
-                actionArea?.className,
+                slotWellBaseClass,
+                layout[key as keyof LayoutState],
+                aligns[key],
+                slot.className,
               )}
             >
-              {showDivider ? (
-                <>
-                  <span
-                    aria-hidden
-                    className="pointer-events-none absolute inset-x-0 top-0 h-px bg-[hsl(var(--accent))]"
-                  />
-                  <span
-                    aria-hidden
-                    className="pointer-events-none absolute inset-x-0 top-0 h-px bg-[hsl(var(--accent))] blur-[6px] opacity-60"
-                  />
-                </>
-              ) : null}
-              {actionArea?.tabs ? (
-                <div
-                  data-area="tabs"
-                  className={cn(
-                    "flex flex-col gap-[var(--space-2)]",
-                    slotContrastClass,
-                    slots.tabs,
-                    aligns.tabs,
-                    actionArea.tabsClassName,
-                  )}
-                >
-                  {actionArea.tabs}
-                </div>
-              ) : null}
-
-              {actionArea?.search ? (
-                <div
-                  data-area="search"
-                  className={cn(
-                    "flex flex-col gap-[var(--space-2)]",
-                    slotContrastClass,
-                    slots.search,
-                    aligns.search,
-                    actionArea.searchClassName,
-                  )}
-                >
-                  {actionArea.search}
-                </div>
-              ) : null}
-
-              {actionArea?.actions ? (
-                <div
-                  data-area="actions"
-                  className={cn(
-                    "flex flex-wrap items-center justify-end gap-[var(--space-2)]",
-                    slotContrastClass,
-                    slots.actions,
-                    aligns.actions,
-                    actionArea.actionsClassName,
-                  )}
-                >
-                  {actionArea.actions}
-                </div>
-              ) : null}
+              <div className={slotContentClass}>{slot.node}</div>
             </div>
-          ) : null}
+          );
+        })}
+      </div>
+    ) : null;
 
-          {showFrame ? (
-            <div
-              aria-hidden
-              className={cn(
-                "absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/55",
-                highContrast && "ring-border/70",
-              )}
-            />
-          ) : null}
+    const haloClasses =
+      "before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:rounded-[inherit] before:opacity-0 before:transition before:duration-300 before:ease-out before:content-[''] before:[box-shadow:0_0_0_2px_hsl(var(--ring)),0_0_24px_hsl(var(--glow)/0.35)] motion-reduce:before:transition-none";
+
+    return (
+      <>
+        {variant !== "unstyled" ? <NeomorphicFrameStyles /> : null}
+        <Comp
+          ref={ref}
+          {...rest}
+          className={cn(
+            "group/hero-frame relative isolate flex flex-col overflow-visible hero-focus",
+            variantStyles
+              ? cn(
+                  "border border-border/55 bg-card/70 text-foreground shadow-outline-subtle hero2-frame hero2-neomorph",
+                  haloClasses,
+                  "has-[:focus-visible]:before:opacity-100",
+                  "data-[has-focus=true]:before:opacity-100",
+                  variantStyles.radius,
+                  variantStyles.padding,
+                )
+              : undefined,
+            className,
+          )}
+          data-has-focus={hasFocus ? "true" : undefined}
+          data-variant={variant}
+          role={roleProp ?? roleFromElement}
+          aria-label={label}
+          aria-labelledby={labelledById}
+          tabIndex={tabIndex ?? -1}
+          onFocusCapture={handleFocusCapture}
+          onBlurCapture={handleBlurCapture}
+        >
+          {resolvedChildren}
+          {slotArea}
         </Comp>
       </>
     );

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -58,10 +58,12 @@ exports[`ReviewsPage > renders default state 1`] = `
     
       </style>
       <div
-        class="relative overflow-hidden hero2-frame hero2-neomorph rounded-card r-card-lg border border-border/40 bg-card/70 shadow-outline-subtle md:px-[var(--space-7)] md:py-[var(--space-7)] lg:px-[var(--space-8)] lg:py-[var(--space-8)] rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-4)]"
+        class="group/hero-frame relative isolate flex flex-col overflow-visible hero-focus border border-border/55 bg-card/70 text-foreground shadow-outline-subtle hero2-frame hero2-neomorph before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:rounded-[inherit] before:opacity-0 before:transition before:duration-300 before:ease-out before:content-[''] before:[box-shadow:0_0_0_2px_hsl(var(--ring)),0_0_24px_hsl(var(--glow)/0.35)] motion-reduce:before:transition-none has-[:focus-visible]:before:opacity-100 data-[has-focus=true]:before:opacity-100 rounded-card r-card-lg md:px-[var(--space-7)] md:py-[var(--space-7)] lg:px-[var(--space-8)] lg:py-[var(--space-8)] rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-4)]"
+        data-variant="default"
+        tabindex="-1"
       >
         <div
-          class="relative z-[2] space-y-[var(--space-5)] md:space-y-[var(--space-6)]"
+          class="relative z-[1] space-y-[var(--space-5)] md:space-y-[var(--space-6)]"
         >
           <div
             class="relative z-[2] space-y-[var(--space-2)]"
@@ -164,221 +166,220 @@ exports[`ReviewsPage > renders default state 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  class="relative z-[2] mt-[var(--space-4)] md:mt-[var(--space-5)] flex flex-col gap-[var(--space-4)] md:gap-[var(--space-5)]"
-                >
-                  <div
-                    class="relative"
-                    style="--divider: var(--ring);"
-                  >
-                    <span
-                      aria-hidden="true"
-                      class="block h-px bg-[hsl(var(--divider))/0.28]"
-                    />
-                    <div
-                      class="flex flex-wrap items-start gap-[var(--space-2)] md:flex-nowrap md:items-center md:gap-[var(--space-4)] lg:gap-[var(--space-5)] pt-[var(--space-4)] md:pt-[var(--space-5)]"
-                    >
-                      <form
-                        class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-[var(--space-2)] data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"
-                        role="search"
-                      >
-                        <div
-                          class="min-w-0"
-                        >
-                          <div
-                            class="flex w-full flex-col gap-[var(--space-1)] min-w-0"
-                          >
-                            <div
-                              class="group/field relative inline-flex min-h-[var(--field-h,var(--control-h-md))] items-center border bg-[hsl(var(--bg))] text-foreground shadow-[inset_0_1px_0_hsl(var(--highlight)/0.08),inset_0_-1px_0_hsl(var(--border)/0.32)] transition-[background,box-shadow,filter] duration-[var(--dur-quick)] ease-out focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] focus-within:ring-offset-0 focus-within:ring-offset-[hsl(var(--bg))] hover:shadow-[inset_0_1px_0_hsl(var(--highlight)/0.12),inset_0_-1px_0_hsl(var(--border)/0.45)] active:brightness-[0.96] data-[disabled=true]:pointer-events-none data-[disabled=true]:border-[hsl(var(--card-hairline)/0.4)] data-[disabled=true]:bg-[hsl(var(--card))] data-[disabled=true]:shadow-[inset_0_1px_0_hsl(var(--highlight)/0.04)] data-[disabled=true]:text-muted-foreground/70 data-[loading=true]:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[invalid=true]:border-[hsl(var(--danger)/0.6)] data-[invalid=true]:focus-within:ring-[hsl(var(--danger))] w-full hero2-neomorph !border border-[hsl(var(--border)/0.4)] !shadow-neo-inset hover:!shadow-neo-soft active:!shadow-neo-inset focus-within:!shadow-neo-soft [--hover:transparent] [--active:transparent] rounded-full [&>input]:rounded-full overflow-hidden hero2-frame"
-                              style="--field-h: var(--control-h-md);"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="lucide lucide-search pointer-events-none absolute left-[var(--space-4)] top-1/2 size-[var(--space-4)] -translate-y-1/2 text-muted-foreground transition-colors duration-[var(--dur-quick)] ease-out group-focus-within:text-accent-foreground group-data-[disabled=true]/field:opacity-[var(--disabled)] group-data-[loading=true]/field:opacity-[var(--loading)] group-data-[invalid=true]/field:text-danger"
-                                fill="none"
-                                height="24"
-                                stroke="currentColor"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="2"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="m21 21-4.34-4.34"
-                                />
-                                <circle
-                                  cx="11"
-                                  cy="11"
-                                  r="8"
-                                />
-                              </svg>
-                              <input
-                                aria-label="Search reviews"
-                                autocapitalize="none"
-                                autocomplete="off"
-                                autocorrect="off"
-                                class="peer block h-[var(--field-h,var(--control-h-md))] w-full rounded-[inherit] border-none bg-transparent px-[var(--space-3)] text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent focus:outline-none focus-visible:outline-none disabled:cursor-not-allowed read-only:cursor-default transition-[color,opacity] group-data-[disabled=true]/field:text-muted-foreground/70 group-data-[disabled=true]/field:placeholder:text-muted-foreground/50 group-data-[loading=true]/field:opacity-[var(--loading)] pl-[var(--space-7)]"
-                                placeholder="Search title, tags, opponent, patch…"
-                                spellcheck="false"
-                                type="search"
-                                value=""
-                              />
-                              <button
-                                aria-label="Clear"
-                                class="inline-flex items-center justify-center select-none rounded-full duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] border bg-card/35 hover:bg-[--hover] [--hover:hsl(var(--panel)/0.45)] [--active:hsl(var(--panel)/0.55)] border-line/35 text-foreground h-[var(--control-h-sm)] w-[var(--control-h-sm)] [&_svg]:size-[var(--space-4)] absolute right-[var(--space-3)] top-1/2 -translate-y-1/2 transition-opacity pointer-events-none opacity-0"
-                                tabindex="0"
-                                title="Clear"
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="lucide lucide-x"
-                                  fill="none"
-                                  height="24"
-                                  stroke="currentColor"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="2"
-                                  viewBox="0 0 24 24"
-                                  width="24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M18 6 6 18"
-                                  />
-                                  <path
-                                    d="m6 6 12 12"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                          </div>
-                        </div>
-                      </form>
-                      <div
-                        class="flex w-full flex-wrap items-center gap-[var(--space-2)] md:w-auto md:flex-nowrap"
-                      >
-                        <div
-                          class="flex flex-col gap-[var(--space-2)] sm:flex-row sm:items-center sm:gap-[var(--space-3)]"
-                        >
-                          <label
-                            class="flex w-full flex-col gap-[var(--space-1)] sm:w-auto sm:flex-row sm:items-center sm:gap-[var(--space-2)]"
-                          >
-                            <span
-                              class="text-ui font-medium text-muted-foreground"
-                            >
-                              Sort
-                            </span>
-                            <div
-                              class="glitch-wrap w-full sm:w-auto"
-                            >
-                              <div
-                                class="group inline-flex rounded-[var(--radius-full)] border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[var(--theme-ring)] focus-within:ring-offset-0"
-                              >
-                                <button
-                                  aria-controls=":r1:-listbox"
-                                  aria-expanded="false"
-                                  aria-haspopup="listbox"
-                                  aria-label="Sort reviews"
-                                  class="_glitchTrigger_843152 relative flex items-center h-[var(--control-h-sm)] rounded-[var(--radius-full)] px-[var(--space-3)] overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none !h-[var(--control-h-lg)] !px-[var(--space-4)]"
-                                  data-lit="true"
-                                  data-open="false"
-                                  type="button"
-                                >
-                                  <span
-                                    class="font-medium _glitchText_843152 text-foreground group-hover:text-foreground"
-                                  >
-                                    Newest
-                                  </span>
-                                  <svg
-                                    aria-hidden="true"
-                                    class="lucide lucide-chevron-down _caret_843152 ml-auto size-[var(--space-4)] shrink-0 opacity-75"
-                                    fill="none"
-                                    height="24"
-                                    stroke="currentColor"
-                                    stroke-linecap="round"
-                                    stroke-linejoin="round"
-                                    stroke-width="2"
-                                    viewBox="0 0 24 24"
-                                    width="24"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="m6 9 6 6 6-6"
-                                    />
-                                  </svg>
-                                  <span
-                                    aria-hidden="true"
-                                    class="_gbIris_843152"
-                                  />
-                                  <span
-                                    aria-hidden="true"
-                                    class="_gbChroma_843152"
-                                  />
-                                  <span
-                                    aria-hidden="true"
-                                    class="_gbFlicker_843152"
-                                  />
-                                  <span
-                                    aria-hidden="true"
-                                    class="_gbScan_843152"
-                                  />
-                                </button>
-                              </div>
-                            </div>
-                          </label>
-                          <button
-                            class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[disabled=true]:opacity-[var(--disabled)] data-[disabled=true]:pointer-events-none h-[var(--control-h-lg)] text-title gap-[var(--space-4)] [&_svg]:size-[var(--space-8)] w-full whitespace-nowrap px-[var(--space-4)] sm:w-auto shadow-[var(--btn-primary-shadow-rest)] hover:shadow-[var(--btn-primary-shadow-hover)] active:shadow-[var(--btn-primary-shadow-active)] active:translate-y-px bg-primary-soft border-[hsl(var(--primary)/0.35)] text-[hsl(var(--primary-foreground))] [--hover:theme('colors.interaction.primary.hover')] [--active:theme('colors.interaction.primary.active')]"
-                            style="--glow-active: hsl(var(--primary) / 0.35); --btn-primary-hover-shadow: 0 2px 6px -1px hsl(var(--primary) / 0.25); --btn-primary-active-shadow: inset 0 0 0 1px hsl(var(--primary) / 0.6); --btn-primary-shadow-rest: 0 0 calc(var(--space-4) / 2) var(--glow-active); --btn-primary-shadow-hover: 0 0 var(--space-4) var(--glow-active); --btn-primary-shadow-active: var(--btn-primary-active-shadow);"
-                            tabindex="0"
-                            type="button"
-                          >
-                            <span
-                              class="absolute inset-0 pointer-events-none rounded-[inherit] bg-[linear-gradient(90deg,hsl(var(--primary)/.18),hsl(var(--primary)/.18))]"
-                            />
-                            <span
-                              class="relative z-10 inline-flex items-center gap-[var(--space-2)]"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="lucide lucide-plus"
-                                fill="none"
-                                height="24"
-                                stroke="currentColor"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="2"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M5 12h14"
-                                />
-                                <path
-                                  d="M12 5v14"
-                                />
-                              </svg>
-                              <span>
-                                New Review
-                              </span>
-                            </span>
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
               </div>
             </section>
           </div>
         </div>
         <div
-          aria-hidden="true"
-          class="absolute inset-0 rounded-[inherit] ring-1 ring-inset ring-border/55"
-        />
+          class="group/hero-slots relative z-[1] isolate w-full grid grid-cols-1 mt-[var(--space-6)] md:mt-[var(--space-7)] pt-[var(--space-5)] md:pt-[var(--space-6)] gap-[var(--space-3)] md:gap-[var(--space-4)] md:grid-cols-12 before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-[hsl(var(--accent))] before:opacity-60 before:content-[''] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-px after:bg-[hsl(var(--accent))] after:opacity-40 after:blur-sm after:content-['']"
+          data-align="between"
+          role="group"
+        >
+          <div
+            class="group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md border border-border/45 bg-card/75 px-[var(--space-3)] py-[var(--space-2)] neo-inset hero-focus shadow-neo-inset transition-shadow focus-within:shadow-neoSoft focus-within:ring-1 focus-within:ring-ring/60 md:col-span-7 md:justify-self-stretch"
+            data-slot="search"
+          >
+            <div
+              class="relative z-[1] flex w-full min-w-0 flex-col"
+            >
+              <form
+                class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-[var(--space-2)] data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"
+                role="search"
+              >
+                <div
+                  class="min-w-0"
+                >
+                  <div
+                    class="flex w-full flex-col gap-[var(--space-1)] min-w-0"
+                  >
+                    <div
+                      class="group/field relative inline-flex min-h-[var(--field-h,var(--control-h-md))] items-center border bg-[hsl(var(--bg))] text-foreground shadow-[inset_0_1px_0_hsl(var(--highlight)/0.08),inset_0_-1px_0_hsl(var(--border)/0.32)] transition-[background,box-shadow,filter] duration-[var(--dur-quick)] ease-out focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] focus-within:ring-offset-0 focus-within:ring-offset-[hsl(var(--bg))] hover:shadow-[inset_0_1px_0_hsl(var(--highlight)/0.12),inset_0_-1px_0_hsl(var(--border)/0.45)] active:brightness-[0.96] data-[disabled=true]:pointer-events-none data-[disabled=true]:border-[hsl(var(--card-hairline)/0.4)] data-[disabled=true]:bg-[hsl(var(--card))] data-[disabled=true]:shadow-[inset_0_1px_0_hsl(var(--highlight)/0.04)] data-[disabled=true]:text-muted-foreground/70 data-[loading=true]:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[invalid=true]:border-[hsl(var(--danger)/0.6)] data-[invalid=true]:focus-within:ring-[hsl(var(--danger))] w-full hero2-neomorph !border border-[hsl(var(--border)/0.4)] !shadow-neo-inset hover:!shadow-neo-soft active:!shadow-neo-inset focus-within:!shadow-neo-soft [--hover:transparent] [--active:transparent] rounded-full [&>input]:rounded-full overflow-hidden hero2-frame"
+                      style="--field-h: var(--control-h-md);"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="lucide lucide-search pointer-events-none absolute left-[var(--space-4)] top-1/2 size-[var(--space-4)] -translate-y-1/2 text-muted-foreground transition-colors duration-[var(--dur-quick)] ease-out group-focus-within:text-accent-foreground group-data-[disabled=true]/field:opacity-[var(--disabled)] group-data-[loading=true]/field:opacity-[var(--loading)] group-data-[invalid=true]/field:text-danger"
+                        fill="none"
+                        height="24"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="m21 21-4.34-4.34"
+                        />
+                        <circle
+                          cx="11"
+                          cy="11"
+                          r="8"
+                        />
+                      </svg>
+                      <input
+                        aria-label="Search reviews"
+                        autocapitalize="none"
+                        autocomplete="off"
+                        autocorrect="off"
+                        class="peer block h-[var(--field-h,var(--control-h-md))] w-full rounded-[inherit] border-none bg-transparent px-[var(--space-3)] text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent focus:outline-none focus-visible:outline-none disabled:cursor-not-allowed read-only:cursor-default transition-[color,opacity] group-data-[disabled=true]/field:text-muted-foreground/70 group-data-[disabled=true]/field:placeholder:text-muted-foreground/50 group-data-[loading=true]/field:opacity-[var(--loading)] pl-[var(--space-7)]"
+                        placeholder="Search title, tags, opponent, patch…"
+                        spellcheck="false"
+                        type="search"
+                        value=""
+                      />
+                      <button
+                        aria-label="Clear"
+                        class="inline-flex items-center justify-center select-none rounded-full duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] border bg-card/35 hover:bg-[--hover] [--hover:hsl(var(--panel)/0.45)] [--active:hsl(var(--panel)/0.55)] border-line/35 text-foreground h-[var(--control-h-sm)] w-[var(--control-h-sm)] [&_svg]:size-[var(--space-4)] absolute right-[var(--space-3)] top-1/2 -translate-y-1/2 transition-opacity pointer-events-none opacity-0"
+                        tabindex="0"
+                        title="Clear"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="lucide lucide-x"
+                          fill="none"
+                          height="24"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          viewBox="0 0 24 24"
+                          width="24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M18 6 6 18"
+                          />
+                          <path
+                            d="m6 6 12 12"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+          <div
+            class="group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md border border-border/45 bg-card/75 px-[var(--space-3)] py-[var(--space-2)] neo-inset hero-focus shadow-neo-inset transition-shadow focus-within:shadow-neoSoft focus-within:ring-1 focus-within:ring-ring/60 md:col-span-5 md:justify-self-end"
+            data-slot="actions"
+          >
+            <div
+              class="relative z-[1] flex w-full min-w-0 flex-col"
+            >
+              <div
+                class="flex flex-col gap-[var(--space-2)] sm:flex-row sm:items-center sm:gap-[var(--space-3)]"
+              >
+                <label
+                  class="flex w-full flex-col gap-[var(--space-1)] sm:w-auto sm:flex-row sm:items-center sm:gap-[var(--space-2)]"
+                >
+                  <span
+                    class="text-ui font-medium text-muted-foreground"
+                  >
+                    Sort
+                  </span>
+                  <div
+                    class="glitch-wrap w-full sm:w-auto"
+                  >
+                    <div
+                      class="group inline-flex rounded-[var(--radius-full)] border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[var(--theme-ring)] focus-within:ring-offset-0"
+                    >
+                      <button
+                        aria-controls=":r1:-listbox"
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-label="Sort reviews"
+                        class="_glitchTrigger_843152 relative flex items-center h-[var(--control-h-sm)] rounded-[var(--radius-full)] px-[var(--space-3)] overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none !h-[var(--control-h-lg)] !px-[var(--space-4)]"
+                        data-lit="true"
+                        data-open="false"
+                        type="button"
+                      >
+                        <span
+                          class="font-medium _glitchText_843152 text-foreground group-hover:text-foreground"
+                        >
+                          Newest
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          class="lucide lucide-chevron-down _caret_843152 ml-auto size-[var(--space-4)] shrink-0 opacity-75"
+                          fill="none"
+                          height="24"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          viewBox="0 0 24 24"
+                          width="24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="m6 9 6 6 6-6"
+                          />
+                        </svg>
+                        <span
+                          aria-hidden="true"
+                          class="_gbIris_843152"
+                        />
+                        <span
+                          aria-hidden="true"
+                          class="_gbChroma_843152"
+                        />
+                        <span
+                          aria-hidden="true"
+                          class="_gbFlicker_843152"
+                        />
+                        <span
+                          aria-hidden="true"
+                          class="_gbScan_843152"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                </label>
+                <button
+                  class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[disabled=true]:opacity-[var(--disabled)] data-[disabled=true]:pointer-events-none h-[var(--control-h-lg)] text-title gap-[var(--space-4)] [&_svg]:size-[var(--space-8)] w-full whitespace-nowrap px-[var(--space-4)] sm:w-auto shadow-[var(--btn-primary-shadow-rest)] hover:shadow-[var(--btn-primary-shadow-hover)] active:shadow-[var(--btn-primary-shadow-active)] active:translate-y-px bg-primary-soft border-[hsl(var(--primary)/0.35)] text-[hsl(var(--primary-foreground))] [--hover:theme('colors.interaction.primary.hover')] [--active:theme('colors.interaction.primary.active')]"
+                  style="--glow-active: hsl(var(--primary) / 0.35); --btn-primary-hover-shadow: 0 2px 6px -1px hsl(var(--primary) / 0.25); --btn-primary-active-shadow: inset 0 0 0 1px hsl(var(--primary) / 0.6); --btn-primary-shadow-rest: 0 0 calc(var(--space-4) / 2) var(--glow-active); --btn-primary-shadow-hover: 0 0 var(--space-4) var(--glow-active); --btn-primary-shadow-active: var(--btn-primary-active-shadow);"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="absolute inset-0 pointer-events-none rounded-[inherit] bg-[linear-gradient(90deg,hsl(var(--primary)/.18),hsl(var(--primary)/.18))]"
+                  />
+                  <span
+                    class="relative z-10 inline-flex items-center gap-[var(--space-2)]"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="lucide lucide-plus"
+                      fill="none"
+                      height="24"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M5 12h14"
+                      />
+                      <path
+                        d="M12 5v14"
+                      />
+                    </svg>
+                    <span>
+                      New Review
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </section>
     <div


### PR DESCRIPTION
## Summary
- finalize the new NeomorphicHeroFrame contract with slot rendering, halo focus states, 12-column helpers, and landmark/ARIA wiring
- adapt PageHeader and demo content to consume slots, expose dense variant usage, and document the slots override workflow
- refresh component gallery and snapshots so slot order, HeroGrid/HeroCol helpers, and dense styling are showcased consistently

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc1919c3b0832cb5114e1543240480