### PR TITLE
Mark hero slots as grouped regions

### DIFF
--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -1010,20 +1010,26 @@ export default function ComponentGallery() {
               align="end"
               label="Hero frame demo"
               slots={{
-                search: (
-                  <SearchBar
-                    value={query}
-                    onValueChange={setQuery}
-                    placeholder="Search layout patterns…"
-                    aria-label="Search layout patterns"
-                    className="w-full"
-                  />
-                ),
-                actions: (
-                  <Button size="sm" variant="secondary" className="whitespace-nowrap">
-                    Assign scout
-                  </Button>
-                ),
+                search: {
+                  node: (
+                    <SearchBar
+                      value={query}
+                      onValueChange={setQuery}
+                      placeholder="Search layout patterns…"
+                      aria-label="Search layout patterns"
+                      className="w-full"
+                    />
+                  ),
+                  label: "Search layout patterns",
+                },
+                actions: {
+                  node: (
+                    <Button size="sm" variant="secondary" className="whitespace-nowrap">
+                      Assign scout
+                    </Button>
+                  ),
+                  label: "Layout quick actions",
+                },
               }}
             >
               <Hero

--- a/src/components/prompts/NeomorphicHeroFrameDemo.tsx
+++ b/src/components/prompts/NeomorphicHeroFrameDemo.tsx
@@ -39,48 +39,57 @@ export default function NeomorphicHeroFrameDemo() {
         as="header"
         label="Mission controls"
         slots={{
-          tabs: (
-            <TabBar
-              items={missionTabs}
-              value={activeView}
-              onValueChange={(key) => setActiveView(key as MissionView)}
-              ariaLabel="Switch mission focus"
-              right={
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="px-2 text-label font-semibold uppercase tracking-[0.08em]"
-                >
-                  View all
+          tabs: {
+            node: (
+              <TabBar
+                items={missionTabs}
+                value={activeView}
+                onValueChange={(key) => setActiveView(key as MissionView)}
+                ariaLabel="Switch mission focus"
+                right={
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="px-2 text-label font-semibold uppercase tracking-[0.08em]"
+                  >
+                    View all
+                  </Button>
+                }
+                showBaseline
+                variant="neo"
+              />
+            ),
+            label: "Switch mission focus",
+          },
+          search: {
+            node: (
+              <SearchBar
+                value={query}
+                onValueChange={setQuery}
+                placeholder="Search mission intel…"
+                aria-label="Search mission intel"
+                loading={activeView === "archive"}
+              />
+            ),
+            label: "Search mission intel",
+          },
+          actions: {
+            node: (
+              <div className="flex items-center gap-2">
+                <ThemeToggle ariaLabel="Toggle theme" className="shrink-0" />
+                <Button size="sm" variant="secondary">
+                  Draft
                 </Button>
-              }
-              showBaseline
-              variant="neo"
-            />
-          ),
-          search: (
-            <SearchBar
-              value={query}
-              onValueChange={setQuery}
-              placeholder="Search mission intel…"
-              aria-label="Search mission intel"
-              loading={activeView === "archive"}
-            />
-          ),
-          actions: (
-            <div className="flex items-center gap-2">
-              <ThemeToggle ariaLabel="Toggle theme" className="shrink-0" />
-              <Button size="sm" variant="secondary">
-                Draft
-              </Button>
-              <Button size="sm" variant="primary" loading>
-                Deploy
-              </Button>
-              <Button size="sm" variant="ghost" disabled>
-                Disabled
-              </Button>
-            </div>
-          ),
+                <Button size="sm" variant="primary" loading>
+                  Deploy
+                </Button>
+                <Button size="sm" variant="ghost" disabled>
+                  Disabled
+                </Button>
+              </div>
+            ),
+            label: "Mission quick actions",
+          },
         }}
       >
         <HeroGrid variant="default">
@@ -123,35 +132,44 @@ export default function NeomorphicHeroFrameDemo() {
         align="between"
         label="Mission filters"
         slots={{
-          tabs: (
-            <TabBar
-              items={statusTabs}
-              value={status}
-              onValueChange={(key) => setStatus(key as MissionStatus)}
-              ariaLabel="Filter mission status"
-              size="sm"
-              variant="neo"
-            />
-          ),
-          search: (
-            <SearchBar
-              value={compactQuery}
-              onValueChange={setCompactQuery}
-              placeholder="Quick search…"
-              aria-label="Search mission status"
-              loading={status === "queued"}
-            />
-          ),
-          actions: (
-            <div className="flex items-center gap-2">
-              <Button size="sm" variant="secondary">
-                Pin view
-              </Button>
-              <Button size="sm" variant="ghost">
-                More
-              </Button>
-            </div>
-          ),
+          tabs: {
+            node: (
+              <TabBar
+                items={statusTabs}
+                value={status}
+                onValueChange={(key) => setStatus(key as MissionStatus)}
+                ariaLabel="Filter mission status"
+                size="sm"
+                variant="neo"
+              />
+            ),
+            label: "Filter mission status",
+          },
+          search: {
+            node: (
+              <SearchBar
+                value={compactQuery}
+                onValueChange={setCompactQuery}
+                placeholder="Quick search…"
+                aria-label="Search mission status"
+                loading={status === "queued"}
+              />
+            ),
+            label: "Search mission status",
+          },
+          actions: {
+            node: (
+              <div className="flex items-center gap-2">
+                <Button size="sm" variant="secondary">
+                  Pin view
+                </Button>
+                <Button size="sm" variant="ghost">
+                  More
+                </Button>
+              </div>
+            ),
+            label: "Mission frame actions",
+          },
         }}
       >
         <HeroGrid variant="compact">

--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -221,21 +221,27 @@ export default function PageHeaderDemo() {
         align="end"
         label="Frame-ready hero"
         slots={{
-          search: (
-            <SearchBar
-              id="hero-flush-search"
-              value={query}
-              onValueChange={setQuery}
-              debounceMs={150}
-              placeholder="Search frame highlights…"
-              aria-label="Search frame highlights"
-            />
-          ),
-          actions: (
-            <Button size="sm" variant="secondary" className="whitespace-nowrap">
-              Assign scout
-            </Button>
-          ),
+          search: {
+            node: (
+              <SearchBar
+                id="hero-flush-search"
+                value={query}
+                onValueChange={setQuery}
+                debounceMs={150}
+                placeholder="Search frame highlights…"
+                aria-label="Search frame highlights"
+              />
+            ),
+            label: "Search frame highlights",
+          },
+          actions: {
+            node: (
+              <Button size="sm" variant="secondary" className="whitespace-nowrap">
+                Assign scout
+              </Button>
+            ),
+            label: "Frame quick actions",
+          },
         }}
       >
         <div className="space-y-[var(--space-4)]">

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -1159,39 +1159,48 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       code: `<NeomorphicHeroFrame
   as="header"
   slots={{
-    tabs: (
-      <TabBar
-        items={[
-          { key: "missions", label: "Missions" },
-          { key: "briefings", label: "Briefings" },
-          { key: "archive", label: "Archive", disabled: true },
-        ]}
-        value="missions"
-        onValueChange={() => {}}
-        ariaLabel="Switch mission focus"
-        showBaseline
-      />
-    ),
-    search: (
-      <SearchBar
-        value=""
-        onValueChange={() => {}}
-        placeholder="Search mission intel…"
-        aria-label="Search mission intel"
-        loading
-      />
-    ),
-    actions: (
-      <div className="flex items-center gap-2">
-        <ThemeToggle ariaLabel="Toggle theme" className="shrink-0" />
-        <Button size="sm" variant="primary" loading>
-          Deploy
-        </Button>
-        <Button size="sm" variant="ghost" disabled>
-          Disabled
-        </Button>
-      </div>
-    ),
+    tabs: {
+      node: (
+        <TabBar
+          items={[
+            { key: "missions", label: "Missions" },
+            { key: "briefings", label: "Briefings" },
+            { key: "archive", label: "Archive", disabled: true },
+          ]}
+          value="missions"
+          onValueChange={() => {}}
+          ariaLabel="Switch mission focus"
+          showBaseline
+        />
+      ),
+      label: "Switch mission focus",
+    },
+    search: {
+      node: (
+        <SearchBar
+          value=""
+          onValueChange={() => {}}
+          placeholder="Search mission intel…"
+          aria-label="Search mission intel"
+          loading
+        />
+      ),
+      label: "Search mission intel",
+    },
+    actions: {
+      node: (
+        <div className="flex items-center gap-2">
+          <ThemeToggle ariaLabel="Toggle theme" className="shrink-0" />
+          <Button size="sm" variant="primary" loading>
+            Deploy
+          </Button>
+          <Button size="sm" variant="ghost" disabled>
+            Disabled
+          </Button>
+        </div>
+      ),
+      label: "Mission quick actions",
+    },
   }}
 >
   <HeroGrid>

--- a/src/components/ui/layout/NeomorphicHeroFrame.tsx
+++ b/src/components/ui/layout/NeomorphicHeroFrame.tsx
@@ -21,6 +21,8 @@ type HeroSlotKey = (typeof heroSlotOrder)[number];
 export interface HeroSlot {
   node: React.ReactNode;
   className?: string;
+  label?: string;
+  labelledById?: string;
 }
 
 export type HeroSlotInput = React.ReactNode | HeroSlot;
@@ -406,6 +408,15 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
         {heroSlotOrder.map((key) => {
           const slot = normalizedSlots[key];
           if (!slot) return null;
+          const slotLabel =
+            typeof slot.label === "string" && slot.label.trim().length > 0
+              ? slot.label.trim()
+              : undefined;
+          const slotLabelledById =
+            typeof slot.labelledById === "string" &&
+            slot.labelledById.trim().length > 0
+              ? slot.labelledById.trim()
+              : undefined;
           return (
             <div
               key={key}
@@ -416,6 +427,9 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
                 aligns[key],
                 slot.className,
               )}
+              role="group"
+              aria-label={slotLabel}
+              aria-labelledby={slotLabelledById}
             >
               <div className={slotContentClass}>{slot.node}</div>
             </div>

--- a/src/stories/planner/NeomorphicHeroFrame.stories.tsx
+++ b/src/stories/planner/NeomorphicHeroFrame.stories.tsx
@@ -89,39 +89,48 @@ function HeroPreview({
       align={align}
       label={frameLabel}
       slots={{
-        tabs: (
-          <TabBar<PlannerView>
-            items={plannerTabs}
-            value={activeView}
-            onValueChange={(key) => setActiveView(key as PlannerView)}
-            ariaLabel="Switch planner view"
-            variant="neo"
-            showBaseline
-          />
-        ),
-        search: (
-          <SearchBar
-            value={searchValue}
-            onValueChange={setSearchValue}
-            placeholder="Search workstreams…"
-            aria-label="Search workstreams"
-            loading={activeView === "resources"}
-          />
-        ),
-        actions: (
-          <div className="flex flex-wrap items-center gap-[var(--space-2)]">
-            <ThemeToggle ariaLabel="Toggle theme" className="shrink-0" />
-            <Button size="sm" variant="secondary">
-              Save view
-            </Button>
-            <Button size="sm" variant="primary" loading>
-              Sync
-            </Button>
-            <Button size="sm" variant="ghost" disabled>
-              Disabled
-            </Button>
-          </div>
-        ),
+        tabs: {
+          node: (
+            <TabBar<PlannerView>
+              items={plannerTabs}
+              value={activeView}
+              onValueChange={(key) => setActiveView(key as PlannerView)}
+              ariaLabel="Switch planner view"
+              variant="neo"
+              showBaseline
+            />
+          ),
+          label: "Switch planner view",
+        },
+        search: {
+          node: (
+            <SearchBar
+              value={searchValue}
+              onValueChange={setSearchValue}
+              placeholder="Search workstreams…"
+              aria-label="Search workstreams"
+              loading={activeView === "resources"}
+            />
+          ),
+          label: "Search workstreams",
+        },
+        actions: {
+          node: (
+            <div className="flex flex-wrap items-center gap-[var(--space-2)]">
+              <ThemeToggle ariaLabel="Toggle theme" className="shrink-0" />
+              <Button size="sm" variant="secondary">
+                Save view
+              </Button>
+              <Button size="sm" variant="primary" loading>
+                Sync
+              </Button>
+              <Button size="sm" variant="ghost" disabled>
+                Disabled
+              </Button>
+            </div>
+          ),
+          label: "Planner frame actions",
+        },
       }}
     >
       <div className="grid gap-[var(--space-4)] md:grid-cols-2 md:gap-[var(--space-6)]">

--- a/tests/components/PageHeader.test.tsx
+++ b/tests/components/PageHeader.test.tsx
@@ -180,4 +180,53 @@ describe("PageHeader", () => {
       }),
     ).toBeNull();
   });
+
+  it("labels hero frame slots using sanitized tab and search metadata", () => {
+    const tabLabelId = "hero-tabs-label";
+    render(
+      <PageHeader
+        header={baseHeader}
+        hero={{
+          ...baseHero,
+          sticky: false,
+          children: (
+            <span id={tabLabelId} className="sr-only">
+              Filter planner highlights
+            </span>
+          ),
+        }}
+        subTabs={{
+          items: [
+            { key: "overview", label: "Overview" },
+            { key: "insights", label: "Insights" },
+          ],
+          value: "overview",
+          onChange: vi.fn(),
+          ariaLabel: "  Filter planner highlights  ",
+          ariaLabelledBy: ` ${tabLabelId} `,
+        }}
+        search={{
+          value: "",
+          onValueChange: () => {},
+          "aria-label": "  Search planner highlights  ",
+        }}
+      />,
+    );
+
+    const tabsSlot = screen.getByRole("group", {
+      name: "Filter planner highlights",
+    });
+    const searchSlot = screen.getByRole("group", {
+      name: "Search planner highlights",
+    });
+
+    expect(tabsSlot).not.toBeNull();
+    expect(tabsSlot).toHaveAttribute("data-slot", "tabs");
+    expect(tabsSlot).toHaveAttribute("aria-labelledby", tabLabelId);
+    expect(tabsSlot).toHaveAttribute("aria-label", "Filter planner highlights");
+
+    expect(searchSlot).not.toBeNull();
+    expect(searchSlot).toHaveAttribute("data-slot", "search");
+    expect(searchSlot).toHaveAttribute("aria-label", "Search planner highlights");
+  });
 });

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -176,8 +176,10 @@ exports[`ReviewsPage > renders default state 1`] = `
           role="group"
         >
           <div
+            aria-label="Search reviews"
             class="group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md border border-border/45 bg-card/75 px-[var(--space-3)] py-[var(--space-2)] neo-inset hero-focus shadow-neo-inset transition-shadow focus-within:shadow-neoSoft focus-within:ring-1 focus-within:ring-ring/60 md:col-span-7 md:justify-self-stretch"
             data-slot="search"
+            role="group"
           >
             <div
               class="relative z-[1] flex w-full min-w-0 flex-col"
@@ -266,6 +268,7 @@ exports[`ReviewsPage > renders default state 1`] = `
           <div
             class="group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md border border-border/45 bg-card/75 px-[var(--space-3)] py-[var(--space-2)] neo-inset hero-focus shadow-neo-inset transition-shadow focus-within:shadow-neoSoft focus-within:ring-1 focus-within:ring-ring/60 md:col-span-5 md:justify-self-end"
             data-slot="actions"
+            role="group"
           >
             <div
               class="relative z-[1] flex w-full min-w-0 flex-col"

--- a/tests/ui/NeomorphicHeroFrame.test.tsx
+++ b/tests/ui/NeomorphicHeroFrame.test.tsx
@@ -75,4 +75,40 @@ describe("NeomorphicHeroFrame", () => {
     expect(outsideButton).toHaveFocus();
     expect(frame).not.toHaveAttribute("data-has-focus");
   });
+
+  it("applies accessible metadata to slot wrappers when provided", () => {
+    render(
+      <NeomorphicHeroFrame
+        slots={{
+          tabs: {
+            node: <div>Tabs area</div>,
+            label: "  Primary tabs  ",
+          },
+          actions: {
+            node: (
+              <div>
+                <span id="actions-heading">Actions</span>
+              </div>
+            ),
+            labelledById: " actions-heading ",
+          },
+        }}
+      >
+        <span>Content</span>
+      </NeomorphicHeroFrame>,
+    );
+
+    const tabsSlot = screen.getByRole("group", { name: "Primary tabs" });
+    const actionsSlot = screen.getByRole("group", { name: "Actions" });
+
+    expect(tabsSlot).not.toBeNull();
+    expect(tabsSlot).toHaveAttribute("data-slot", "tabs");
+    expect(tabsSlot).toHaveAttribute("aria-label", "Primary tabs");
+    expect(tabsSlot).not.toHaveAttribute("aria-labelledby");
+
+    expect(actionsSlot).not.toBeNull();
+    expect(actionsSlot).toHaveAttribute("data-slot", "actions");
+    expect(actionsSlot).toHaveAttribute("aria-labelledby", "actions-heading");
+    expect(actionsSlot).not.toHaveAttribute("aria-label");
+  });
 });


### PR DESCRIPTION
## Summary
- treat each hero slot wrapper as an ARIA group so slot labels become discoverable to assistive tech
- update PageHeader and NeomorphicHeroFrame tests to query the labelled groups directly
- refresh the reviews page snapshot to capture the new grouped slot markup

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc414c59c8832c9a720917d7b4e51a