### PR TITLE
Point navigation to components route

### DIFF
--- a/src/app/components/page.tsx
+++ b/src/app/components/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
   description: "Browse Planner UI building blocks and examples.",
 };
 
-export default function CompsRoute() {
+export default function ComponentsRoute() {
   return (
     <Suspense
       fallback={

--- a/src/components/chrome/nav-items.ts
+++ b/src/components/chrome/nav-items.ts
@@ -11,6 +11,6 @@ export const NAV_ITEMS = [
   { href: "/planner", label: "Planner" },
   { href: "/goals", label: "Goals" },
   { href: "/team", label: "Team" },
-  { href: "/comps", label: "Components" },
+  { href: "/components", label: "Components" },
   { href: "/prompts", label: "Prompts" },
 ] as const satisfies readonly NavItem[];

--- a/src/components/home/BottomNav.tsx
+++ b/src/components/home/BottomNav.tsx
@@ -18,7 +18,7 @@ const LINKS = [
   { href: "/planner", label: "Planner", icon: CalendarDays },
   { href: "/reviews", label: "Reviews", icon: BookOpen },
   { href: "/team", label: "Team", icon: Users },
-  { href: "/comps", label: "Components", icon: PanelsTopLeft },
+  { href: "/components", label: "Components", icon: PanelsTopLeft },
   { href: "/prompts", label: "Prompts", icon: Sparkles },
 ];
 


### PR DESCRIPTION
## Summary
- update shared chrome and home navigation links to use the /components path
- relocate the components gallery route under /components and align the component export name

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc315d48d0832c9e253dcb16230473