### PR TITLE
Add client directive to ComponentsView

### DIFF
--- a/src/components/prompts/ComponentsView.tsx
+++ b/src/components/prompts/ComponentsView.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import Fuse from "fuse.js";
 import { Card, CardContent, NeoCard } from "@/components/ui";


### PR DESCRIPTION
## Summary
- mark the ComponentsView module as a client component so the Prompts tab renders without hydration issues

## Testing
- npm run build
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc1f5e699c832c9d76c79e7d19b66c