### PR TITLE
Gate deep serialization checks to development

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -160,7 +160,10 @@ function describeNonSerializable(
 }
 
 export function scheduleWrite(key: string, value: unknown) {
-  const issue = describeNonSerializable(value);
+  let issue: string | null = null;
+  if (process.env.NODE_ENV !== "production") {
+    issue = describeNonSerializable(value);
+  }
   if (issue) {
     if (process.env.NODE_ENV !== "production") {
       console.warn(

--- a/tests/lib/db.test.ts
+++ b/tests/lib/db.test.ts
@@ -210,6 +210,32 @@ describe("scheduleWrite", () => {
     vi.doUnmock("@/lib/utils");
     warnSpy.mockRestore();
   });
+
+  it("warns about circular references during development", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const { scheduleWrite, flushWriteLocal } = await import("@/lib/db");
+
+      const key = "noxis-planner:circular";
+      const value: Record<string, unknown> = {};
+      value.self = value;
+
+      scheduleWrite(key, value);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        `Skipping persistence for "${key}" because value.self contains a circular reference.`,
+        value,
+      );
+
+      flushWriteLocal();
+      expect(storageMock.setItem).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllEnvs();
+      warnSpy.mockRestore();
+    }
+  });
 });
 
 describe("useStorageSync", () => {


### PR DESCRIPTION
## Summary
- Skip the expensive describeNonSerializable walk when NODE_ENV is production so plain planner state writes stay cheap.
- Add a regression test that ensures development builds still warn about circular persistence loops.

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc463cebb8832c8488a35fb0862b60