### PR TITLE
Optimize scheduleWrite cloning

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -13,7 +13,6 @@ import {
   writeLocal as baseWriteLocal,
 } from "./local-bootstrap";
 import { createStorageKey, OLD_STORAGE_PREFIX } from "./storage-key";
-import { safeClone } from "./utils";
 
 export { createStorageKey } from "./storage-key";
 
@@ -26,8 +25,12 @@ declare global {
   }
 }
 
+type QueuedWrite =
+  | { type: "raw"; value: unknown }
+  | { type: "json"; serialized: string };
+
 // Debounced write queue
-const writeQueue = new Map<string, unknown>();
+const writeQueue = new Map<string, QueuedWrite>();
 let writeTimer: ReturnType<typeof setTimeout> | null = null;
 
 export let writeLocalDelay = 50;
@@ -40,9 +43,14 @@ function flushWriteQueue() {
     clearTimeout(writeTimer);
     writeTimer = null;
   }
-  for (const [k, v] of writeQueue) {
+  for (const [k, entry] of writeQueue) {
     try {
-      baseWriteLocal(k, v);
+      if (entry.type === "json") {
+        if (typeof window === "undefined") continue;
+        window.localStorage.setItem(k, entry.serialized);
+      } else {
+        baseWriteLocal(k, entry.value);
+      }
     } catch {
       // ignore
     }
@@ -170,21 +178,46 @@ export function scheduleWrite(key: string, value: unknown) {
     }
     return;
   }
-  let persistedValue: unknown = value;
+  let entry: QueuedWrite;
   if (value !== null && typeof value === "object") {
-    const clonedValue = safeClone(value);
-    if (typeof clonedValue === "undefined") {
-      if (process.env.NODE_ENV !== "production") {
-        console.warn(
-          `Skipping persistence for "${key}" because value could not be cloned.`,
-          value,
-        );
+    let serialized: string | null = null;
+    try {
+      const maybeSerialized = JSON.stringify(value);
+      if (typeof maybeSerialized === "string") {
+        serialized = maybeSerialized;
       }
-      return;
+    } catch {
+      serialized = null;
     }
-    persistedValue = clonedValue;
+
+    if (serialized !== null) {
+      entry = { type: "json", serialized };
+    } else {
+      const clonedValue =
+        typeof structuredClone === "function"
+          ? (() => {
+              try {
+                return structuredClone(value);
+              } catch {
+                return undefined;
+              }
+            })()
+          : undefined;
+      if (typeof clonedValue === "undefined") {
+        if (process.env.NODE_ENV !== "production") {
+          console.warn(
+            `Skipping persistence for "${key}" because value could not be cloned.`,
+            value,
+          );
+        }
+        return;
+      }
+      entry = { type: "raw", value: clonedValue };
+    }
+  } else {
+    entry = { type: "raw", value };
   }
-  writeQueue.set(key, persistedValue);
+  writeQueue.set(key, entry);
   if (writeTimer) clearTimeout(writeTimer);
   writeTimer = setTimeout(flushWriteQueue, writeLocalDelay);
 }

--- a/tests/lib/db.test.ts
+++ b/tests/lib/db.test.ts
@@ -178,18 +178,18 @@ describe("scheduleWrite", () => {
   });
 
   it("skips persistence when cloning fails", async () => {
-    const safeCloneMock = vi.fn(() => undefined);
-    vi.doMock("@/lib/utils", async () => {
-      const actual = await vi.importActual<typeof import("@/lib/utils")>(
-        "@/lib/utils",
-      );
-      return {
-        ...actual,
-        safeClone: safeCloneMock as typeof actual.safeClone,
-      };
-    });
-
+    const stringifySpy = vi
+      .spyOn(JSON, "stringify")
+      .mockImplementation(() => {
+        throw new Error("nope");
+      });
+    const structuredCloneSpy = vi
+      .spyOn(globalThis, "structuredClone")
+      .mockImplementation(() => {
+        throw new Error("still nope");
+      });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
     const { scheduleWrite, flushWriteLocal } = await import("@/lib/db");
 
     const key = "noxis-planner:clone-fail";
@@ -197,8 +197,8 @@ describe("scheduleWrite", () => {
 
     scheduleWrite(key, value);
 
-    expect(safeCloneMock).toHaveBeenCalledTimes(1);
-    expect(safeCloneMock).toHaveBeenCalledWith(value);
+    expect(stringifySpy).toHaveBeenCalledTimes(1);
+    expect(structuredCloneSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(
       `Skipping persistence for "${key}" because value could not be cloned.`,
       value,
@@ -207,8 +207,43 @@ describe("scheduleWrite", () => {
     flushWriteLocal();
     expect(storageMock.setItem).not.toHaveBeenCalled();
 
-    vi.doUnmock("@/lib/utils");
+    stringifySpy.mockRestore();
+    structuredCloneSpy.mockRestore();
     warnSpy.mockRestore();
+  });
+});
+
+describe("writeLocal", () => {
+  it("serializes objects once and ignores subsequent mutations", async () => {
+    vi.useFakeTimers();
+
+    const key = "mutations";
+    const value = { count: 1, nested: { done: false } };
+    const expectedSerialized = JSON.stringify(value);
+    const stringifySpy = vi.spyOn(JSON, "stringify");
+
+    const { writeLocal, flushWriteLocal, createStorageKey } = await import(
+      "@/lib/db"
+    );
+
+    writeLocal(key, value);
+    value.count = 9;
+    value.nested.done = true;
+
+    expect(storageMock.setItem).not.toHaveBeenCalled();
+
+    vi.runAllTimers();
+    flushWriteLocal();
+
+    const fullKey = createStorageKey(key);
+    expect(storageMock.setItem).toHaveBeenCalledWith(
+      fullKey,
+      expectedSerialized,
+    );
+    expect(storageMock.store.get(fullKey)).toBe(expectedSerialized);
+    expect(stringifySpy).toHaveBeenCalledTimes(1);
+
+    stringifySpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary
- cache debounced JSON writes as serialized snapshots and fall back to structuredClone only when JSON serialization fails
- extend db tests to stub serialization failures and assert queued writes ignore later mutations without double encoding

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc45728fc8832cacc199b29b6e3b57