### PR TITLE
Align PageHeader demo chip typography with tokens

### DIFF
--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -404,12 +404,12 @@ export default function PageHeaderDemo() {
         PageHeader now routes shared sub-tabs, search, and quick actions into
         the frame’s action grid so controls align with the 12-column layout
         while the inner hero stays calm, single-framed, and flush. It forwards
-        <code className="ml-1 rounded bg-[hsl(var(--card)/0.6)] px-1.5 py-0.5 font-mono text-[0.75rem] text-foreground/80">
+        <code className="ml-1 rounded bg-[hsl(var(--card)/0.6)] px-1.5 py-0.5 font-mono text-label text-foreground/80">
           {"hero.padding = \"none\""}
         </code>{" "}
         so the content hugs the frame. Want the Hero divider row instead? Pass
         {" "}
-        <code className="ml-1 rounded bg-[hsl(var(--card)/0.6)] px-1.5 py-0.5 font-mono text-[0.75rem] text-foreground/80">
+        <code className="ml-1 rounded bg-[hsl(var(--card)/0.6)] px-1.5 py-0.5 font-mono text-label text-foreground/80">
           {"frameProps={{ slots: null }}"}
         </code>{" "}
         to hand control back to Hero while keeping tone overrides intact.


### PR DESCRIPTION
## Summary
- replace the hard-coded `text-[0.75rem]` utility on the PageHeader demo chips with the design token `text-label`
- verified in the components gallery that the chip text still fits the surrounding copy without shifting the layout

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc5c2ddab8832cbe924448f9748c44