### PR TITLE
Align PageHeader demo spacing with tokens

### DIFF
--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -68,7 +68,7 @@ export default function PageHeaderDemo() {
 
   const primaryNav = (
     <nav aria-label="Planner views" className="w-full">
-      <ul className="flex items-center gap-1 list-none">
+      <ul className="flex items-center list-none gap-[var(--space-1)]">
         {compactNavItems.map((item) => {
           const isActive = activePrimaryNav === item.key;
           return (
@@ -78,7 +78,7 @@ export default function PageHeaderDemo() {
                 onClick={() => setActivePrimaryNav(item.key)}
                 data-state={isActive ? "active" : "inactive"}
                 aria-current={isActive ? "page" : undefined}
-                className="inline-flex items-center rounded-full border border-transparent px-3 py-1.5 text-label font-semibold uppercase tracking-[0.02em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=inactive]:hover:bg-[--hover] data-[state=inactive]:hover:text-foreground data-[state=active]:bg-[hsl(var(--card)/0.85)] data-[state=active]:text-foreground data-[state=active]:shadow-[0_0_0_1px_hsl(var(--ring)/0.35)]"
+                className="inline-flex items-center rounded-full border border-transparent px-[var(--space-3)] py-[calc(var(--space-1)+var(--space-0-5))] text-label font-semibold uppercase tracking-[0.02em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=inactive]:hover:bg-[--hover] data-[state=inactive]:hover:text-foreground data-[state=active]:bg-[hsl(var(--card)/0.85)] data-[state=active]:text-foreground data-[state=active]:shadow-[0_0_0_1px_hsl(var(--ring)/0.35)]"
               >
                 {item.label}
               </button>
@@ -98,7 +98,7 @@ export default function PageHeaderDemo() {
         className="text-muted-foreground data-[state=active]:text-foreground"
         data-state="active"
       >
-        <Bell className="h-4 w-4" />
+        <Bell className="h-[var(--space-4)] w-[var(--space-4)]" />
       </IconButton>
       <button
         type="button"
@@ -113,16 +113,16 @@ export default function PageHeaderDemo() {
           }
         }}
         data-state={profileOpen ? "open" : "inactive"}
-        className="inline-flex items-center gap-2 rounded-full border border-transparent bg-[hsl(var(--card)/0.55)] px-3 py-1.5 text-ui font-medium transition-colors hover:bg-[--hover] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=open]:bg-[hsl(var(--card)/0.85)]"
+        className="inline-flex items-center gap-[var(--space-2)] rounded-full border border-transparent bg-[hsl(var(--card)/0.55)] px-[var(--space-3)] py-[calc(var(--space-1)+var(--space-0-5))] text-ui font-medium transition-colors hover:bg-[--hover] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=open]:bg-[hsl(var(--card)/0.85)]"
       >
-        <CircleUser className="h-4 w-4" />
+        <CircleUser className="h-[var(--space-4)] w-[var(--space-4)]" />
         <span className="hidden sm:inline">Profile</span>
       </button>
     </>
   );
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-[var(--space-5)]">
       <Header
         eyebrow="Planner"
         heading="Compact Header Layout with Balanced Wrapping"
@@ -163,9 +163,9 @@ export default function PageHeaderDemo() {
           ariaLabel: "Switch dashboard view",
         }}
       >
-        <div className="flex flex-wrap items-center gap-3">
+        <div className="flex flex-wrap items-center gap-[var(--space-3)]">
           <p className="text-ui text-muted-foreground">{tabCopy[activeTab]}</p>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-[var(--space-2)]">
             <Button size="sm" variant="secondary">
               Invite teammate
             </Button>
@@ -198,12 +198,12 @@ export default function PageHeaderDemo() {
           "aria-label": "Search scouting intel",
         }}
         actions={
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-[var(--space-2)]">
             <ThemeToggle ariaLabel="Toggle theme" className="shrink-0" />
             <Button
               size="sm"
               variant="primary"
-              className="px-4 whitespace-nowrap"
+              className="px-[var(--space-4)] whitespace-nowrap"
             >
               New report
             </Button>
@@ -296,7 +296,7 @@ export default function PageHeaderDemo() {
               alt="Planner logo"
               width={48}
               height={48}
-              className="h-12 w-auto object-contain"
+              className="h-[var(--space-7)] w-auto object-contain"
             />
           ),
           sticky: false,
@@ -325,7 +325,7 @@ export default function PageHeaderDemo() {
               <Button
                 variant="primary"
                 size="sm"
-                className="px-4 whitespace-nowrap"
+                className="px-[var(--space-4)] whitespace-nowrap"
               >
                 Plan Week
               </Button>
@@ -364,7 +364,7 @@ export default function PageHeaderDemo() {
               alt="Planner logo"
               width={48}
               height={48}
-              className="h-12 w-auto object-contain"
+              className="h-[var(--space-7)] w-auto object-contain"
             />
           ),
           sticky: false,
@@ -384,12 +384,12 @@ export default function PageHeaderDemo() {
             </p>
           ),
           actions: (
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-[var(--space-2)]">
               <ThemeToggle ariaLabel="Toggle theme" className="shrink-0" />
               <Button
                 variant="primary"
                 size="sm"
-                className="px-4 whitespace-nowrap"
+                className="px-[var(--space-4)] whitespace-nowrap"
               >
                 Launch Event
               </Button>
@@ -404,12 +404,12 @@ export default function PageHeaderDemo() {
         PageHeader now routes shared sub-tabs, search, and quick actions into
         the frame’s action grid so controls align with the 12-column layout
         while the inner hero stays calm, single-framed, and flush. It forwards
-        <code className="ml-1 rounded bg-[hsl(var(--card)/0.6)] px-1.5 py-0.5 font-mono text-[0.75rem] text-foreground/80">
+        <code className="ml-[var(--space-1)] rounded bg-[hsl(var(--card)/0.6)] px-[var(--space-2)] py-[var(--space-0-5)] font-mono text-label text-foreground/80">
           {"hero.padding = \"none\""}
         </code>{" "}
         so the content hugs the frame. Want the Hero divider row instead? Pass
         {" "}
-        <code className="ml-1 rounded bg-[hsl(var(--card)/0.6)] px-1.5 py-0.5 font-mono text-[0.75rem] text-foreground/80">
+        <code className="ml-[var(--space-1)] rounded bg-[hsl(var(--card)/0.6)] px-[var(--space-2)] py-[var(--space-0-5)] font-mono text-label text-foreground/80">
           {"frameProps={{ slots: null }}"}
         </code>{" "}
         to hand control back to Hero while keeping tone overrides intact.


### PR DESCRIPTION
## Summary
- replace primary navigation and profile controls with spacing tokens so they sit on the sanctioned scale
- swap inline code badge spacing and text utilities for the official token classes and audit remaining ad-hoc spacing

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc5ffc68b8832cbb79335afab2ac56