### PR TITLE
Fix Hardstuck accent text color

### DIFF
--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -264,7 +264,7 @@ html.theme-hardstuck {
   --accent: 120 100% 60%;
   --accent-2: 120 100% 20%;
   --accent-foreground: 0 0% 0%;
-  --text-on-accent: hsl(var(--background));
+  --text-on-accent: hsl(var(--hardstuck-foreground));
   --accent-soft: 120 100% 12%;
   --glow: 120 100% 60%;
   --ring-muted: 120 30% 20%;


### PR DESCRIPTION
## Summary
- update the Hardstuck theme token so accent surfaces reference the shared hardstuck foreground tone for text contrast

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc4c874b90832ca2e0a5fa215e4140