### PR TITLE
Normalize PageHeader actions slot handling

### DIFF
--- a/tests/components/PageHeader.test.tsx
+++ b/tests/components/PageHeader.test.tsx
@@ -230,6 +230,14 @@ describe("PageHeader", () => {
     expect(searchSlot).toHaveAttribute("aria-label", "Search planner highlights");
   });
 
+  it("omits the actions slot container when actions resolve to false", () => {
+    const { container } = render(
+      <PageHeader header={baseHeader} hero={baseHero} actions={false} />,
+    );
+
+    expect(container.querySelector('[data-slot="actions"]')).toBeNull();
+  });
+
   describe("frame alignment fallbacks", () => {
     const createSubTabs = () => ({
       items: [


### PR DESCRIPTION
## Summary
- sanitize PageHeader hero action values and frame slot registration so non-renderable inputs are ignored
- ensure the sanitized actions value is reused by the Hero props and slot merger logic
- add a regression test covering actions={false} to verify the slot container is omitted

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc737fba9c832ca3f679a78145bff1