### PR TITLE
Use local midnight parsing when pruning planner days

### DIFF
--- a/src/components/planner/plannerStore.ts
+++ b/src/components/planner/plannerStore.ts
@@ -3,7 +3,7 @@
 import "./style.css";
 import * as React from "react";
 import { usePersistentState } from "@/lib/db";
-import { toISODate } from "@/lib/date";
+import { fromISODate, toISODate } from "@/lib/date";
 
 export type ISODate = string;
 
@@ -162,8 +162,8 @@ export function pruneOldDays(
   let mutated = false;
 
   for (const iso of Object.keys(days)) {
-    const isoDate = new Date(`${iso}T00:00:00.000Z`);
-    if (Number.isNaN(isoDate.getTime())) {
+    const isoDate = fromISODate(iso);
+    if (!isoDate) {
       continue;
     }
     if (isoDate.getTime() < cutoffTime) {

--- a/tests/planner/pruneOldDays.test.ts
+++ b/tests/planner/pruneOldDays.test.ts
@@ -67,5 +67,31 @@ describe("pruneOldDays", () => {
     expect(result[expiredIso]).toBeUndefined();
     expect(map[expiredIso]).toBeDefined();
   });
+
+  it("retains the threshold day for negative timezone offsets", () => {
+    const originalTZ = process.env.TZ;
+    process.env.TZ = "America/Los_Angeles";
+
+    try {
+      const maxAgeDays = 30;
+      const reference = new Date("2024-03-05T00:00:00-08:00");
+      const thresholdIso = isoDaysAgo(reference, maxAgeDays);
+
+      const map: Record<string, DayRecord> = {
+        [thresholdIso]: createDay(),
+      };
+
+      const result = pruneOldDays(map, { now: reference, maxAgeDays });
+
+      expect(result).toBe(map);
+      expect(result[thresholdIso]).toBe(map[thresholdIso]);
+    } finally {
+      if (originalTZ === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = originalTZ;
+      }
+    }
+  });
 });
 


### PR DESCRIPTION
## Summary
- update `pruneOldDays` to parse ISO keys with the shared `fromISODate` helper and skip invalid values
- add a regression test covering negative timezone offsets so entries at the retention threshold are preserved

## Testing
- npm test -- --run tests/planner
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc3f3fbd0c832cb68e031ae427df57