### PR TITLE
Refactor prompts page into persistent tab panels

### DIFF
--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -11,6 +11,10 @@ import {
   TabBar,
   Progress,
   GlitchProgress,
+  Tabs,
+  TabList,
+  Tab,
+  TabPanel,
   Spinner,
   ThemeToggle,
   AnimationToggle,
@@ -70,6 +74,7 @@ const fieldStoryHref = "/storybook/?path=/story/primitives-field--state-gallery"
 import IconButtonShowcase from "./IconButtonShowcase";
 
 type View = "buttons" | "inputs" | "prompts" | "planner" | "misc";
+type DemoTabKey = "overview" | "prompts" | "notes";
 
 const viewTabs: TabItem<View>[] = [
   { key: "buttons", label: "Buttons" },
@@ -148,6 +153,7 @@ export default function ComponentGallery() {
   const [side, setSide] = React.useState<GameSide>("Blue");
   const [pillars, setPillars] = React.useState<Pillar[]>([]);
   const [selectValue, setSelectValue] = React.useState<string | undefined>();
+  const [tabsDemo, setTabsDemo] = React.useState<DemoTabKey>("overview");
   const [view, setView] = React.useState<View>("buttons");
   const [headerTab, setHeaderTab] = React.useState("one");
   const [tactilePrimaryActive, setTactilePrimaryActive] = React.useState(false);
@@ -332,6 +338,39 @@ export default function ComponentGallery() {
         ),
       },
       {
+        label: "Tabs (panels)",
+        element: (
+          <Tabs<DemoTabKey>
+            value={tabsDemo}
+            onValueChange={(next) => setTabsDemo(next as DemoTabKey)}
+            className="w-full max-w-md"
+          >
+            <TabList ariaLabel="Tabs demo">
+              <Tab value="overview">Overview</Tab>
+              <Tab value="prompts">Prompts</Tab>
+              <Tab value="notes">Notes</Tab>
+            </TabList>
+            <div className="mt-[var(--space-3)] rounded-card border border-border/30 bg-card/60 p-[var(--space-4)] text-ui">
+              <TabPanel value="overview">
+                <p className="text-ui text-muted-foreground">
+                  Compare Planner personas and tone options.
+                </p>
+              </TabPanel>
+              <TabPanel value="prompts">
+                <p className="text-ui text-muted-foreground">
+                  Reuse prompt starters for different reviews.
+                </p>
+              </TabPanel>
+              <TabPanel value="notes">
+                <p className="text-ui text-muted-foreground">
+                  Capture follow-ups and action items for later.
+                </p>
+              </TabPanel>
+            </div>
+          </Tabs>
+        ),
+      },
+      {
         label: "SideSelector",
         element: (
           <SideSelector value={side} onChange={setSide} className="w-56" />
@@ -347,6 +386,7 @@ export default function ComponentGallery() {
       side,
       tactilePrimaryActive,
       tactileSecondaryActive,
+      tabsDemo,
     ],
   );
 

--- a/src/components/prompts/PromptsChatPanel.tsx
+++ b/src/components/prompts/PromptsChatPanel.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import * as React from "react";
+import {
+  Button,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from "@/components/ui";
+import Badge from "@/components/ui/primitives/Badge";
+import PromptsComposePanel from "./PromptsComposePanel";
+import PromptList from "./PromptList";
+import type { PromptWithTitle } from "./usePrompts";
+
+interface PersonaOption {
+  id: string;
+  title: string;
+  tone: string;
+  description: string;
+  prompt: string;
+}
+
+interface PromptStarter {
+  id: string;
+  label: string;
+  title: string;
+  body: string;
+}
+
+const PERSONAS: PersonaOption[] = [
+  {
+    id: "macro-analyst",
+    title: "Macro Analyst",
+    tone: "Strategy",
+    description: "Dissect rotations, timer control, and objective trade-offs.",
+    prompt:
+      "You are a macro analyst reviewing a League of Legends match. Highlight rotation timings, objective windows, and where tempo was lost or gained. Suggest map movements that would pressure the opponent and recover tempo spikes.",
+  },
+  {
+    id: "mechanics-coach",
+    title: "Mechanics Coach",
+    tone: "Execution",
+    description: "Call out micro mistakes and drills to sharpen reactions.",
+    prompt:
+      "Act as a mechanics coach. Break down misplays, target selection, and ability usage frame-by-frame. Recommend specific practice drills to fix each issue and note situations that were played perfectly.",
+  },
+  {
+    id: "comms-lead",
+    title: "Comms Lead",
+    tone: "Communication",
+    description: "Track shot-calls, information gaps, and clarity in fights.",
+    prompt:
+      "Review the team's voice comms as a communication lead. Note high-impact calls, missing information, and moments where clarity broke down. Provide phrasing that keeps the team aligned under pressure.",
+  },
+];
+
+const PROMPT_STARTERS: PromptStarter[] = [
+  {
+    id: "scrim-review",
+    label: "Scrim postmortem",
+    title: "Scrim postmortem",
+    body:
+      "Summarize the last scrim. Capture three wins, three losses, and the decisive moment. End with a priority list for tomorrow's block.",
+  },
+  {
+    id: "draft-eval",
+    label: "Draft feedback",
+    title: "Draft feedback",
+    body:
+      "Evaluate our draft. Did we secure the tools needed for win conditions? Flag risky matchups, missing engage, or lack of wave control, and suggest two adjustments.",
+  },
+  {
+    id: "patch-adapt",
+    label: "Patch adaptation",
+    title: "Patch adaptation checklist",
+    body:
+      "Audit how the latest patch changes alter our champion pools and practice priorities. Identify two comps that gain value and two that require counter strategies.",
+  },
+];
+
+export interface PromptsChatPanelHandle {
+  save: () => void;
+  hasDraft: boolean;
+}
+
+interface PromptsChatPanelProps {
+  prompts: PromptWithTitle[];
+  query: string;
+  onSavePrompt: (title: string, text: string) => boolean;
+  onDraftStateChange?: (state: { hasDraft: boolean }) => void;
+}
+
+const PromptsChatPanel = React.forwardRef<
+  PromptsChatPanelHandle,
+  PromptsChatPanelProps
+>(function PromptsChatPanel(
+  { prompts, query, onSavePrompt, onDraftStateChange },
+  ref,
+) {
+  const [titleDraft, setTitleDraft] = React.useState("");
+  const [textDraft, setTextDraft] = React.useState("");
+
+  const hasDraft = React.useMemo(
+    () => titleDraft.trim().length > 0 || textDraft.trim().length > 0,
+    [titleDraft, textDraft],
+  );
+
+  const handleSave = React.useCallback(() => {
+    if (!hasDraft) return;
+    const saved = onSavePrompt(titleDraft, textDraft);
+    if (saved) {
+      setTitleDraft("");
+      setTextDraft("");
+    }
+  }, [hasDraft, onSavePrompt, textDraft, titleDraft]);
+
+  const applyPersona = React.useCallback((persona: PersonaOption) => {
+    setTitleDraft(persona.title);
+    setTextDraft(persona.prompt);
+  }, []);
+
+  const applyStarter = React.useCallback((starter: PromptStarter) => {
+    setTitleDraft((prev) => (prev.trim().length > 0 ? prev : starter.title));
+    setTextDraft((prev) => {
+      const base = prev.trim().length > 0 ? `${prev.trim()}\n\n` : "";
+      return `${base}${starter.body}`;
+    });
+  }, []);
+
+  React.useEffect(() => {
+    onDraftStateChange?.({ hasDraft });
+  }, [hasDraft, onDraftStateChange]);
+
+  React.useImperativeHandle(
+    ref,
+    () => ({
+      save: handleSave,
+      hasDraft,
+    }),
+    [handleSave, hasDraft],
+  );
+
+  return (
+    <div className="space-y-[var(--space-6)]">
+      <div className="grid grid-cols-1 gap-[var(--space-6)] lg:grid-cols-12">
+        <div className="space-y-[var(--space-4)] lg:col-span-5">
+          <Card className="h-full space-y-[var(--space-4)]">
+            <CardHeader>
+              <CardTitle>Compose a new prompt</CardTitle>
+              <CardDescription>
+                Tailor requests for reviews, VOD summaries, or scrim follow-ups.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-[var(--space-4)]">
+              <PromptsComposePanel
+                title={titleDraft}
+                onTitleChange={setTitleDraft}
+                text={textDraft}
+                onTextChange={setTextDraft}
+              />
+              <div className="space-y-[var(--space-2)]">
+                <p className="text-label font-medium tracking-[0.02em] text-muted-foreground">
+                  Quick starters
+                </p>
+                <div className="flex flex-wrap gap-[var(--space-2)]">
+                  {PROMPT_STARTERS.map((starter) => (
+                    <Button
+                      key={starter.id}
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      className="border border-border/30 bg-transparent hover:bg-accent/15"
+                      onClick={() => applyStarter(starter)}
+                    >
+                      {starter.label}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            </CardContent>
+            <CardFooter className="justify-end">
+              <Button
+                type="button"
+                variant="primary"
+                onClick={handleSave}
+                disabled={!hasDraft}
+              >
+                Save prompt
+              </Button>
+            </CardFooter>
+          </Card>
+        </div>
+        <div className="space-y-[var(--space-4)] lg:col-span-7">
+          <Card>
+            <CardHeader>
+              <CardTitle>Personas</CardTitle>
+              <CardDescription>
+                Swap ChatGPT&rsquo;s perspective to match the review you&rsquo;re running.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-[var(--space-3)] sm:grid-cols-2">
+                {PERSONAS.map((persona) => (
+                  <Card
+                    key={persona.id}
+                    asChild
+                    className="h-full cursor-pointer transition-transform duration-200 hover:-translate-y-[1px]"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => applyPersona(persona)}
+                      className="flex h-full w-full flex-col text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                    >
+                      <CardHeader className="space-y-[var(--space-2)]">
+                        <div className="flex items-start justify-between gap-[var(--space-2)]">
+                          <CardTitle className="text-ui font-semibold">
+                            {persona.title}
+                          </CardTitle>
+                          <Badge size="xs" tone="accent">
+                            {persona.tone}
+                          </Badge>
+                        </div>
+                        <CardDescription>{persona.description}</CardDescription>
+                      </CardHeader>
+                      <CardContent className="pt-0 text-ui text-muted-foreground">
+                        {persona.prompt}
+                      </CardContent>
+                    </button>
+                  </Card>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Saved prompts</CardTitle>
+              <CardDescription>
+                Reuse snippets filtered by your search above.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <PromptList prompts={prompts} query={query} />
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+export default PromptsChatPanel;

--- a/src/components/prompts/PromptsCodexPanel.tsx
+++ b/src/components/prompts/PromptsCodexPanel.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import * as React from "react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  Button,
+} from "@/components/ui";
+import Badge from "@/components/ui/primitives/Badge";
+
+interface CodePrompt {
+  id: string;
+  title: string;
+  focus: string;
+  description: string;
+  body: string;
+}
+
+const CODEX_PROMPTS: CodePrompt[] = [
+  {
+    id: "risk-audit",
+    title: "Risk audit",
+    focus: "Safety",
+    description: "Surface regressions and side-effects that could impact live traffic.",
+    body:
+      "Review this diff for hidden risks. Highlight database or caching changes, concurrency edge cases, and failure recovery paths. Flag any migrations that need rollback plans and confirm metrics or feature flags that should be monitored after deploy.",
+  },
+  {
+    id: "context-brief",
+    title: "Context brief",
+    focus: "Clarity",
+    description: "Summarize intent, reviewers, and testing requirements before handoff.",
+    body:
+      "Summarize this change for a teammate stepping in cold. Explain the problem it solves, the scope of files touched, and tests that must pass before merge. Call out reviewers best suited for the diff and dependencies that should release alongside it.",
+  },
+  {
+    id: "refactor-plan",
+    title: "Refactor checklist",
+    focus: "Maintainability",
+    description: "Ensure the code stays approachable after large structural updates.",
+    body:
+      "Draft a refactor plan for this diff. Identify modules that grew in complexity, functions that should be extracted, and opportunities for stronger typing. Suggest follow-up tasks to improve observability and documentation once the change lands.",
+  },
+];
+
+export default function PromptsCodexPanel() {
+  const [copiedId, setCopiedId] = React.useState<string | null>(null);
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  React.useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, []);
+
+  const handleCopy = React.useCallback((prompt: CodePrompt) => {
+    if (typeof navigator === "undefined" || !navigator.clipboard) {
+      return;
+    }
+    navigator.clipboard
+      .writeText(prompt.body)
+      .then(() => {
+        setCopiedId(prompt.id);
+        if (timerRef.current) {
+          clearTimeout(timerRef.current);
+        }
+        timerRef.current = setTimeout(() => {
+          setCopiedId((prev) => (prev === prompt.id ? null : prev));
+        }, 2000);
+      })
+      .catch(() => {
+        setCopiedId(null);
+      });
+  }, []);
+
+  return (
+    <Card className="space-y-[var(--space-4)]">
+      <CardHeader>
+        <CardTitle>Codex review prompts</CardTitle>
+        <CardDescription>
+          Reuse focused checklists when shipping risky diffs or large refactors.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-[var(--space-3)]">
+        {CODEX_PROMPTS.map((prompt) => (
+          <Card key={prompt.id} asChild>
+            <article className="flex flex-col gap-[var(--space-3)]">
+              <header className="flex flex-wrap items-start justify-between gap-[var(--space-2)]">
+                <div>
+                  <CardTitle className="text-ui font-semibold">
+                    {prompt.title}
+                  </CardTitle>
+                  <CardDescription>{prompt.description}</CardDescription>
+                </div>
+                <Badge size="xs" tone="accent">
+                  {prompt.focus}
+                </Badge>
+              </header>
+              <p className="text-ui text-muted-foreground">{prompt.body}</p>
+              <div className="flex items-center justify-end gap-[var(--space-2)]">
+                {copiedId === prompt.id ? (
+                  <Badge size="xs" tone="accent">
+                    Copied
+                  </Badge>
+                ) : null}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="border border-border/30 bg-transparent hover:bg-accent/15"
+                  onClick={() => handleCopy(prompt)}
+                >
+                  Copy prompt
+                </Button>
+              </div>
+            </article>
+          </Card>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/prompts/PromptsNotesPanel.tsx
+++ b/src/components/prompts/PromptsNotesPanel.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import * as React from "react";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, Textarea, Label } from "@/components/ui";
+import { usePersistentState } from "@/lib/db";
+import useDebouncedCallback from "@/lib/useDebouncedCallback";
+
+export default function PromptsNotesPanel() {
+  const [notes, setNotes] = usePersistentState<string>("prompts.notes.v1", "");
+  const [status, setStatus] = React.useState<"idle" | "saving" | "saved">("idle");
+  const [lastSaved, setLastSaved] = React.useState<number | null>(null);
+  const firstRenderRef = React.useRef(true);
+  const notesId = React.useId();
+
+  const [scheduleSaved, cancelScheduled] = useDebouncedCallback(() => {
+    setStatus("saved");
+    setLastSaved(Date.now());
+  }, 600);
+
+  React.useEffect(() => cancelScheduled, [cancelScheduled]);
+
+  React.useEffect(() => {
+    if (firstRenderRef.current) {
+      firstRenderRef.current = false;
+      if (notes.trim().length > 0) {
+        setStatus("saved");
+        setLastSaved(Date.now());
+      }
+      return;
+    }
+    setStatus("saving");
+    scheduleSaved();
+  }, [notes, scheduleSaved]);
+
+  const handleChange = React.useCallback<React.ChangeEventHandler<HTMLTextAreaElement>>(
+    (event) => {
+      setNotes(event.target.value);
+    },
+    [setNotes],
+  );
+
+  const statusLabel = React.useMemo(() => {
+    if (status === "saving") return "Saving…";
+    if (status === "saved" && lastSaved) {
+      const time = new Date(lastSaved).toLocaleTimeString([], {
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+      return `Autosaved ${time}`;
+    }
+    return "Autosave keeps these notes ready when you return.";
+  }, [lastSaved, status]);
+
+  return (
+    <Card className="space-y-[var(--space-4)]">
+      <CardHeader>
+        <CardTitle>Notebook</CardTitle>
+        <CardDescription>
+          Keep research, draft ideas, or review prep in a scratchpad that persists across sessions.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-[var(--space-3)]">
+        <div className="space-y-[var(--space-2)]">
+          <Label htmlFor={notesId}>Notes</Label>
+          <Textarea
+            id={notesId}
+            value={notes}
+            onChange={handleChange}
+            placeholder="Capture reactions, follow-ups, or context you don’t want to lose."
+            resize="resize-y"
+            rows={8}
+          />
+        </div>
+        <p className="text-label text-muted-foreground" aria-live="polite">
+          {statusLabel}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -1,57 +1,95 @@
 "use client";
 
-/**
- * PromptsPage — Title + Search in Header (hero)
- * - Sticky header holds: Title + count (left), Search + Save (right)
- * - Body: compose panel (title + text) and the list
- */
-
 import * as React from "react";
-import { SectionCard } from "@/components/ui";
+import { Tabs, TabList, Tab, TabPanel } from "@/components/ui";
+import { usePersistentState } from "@/lib/db";
 import PromptsHeader from "./PromptsHeader";
-import PromptsComposePanel from "./PromptsComposePanel";
-import PromptsDemos from "./PromptsDemos";
-import PromptList from "./PromptList";
+import PromptsChatPanel, { PromptsChatPanelHandle } from "./PromptsChatPanel";
+import PromptsCodexPanel from "./PromptsCodexPanel";
+import PromptsNotesPanel from "./PromptsNotesPanel";
 import { usePrompts } from "./usePrompts";
+
+const PROMPT_TAB_KEYS = ["chat", "codex", "notes"] as const;
+
+type PromptsTabKey = (typeof PROMPT_TAB_KEYS)[number];
+
+function isPromptsTabKey(value: unknown): value is PromptsTabKey {
+  return (
+    typeof value === "string" &&
+    (PROMPT_TAB_KEYS as readonly string[]).includes(value)
+  );
+}
 
 export default function PromptsPage() {
   const { prompts, query, setQuery, filtered, save } = usePrompts();
+  const [activeTab, setActiveTab] = usePersistentState<PromptsTabKey>(
+    "prompts.tab.v1",
+    "chat",
+    {
+      decode: (value) => (isPromptsTabKey(value) ? value : null),
+    },
+  );
 
-  // Drafts
-  const [titleDraft, setTitleDraft] = React.useState("");
-  const [textDraft, setTextDraft] = React.useState("");
+  const chatPanelRef = React.useRef<PromptsChatPanelHandle>(null);
+  const [chatHasDraft, setChatHasDraft] = React.useState(false);
+
+  const handleDraftStateChange = React.useCallback(
+    ({ hasDraft }: { hasDraft: boolean }) => {
+      setChatHasDraft(hasDraft);
+    },
+    [],
+  );
+
+  const handleTabChange = React.useCallback(
+    (next: PromptsTabKey) => {
+      setActiveTab(next);
+    },
+    [setActiveTab],
+  );
 
   const handleSave = React.useCallback(() => {
-    if (save(titleDraft, textDraft)) {
-      setTitleDraft("");
-      setTextDraft("");
-    }
-  }, [save, titleDraft, textDraft]);
+    if (activeTab !== "chat") return;
+    chatPanelRef.current?.save();
+  }, [activeTab]);
+
+  const isSaveDisabled = activeTab !== "chat" || !chatHasDraft;
 
   return (
-    <SectionCard>
-      <SectionCard.Header sticky topClassName="top-8" className="gap-3">
+    <Tabs<PromptsTabKey>
+      value={activeTab}
+      onValueChange={handleTabChange}
+      className="flex flex-col gap-[var(--space-6)]"
+    >
+      <div className="sticky top-8 z-10 space-y-[var(--space-3)] bg-background/95 pb-[var(--space-3)] pt-[var(--space-3)] supports-[backdrop-filter]:backdrop-blur">
         <PromptsHeader
           count={prompts.length}
           query={query}
           onQueryChange={setQuery}
           onSave={handleSave}
-          disabled={!titleDraft.trim() && !textDraft.trim()}
+          disabled={isSaveDisabled}
         />
-      </SectionCard.Header>
-      <SectionCard.Body>
-        <PromptsComposePanel
-          title={titleDraft}
-          onTitleChange={setTitleDraft}
-          text={textDraft}
-          onTextChange={setTextDraft}
+        <TabList ariaLabel="Prompt panels" className="self-start">
+          <Tab value="chat">ChatGPT workspace</Tab>
+          <Tab value="codex">Codex review kits</Tab>
+          <Tab value="notes">Notes</Tab>
+        </TabList>
+      </div>
+      <TabPanel value="chat">
+        <PromptsChatPanel
+          ref={chatPanelRef}
+          prompts={filtered}
+          query={query}
+          onSavePrompt={save}
+          onDraftStateChange={handleDraftStateChange}
         />
-
-        <PromptList prompts={filtered} query={query} />
-
-        <PromptsDemos />
-      </SectionCard.Body>
-    </SectionCard>
+      </TabPanel>
+      <TabPanel value="codex">
+        <PromptsCodexPanel />
+      </TabPanel>
+      <TabPanel value="notes">
+        <PromptsNotesPanel />
+      </TabPanel>
+    </Tabs>
   );
 }
 

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -61,6 +61,8 @@ export { default as SearchBar } from "./primitives/SearchBar";
 export * from "./primitives/SearchBar";
 export { default as SegmentedButton } from "./primitives/SegmentedButton";
 export * from "./primitives/SegmentedButton";
+export { default as Tabs } from "./primitives/Tabs";
+export * from "./primitives/Tabs";
 export { default as Textarea } from "./primitives/Textarea";
 export * from "./primitives/Textarea";
 export { default as AnimatedSelect } from "./select/AnimatedSelect";

--- a/src/components/ui/primitives/Tabs.tsx
+++ b/src/components/ui/primitives/Tabs.tsx
@@ -1,0 +1,378 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type TabsValue = string;
+
+type TabRegistration<K extends TabsValue> = {
+  value: K;
+  ref: React.RefObject<HTMLButtonElement | null>;
+  id: string;
+  panelId: string;
+  disabled: boolean;
+  order: number;
+};
+
+type TabsContextValue<K extends TabsValue> = {
+  idBase: string;
+  activeValue: K;
+  setActiveValue: (value: K) => void;
+  registerTab: (registration: TabRegistration<K>) => () => void;
+  getTabs: () => TabRegistration<K>[];
+  focusTab: (value: K) => void;
+  getTabByValue: (value: K) => TabRegistration<K> | undefined;
+};
+
+const TabsContext = React.createContext<TabsContextValue<string> | null>(null);
+
+function useTabsContext<K extends TabsValue>() {
+  const context = React.useContext(TabsContext) as TabsContextValue<K> | null;
+  if (!context) {
+    throw new Error("Tabs components must be used within <Tabs>.");
+  }
+  return context;
+}
+
+type TabsOwnProps<K extends TabsValue> = {
+  value?: K;
+  defaultValue?: K;
+  onValueChange?: (value: K) => void;
+  idBase?: string;
+};
+
+export type TabsProps<K extends TabsValue = string> = TabsOwnProps<K> &
+  React.HTMLAttributes<HTMLDivElement>;
+
+export function Tabs<K extends TabsValue = string>({
+  value,
+  defaultValue,
+  onValueChange,
+  idBase,
+  className,
+  children,
+  ...rest
+}: TabsProps<K>) {
+  const isControlled = typeof value !== "undefined";
+  const [internalValue, setInternalValue] = React.useState<K>(() => {
+    if (typeof value !== "undefined") return value;
+    if (typeof defaultValue !== "undefined") return defaultValue;
+    return "" as K;
+  });
+
+  const activeValue = (isControlled ? value : internalValue) ?? ("" as K);
+
+  const tabsRef = React.useRef<Array<TabRegistration<K>>>([]);
+  const autoId = React.useId();
+  const baseId = idBase ?? autoId;
+
+  const setValue = React.useCallback(
+    (next: K) => {
+      if (!isControlled) {
+        setInternalValue(next);
+      }
+      if (onValueChange) {
+        onValueChange(next);
+      }
+    },
+    [isControlled, onValueChange],
+  );
+
+  const registerTab = React.useCallback(
+    (registration: TabRegistration<K>) => {
+      tabsRef.current = tabsRef.current
+        .filter((tab) => tab.value !== registration.value)
+        .concat(registration)
+        .sort((a, b) => a.order - b.order);
+
+      return () => {
+        tabsRef.current = tabsRef.current.filter(
+          (tab) => tab.value !== registration.value,
+        );
+      };
+    },
+    [],
+  );
+
+  const getTabs = React.useCallback(() => [...tabsRef.current], []);
+
+  const getTabByValue = React.useCallback(
+    (nextValue: K) => tabsRef.current.find((tab) => tab.value === nextValue),
+    [],
+  );
+
+  const focusTab = React.useCallback((nextValue: K) => {
+    const target = tabsRef.current.find((tab) => tab.value === nextValue);
+    target?.ref.current?.focus();
+  }, []);
+
+  React.useEffect(() => {
+    if (isControlled) return;
+    const tabs = tabsRef.current;
+    if (tabs.length === 0) return;
+    const current = tabs.find((tab) => tab.value === activeValue && !tab.disabled);
+    if (current) return;
+    const fallback =
+      tabs.find((tab) => !tab.disabled)?.value ?? tabs[0]?.value ?? activeValue;
+    if (fallback !== activeValue) {
+      setInternalValue(fallback as K);
+    }
+  }, [activeValue, isControlled]);
+
+  const contextValue = React.useMemo<TabsContextValue<K>>(
+    () => ({
+      idBase: baseId,
+      activeValue,
+      setActiveValue: setValue,
+      registerTab,
+      getTabs,
+      focusTab,
+      getTabByValue,
+    }),
+    [activeValue, baseId, focusTab, getTabByValue, getTabs, registerTab, setValue],
+  );
+
+  return (
+    <TabsContext.Provider
+      value={contextValue as unknown as TabsContextValue<string>}
+    >
+      <div data-tabs-root className={className} {...rest}>
+        {children}
+      </div>
+    </TabsContext.Provider>
+  );
+}
+
+type TabListContextValue = {
+  assignOrder: () => number;
+};
+
+const TabListContext = React.createContext<TabListContextValue | null>(null);
+
+function useTabListContext() {
+  const context = React.useContext(TabListContext);
+  if (!context) {
+    throw new Error("<Tab> must be used inside a <TabList>.");
+  }
+  return context;
+}
+
+type AriaLabelProps =
+  | { ariaLabel: string; ariaLabelledBy?: string }
+  | { ariaLabel?: string; ariaLabelledBy: string };
+
+export type TabListProps = React.HTMLAttributes<HTMLDivElement> &
+  AriaLabelProps;
+
+export const TabList = React.forwardRef<HTMLDivElement, TabListProps>(
+  ({ className, children, ariaLabel, ariaLabelledBy, ...rest }, ref) => {
+    const tabs = useTabsContext();
+    const orderRef = React.useRef(0);
+    orderRef.current = 0;
+
+    const assignOrder = React.useCallback(() => {
+      orderRef.current += 1;
+      return orderRef.current;
+    }, []);
+
+    const a11yLabel =
+      typeof ariaLabel === "string" && ariaLabel.trim().length > 0
+        ? ariaLabel.trim()
+        : undefined;
+    const a11yLabelledBy =
+      typeof ariaLabelledBy === "string" && ariaLabelledBy.trim().length > 0
+        ? ariaLabelledBy.trim()
+        : undefined;
+
+    React.useEffect(() => {
+      if (process.env.NODE_ENV !== "production") {
+        if (!a11yLabel && !a11yLabelledBy) {
+          console.warn(
+            "TabList requires either ariaLabel or ariaLabelledBy to describe the tablist.",
+          );
+        }
+      }
+    }, [a11yLabel, a11yLabelledBy]);
+
+    const handleKeyDown = React.useCallback<
+      React.KeyboardEventHandler<HTMLDivElement>
+    >(
+      (event) => {
+        const { key } = event;
+        if (!tabs) return;
+        if (![
+          "ArrowLeft",
+          "ArrowRight",
+          "Home",
+          "End",
+        ].includes(key)) {
+          return;
+        }
+        event.preventDefault();
+        const available = tabs.getTabs().filter((tab) => !tab.disabled);
+        if (available.length === 0) return;
+        const currentIndex = available.findIndex(
+          (tab) => tab.value === tabs.activeValue,
+        );
+        let nextIndex = currentIndex;
+        if (key === "Home") nextIndex = 0;
+        else if (key === "End") nextIndex = available.length - 1;
+        else if (key === "ArrowLeft") {
+          nextIndex = currentIndex <= 0 ? available.length - 1 : currentIndex - 1;
+        } else if (key === "ArrowRight") {
+          nextIndex = currentIndex >= available.length - 1 ? 0 : currentIndex + 1;
+        }
+        const next = available[nextIndex] ?? available[0];
+        tabs.setActiveValue(next.value);
+        tabs.focusTab(next.value);
+      },
+      [tabs],
+    );
+
+    return (
+      <TabListContext.Provider value={{ assignOrder }}>
+        <div
+          ref={ref}
+          role="tablist"
+          className={cn(
+            "inline-flex max-w-full items-center gap-[var(--space-2)] rounded-card border border-border/30 bg-card/70 p-[var(--space-2)] shadow-inner",
+            className,
+          )}
+          aria-label={a11yLabel}
+          aria-labelledby={a11yLabelledBy}
+          onKeyDown={handleKeyDown}
+          {...rest}
+        >
+          {children}
+        </div>
+      </TabListContext.Provider>
+    );
+  },
+);
+TabList.displayName = "TabList";
+
+type TabProps<K extends TabsValue = string> =
+  React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    value: K;
+  };
+
+export const Tab = React.forwardRef<HTMLButtonElement, TabProps>(
+  ({ value, className, onClick, disabled, id, children, ...rest }, ref) => {
+    const tabs = useTabsContext<string>();
+    const list = useTabListContext();
+    const buttonRef = React.useRef<HTMLButtonElement | null>(null);
+
+    const setButtonRef = React.useCallback(
+      (node: HTMLButtonElement | null) => {
+        buttonRef.current = node;
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          (ref as React.MutableRefObject<HTMLButtonElement | null>).current = node;
+        }
+      },
+      [ref],
+    );
+
+    const orderRef = React.useRef<number | null>(null);
+    if (orderRef.current === null) {
+      orderRef.current = list.assignOrder();
+    }
+
+    const tabId = id ?? `${tabs.idBase}-tab-${value}`;
+    const panelId = `${tabs.idBase}-panel-${value}`;
+
+    const isActive = tabs.activeValue === value;
+
+    React.useLayoutEffect(() => {
+      const cleanup = tabs.registerTab({
+        value: value as string,
+        ref: buttonRef,
+        id: tabId,
+        panelId,
+        disabled: Boolean(disabled),
+        order: orderRef.current ?? 0,
+      });
+      return cleanup;
+    }, [disabled, panelId, tabId, tabs, value]);
+
+    const handleClick = React.useCallback<
+      React.MouseEventHandler<HTMLButtonElement>
+    >(
+      (event) => {
+        if (disabled) {
+          event.preventDefault();
+          event.stopPropagation();
+          return;
+        }
+        onClick?.(event);
+        if (event.defaultPrevented) return;
+        tabs.setActiveValue(value as string);
+      },
+      [disabled, onClick, tabs, value],
+    );
+
+    return (
+      <button
+        {...rest}
+        ref={setButtonRef}
+        type="button"
+        id={tabId}
+        role="tab"
+        aria-selected={isActive}
+        aria-controls={panelId}
+        aria-disabled={disabled || undefined}
+        tabIndex={isActive ? 0 : -1}
+        data-active={isActive ? "true" : undefined}
+        data-disabled={disabled ? "true" : undefined}
+        className={cn(
+          "btn-like-segmented px-[var(--space-4)] py-[var(--space-2)] text-ui font-medium transition-colors",
+          isActive && "is-active",
+          disabled && "pointer-events-none opacity-[var(--disabled)]",
+          className,
+        )}
+        onClick={handleClick}
+      >
+        <span className="truncate">{children}</span>
+      </button>
+    );
+  },
+);
+Tab.displayName = "Tab";
+
+type TabPanelProps<K extends TabsValue = string> =
+  React.HTMLAttributes<HTMLDivElement> & {
+    value: K;
+  };
+
+export const TabPanel = React.forwardRef<HTMLDivElement, TabPanelProps>(
+  ({ value, className, children, id, ...rest }, ref) => {
+    const tabs = useTabsContext<string>();
+    const record = tabs.getTabByValue(value as string);
+    const panelId = id ?? record?.panelId ?? `${tabs.idBase}-panel-${value}`;
+    const labelledBy = record?.id ?? `${tabs.idBase}-tab-${value}`;
+    const isActive = tabs.activeValue === value;
+
+    return (
+      <div
+        {...rest}
+        ref={ref}
+        id={panelId}
+        role="tabpanel"
+        aria-labelledby={labelledBy}
+        hidden={!isActive}
+        tabIndex={isActive ? 0 : -1}
+        data-active={isActive ? "true" : undefined}
+        className={cn(
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+          className,
+        )}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+TabPanel.displayName = "TabPanel";
+
+export default Tabs;


### PR DESCRIPTION
## Summary
- replace the prompts page card layout with design-system tabs that persist the active tab and wire the header save action to the chat panel
- mount the new ChatGPT, Codex, and Notes panels so compose controls, reusable prompts, and autosaved notes live in dedicated views
- export the Tabs primitives, tighten their typing, and update the component gallery demo dependencies

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc4b150fa8832c84c89f9cfa1e252f