### PR TITLE
Adjust PageHeader frame align fallback

### DIFF
--- a/tests/components/PageHeader.test.tsx
+++ b/tests/components/PageHeader.test.tsx
@@ -229,4 +229,94 @@ describe("PageHeader", () => {
     expect(searchSlot).toHaveAttribute("data-slot", "search");
     expect(searchSlot).toHaveAttribute("aria-label", "Search planner highlights");
   });
+
+  it("centers the frame slots when only hero actions render", () => {
+    const { container } = render(
+      <PageHeader
+        header={baseHeader}
+        hero={{
+          ...baseHero,
+          actions: <button type="button">Act</button>,
+        }}
+      />,
+    );
+
+    const slotStrip = container.querySelector("[data-align]") as HTMLElement | null;
+    if (!slotStrip) {
+      throw new Error("Expected hero frame slots to render");
+    }
+    expect(slotStrip).toHaveAttribute("data-align", "center");
+  });
+
+  it("mirrors search alignment when it is the lone frame slot", () => {
+    const { container } = render(
+      <PageHeader
+        header={baseHeader}
+        hero={baseHero}
+        search={{
+          value: "",
+          onValueChange: () => {},
+          "aria-label": "Search", 
+        }}
+      />,
+    );
+
+    const slotStrip = container.querySelector("[data-align]") as HTMLElement | null;
+    if (!slotStrip) {
+      throw new Error("Expected hero frame slots to render");
+    }
+    expect(slotStrip).toHaveAttribute("data-align", "center");
+  });
+
+  it("leans toward the tab intent when tabs and search share the frame", () => {
+    const { container } = render(
+      <PageHeader
+        header={baseHeader}
+        hero={baseHero}
+        subTabs={{
+          items: [
+            { key: "overview", label: "Overview" },
+            { key: "insights", label: "Insights" },
+          ],
+          value: "overview",
+          onChange: vi.fn(),
+          ariaLabel: "Switch view",
+        }}
+        search={{
+          value: "",
+          onValueChange: () => {},
+          "aria-label": "Search",
+        }}
+      />,
+    );
+
+    const slotStrip = container.querySelector("[data-align]") as HTMLElement | null;
+    if (!slotStrip) {
+      throw new Error("Expected hero frame slots to render");
+    }
+    expect(slotStrip).toHaveAttribute("data-align", "end");
+  });
+
+  it("balances search and actions toward the center when both render", () => {
+    const { container } = render(
+      <PageHeader
+        header={baseHeader}
+        hero={{
+          ...baseHero,
+          actions: <button type="button">Act</button>,
+        }}
+        search={{
+          value: "",
+          onValueChange: () => {},
+          "aria-label": "Search",
+        }}
+      />,
+    );
+
+    const slotStrip = container.querySelector("[data-align]") as HTMLElement | null;
+    if (!slotStrip) {
+      throw new Error("Expected hero frame slots to render");
+    }
+    expect(slotStrip).toHaveAttribute("data-align", "center");
+  });
 });

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -172,12 +172,12 @@ exports[`ReviewsPage > renders default state 1`] = `
         </div>
         <div
           class="group/hero-slots relative z-[1] isolate w-full grid grid-cols-1 mt-[var(--space-6)] md:mt-[var(--space-7)] pt-[var(--space-5)] md:pt-[var(--space-6)] gap-[var(--space-3)] md:gap-[var(--space-4)] md:grid-cols-12 before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-[hsl(var(--accent))] before:opacity-60 before:content-[''] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-px after:bg-[hsl(var(--accent))] after:opacity-40 after:blur-sm after:content-['']"
-          data-align="between"
+          data-align="center"
           role="group"
         >
           <div
             aria-label="Search reviews"
-            class="group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md border border-border/45 bg-card/75 px-[var(--space-3)] py-[var(--space-2)] neo-inset hero-focus shadow-neo-inset transition-shadow focus-within:shadow-neoSoft focus-within:ring-1 focus-within:ring-ring/60 md:col-span-7 md:justify-self-stretch"
+            class="group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md border border-border/45 bg-card/75 px-[var(--space-3)] py-[var(--space-2)] neo-inset hero-focus shadow-neo-inset transition-shadow focus-within:shadow-neoSoft focus-within:ring-1 focus-within:ring-ring/60 md:col-span-7 md:justify-self-center"
             data-slot="search"
             role="group"
           >
@@ -266,7 +266,7 @@ exports[`ReviewsPage > renders default state 1`] = `
             </div>
           </div>
           <div
-            class="group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md border border-border/45 bg-card/75 px-[var(--space-3)] py-[var(--space-2)] neo-inset hero-focus shadow-neo-inset transition-shadow focus-within:shadow-neoSoft focus-within:ring-1 focus-within:ring-ring/60 md:col-span-5 md:justify-self-end"
+            class="group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md border border-border/45 bg-card/75 px-[var(--space-3)] py-[var(--space-2)] neo-inset hero-focus shadow-neo-inset transition-shadow focus-within:shadow-neoSoft focus-within:ring-1 focus-within:ring-ring/60 md:col-span-5 md:justify-self-center"
             data-slot="actions"
             role="group"
           >


### PR DESCRIPTION
## Summary
- derive PageHeader frame alignment from the rendered slots when no explicit align is provided
- add coverage for the new alignment heuristics and update the reviews snapshot to match the centered layout

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc4e7fdf1c832ca3c02fcf6eb457c7