### PR TITLE
Restrict TaskRow image URLs to https

### DIFF
--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -53,8 +53,8 @@ export default function TaskRow({
 
     try {
       const parsed = new URL(value);
-      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-        return "Image URL must start with http or https.";
+      if (parsed.protocol !== "https:") {
+        return "Image URL must start with https.";
       }
     } catch {
       return "Enter a valid image URL.";

--- a/tests/planner/TaskRow.test.tsx
+++ b/tests/planner/TaskRow.test.tsx
@@ -130,4 +130,37 @@ describe("TaskRow", () => {
     expect(input).toHaveValue("");
     expect(attachButton).toBeDisabled();
   });
+
+  it("rejects non-https image URLs", async () => {
+    const handleAddImage = vi.fn();
+    render(
+      <TaskRow
+        task={{
+          id: "1",
+          title: "Attachable",
+          done: false,
+          createdAt: Date.now(),
+          images: [],
+        }}
+        onToggle={noop}
+        onDelete={noop}
+        onEdit={noop}
+        onSelect={noop}
+        onAddImage={handleAddImage}
+        onRemoveImage={noop}
+      />,
+    );
+
+    const input = screen.getByLabelText("Add image URL");
+    const form = input.closest("form") as HTMLFormElement;
+
+    fireEvent.change(input, {
+      target: { value: "http://example.com/insecure.png" },
+    });
+    fireEvent.submit(form);
+
+    await screen.findByText("Image URL must start with https.");
+    expect(handleAddImage).not.toHaveBeenCalled();
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
 });


### PR DESCRIPTION
## Summary
- require TaskRow image attachments to use https URLs and update the validation copy
- cover http input rejection with a dedicated TaskRow unit test

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc2356af24832c9542b31013f8ade5