### PR TITLE
Refactor prompts page into tabbed workspace

### DIFF
--- a/src/components/prompts/ChatPromptsTab.tsx
+++ b/src/components/prompts/ChatPromptsTab.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import * as React from "react";
+
+import { Card } from "@/components/ui";
+import PromptsComposePanel from "./PromptsComposePanel";
+import PromptList from "./PromptList";
+import type { Persona, PromptWithTitle } from "./types";
+import { LOCALE } from "@/lib/utils";
+
+interface ChatPromptsTabProps {
+  title: string;
+  text: string;
+  onTitleChange: (value: string) => void;
+  onTextChange: (value: string) => void;
+  prompts: PromptWithTitle[];
+  query: string;
+  personas: Persona[];
+}
+
+export default function ChatPromptsTab({
+  title,
+  text,
+  onTitleChange,
+  onTextChange,
+  prompts,
+  query,
+  personas,
+}: ChatPromptsTabProps) {
+  const composeHeadingId = React.useId();
+  const personasHeadingId = React.useId();
+  const libraryHeadingId = React.useId();
+
+  return (
+    <div className="flex flex-col gap-[var(--space-6)]">
+      <section
+        aria-labelledby={composeHeadingId}
+        className="flex flex-col gap-[var(--space-3)]"
+      >
+        <div className="space-y-[var(--space-1)]">
+          <h3 id={composeHeadingId} className="type-title">
+            Compose prompt
+          </h3>
+          <p className="text-ui text-muted-foreground">
+            Draft a ChatGPT request and save it for future reuse.
+          </p>
+        </div>
+        <PromptsComposePanel
+          title={title}
+          onTitleChange={onTitleChange}
+          text={text}
+          onTextChange={onTextChange}
+        />
+      </section>
+
+      <section
+        aria-labelledby={personasHeadingId}
+        className="flex flex-col gap-[var(--space-3)]"
+      >
+        <div className="space-y-[var(--space-1)]">
+          <h3 id={personasHeadingId} className="type-title">
+            Personas
+          </h3>
+          <p className="text-ui text-muted-foreground">
+            Keep tailored introductions to quickly set tone and context.
+          </p>
+        </div>
+        {personas.length > 0 ? (
+          <ul className="grid gap-[var(--space-3)] md:grid-cols-2">
+            {personas.map((persona) => (
+              <li key={persona.id}>
+                <Card className="flex h-full flex-col gap-[var(--space-3)] p-[var(--space-4)]">
+                  <header className="space-y-[var(--space-1)]">
+                    <h4 className="font-semibold text-body">{persona.name}</h4>
+                    {persona.description ? (
+                      <p className="text-ui text-muted-foreground">
+                        {persona.description}
+                      </p>
+                    ) : null}
+                    <time
+                      dateTime={new Date(persona.createdAt).toISOString()}
+                      className="block text-label text-muted-foreground"
+                    >
+                      Added {new Date(persona.createdAt).toLocaleString(LOCALE)}
+                    </time>
+                  </header>
+                  <p className="whitespace-pre-wrap rounded-lg bg-card/60 p-[var(--space-3)] text-ui">
+                    {persona.prompt}
+                  </p>
+                </Card>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-ui text-muted-foreground">
+            No personas yet. Start a collection to keep favorite tones handy.
+          </p>
+        )}
+      </section>
+
+      <section
+        aria-labelledby={libraryHeadingId}
+        className="flex flex-col gap-[var(--space-3)]"
+      >
+        <div className="space-y-[var(--space-1)]">
+          <h3 id={libraryHeadingId} className="type-title">
+            Reusable prompts
+          </h3>
+          <p className="text-ui text-muted-foreground">
+            Saved ChatGPT prompts appear here with newest first.
+          </p>
+        </div>
+        <PromptList prompts={prompts} query={query} />
+      </section>
+    </div>
+  );
+}

--- a/src/components/prompts/CodexPromptsTab.tsx
+++ b/src/components/prompts/CodexPromptsTab.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import * as React from "react";
+
+import PromptsComposePanel from "./PromptsComposePanel";
+import PromptList from "./PromptList";
+import type { PromptWithTitle } from "./types";
+
+interface CodexPromptsTabProps {
+  title: string;
+  text: string;
+  onTitleChange: (value: string) => void;
+  onTextChange: (value: string) => void;
+  prompts: PromptWithTitle[];
+  query: string;
+}
+
+export default function CodexPromptsTab({
+  title,
+  text,
+  onTitleChange,
+  onTextChange,
+  prompts,
+  query,
+}: CodexPromptsTabProps) {
+  const composeHeadingId = React.useId();
+  const libraryHeadingId = React.useId();
+
+  return (
+    <div className="flex flex-col gap-[var(--space-6)]">
+      <section
+        aria-labelledby={composeHeadingId}
+        className="flex flex-col gap-[var(--space-3)]"
+      >
+        <div className="space-y-[var(--space-1)]">
+          <h3 id={composeHeadingId} className="type-title">
+            Review checklist
+          </h3>
+          <p className="text-ui text-muted-foreground">
+            Capture Codex review prompts that help validate architecture,
+            testing, and release notes.
+          </p>
+        </div>
+        <PromptsComposePanel
+          title={title}
+          onTitleChange={onTitleChange}
+          text={text}
+          onTextChange={onTextChange}
+        />
+      </section>
+
+      <section
+        aria-labelledby={libraryHeadingId}
+        className="flex flex-col gap-[var(--space-3)]"
+      >
+        <div className="space-y-[var(--space-1)]">
+          <h3 id={libraryHeadingId} className="type-title">
+            Codex prompts
+          </h3>
+          <p className="text-ui text-muted-foreground">
+            Saved checklists appear here for quick reuse during reviews.
+          </p>
+        </div>
+        <PromptList prompts={prompts} query={query} />
+      </section>
+    </div>
+  );
+}

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -33,6 +33,9 @@ import {
   PillarSelector,
   Field,
   Label,
+  Tabs,
+  TabList,
+  TabPanel,
   type TabItem,
 } from "@/components/ui";
 import Badge from "@/components/ui/primitives/Badge";
@@ -245,6 +248,37 @@ export default function ComponentGallery() {
             ariaLabel="Sample tabs"
             linkPanels={false}
           />
+        ),
+      },
+      {
+        label: "Tabs primitive",
+        element: (
+          <Tabs defaultValue="chat" className="max-w-md">
+            <TabList
+              items={[
+                { key: "chat", label: "Chat" },
+                { key: "codex", label: "Codex" },
+                { key: "notes", label: "Notes" },
+              ]}
+              ariaLabel="Tabs primitive demo"
+              showBaseline
+            />
+            <TabPanel value="chat">
+              <Card className="p-[var(--space-4)] text-ui">
+                Compose prompts
+              </Card>
+            </TabPanel>
+            <TabPanel value="codex">
+              <Card className="p-[var(--space-4)] text-ui">
+                Review checklists
+              </Card>
+            </TabPanel>
+            <TabPanel value="notes">
+              <Card className="p-[var(--space-4)] text-ui">
+                Autosave notes
+              </Card>
+            </TabPanel>
+          </Tabs>
         ),
       },
       {

--- a/src/components/prompts/NotesTab.tsx
+++ b/src/components/prompts/NotesTab.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import * as React from "react";
+
+import { Label, Textarea } from "@/components/ui";
+
+interface NotesTabProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export default function NotesTab({ value, onChange }: NotesTabProps) {
+  const notesId = React.useId();
+
+  return (
+    <div className="max-w-3xl space-y-[var(--space-3)]">
+      <div className="space-y-[var(--space-2)]">
+        <Label htmlFor={notesId}>Scratchpad</Label>
+        <Textarea
+          id={notesId}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder="Capture ideas, snippets, or follow-ups…"
+          resize="resize-y"
+          aria-describedby={`${notesId}-help`}
+        />
+        <p
+          id={`${notesId}-help`}
+          className="text-label text-muted-foreground"
+        >
+          Notes auto-save locally and sync across refreshes.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -61,6 +61,8 @@ export { default as SearchBar } from "./primitives/SearchBar";
 export * from "./primitives/SearchBar";
 export { default as SegmentedButton } from "./primitives/SegmentedButton";
 export * from "./primitives/SegmentedButton";
+export { default as Tabs } from "./primitives/Tabs";
+export * from "./primitives/Tabs";
 export { default as Textarea } from "./primitives/Textarea";
 export * from "./primitives/Textarea";
 export { default as AnimatedSelect } from "./select/AnimatedSelect";

--- a/src/components/ui/primitives/Tabs.tsx
+++ b/src/components/ui/primitives/Tabs.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import TabBar, {
+  type TabBarProps,
+  type TabItem,
+} from "../layout/TabBar";
+
+interface TabsContextValue<Key extends string> {
+  value: Key;
+  setValue: (value: Key) => void;
+  idBase: string;
+}
+
+const TabsContext = React.createContext<TabsContextValue<string> | null>(null);
+
+function useTabsContext<Key extends string>() {
+  const context = React.useContext(TabsContext);
+  if (!context) {
+    throw new Error("Tab components must be used within a <Tabs> provider.");
+  }
+  return context as unknown as TabsContextValue<Key>;
+}
+
+export interface TabsProps<Key extends string = string>
+  extends React.HTMLAttributes<HTMLDivElement> {
+  value?: Key;
+  defaultValue?: Key;
+  onValueChange?: (value: Key) => void;
+  idBase?: string;
+}
+
+export function Tabs<Key extends string = string>({
+  value,
+  defaultValue,
+  onValueChange,
+  idBase,
+  children,
+  className,
+  ...rest
+}: TabsProps<Key>) {
+  const [internal, setInternal] = React.useState<Key | undefined>(defaultValue);
+  const controlled = value !== undefined;
+  const activeValue = controlled ? value : internal;
+
+  React.useEffect(() => {
+    if (process.env.NODE_ENV !== "production") {
+      if (activeValue === undefined && defaultValue === undefined) {
+        console.warn("Tabs requires a value or defaultValue to be provided.");
+      }
+    }
+  }, [activeValue, defaultValue]);
+
+  const resolvedValue = (activeValue ?? defaultValue) as Key;
+
+  const handleValueChange = React.useCallback(
+    (next: Key) => {
+      if (!controlled) {
+        setInternal(next);
+      }
+      onValueChange?.(next);
+    },
+    [controlled, onValueChange],
+  );
+
+  const generatedId = React.useId();
+  const baseId = idBase ?? generatedId;
+
+  const context = React.useMemo<TabsContextValue<Key>>(
+    () => ({ value: resolvedValue, setValue: handleValueChange, idBase: baseId }),
+    [baseId, handleValueChange, resolvedValue],
+  );
+
+  return (
+    <TabsContext.Provider value={context as unknown as TabsContextValue<string>}>
+      <div className={cn("flex flex-col gap-[var(--space-6)]", className)} {...rest}>
+        {children}
+      </div>
+    </TabsContext.Provider>
+  );
+}
+
+export type TabListItem<Key extends string = string> = TabItem<Key>;
+
+export type TabListProps<
+  Key extends string = string,
+  Extra extends Record<string, unknown> | undefined = undefined,
+> = Omit<TabBarProps<Key, Extra>, "value" | "onValueChange" | "idBase"> & {
+  value?: never;
+  onValueChange?: never;
+  idBase?: never;
+};
+
+export function TabList<
+  Key extends string = string,
+  Extra extends Record<string, unknown> | undefined = undefined,
+>(props: TabListProps<Key, Extra>) {
+  const { value, setValue, idBase } = useTabsContext<Key>();
+  const { linkPanels = true, ...rest } = props;
+  const tabBarProps = rest as unknown as TabBarProps<Key, Extra>;
+  return (
+    <TabBar
+      {...tabBarProps}
+      value={value}
+      onValueChange={setValue}
+      idBase={idBase}
+      linkPanels={linkPanels}
+    />
+  );
+}
+
+export interface TabPanelProps<Key extends string = string>
+  extends React.HTMLAttributes<HTMLDivElement> {
+  value: Key;
+  forceMount?: boolean;
+}
+
+export function TabPanel<Key extends string = string>({
+  value,
+  children,
+  className,
+  forceMount = false,
+  ...rest
+}: TabPanelProps<Key>) {
+  const { value: activeValue, idBase } = useTabsContext<Key>();
+  const isActive = activeValue === value;
+  const panelId = `${idBase}-${value}-panel`;
+  const tabId = `${idBase}-${value}-tab`;
+  const shouldRender = forceMount || isActive;
+
+  return (
+    <div
+      role="tabpanel"
+      id={panelId}
+      aria-labelledby={tabId}
+      hidden={!isActive}
+      tabIndex={isActive ? 0 : -1}
+      data-state={isActive ? "active" : "inactive"}
+      className={cn(
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+        className,
+      )}
+      {...rest}
+    >
+      {shouldRender ? children : null}
+    </div>
+  );
+}
+
+export default Tabs;


### PR DESCRIPTION
## Summary
- replace the prompts page layout with the design-system Tabs, TabList, and TabPanel primitives wired through persistent state
- introduce dedicated ChatGPT, Codex, and Notes panels with compose controls, persona listings, prompt libraries, and autosave support
- expose the Tabs primitives through the UI index and document them in the component gallery for design-system coverage

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc5543bc2c832ca8b622ad72e0596a