### PR TITLE
Fix components view focus effect

### DIFF
--- a/src/components/components/ComponentsPage.tsx
+++ b/src/components/components/ComponentsPage.tsx
@@ -159,6 +159,7 @@ export default function ComponentsPage() {
   const [query, setQuery] = usePersistentState("components-query", "");
   const componentsPanelRef = React.useRef<HTMLDivElement>(null);
   const colorsPanelRef = React.useRef<HTMLDivElement>(null);
+  const previousViewRef = React.useRef<ComponentsView | null>(null);
   const sectionLabel = React.useMemo(
     () =>
       section
@@ -256,10 +257,12 @@ export default function ComponentsPage() {
   }, [paramsString, query, queryParam, router, startTransition]);
 
   React.useEffect(() => {
-    if (view === "components") {
+    const previousView = previousViewRef.current;
+    if (view === "components" && previousView !== "components") {
       componentsPanelRef.current?.focus();
     }
-  }, [section, view]);
+    previousViewRef.current = view;
+  }, [view]);
 
   React.useEffect(() => {
     if (view === "colors") {


### PR DESCRIPTION
## Summary
- ensure the components view focus effect only runs when entering the components panel
- keep the colors panel focus behavior unchanged when switching views

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc6e1d0684832caec7b841238e84ae