### PR TITLE
Handle missing asChild Button child safely

### DIFF
--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -381,6 +381,17 @@ export const Button = React.forwardRef<
       tabIndex: tabIndex ?? (isDisabled ? -1 : undefined),
       ...slotProps,
     };
+    const childCount = React.Children.count(children);
+
+    if (childCount !== 1 || !React.isValidElement(children)) {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(
+          "[Button] `asChild` requires a single valid React element child.",
+        );
+      }
+
+      return null;
+    }
     const child = React.Children.only(
       children,
     ) as React.ReactElement<{ children?: React.ReactNode }>;

--- a/tests/primitives/button.test.tsx
+++ b/tests/primitives/button.test.tsx
@@ -101,6 +101,27 @@ describe("Button", () => {
     expect(content).not.toMatch(/\bpx-(5|6)\b/);
   });
 
+  it("warns and renders nothing when asChild is missing a valid child", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let renderResult: ReturnType<typeof render> | undefined;
+
+    try {
+      expect(() => {
+        renderResult = render(<Button asChild />);
+      }).not.toThrow();
+
+      expect(renderResult).toBeDefined();
+      const container = renderResult!.container;
+
+      expect(container.firstChild).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[Button] `asChild` requires a single valid React element child.",
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("matches snapshot for secondary danger tone", () => {
     const { container } = render(
       <Button variant="secondary" tone="danger">


### PR DESCRIPTION
## Summary
- guard the Button asChild path against missing or invalid children and warn during development
- add a regression test that renders `<Button asChild>` without a child to ensure it fails gracefully

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc3e02c620832c8e062d806643e043