### PR TITLE
Update animation toggle cleanup to respect user preference

### DIFF
--- a/src/components/ui/AnimationToggle.tsx
+++ b/src/components/ui/AnimationToggle.tsx
@@ -17,6 +17,9 @@ export default function AnimationToggle({
   const [enabled, setEnabled] = usePersistentState<boolean>(KEY, true);
   const [showNotice, setShowNotice] = React.useState(false);
   const reduceMotion = usePrefersReducedMotion();
+  const appliedByToggleRef = React.useRef(false);
+  const latestEnabledRef = React.useRef(enabled);
+  latestEnabledRef.current = enabled;
 
   React.useEffect(() => {
     if (readLocal<boolean>(KEY) === null && reduceMotion) {
@@ -27,9 +30,20 @@ export default function AnimationToggle({
   }, [reduceMotion, setEnabled]);
 
   React.useEffect(() => {
-    document.documentElement.classList.toggle("no-animations", !enabled);
+    const root = document.documentElement;
+
+    if (!enabled) {
+      if (!root.classList.contains("no-animations")) {
+        root.classList.add("no-animations");
+      }
+      appliedByToggleRef.current = true;
+    }
+
     return () => {
-      document.documentElement.classList.remove("no-animations");
+      if (latestEnabledRef.current && appliedByToggleRef.current) {
+        root.classList.remove("no-animations");
+        appliedByToggleRef.current = false;
+      }
     };
   }, [enabled]);
 

--- a/tests/ui/animation-toggle.test.tsx
+++ b/tests/ui/animation-toggle.test.tsx
@@ -49,6 +49,23 @@ describe("AnimationToggle", () => {
     });
   });
 
+  it("leaves reduced motion class in place when unmounted while disabled", async () => {
+    const { getByRole, unmount } = render(<AnimationToggle />);
+    const button = getByRole("button");
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains("no-animations")).toBe(
+        true,
+      );
+    });
+
+    unmount();
+
+    expect(document.documentElement.classList.contains("no-animations")).toBe(true);
+  });
+
   it("is focusable for keyboard users", () => {
     const { getByRole } = render(<AnimationToggle />);
     const button = getByRole("button");


### PR DESCRIPTION
## Summary
- ensure `AnimationToggle` only removes the `no-animations` class when motion is being re-enabled by the current instance
- guard cleanup with the latest enabled state so the reduced-motion class persists across screens until toggled back on
- add a regression test covering the unmount scenario where animations remain disabled

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc64528bcc832c99e2f6b48b0d951f