### PR TITLE
Use card hairline token for DashboardCard divider

### DIFF
--- a/src/components/home/DashboardCard.tsx
+++ b/src/components/home/DashboardCard.tsx
@@ -25,7 +25,7 @@ export default function DashboardCard({
       </div>
       {children && (
         <div
-          className="border-t border-[hsl(var(--foreground)/0.16)] pt-[var(--space-4)] space-y-[var(--space-4)]"
+          className="border-t border-card-hairline/60 pt-[var(--space-4)] space-y-[var(--space-4)]"
         >
           {children}
         </div>


### PR DESCRIPTION
## Summary
- replace the DashboardCard content divider border color with the card hairline token to align with design system helpers

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc60700824832cb77597876005fac7