### PR TITLE
Update gradient swatch to use semantic accent token

### DIFF
--- a/src/components/prompts/ColorsView.tsx
+++ b/src/components/prompts/ColorsView.tsx
@@ -70,9 +70,9 @@ function Swatch({ token }: SwatchProps) {
 function GradientSwatch() {
   return (
     <li className="col-span-full xl:col-span-6 flex flex-col items-center gap-[var(--space-2)]">
-      <div className="h-16 w-full rounded-card r-card-md bg-gradient-to-r from-primary via-accent to-transparent" />
+      <div className="h-16 w-full rounded-card r-card-md bg-gradient-to-r from-primary via-accent to-[hsl(var(--accent-2))]" />
       <span className="text-label font-medium">
-        from-primary via-accent to-transparent
+        from-primary via-accent to-[hsl(var(--accent-2))]
       </span>
     </li>
   );


### PR DESCRIPTION
## Summary
- replace the gradient swatch's transparent stop with the accent-2 semantic token
- update the label text to document the new gradient stops

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc6d913dd8832c9928daa3c508dda4