### PR TITLE
Wrap RemindersTab gallery entry with provider

### DIFF
--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -81,6 +81,7 @@ import {
   TimerRing,
   TimerTab,
 } from "@/components/goals";
+import { RemindersProvider } from "@/components/goals/reminders/useReminders";
 import { ProgressRingIcon, TimerRingIcon } from "@/icons";
 import { Circle, CircleDot, CircleCheck, Plus } from "lucide-react";
 
@@ -757,9 +758,15 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
     {
       id: "reminders-tab",
       name: "RemindersTab",
-      element: <RemindersTab />,
+      element: (
+        <RemindersProvider>
+          <RemindersTab />
+        </RemindersProvider>
+      ),
       tags: ["reminders", "tab"],
-      code: `<RemindersTab />`,
+      code: `<RemindersProvider>
+  <RemindersTab />
+</RemindersProvider>`,
     },
     {
       id: "timer-ring",


### PR DESCRIPTION
## Summary
- wrap the planner gallery RemindersTab spec in RemindersProvider so it can access reminders context without throwing
- update the corresponding code example to reflect the provider wrapper

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc67347218832c8d94464e07079243