### PR TITLE
Add keyboard active state feedback to SpecCard

### DIFF
--- a/src/components/prompts/ComponentsView.tsx
+++ b/src/components/prompts/ComponentsView.tsx
@@ -80,6 +80,31 @@ function SpecCard({
     setIsPressed(false);
   }, []);
 
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      if (isDisabled) return;
+
+      if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
+        if (event.key !== "Enter") {
+          event.preventDefault();
+        }
+        setIsPressed(true);
+      }
+    },
+    [isDisabled],
+  );
+
+  const handleKeyUp = React.useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      if (isDisabled) return;
+
+      if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
+        setIsPressed(false);
+      }
+    },
+    [isDisabled],
+  );
+
   const cardClassName = cn(
     "group/spec-card relative isolate flex flex-col gap-[var(--space-4)] overflow-hidden",
     "rounded-[var(--radius-card)] border border-[hsl(var(--card-hairline)/0.75)]",
@@ -116,6 +141,9 @@ function SpecCard({
       onPointerUp={handlePointerReset}
       onPointerLeave={handlePointerReset}
       onPointerCancel={handlePointerReset}
+      onKeyDown={handleKeyDown}
+      onKeyUp={handleKeyUp}
+      onBlur={handlePointerReset}
       style={{
         ...cardTokens,
         "--spec-card-shadow": isPressed


### PR DESCRIPTION
## Summary
- add keyboard handlers to SpecCard so Enter and Space trigger the same active styling as pointer presses
- reset the pressed state on keyup and blur to keep the focus-visible ring layered above the raised card

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc4d875534832ca3c753ddcb479221