### PR TITLE
Align color swatch labels to the left

### DIFF
--- a/src/components/prompts/ColorsView.tsx
+++ b/src/components/prompts/ColorsView.tsx
@@ -20,21 +20,21 @@ type SwatchProps = { token: string };
 
 function Swatch({ token }: SwatchProps) {
   return (
-    <li className="flex flex-col items-center gap-[var(--space-2)] xl:col-span-3">
+    <li className="flex flex-col items-start gap-[var(--space-2)] xl:col-span-3">
       <div
         className="h-16 w-full rounded-card r-card-md border border-[var(--card-hairline)]"
         style={{ backgroundColor: `hsl(var(--${token}))` }}
       />
-      <span className="text-label font-medium">{token}</span>
+      <span className="w-full text-left text-label font-medium">{token}</span>
     </li>
   );
 }
 
 function GradientSwatch() {
   return (
-    <li className="col-span-full xl:col-span-6 flex flex-col items-center gap-[var(--space-2)]">
+    <li className="col-span-full xl:col-span-6 flex flex-col items-start gap-[var(--space-2)]">
       <div className="h-16 w-full rounded-card r-card-md bg-gradient-to-r from-primary via-accent to-transparent" />
-      <span className="text-label font-medium">
+      <span className="w-full text-left text-label font-medium">
         from-primary via-accent to-transparent
       </span>
     </li>


### PR DESCRIPTION
## Summary
- left-align color swatch content by using start alignment on the column layout
- give swatch labels full-width, left-aligned text to keep spacing consistent with the color block

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc693b2e8c832c97b6f965fd9541fc