### PR TITLE
Align weekly focus list spacing tokens

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -537,11 +537,11 @@ function HomePageContent() {
                     <DashboardList
                       items={weeklyHighlights}
                       getKey={(highlight) => highlight.id}
-                      itemClassName="py-3"
+                      itemClassName="py-[var(--space-2)]"
                       empty="No highlights scheduled"
                       renderItem={(highlight) => (
-                        <div className="flex flex-col gap-2">
-                          <div className="flex items-baseline justify-between gap-3">
+                        <div className="flex flex-col gap-[var(--space-2)]">
+                          <div className="flex items-baseline justify-between gap-[var(--space-3)]">
                             <p className="text-ui font-medium">{highlight.title}</p>
                             <span className="text-label text-muted-foreground">
                               {highlight.schedule}


### PR DESCRIPTION
## Summary
- align the weekly focus DashboardList item padding with spacing tokens to match the design rhythm
- switch the highlight list row gaps to tokenized utilities for consistency with goals and reviews cards

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc5fdba4b8832c97f6f1b074961285