### PR TITLE
Refine SpecCard surface styling

### DIFF
--- a/src/components/prompts/ComponentsView.tsx
+++ b/src/components/prompts/ComponentsView.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import Fuse from "fuse.js";
-import { Card, CardContent, NeoCard } from "@/components/ui";
+import { Card, CardContent } from "@/components/ui";
 import Badge from "@/components/ui/primitives/Badge";
 import { SPEC_DATA, type Section, type Spec } from "./constants";
 import { cn } from "@/lib/utils";
@@ -46,20 +46,14 @@ function SpecCard({
   const cardTokens = React.useMemo(
     () =>
       ({
-        "--spec-card-shadow-rest":
-          "0 0 0 var(--hairline-w) hsl(var(--card-hairline)) inset, 0 calc(var(--space-6) - var(--space-0-5)) calc(var(--space-8) - var(--space-1)) hsl(var(--shadow-base) / 0.32)",
-        "--spec-card-shadow-hover":
-          "0 calc(var(--space-5) - var(--space-0-5)) var(--space-7) hsl(var(--shadow-color) / 0.28)",
-        "--spec-card-shadow-active":
-          "inset 0 0 0 var(--hairline-w) hsl(var(--card-hairline)), inset 0 var(--space-0-5) 0 hsl(var(--foreground) / 0.06), 0 calc(var(--space-4) - var(--space-0-5)) var(--space-6) hsl(var(--shadow-color) / 0.33)",
-        "--spec-card-shadow-disabled":
-          "inset 0 0 0 var(--space-0-25) hsl(var(--card-hairline) / 0.7)",
-        "--spec-card-raise": reduceMotion
-          ? "calc(var(--space-0-25) * 0)"
-          : "var(--space-0-25)",
-        "--spec-card-press": reduceMotion
-          ? "calc(var(--space-0-25) * 0)"
-          : "var(--space-0-25)",
+        "--spec-card-raise": reduceMotion ? "0px" : "var(--space-0-25)",
+        "--spec-card-press": reduceMotion ? "0px" : "var(--space-0-25)",
+        "--shadow-raised":
+          "0 calc(var(--space-4) - var(--space-0-5)) var(--space-7) hsl(var(--shadow-color) / 0.3)",
+        "--shadow-raised-hover":
+          "0 calc(var(--space-5)) calc(var(--space-8) - var(--space-0-5)) hsl(var(--shadow-color) / 0.36)",
+        "--shadow-inset":
+          "inset 0 0 0 var(--hairline-w) hsl(var(--card-hairline)), inset 0 var(--space-0-25) 0 hsl(var(--foreground) / 0.08), 0 calc(var(--space-3) + var(--space-0-25)) var(--space-6) hsl(var(--shadow-color) / 0.33)",
       }) as React.CSSProperties,
     [reduceMotion],
   );
@@ -87,92 +81,130 @@ function SpecCard({
   }, []);
 
   const cardClassName = cn(
-    "group/spec-card relative flex flex-col gap-[var(--space-4)] px-[var(--space-6)] py-[var(--space-4)]",
-    "shadow-[var(--spec-card-shadow-rest)] hover:shadow-[var(--spec-card-shadow-hover)]",
+    "group/spec-card relative isolate flex flex-col gap-[var(--space-4)] overflow-hidden",
+    "rounded-[var(--radius-card)] border border-[hsl(var(--card-hairline)/0.75)]",
+    "bg-[linear-gradient(140deg,hsl(var(--card)/0.95),hsl(var(--surface-2)/0.78))]",
+    "px-[var(--space-6)] py-[var(--space-5)]",
+    "shadow-[var(--spec-card-shadow,var(--shadow-raised))]",
+    "hover:shadow-[var(--shadow-raised-hover,var(--shadow-raised))] focus-visible:shadow-[var(--shadow-raised-hover,var(--shadow-raised))]",
     "transition-[transform,box-shadow,filter] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none",
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card",
-    "motion-safe:hover:-translate-y-[var(--spec-card-raise)] data-[active=true]:translate-y-[var(--spec-card-press)]",
-    "data-[active=true]:shadow-[var(--spec-card-shadow-active)]",
-    "motion-reduce:hover:translate-y-0 motion-reduce:data-[active=true]:translate-y-0",
-    "aria-[disabled=true]:pointer-events-none aria-[disabled=true]:shadow-[var(--spec-card-shadow-disabled)] aria-[disabled=true]:opacity-60",
-    "before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-[var(--hairline-w)] before:rounded-t-[calc(var(--radius-card)-var(--hairline-w))] before:bg-gradient-to-r before:from-transparent before:via-[hsl(var(--ring)/0.4)] before:to-transparent before:opacity-75 before:transition-opacity before:duration-[var(--dur-quick)] before:ease-out data-[active=true]:before:opacity-100",
+    "hover:-translate-y-[var(--spec-card-raise)] focus-visible:-translate-y-[var(--spec-card-raise)] data-[active=true]:translate-y-[var(--spec-card-press)]",
+    "motion-reduce:hover:translate-y-0 motion-reduce:focus-visible:translate-y-0 motion-reduce:data-[active=true]:translate-y-0",
+    "data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-60 data-[disabled=true]:shadow-[var(--shadow-inset)]",
+    "before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit]",
+    "before:bg-[radial-gradient(125%_85%_at_18%_-25%,hsl(var(--accent)/0.3),transparent_65%),radial-gradient(125%_85%_at_82%_-20%,hsl(var(--ring)/0.28),transparent_60%)]",
+    "before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55",
+    "after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit]",
+    "after:bg-[linear-gradient(120deg,hsl(var(--accent)/0.12)_0%,transparent_58%,hsl(var(--ring)/0.16)_100%),repeating-linear-gradient(0deg,hsl(var(--ring)/0.12)_0,hsl(var(--ring)/0.12)_1px,transparent_1px,transparent_calc(var(--space-3)))]",
+    "after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45",
   );
 
   const frameClassName = cn(
     "relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)]",
-    "shadow-[inset_0_0_0_var(--space-0-25)_hsl(var(--card-hairline)/0.55),inset_0_var(--space-0-25)_0_hsl(var(--foreground)/0.06)]",
+    "shadow-[var(--shadow-inset)]",
     "before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--space-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude]",
     "after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--space-0-5)] after:rounded-[inherit] after:bg-[linear-gradient(90deg,hsl(var(--accent)/0.28),transparent_55%,hsl(var(--accent-2)/0.32))] after:opacity-70 after:mix-blend-screen",
     "group-data-[active=true]/spec-card:before:opacity-55",
   );
 
   return (
-    <NeoCard
-      asChild
+    <article
       data-active={isPressed ? "true" : undefined}
-      aria-disabled={isDisabled ? "true" : undefined}
+      data-disabled={isDisabled ? "true" : undefined}
       onPointerDown={handlePointerDown}
       onPointerUp={handlePointerReset}
       onPointerLeave={handlePointerReset}
       onPointerCancel={handlePointerReset}
-      style={cardTokens}
+      style={{
+        ...cardTokens,
+        "--spec-card-shadow": isPressed
+          ? "var(--shadow-inset)"
+          : "var(--shadow-raised)",
+      } as React.CSSProperties}
       className={cardClassName}
       tabIndex={isDisabled ? -1 : 0}
       aria-labelledby={headingId}
       aria-describedby={descriptionId}
     >
-      <article>
-        <header className="flex items-center justify-between">
-          <h3
-            id={headingId}
-            className="text-title leading-[1.3] font-semibold tracking-[-0.01em]"
+      <header className="flex items-center justify-between">
+        <h3
+          id={headingId}
+          className="text-title leading-[1.3] font-semibold tracking-[-0.01em]"
+        >
+          {name}
+        </h3>
+        {code ? (
+          <button
+            type="button"
+            onClick={handleToggleCode}
+            aria-expanded={showCode}
+            aria-controls={codeId}
+            disabled={isDisabled}
+            data-pressed={showCode ? "true" : undefined}
+            className={cn(
+              "group/button relative inline-flex h-12 items-center justify-center gap-[var(--space-1)]",
+              "rounded-full px-[var(--space-5)] text-ui font-medium tracking-[-0.01em]",
+              "bg-[linear-gradient(140deg,hsl(var(--card)/0.98),hsl(var(--surface-2)/0.82))] text-foreground",
+              "border border-[hsl(var(--ring)/0.45)]",
+              "shadow-[var(--shadow-raised)] hover:shadow-[var(--shadow-raised-hover,var(--shadow-raised))] focus-visible:shadow-[var(--shadow-raised-hover,var(--shadow-raised))]",
+              "transition-[transform,box-shadow,background,filter] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none",
+              "hover:-translate-y-[var(--space-0-25)] focus-visible:-translate-y-[var(--space-0-25)]",
+              "active:translate-y-[var(--space-0-25)] active:shadow-[var(--shadow-inset)]",
+              "data-[pressed=true]:translate-y-[var(--space-0-25)] data-[pressed=true]:shadow-[var(--shadow-inset)]",
+              "motion-reduce:hover:translate-y-0 motion-reduce:focus-visible:translate-y-0 motion-reduce:active:translate-y-0",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card",
+              "before:pointer-events-none before:absolute before:-inset-px before:rounded-full before:border before:border-[hsl(var(--ring)/0.35)] before:opacity-0 before:transition-opacity before:duration-[var(--dur-quick)] before:ease-out",
+              "focus-visible:before:opacity-100",
+              "after:pointer-events-none after:absolute after:inset-0 after:rounded-full after:bg-[radial-gradient(120%_95%_at_50%_0%,hsl(var(--accent)/0.24),transparent_65%)] after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out",
+              "hover:after:opacity-100 focus-visible:after:opacity-100",
+              "disabled:cursor-not-allowed disabled:opacity-60 disabled:shadow-[var(--shadow-inset)] disabled:translate-y-0",
+            )}
+            style={
+              {
+                "--shadow-raised":
+                  "0 var(--space-1) calc(var(--space-3) + var(--space-0-25)) hsl(var(--shadow-color) / 0.26)",
+                "--shadow-raised-hover":
+                  "0 calc(var(--space-2) - var(--space-0-25)) var(--space-4) hsl(var(--shadow-color) / 0.32)",
+                "--shadow-inset":
+                  "inset 0 0 0 var(--hairline-w) hsl(var(--ring) / 0.45), inset 0 var(--space-0-25) 0 hsl(var(--foreground) / 0.08), 0 var(--space-2) var(--space-4) hsl(var(--shadow-color) / 0.28)",
+              } as React.CSSProperties
+            }
           >
-            {name}
-          </h3>
-          {code ? (
-            <button
-              type="button"
-              onClick={handleToggleCode}
-              aria-expanded={showCode}
-              aria-controls={codeId}
-              disabled={isDisabled}
-              className="inline-flex h-12 items-center justify-center rounded-full px-4 text-ui font-medium underline underline-offset-4 transition-colors motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card"
-            >
-              {showCode ? "Hide code" : "Show code"}
-            </button>
-          ) : null}
-        </header>
-        {description ? (
-          <p
-            id={descriptionId}
-            className="text-ui text-muted-foreground line-clamp-2"
-          >
-            {description}
-          </p>
+            {showCode ? "Hide code" : "Show code"}
+          </button>
         ) : null}
-        <div className={frameClassName}>{element}</div>
-        {showCode && code ? (
-          <pre
-            id={codeId}
-            className="rounded-card r-card-md bg-muted p-4 text-label overflow-x-auto"
-          >
-            <code>{code}</code>
-          </pre>
-        ) : null}
-        {props ? (
-          <footer className="mt-auto">
-            <ul className="flex flex-wrap items-center gap-x-[var(--space-3)] gap-y-[var(--space-2)] text-label text-muted-foreground">
-              {props.map((p) => (
-                <li key={p.label} className="flex items-center gap-[var(--space-1)]">
-                  <span className="font-medium text-foreground">{p.label}</span>
-                  <span>{p.value}</span>
-                </li>
-              ))}
-            </ul>
-          </footer>
-        ) : null}
-      </article>
-    </NeoCard>
+      </header>
+      {description ? (
+        <p
+          id={descriptionId}
+          className="text-ui text-muted-foreground line-clamp-2"
+        >
+          {description}
+        </p>
+      ) : null}
+      <div className={frameClassName}>{element}</div>
+      {showCode && code ? (
+        <pre
+          id={codeId}
+          className="rounded-card r-card-md bg-muted/80 p-4 text-label overflow-x-auto shadow-[var(--shadow-inset)]"
+        >
+          <code>{code}</code>
+        </pre>
+      ) : null}
+      {props ? (
+        <footer className="mt-auto">
+          <ul className="flex flex-wrap items-center gap-x-[var(--space-3)] gap-y-[var(--space-2)] text-label text-muted-foreground">
+            {props.map((p) => (
+              <li key={p.label} className="flex items-center gap-[var(--space-1)]">
+                <span className="font-medium text-foreground">{p.label}</span>
+                <span>{p.value}</span>
+              </li>
+            ))}
+          </ul>
+        </footer>
+      ) : null}
+    </article>
   );
 }
 


### PR DESCRIPTION
## Summary
- restyle the SpecCard wrapper to use the new article surface with gradient background, glitch overlays, and dynamic raised/inset shadows
- refresh the code toggle into a lifted pill button with motion-aware hover, focus, and pressed treatments
- update the preview frame and code block to share the inset shadow depth from the new design system

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc3fbcdc64832cac942a39470eb727