### PR TITLE
Align ComponentsView spacing tokens

### DIFF
--- a/src/components/prompts/ComponentsView.tsx
+++ b/src/components/prompts/ComponentsView.tsx
@@ -276,7 +276,7 @@ export default function ComponentsView({
   }, [filteredCount, onFilteredCountChange]);
 
   return (
-    <div className="space-y-8">
+    <div className="flex flex-col gap-[var(--space-6)]">
       <header className="flex flex-wrap items-center justify-between gap-[var(--space-3)]">
         <h2 className="text-ui font-semibold tracking-[-0.01em] text-muted-foreground">
           {sectionLabel} specs


### PR DESCRIPTION
## Summary
- replace the ComponentsView wrapper spacing utility with the design token gap value

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc4d68e9ec832cb3fb2502682ff271