### PR TITLE
Add day focus hook and tests

### DIFF
--- a/src/components/planner/FocusPanel.tsx
+++ b/src/components/planner/FocusPanel.tsx
@@ -2,9 +2,9 @@
 "use client";
 
 /**
- * FocusPanel — “focus of the day” bound to day.notes (scoped by iso).
- * - Hydration-safe: local state initializes from day.notes, then syncs via effect
- * - No setState loops: setFocus only fires if focus !== iso
+ * FocusPanel — “focus of the day” bound to day.focus (scoped by iso).
+ * - Hydration-safe: local state initializes from day.focus, then syncs via effect
+ * - No setState loops: setter only fires when the trimmed focus changes
  * - UX: Save disabled when unchanged; auto-saves on blur
  */
 
@@ -14,14 +14,15 @@ import * as React from "react";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import Input from "@/components/ui/primitives/Input";
 import Button from "@/components/ui/primitives/Button";
-import { useDayNotes } from "./useDayNotes";
+import { useDayFocus } from "./useDayFocus";
 import type { ISODate } from "./plannerStore";
 
 type Props = { iso: ISODate };
 
 export default function FocusPanel({ iso }: Props) {
   const { value, setValue, saving, isDirty, lastSavedRef, commit } =
-    useDayNotes(iso);
+    useDayFocus(iso);
+  const headerId = React.useMemo(() => `focus-${iso}-header`, [iso]);
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -30,7 +31,7 @@ export default function FocusPanel({ iso }: Props) {
 
   return (
     <SectionCard className="card-neo-soft">
-      <SectionCard.Header title="Daily Focus" />
+      <SectionCard.Header id={headerId} title="Daily Focus" />
       <SectionCard.Body>
         <form onSubmit={onSubmit} className="flex items-center gap-[var(--space-2)]">
           <Input
@@ -42,6 +43,7 @@ export default function FocusPanel({ iso }: Props) {
             autoComplete="off"
             className="flex-1"
             aria-label="Daily focus"
+            aria-labelledby={headerId}
           />
           <Button
             type="submit"

--- a/src/components/planner/index.ts
+++ b/src/components/planner/index.ts
@@ -19,6 +19,7 @@ export * from "./dayCrud";
 export * from "./plannerCrud";
 export * from "./plannerStore";
 export * from "./useDay";
+export * from "./useDayFocus";
 export * from "./useDayNotes";
 export * from "./useFocusDate";
 export * from "./usePlannerStore";

--- a/src/components/planner/plannerCrud.ts
+++ b/src/components/planner/plannerCrud.ts
@@ -15,6 +15,14 @@ import type { ISODate, DayRecord } from "./plannerStore";
 
 export type UpsertDay = (iso: ISODate, fn: (d: DayRecord) => DayRecord) => void;
 
+export function setNotes(day: DayRecord, notes: string): DayRecord {
+  return { ...day, notes };
+}
+
+export function setFocus(day: DayRecord, focus: string): DayRecord {
+  return { ...day, focus };
+}
+
 export function makeCrud(iso: ISODate, upsertDay: UpsertDay) {
   const addProject = (name: string) => {
     const id = uid("proj");
@@ -52,7 +60,11 @@ export function makeCrud(iso: ISODate, upsertDay: UpsertDay) {
   const removeTaskImage = (id: string, url: string) =>
     upsertDay(iso, (d) => dayRemoveTaskImage(d, id, url));
 
-  const setNotes = (notes: string) => upsertDay(iso, (d) => ({ ...d, notes }));
+  const setNotesForDay = (notes: string) =>
+    upsertDay(iso, (d) => setNotes(d, notes));
+
+  const setFocusForDay = (focus: string) =>
+    upsertDay(iso, (d) => setFocus(d, focus));
 
   return {
     addProject,
@@ -65,6 +77,7 @@ export function makeCrud(iso: ISODate, upsertDay: UpsertDay) {
     removeTask,
     addTaskImage,
     removeTaskImage,
-    setNotes,
+    setNotes: setNotesForDay,
+    setFocus: setFocusForDay,
   } as const;
 }

--- a/src/components/planner/useDayFocus.ts
+++ b/src/components/planner/useDayFocus.ts
@@ -1,9 +1,9 @@
-// src/components/planner/useDayNotes.ts
+// src/components/planner/useDayFocus.ts
 "use client";
 
 import * as React from "react";
 
-import { setNotes as applyNotes } from "./plannerCrud";
+import { setFocus as applyFocus } from "./plannerCrud";
 import { usePlannerStore } from "./usePlannerStore";
 import type { ISODate } from "./plannerStore";
 
@@ -16,21 +16,21 @@ const scheduleSavingReset = (callback: VoidFunction) => {
   setTimeout(callback, 0);
 };
 
-export function useDayNotes(iso: ISODate) {
+export function useDayFocus(iso: ISODate) {
   const { getDay, upsertDay } = usePlannerStore();
   const day = getDay(iso);
-  const persistedNotes = day.notes ?? "";
+  const persistedFocus = day.focus ?? "";
 
-  const setNotesForIso = React.useCallback(
-    (notes: string) => {
-      upsertDay(iso, (d) => applyNotes(d, notes));
+  const setFocusForIso = React.useCallback(
+    (focusValue: string) => {
+      upsertDay(iso, (d) => applyFocus(d, focusValue));
     },
     [iso, upsertDay],
   );
 
-  const [value, setValue] = React.useState<string>(() => persistedNotes);
+  const [value, setValue] = React.useState<string>(() => persistedFocus);
   const [saving, setSaving] = React.useState(false);
-  const lastSavedRef = React.useRef(persistedNotes.trim());
+  const lastSavedRef = React.useRef(persistedFocus.trim());
 
   const trimmed = React.useMemo(() => value.trim(), [value]);
   const isDirty = trimmed !== lastSavedRef.current;
@@ -39,19 +39,19 @@ export function useDayNotes(iso: ISODate) {
     if (!isDirty) return;
     setSaving(true);
     try {
-      setNotesForIso(trimmed);
+      setFocusForIso(trimmed);
       lastSavedRef.current = trimmed;
     } finally {
       scheduleSavingReset(() => {
         setSaving(false);
       });
     }
-  }, [isDirty, setNotesForIso, trimmed]);
+  }, [isDirty, setFocusForIso, trimmed]);
 
   React.useEffect(() => {
-    setValue(persistedNotes);
-    lastSavedRef.current = persistedNotes.trim();
-  }, [iso, persistedNotes]);
+    setValue(persistedFocus);
+    lastSavedRef.current = persistedFocus.trim();
+  }, [iso, persistedFocus]);
 
   return { value, setValue, saving, isDirty, lastSavedRef, commit } as const;
 }

--- a/src/components/planner/usePlannerStore.ts
+++ b/src/components/planner/usePlannerStore.ts
@@ -120,6 +120,7 @@ export function usePlannerStore() {
     () => makeCrud(focus, upsertDay),
     [focus, upsertDay],
   );
+  const { setFocus: setDayFocus, ...restCrud } = crud;
 
   return {
     days,
@@ -129,6 +130,7 @@ export function usePlannerStore() {
     getDay,
     setDay,
     upsertDay,
-    ...crud,
+    setDayFocus,
+    ...restCrud,
   } as const;
 }

--- a/tests/planner/FocusPanel.test.tsx
+++ b/tests/planner/FocusPanel.test.tsx
@@ -1,0 +1,84 @@
+import * as React from "react";
+import {
+  render,
+  screen,
+  waitFor,
+  act,
+  fireEvent,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect } from "vitest";
+
+import {
+  FocusPanel,
+  PlannerProvider,
+  usePlannerStore,
+  todayISO,
+} from "@/components/planner";
+import type { DayRecord, ISODate } from "@/components/planner";
+
+type PlannerHandle = ReturnType<typeof usePlannerStore> & {
+  latestDay: DayRecord;
+};
+
+const PlannerState = React.forwardRef<PlannerHandle, { iso: ISODate }>(
+  ({ iso }, ref) => {
+    const planner = usePlannerStore();
+    const day = planner.getDay(iso);
+
+    React.useImperativeHandle(
+      ref,
+      () => ({
+        ...planner,
+        latestDay: day,
+      }),
+      [planner, day],
+    );
+
+    return null;
+  },
+);
+
+PlannerState.displayName = "PlannerState";
+
+describe("FocusPanel", () => {
+  it("updates the day focus without mutating notes", async () => {
+    const iso = todayISO();
+    const plannerRef = React.createRef<PlannerHandle>();
+    const user = userEvent.setup();
+
+    render(
+      <PlannerProvider>
+        <FocusPanel iso={iso} />
+        <PlannerState ref={plannerRef} iso={iso} />
+      </PlannerProvider>,
+    );
+
+    expect(plannerRef.current).toBeTruthy();
+
+    act(() => {
+      plannerRef.current!.upsertDay(iso, (day) => ({
+        ...day,
+        notes: "Existing notes",
+      }));
+    });
+
+    await waitFor(() => {
+      expect(plannerRef.current!.latestDay.notes).toBe("Existing notes");
+    });
+
+    const input = screen.getByRole("textbox", { name: /daily focus/i });
+    await user.clear(input);
+    await user.type(input, " Deep work sprint ");
+
+    act(() => {
+      fireEvent.blur(input);
+    });
+
+    await waitFor(() => {
+      const day = plannerRef.current!.latestDay;
+      expect(day.focus).toBe("Deep work sprint");
+      expect(day.notes).toBe("Existing notes");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add shared setNotes/setFocus helpers to planner CRUD utilities and expose setDayFocus on the store
- introduce a dedicated useDayFocus hook and switch FocusPanel to the new focus state wiring
- cover FocusPanel with a planner test to ensure focus updates do not mutate the day notes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc4ad90734832c995ae97a47b81a98