### PR TITLE
Derive PageHeader frame alignment from rendered slots

### DIFF
--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -21,6 +21,7 @@ import SearchBar, {
   type SearchBarProps,
 } from "@/components/ui/primitives/SearchBar";
 import { NeomorphicFrameStyles } from "./NeomorphicFrameStyles";
+import type { Align } from "./NeomorphicHeroFrame";
 
 function cx(...p: Array<string | false | null | undefined>) {
   return p.filter(Boolean).join(" ");
@@ -84,7 +85,7 @@ export interface HeroProps<Key extends string = string>
   };
 
   /** Built-in bottom search (preferred). `round` makes it pill. */
-  search?: (SearchBarProps & { round?: boolean }) | null;
+  search?: (SearchBarProps & { round?: boolean; align?: Align }) | null;
 }
 
 function Hero<Key extends string = string>({
@@ -259,22 +260,31 @@ function Hero<Key extends string = string>({
         value={tabs.value}
         onValueChange={tabs.onChange}
         size={tabs.size ?? "md"}
-      align={tabs.align ?? "end"}
-      showBaseline={tabs.showBaseline ?? true}
-      variant={tabs.variant ?? heroVariant}
-      className={cx("justify-end", tabs.className)}
-      ariaLabel="Hero tabs"
-      linkPanels={tabs.linkPanels}
-    />
-  ) : null;
+        align={tabs.align ?? "end"}
+        showBaseline={tabs.showBaseline ?? true}
+        variant={tabs.variant ?? heroVariant}
+        className={cx("justify-end", tabs.className)}
+        ariaLabel="Hero tabs"
+        linkPanels={tabs.linkPanels}
+      />
+    ) : null;
 
   const searchProps =
     search != null
-      ? {
-          ...search,
-          round: search.round ?? true,
-          variant: search.variant ?? heroVariant,
-        }
+      ? (() => {
+          const {
+            align: _searchAlign,
+            round,
+            variant,
+            ...restSearch
+          } = search;
+          void _searchAlign;
+          return {
+            ...restSearch,
+            round: round ?? true,
+            variant: variant ?? heroVariant,
+          };
+        })()
       : search;
 
   return (

--- a/tests/components/PageHeader.test.tsx
+++ b/tests/components/PageHeader.test.tsx
@@ -180,4 +180,82 @@ describe("PageHeader", () => {
       }),
     ).toBeNull();
   });
+
+  it("centers the frame when only the search slot renders", () => {
+    const { container } = render(
+      <PageHeader
+        header={baseHeader}
+        hero={{
+          ...baseHero,
+          search: {
+            value: "",
+            onValueChange: vi.fn(),
+            "aria-label": "Search",
+          },
+        }}
+      />,
+    );
+
+    const slotGroup = container.querySelector('[data-align]');
+    expect(slotGroup).not.toBeNull();
+    expect(slotGroup).toHaveAttribute("data-align", "center");
+    const slots = container.querySelectorAll('[data-slot]');
+    expect(slots).toHaveLength(1);
+    expect(slots[0]).toHaveAttribute("data-slot", "search");
+  });
+
+  it("biases toward center when search and actions slots render", () => {
+    const { container } = render(
+      <PageHeader
+        header={baseHeader}
+        hero={{
+          ...baseHero,
+          search: {
+            value: "",
+            onValueChange: vi.fn(),
+            "aria-label": "Search",
+          },
+          actions: <button type="button">Sync</button>,
+        }}
+      />,
+    );
+
+    const slotGroup = container.querySelector('[data-align]');
+    expect(slotGroup).not.toBeNull();
+    expect(slotGroup).toHaveAttribute("data-align", "center");
+    const slotKeys = Array.from(
+      container.querySelectorAll('[data-slot]'),
+      (node) => node.getAttribute("data-slot"),
+    );
+    expect(slotKeys).toContain("search");
+    expect(slotKeys).toContain("actions");
+  });
+
+  it("leans toward the end when only tabs and actions render", () => {
+    const { container } = render(
+      <PageHeader
+        header={baseHeader}
+        hero={{
+          ...baseHero,
+          subTabs: {
+            items: [
+              { key: "overview", label: "Overview" },
+              { key: "insights", label: "Insights" },
+            ],
+            value: "overview",
+            onChange: vi.fn(),
+            ariaLabel: "Hero tabs",
+          },
+          actions: <button type="button">Sync</button>,
+        }}
+      />,
+    );
+
+    const slotGroup = container.querySelector('[data-align]');
+    expect(slotGroup).not.toBeNull();
+    expect(slotGroup).toHaveAttribute("data-align", "end");
+    const slots = container.querySelectorAll('[data-slot]');
+    expect(slots).toHaveLength(2);
+    expect(slots[0]).toHaveAttribute("data-slot", "tabs");
+  });
 });

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -172,11 +172,11 @@ exports[`ReviewsPage > renders default state 1`] = `
         </div>
         <div
           class="group/hero-slots relative z-[1] isolate w-full grid grid-cols-1 mt-[var(--space-6)] md:mt-[var(--space-7)] pt-[var(--space-5)] md:pt-[var(--space-6)] gap-[var(--space-3)] md:gap-[var(--space-4)] md:grid-cols-12 before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-[hsl(var(--accent))] before:opacity-60 before:content-[''] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-px after:bg-[hsl(var(--accent))] after:opacity-40 after:blur-sm after:content-['']"
-          data-align="between"
+          data-align="center"
           role="group"
         >
           <div
-            class="group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md border border-border/45 bg-card/75 px-[var(--space-3)] py-[var(--space-2)] neo-inset hero-focus shadow-neo-inset transition-shadow focus-within:shadow-neoSoft focus-within:ring-1 focus-within:ring-ring/60 md:col-span-7 md:justify-self-stretch"
+            class="group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md border border-border/45 bg-card/75 px-[var(--space-3)] py-[var(--space-2)] neo-inset hero-focus shadow-neo-inset transition-shadow focus-within:shadow-neoSoft focus-within:ring-1 focus-within:ring-ring/60 md:col-span-7 md:justify-self-center"
             data-slot="search"
           >
             <div
@@ -264,7 +264,7 @@ exports[`ReviewsPage > renders default state 1`] = `
             </div>
           </div>
           <div
-            class="group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md border border-border/45 bg-card/75 px-[var(--space-3)] py-[var(--space-2)] neo-inset hero-focus shadow-neo-inset transition-shadow focus-within:shadow-neoSoft focus-within:ring-1 focus-within:ring-ring/60 md:col-span-5 md:justify-self-end"
+            class="group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md border border-border/45 bg-card/75 px-[var(--space-3)] py-[var(--space-2)] neo-inset hero-focus shadow-neo-inset transition-shadow focus-within:shadow-neoSoft focus-within:ring-1 focus-within:ring-ring/60 md:col-span-5 md:justify-self-center"
             data-slot="actions"
           >
             <div


### PR DESCRIPTION
## Summary
- derive the neomorphic hero frame alignment from the rendered tabs/search/actions slots when no explicit align is provided
- extend Hero search props to tolerate align metadata while stripping it before rendering the search bar
- exercise the new alignment heuristics with focused PageHeader tests and refresh affected snapshots

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc46e84904832cba76fd348bfc9777