### PR TITLE
Refine components gallery hero frame tokens

### DIFF
--- a/src/components/components/ComponentsPage.tsx
+++ b/src/components/components/ComponentsPage.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { PanelsTopLeft } from "lucide-react";
 import { PageHeader, PageShell } from "@/components/ui";
 import Badge from "@/components/ui/primitives/Badge";
+import { cn } from "@/lib/utils";
 import ComponentsViewPanel from "@/components/prompts/ComponentsView";
 import ColorsView from "@/components/prompts/ColorsView";
 import {
@@ -111,6 +112,36 @@ const COLORS_HERO_COPY = {
     "Core palettes, gradients, and section cards for Planner surfaces.",
 };
 
+const NEO_TABLIST_SHARED_CLASSES = [
+  "data-[variant=neo]:gap-[var(--space-2)]",
+  "data-[variant=neo]:px-[var(--space-2)]",
+  "data-[variant=neo]:py-[var(--space-2)]",
+  "data-[variant=neo]:[--neo-tablist-bg:linear-gradient(135deg,hsl(var(--card)/0.9),hsl(var(--panel)/0.74))]",
+  "data-[variant=neo]:[--neo-tab-bg:linear-gradient(135deg,hsl(var(--card)/0.96),hsl(var(--panel)/0.82))]",
+  "data-[variant=neo]:[--shadow-raised:inset_var(--space-1)_var(--space-1)_var(--space-3)_hsl(var(--background)/0.55),inset_-var(--space-1)_-var(--space-1)_var(--space-3)_hsl(var(--highlight)/0.12),0_var(--space-3)_var(--space-6)_hsl(var(--shadow-color)/0.32)]",
+  "data-[variant=neo]:[&_[data-active=true]]:relative",
+  "data-[variant=neo]:[&_[data-active=true]::after]:content-['']",
+  "data-[variant=neo]:[&_[data-active=true]::after]:pointer-events-none",
+  "data-[variant=neo]:[&_[data-active=true]::after]:absolute",
+  "data-[variant=neo]:[&_[data-active=true]::after]:left-[var(--space-3)]",
+  "data-[variant=neo]:[&_[data-active=true]::after]:right-[var(--space-3)]",
+  "data-[variant=neo]:[&_[data-active=true]::after]:-bottom-[var(--space-2)]",
+  "data-[variant=neo]:[&_[data-active=true]::after]:h-px",
+  "data-[variant=neo]:[&_[data-active=true]::after]:rounded-full",
+  "data-[variant=neo]:[&_[data-active=true]::after]:underline-gradient",
+].join(" ");
+
+const HEADER_FRAME_CLASSNAME = [
+  "shadow-[var(--shadow-raised)]",
+  "before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:rounded-[inherit]",
+  "before:bg-[radial-gradient(120%_82%_at_12%_-20%,hsl(var(--accent)/0.3),transparent_65%),radial-gradient(110%_78%_at_88%_-12%,hsl(var(--ring)/0.28),transparent_70%)]",
+  "before:opacity-80 before:mix-blend-screen",
+  "after:pointer-events-none after:absolute after:inset-0 after:-z-20 after:rounded-[inherit]",
+  "after:bg-[linear-gradient(135deg,hsl(var(--card)/0.9),hsl(var(--panel)/0.78)),radial-gradient(120%_140%_at_50%_120%,hsl(var(--accent-2)/0.2),transparent_75%)]",
+  "after:opacity-70 after:mix-blend-soft-light",
+  "motion-reduce:before:opacity-60 motion-reduce:after:opacity-50",
+].join(" ");
+
 export default function ComponentsPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -172,6 +203,11 @@ export default function ComponentsPage() {
   const searchLabel = React.useMemo(
     () => `Search ${sectionCopy.heading}`,
     [sectionCopy.heading],
+  );
+
+  const searchPlaceholder = React.useMemo(
+    () => `Search ${sectionLabel.toLowerCase()} specs…`,
+    [sectionLabel],
   );
 
   React.useEffect(() => {
@@ -252,6 +288,7 @@ export default function ComponentsPage() {
       aria-labelledby="components-header"
     >
       <PageHeader
+        containerClassName="relative isolate"
         header={{
           id: "components-header",
           heading: "Component Gallery",
@@ -264,11 +301,12 @@ export default function ComponentsPage() {
             ariaLabel: "Component gallery view",
             idBase: "components",
             linkPanels: true,
+            variant: "neo",
+            tablistClassName: NEO_TABLIST_SHARED_CLASSES,
           },
         }}
         frameProps={{
-          className:
-            "before:pointer-events-none before:absolute before:inset-0 before:z-0 before:rounded-[inherit] before:bg-[radial-gradient(120%_85%_at_10%_-25%,hsl(var(--accent)/0.22),transparent_60%),radial-gradient(120%_85%_at_90%_-25%,hsl(var(--ring)/0.24),transparent_60%)] before:opacity-80 before:mix-blend-screen after:pointer-events-none after:absolute after:inset-0 after:z-0 after:rounded-[inherit] after:bg-[linear-gradient(135deg,hsl(var(--ring)/0.12)_0%,transparent_65%,hsl(var(--accent)/0.16)_100%)] after:opacity-60 after:mix-blend-soft-light",
+          className: HEADER_FRAME_CLASSNAME,
         }}
         hero={{
           frame: true,
@@ -282,7 +320,7 @@ export default function ComponentsPage() {
             </span>
           ),
           barClassName:
-            "isolate overflow-hidden rounded-[var(--radius-2xl)] before:pointer-events-none before:absolute before:inset-0 before:z-0 before:bg-[radial-gradient(120%_80%_at_15%_-20%,hsl(var(--accent)/0.35),transparent_60%),radial-gradient(110%_70%_at_85%_-10%,hsl(var(--ring)/0.3),transparent_65%)] before:opacity-75 before:mix-blend-screen after:pointer-events-none after:absolute after:inset-0 after:z-0 after:bg-[linear-gradient(120deg,hsl(var(--accent)/0.1)_0%,transparent_55%,hsl(var(--ring)/0.14)_100%),repeating-linear-gradient(0deg,hsl(var(--ring)/0.1)_0,hsl(var(--ring)/0.1)_1px,transparent_1px,transparent_var(--space-3))] after:opacity-70 after:mix-blend-soft-light motion-reduce:after:opacity-50",
+            "isolate overflow-hidden rounded-[var(--radius-2xl)] before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:bg-[radial-gradient(118%_82%_at_15%_-18%,hsl(var(--accent)/0.34),transparent_65%),radial-gradient(112%_78%_at_85%_-12%,hsl(var(--ring)/0.3),transparent_70%)] before:opacity-80 before:mix-blend-screen after:pointer-events-none after:absolute after:inset-0 after:-z-20 after:bg-[linear-gradient(135deg,hsl(var(--card)/0.9),hsl(var(--panel)/0.78)),repeating-linear-gradient(0deg,hsl(var(--ring)/0.12)_0_hsl(var(--ring)/0.12)_1px,transparent_1px,transparent_var(--space-2))] after:opacity-70 after:mix-blend-soft-light motion-reduce:after:opacity-50",
           subTabs:
             view === "components"
               ? {
@@ -295,10 +333,53 @@ export default function ComponentsPage() {
                   size: "sm",
                   variant: "neo",
                   showBaseline: true,
-                  tablistClassName:
-                    "data-[variant=neo]:[--ring:var(--accent)] data-[variant=neo]:px-[calc(var(--space-1)*0.75)] data-[variant=neo]:py-[calc(var(--space-1)*0.75)] data-[variant=neo]:gap-[calc(var(--space-1)*0.75)] data-[variant=neo]:[--neo-tablist-bg:linear-gradient(140deg,hsl(var(--card)/0.9),hsl(var(--surface-2)/0.74))] data-[variant=neo]:[--neo-tab-bg:linear-gradient(145deg,hsl(var(--background)/0.96),hsl(var(--card)/0.82))] motion-reduce:transition-none",
+                  tablistClassName: NEO_TABLIST_SHARED_CLASSES,
                   className:
-                    "max-w-full data-[variant=neo]:[&>div[aria-hidden]]:[background:linear-gradient(90deg,transparent,hsl(var(--accent)/0.55),transparent)] data-[variant=neo]:[&>div[aria-hidden]]:opacity-85",
+                    "max-w-full data-[variant=neo]:[&>div[aria-hidden]]:[background:linear-gradient(90deg,transparent,hsl(var(--accent)/0.45),transparent)] data-[variant=neo]:[&>div[aria-hidden]]:opacity-80",
+                  renderItem: ({ item, active, props, ref, disabled }) => {
+                    const { className: baseClassName, onClick, ...restProps } = props;
+                    const handleClick: React.MouseEventHandler<HTMLElement> = (
+                      event,
+                    ) => {
+                      onClick?.(event);
+                    };
+                    return (
+                      <button
+                        type="button"
+                        {...restProps}
+                        ref={ref as React.Ref<HTMLButtonElement>}
+                        className={cn(
+                          baseClassName,
+                          "relative isolate overflow-hidden px-[var(--space-4)] font-medium transition-[color,box-shadow,transform] duration-200 ease-out",
+                          "before:pointer-events-none before:absolute before:inset-0 before:rounded-full before:bg-[radial-gradient(120%_120%_at_50%_0%,hsl(var(--highlight)/0.22),transparent)] before:opacity-0 before:transition-opacity before:duration-200",
+                          !disabled && "hover:before:opacity-100",
+                          "focus-visible:ring-offset-2 focus-visible:[--tw-ring-offset-color:hsl(var(--card)/0.78)]",
+                          active
+                            ? "shadow-[var(--shadow-inset)]"
+                            : "text-foreground/80 shadow-[inset_var(--space-1)_var(--space-1)_var(--space-3)_hsl(var(--background)/0.55),inset_-var(--space-1)_-var(--space-1)_var(--space-3)_hsl(var(--highlight)/0.12)]",
+                          disabled && "pointer-events-none opacity-[var(--disabled)]",
+                        )}
+                        onClick={(event) => {
+                          if (disabled) {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            return;
+                          }
+                          handleClick(event);
+                        }}
+                        disabled={disabled}
+                      >
+                        <span className="relative z-10 truncate">{item.label}</span>
+                        <span
+                          aria-hidden
+                          className={cn(
+                            "pointer-events-none absolute left-[var(--space-3)] right-[var(--space-3)] -bottom-[var(--space-2)] h-px underline-gradient transition-opacity duration-200 ease-out",
+                            active ? "opacity-100" : "opacity-0",
+                          )}
+                        />
+                      </button>
+                    );
+                  },
                 }
               : undefined,
           search:
@@ -310,19 +391,34 @@ export default function ComponentsPage() {
                   debounceMs: 250,
                   round: true,
                   variant: "neo",
-                  fieldClassName:
+                  label: searchLabel,
+                  placeholder: searchPlaceholder,
+                  fieldClassName: cn(
+                    "bg-[linear-gradient(135deg,hsl(var(--card)/0.95),hsl(var(--panel)/0.82))]",
+                    "!shadow-[inset_var(--space-1)_var(--space-1)_var(--space-3)_hsl(var(--background)/0.52),inset_-var(--space-1)_-var(--space-1)_var(--space-3)_hsl(var(--highlight)/0.1),0_var(--space-3)_var(--space-6)_hsl(var(--shadow-color)/0.28)]",
+                    "hover:!shadow-[inset_var(--space-1)_var(--space-1)_var(--space-3)_hsl(var(--background)/0.46),inset_-var(--space-1)_-var(--space-1)_var(--space-3)_hsl(var(--highlight)/0.14),0_var(--space-3)_var(--space-6)_hsl(var(--shadow-color)/0.32)]",
+                    "active:!shadow-[inset_var(--space-1)_var(--space-1)_var(--space-3)_hsl(var(--background)/0.6),inset_-var(--space-1)_-var(--space-1)_var(--space-3)_hsl(var(--highlight)/0.16)]",
+                    "focus-within:!shadow-[inset_var(--space-1)_var(--space-1)_var(--space-3)_hsl(var(--background)/0.45),inset_-var(--space-1)_-var(--space-1)_var(--space-3)_hsl(var(--highlight)/0.12),0_var(--space-3)_var(--space-6)_hsl(var(--shadow-color)/0.32)]",
+                    "focus-within:[--tw-ring-offset-width:var(--space-1)]",
+                    "focus-within:[--tw-ring-offset-color:hsl(var(--panel)/0.82)]",
                     "motion-reduce:transition-none motion-reduce:hover:!shadow-neo-inset motion-reduce:active:!shadow-neo-inset motion-reduce:focus-within:!shadow-neo-soft",
+                  ),
                   right: (
                     <Badge
                       tone="accent"
                       size="sm"
                       aria-live="polite"
-                      className="shadow-none bg-[hsl(var(--surface-2)/0.68)] text-[hsl(var(--foreground)/0.92)] border-[hsl(var(--accent)/0.55)] motion-reduce:transition-none"
+                      className={cn(
+                        "border-[hsl(var(--accent)/0.5)]",
+                        "bg-[linear-gradient(140deg,hsl(var(--accent)/0.24),hsl(var(--accent-2)/0.18))]",
+                        "text-[hsl(var(--accent-foreground))]",
+                        "shadow-[0_var(--space-2)_var(--space-5)_hsl(var(--shadow-color)/0.28),0_0_0_1px_hsl(var(--accent)/0.32)]",
+                        "motion-reduce:transition-none",
+                      )}
                     >
                       {resultsLabel}
                     </Badge>
                   ),
-                  "aria-label": searchLabel,
                 }
               : undefined,
         }}


### PR DESCRIPTION
## Summary
- extract a shared HEADER_FRAME_CLASSNAME so the components gallery header uses the raised shadow token and updated radial overlays
- surface a visible label for the gallery search field while keeping the existing neo styling helpers

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc3a249764832c862da95775c1ece6