### PR TITLE
Adjust primary nav tracking for page header demo

### DIFF
--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -78,7 +78,7 @@ export default function PageHeaderDemo() {
                 onClick={() => setActivePrimaryNav(item.key)}
                 data-state={isActive ? "active" : "inactive"}
                 aria-current={isActive ? "page" : undefined}
-                className="inline-flex items-center rounded-full border border-transparent px-3 py-1.5 text-label font-semibold uppercase tracking-[0.08em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=inactive]:hover:bg-[--hover] data-[state=inactive]:hover:text-foreground data-[state=active]:bg-[hsl(var(--card)/0.85)] data-[state=active]:text-foreground data-[state=active]:shadow-[0_0_0_1px_hsl(var(--ring)/0.35)]"
+                className="inline-flex items-center rounded-full border border-transparent px-3 py-1.5 text-label font-semibold uppercase tracking-[0.02em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=inactive]:hover:bg-[--hover] data-[state=inactive]:hover:text-foreground data-[state=active]:bg-[hsl(var(--card)/0.85)] data-[state=active]:text-foreground data-[state=active]:shadow-[0_0_0_1px_hsl(var(--ring)/0.35)]"
               >
                 {item.label}
               </button>


### PR DESCRIPTION
## Summary
- update the primary navigation buttons in the page header demo to use the design tracking ramp value
- confirm the component gallery entry still wraps and highlights correctly after the spacing adjustment

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc5b9e57d0832ca92b56d2132228df