### PR TITLE
refactor: centralize security headers module

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,12 +1,10 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import securityHeadersMap from "./security-headers.json" assert { type: "json" };
-
-const securityHeaders = Object.entries(securityHeadersMap);
+import { securityHeaders } from "./security-headers.mjs";
 
 export function middleware(_request: NextRequest) {
   const response = NextResponse.next();
-  for (const [key, value] of securityHeaders) {
+  for (const { key, value } of securityHeaders) {
     response.headers.set(key, value);
   }
   return response;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,10 +1,6 @@
 import path from "path";
 import { fileURLToPath } from "url";
-import { readFileSync } from "node:fs";
-
-const securityHeadersMap = JSON.parse(
-  readFileSync(new URL("./security-headers.json", import.meta.url), "utf8"),
-);
+import { securityHeaders } from "./security-headers.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -27,10 +23,6 @@ const slug = envSlug ?? repositorySlug;
 const normalizedBasePath = slug ? `/${slug}` : undefined;
 const isUserOrOrgGitHubPage = (repositorySlug ?? slug)?.endsWith(".github.io") ?? false;
 const shouldApplyBasePath = Boolean(isGitHubPages && normalizedBasePath && !isUserOrOrgGitHubPage);
-
-const securityHeaders = Object.entries(securityHeadersMap).map(
-  ([key, value]) => ({ key, value }),
-);
 
 const nextConfig = {
   reactStrictMode: true,

--- a/security-headers.d.mts
+++ b/security-headers.d.mts
@@ -1,0 +1,7 @@
+export interface SecurityHeader {
+  readonly key: string;
+  readonly value: string;
+}
+
+export declare const securityHeadersMap: Readonly<Record<string, string>>;
+export declare const securityHeaders: ReadonlyArray<SecurityHeader>;

--- a/security-headers.json
+++ b/security-headers.json
@@ -1,8 +1,0 @@
-{
-  "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; media-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; manifest-src 'self'; worker-src 'self' blob:; frame-src 'none'",
-  "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
-  "Referrer-Policy": "strict-origin-when-cross-origin",
-  "X-Frame-Options": "DENY",
-  "X-Content-Type-Options": "nosniff",
-  "Permissions-Policy": "accelerometer=(), autoplay=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), usb=(), xr-spatial-tracking=()"
-}

--- a/security-headers.mjs
+++ b/security-headers.mjs
@@ -1,0 +1,20 @@
+/**
+ * @typedef {{ readonly key: string; readonly value: string }} SecurityHeader
+ */
+
+/** @type {Readonly<Record<string, string>>} */
+export const securityHeadersMap = Object.freeze({
+  "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; media-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; manifest-src 'self'; worker-src 'self' blob:; frame-src 'none'",
+  "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "X-Frame-Options": "DENY",
+  "X-Content-Type-Options": "nosniff",
+  "Permissions-Policy": "accelerometer=(), autoplay=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), usb=(), xr-spatial-tracking=()",
+});
+
+/** @type {ReadonlyArray<SecurityHeader>} */
+export const securityHeaders = Object.freeze(
+  Object.entries(securityHeadersMap).map(([key, value]) =>
+    Object.freeze({ key, value }),
+  ),
+);


### PR DESCRIPTION
## Summary
- move shared security header definitions into an ES module that both Next config and middleware can consume
- update Next config to import the prebuilt header list instead of relying on JSON import assertions
- wire middleware to the shared header list and add type declarations for the module

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc1f8c87a4832c94d488b593ecdf9b