### PR TITLE
Refine prompts layout with page shell and header

### DIFF
--- a/src/components/prompts/PromptsHeader.tsx
+++ b/src/components/prompts/PromptsHeader.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import * as React from "react";
-import { Button, SearchBar } from "@/components/ui";
+import { Button, PageHeader } from "@/components/ui";
 import Badge from "@/components/ui/primitives/Badge";
-import useDebouncedCallback from "@/lib/useDebouncedCallback";
 
 const chips = ["hover", "focus", "active", "disabled", "loading"];
 
 interface PromptsHeaderProps {
+  id?: string;
   count: number;
   query: string;
   onQueryChange: (value: string) => void;
@@ -16,59 +16,69 @@ interface PromptsHeaderProps {
 }
 
 export default function PromptsHeader({
+  id = "prompts-header",
   count,
   query,
   onQueryChange,
   onSave,
   disabled,
 }: PromptsHeaderProps) {
-  const [localQuery, setLocalQuery] = React.useState(query);
-  const [emitQueryChange] = useDebouncedCallback(onQueryChange, 300);
-
-  React.useEffect(() => {
-    setLocalQuery(query);
-  }, [query]);
-
-  const handleChange = React.useCallback(
-    (val: string) => {
-      setLocalQuery(val);
-      emitQueryChange(val);
+  const handleChip = React.useCallback(
+    (chip: string) => {
+      onQueryChange(chip);
     },
-    [emitQueryChange],
+    [onQueryChange],
   );
 
-  const handleChip = (chip: string) => {
-    setLocalQuery(chip);
-    onQueryChange(chip);
-  };
+  const searchId = `${id}-search`;
 
   return (
-    <div className="flex items-center justify-between w-full">
-      <div className="flex items-center gap-3">
-        <h2 className="card-title">Prompts</h2>
-        <span className="pill">{count} saved</span>
-      </div>
-      <div className="flex items-center gap-2 min-w-0">
-        <div className="w-48 sm:w-64 md:w-80">
-          <SearchBar
-            value={localQuery}
-            onValueChange={handleChange}
-            placeholder="Search prompts…"
-            debounceMs={0}
-          />
-        </div>
-        <div className="hidden sm:flex gap-1">
-          {chips.map((c) => (
-            <Badge key={c} interactive onClick={() => handleChip(c)}>
-              {c}
-            </Badge>
-          ))}
-        </div>
-        <Button variant="primary" onClick={onSave} disabled={disabled}>
-          Save
-        </Button>
-      </div>
-    </div>
+    <PageHeader
+      containerClassName="relative isolate"
+      header={{
+        id,
+        heading: "Prompts",
+        sticky: false,
+        right: (
+          <span className="pill" aria-live="polite">
+            {count} saved
+          </span>
+        ),
+      }}
+      hero={{
+        frame: false,
+        sticky: false,
+        tone: "supportive",
+        topClassName: "top-[var(--header-stack)]",
+        heading: (
+          <span className="sr-only" id={`${id}-hero`}>
+            Prompt workspace controls
+          </span>
+        ),
+        children: (
+          <div className="hidden sm:flex flex-wrap items-center gap-[var(--space-2)]">
+            {chips.map((chip) => (
+              <Badge key={chip} interactive onClick={() => handleChip(chip)}>
+                {chip}
+              </Badge>
+            ))}
+          </div>
+        ),
+        search: {
+          id: searchId,
+          value: query,
+          onValueChange: onQueryChange,
+          debounceMs: 300,
+          placeholder: "Search prompts…",
+          "aria-label": "Search prompts",
+        },
+        actions: (
+          <Button type="button" variant="primary" onClick={onSave} disabled={disabled}>
+            Save
+          </Button>
+        ),
+      }}
+    />
   );
 }
 

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 
+import { PageShell } from "@/components/ui";
 import { Tabs, TabList, TabPanel, type TabListItem } from "@/components/ui/primitives/Tabs";
 import { usePersistentState } from "@/lib/db";
 import PromptsHeader from "./PromptsHeader";
@@ -133,48 +134,55 @@ export default function PromptsPage() {
   }, [activeTab, chatPrompts.length, codexPrompts.length, notes]);
 
   return (
-    <Tabs value={activeTab} onValueChange={setActiveTab} idBase="prompts-tabs">
-      <PromptsHeader
-        count={activeCount}
-        query={activeQuery}
-        onQueryChange={handleQueryChange}
-        onSave={handleSave}
-        disabled={saveDisabled}
-      />
-
-      <TabList
-        items={tabItems}
-        ariaLabel="Prompt workspaces"
-        showBaseline
-      />
-
-      <TabPanel value="chat" className="pb-[var(--space-8)]">
-        <ChatPromptsTab
-          title={chatTitleDraft}
-          text={chatTextDraft}
-          onTitleChange={setChatTitleDraft}
-          onTextChange={setChatTextDraft}
-          prompts={chatFiltered}
-          query={chatQuery}
-          personas={personas}
+    <PageShell
+      as="main"
+      className="space-y-[var(--space-6)] py-[var(--space-6)]"
+      aria-labelledby="prompts-header"
+    >
+      <Tabs value={activeTab} onValueChange={setActiveTab} idBase="prompts-tabs">
+        <PromptsHeader
+          id="prompts-header"
+          count={activeCount}
+          query={activeQuery}
+          onQueryChange={handleQueryChange}
+          onSave={handleSave}
+          disabled={saveDisabled}
         />
-      </TabPanel>
 
-      <TabPanel value="codex" className="pb-[var(--space-8)]">
-        <CodexPromptsTab
-          title={codexTitleDraft}
-          text={codexTextDraft}
-          onTitleChange={setCodexTitleDraft}
-          onTextChange={setCodexTextDraft}
-          prompts={codexFiltered}
-          query={codexQuery}
+        <TabList
+          items={tabItems}
+          ariaLabel="Prompt workspaces"
+          showBaseline
         />
-      </TabPanel>
 
-      <TabPanel value="notes" className="pb-[var(--space-8)]">
-        <NotesTab value={notes} onChange={setNotes} />
-      </TabPanel>
-    </Tabs>
+        <TabPanel value="chat" className="pb-[var(--space-8)]">
+          <ChatPromptsTab
+            title={chatTitleDraft}
+            text={chatTextDraft}
+            onTitleChange={setChatTitleDraft}
+            onTextChange={setChatTextDraft}
+            prompts={chatFiltered}
+            query={chatQuery}
+            personas={personas}
+          />
+        </TabPanel>
+
+        <TabPanel value="codex" className="pb-[var(--space-8)]">
+          <CodexPromptsTab
+            title={codexTitleDraft}
+            text={codexTextDraft}
+            onTitleChange={setCodexTitleDraft}
+            onTextChange={setCodexTextDraft}
+            prompts={codexFiltered}
+            query={codexQuery}
+          />
+        </TabPanel>
+
+        <TabPanel value="notes" className="pb-[var(--space-8)]">
+          <NotesTab value={notes} onChange={setNotes} />
+        </TabPanel>
+      </Tabs>
+    </PageShell>
   );
 }
 

--- a/tests/prompts/prompts-header.test.tsx
+++ b/tests/prompts/prompts-header.test.tsx
@@ -12,6 +12,7 @@ describe("PromptsHeader", () => {
   it("renders count, search input, and disabled save button", () => {
     const handleQuery = vi.fn();
     const handleSave = vi.fn();
+    vi.useFakeTimers();
     render(
       <PromptsHeader
         count={2}
@@ -31,11 +32,9 @@ describe("PromptsHeader", () => {
     const save = screen.getByRole("button", { name: "Save" });
     expect(save).toBeDisabled();
 
-    vi.useFakeTimers();
     fireEvent.change(search, { target: { value: "changed" } });
     vi.advanceTimersByTime(300);
     expect(handleQuery).toHaveBeenCalledWith("changed");
-    vi.useRealTimers();
   });
 
   it("calls onSave when save button clicked", () => {


### PR DESCRIPTION
## Summary
- wrap the prompts view in PageShell so the layout matches other screens
- rebuild PromptsHeader on top of PageHeader to host the heading, search, chips, and save action
- update the prompts header test to align with the new debounced search setup

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc74876528832c8e00173f88dac887