### PR TITLE
Add focus autosave hook and tests

### DIFF
--- a/src/components/planner/FocusPanel.tsx
+++ b/src/components/planner/FocusPanel.tsx
@@ -2,8 +2,8 @@
 "use client";
 
 /**
- * FocusPanel — “focus of the day” bound to day.notes (scoped by iso).
- * - Hydration-safe: local state initializes from day.notes, then syncs via effect
+ * FocusPanel — “focus of the day” bound to day.focus (scoped by iso).
+ * - Hydration-safe: local state initializes from day.focus, then syncs via effect
  * - No setState loops: setFocus only fires if focus !== iso
  * - UX: Save disabled when unchanged; auto-saves on blur
  */
@@ -14,14 +14,14 @@ import * as React from "react";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import Input from "@/components/ui/primitives/Input";
 import Button from "@/components/ui/primitives/Button";
-import { useDayNotes } from "./useDayNotes";
+import { useDayFocus } from "./useDayNotes";
 import type { ISODate } from "./plannerStore";
 
 type Props = { iso: ISODate };
 
 export default function FocusPanel({ iso }: Props) {
   const { value, setValue, saving, isDirty, lastSavedRef, commit } =
-    useDayNotes(iso);
+    useDayFocus(iso);
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/tests/planner/FocusPanelWeekNotes.integration.test.tsx
+++ b/tests/planner/FocusPanelWeekNotes.integration.test.tsx
@@ -1,0 +1,110 @@
+import * as React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, beforeEach, afterEach, describe, expect, it } from "vitest";
+import {
+  FocusPanel,
+  PlannerProvider,
+  WeekNotes,
+} from "@/components/planner";
+import {
+  createStorageKey,
+  flushWriteLocal,
+  setWriteLocalDelay,
+  writeLocalDelay,
+} from "@/lib/db";
+
+const ISO = new Date().toISOString().slice(0, 10);
+const INITIAL_FOCUS = "Deep work sprint";
+const INITIAL_NOTES = "Prep deck, sync with design.";
+
+describe("FocusPanel and WeekNotes integration", () => {
+  let storageKey: string;
+  let originalWriteDelay: number;
+
+  beforeAll(() => {
+    storageKey = createStorageKey("planner:days");
+    originalWriteDelay = writeLocalDelay;
+  });
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    setWriteLocalDelay(0);
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        [ISO]: {
+          focus: INITIAL_FOCUS,
+          notes: INITIAL_NOTES,
+          projects: [],
+          tasks: [],
+        },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    flushWriteLocal();
+    window.localStorage.clear();
+    setWriteLocalDelay(originalWriteDelay);
+  });
+
+  it("displays and persists focus separately from notes", async () => {
+    render(
+      <PlannerProvider>
+        <FocusPanel iso={ISO} />
+        <WeekNotes iso={ISO} />
+      </PlannerProvider>,
+    );
+
+    const focusInput = screen.getByPlaceholderText(
+      "What’s the one thing today?",
+    ) as HTMLInputElement;
+    const notesTextarea = screen.getByRole("textbox", {
+      name: "Notes",
+    }) as HTMLTextAreaElement;
+
+    await waitFor(() => {
+      expect(focusInput).toHaveValue(INITIAL_FOCUS);
+    });
+    await waitFor(() => {
+      expect(notesTextarea).toHaveValue(INITIAL_NOTES);
+    });
+
+    const user = userEvent.setup();
+
+    await user.clear(focusInput);
+    const UPDATED_FOCUS = "Team OKR planning";
+    await user.type(focusInput, UPDATED_FOCUS);
+    await waitFor(() => {
+      expect(focusInput).toHaveValue(UPDATED_FOCUS);
+    });
+    focusInput.blur();
+
+    await waitFor(() => {
+      flushWriteLocal();
+      const stored = JSON.parse(
+        window.localStorage.getItem(storageKey) ?? "{}",
+      ) as Record<string, { focus?: string; notes?: string }>;
+      expect(stored[ISO]?.focus).toBe(UPDATED_FOCUS);
+      expect(stored[ISO]?.notes).toBe(INITIAL_NOTES);
+    });
+
+    await user.clear(notesTextarea);
+    const UPDATED_NOTES = "Draft agenda and share links.";
+    await user.type(notesTextarea, UPDATED_NOTES);
+    await waitFor(() => {
+      expect(notesTextarea).toHaveValue(UPDATED_NOTES);
+    });
+    notesTextarea.blur();
+
+    await waitFor(() => {
+      flushWriteLocal();
+      const stored = JSON.parse(
+        window.localStorage.getItem(storageKey) ?? "{}",
+      ) as Record<string, { focus?: string; notes?: string }>;
+      expect(stored[ISO]?.focus).toBe(UPDATED_FOCUS);
+      expect(stored[ISO]?.notes).toBe(UPDATED_NOTES);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extend the autosave hook to support both notes and focus fields and export a dedicated `useDayFocus`
- update `FocusPanel` to hydrate and persist the new focus field while keeping autosave UX intact
- add an integration test covering independent focus and notes rendering and persistence

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc49484ffc832c91fd93848ff5e753