### PR TITLE
Add size support to AnimatedSelect trigger

### DIFF
--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -509,14 +509,37 @@ export default function ComponentGallery() {
       {
         label: "AnimatedSelect",
         element: (
-          <Select
-            variant="animated"
-            items={selectItems}
-            value={selectValue}
-            onChange={setSelectValue}
-            className="w-56"
-            hideLabel
-          />
+          <div className="w-56 space-y-2">
+            <Select
+              variant="animated"
+              size="sm"
+              items={selectItems}
+              value={selectValue}
+              onChange={setSelectValue}
+              className="w-full"
+              hideLabel
+              placeholder="Small"
+            />
+            <Select
+              variant="animated"
+              items={selectItems}
+              value={selectValue}
+              onChange={setSelectValue}
+              className="w-full"
+              hideLabel
+              placeholder="Medium"
+            />
+            <Select
+              variant="animated"
+              size="lg"
+              items={selectItems}
+              value={selectValue}
+              onChange={setSelectValue}
+              className="w-full"
+              hideLabel
+              placeholder="Large"
+            />
+          </div>
         ),
       },
     ],

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -121,7 +121,7 @@ export default function ReviewsPage({
                     { value: "title", label: "Title" },
                   ]}
                   className="w-full sm:w-auto"
-                  buttonClassName="!h-[var(--control-h-lg)] !px-[var(--space-4)]"
+                  size="lg"
                 />
               </label>
               <Button

--- a/src/components/ui/select/AnimatedSelect.tsx
+++ b/src/components/ui/select/AnimatedSelect.tsx
@@ -18,6 +18,39 @@ type AnimatedSelectComponentProps = AnimatedSelectProps & {
   styles?: SelectStyles;
 };
 
+type SelectSize = NonNullable<AnimatedSelectProps["size"]>;
+
+const DEFAULT_TRIGGER_SIZE: SelectSize = "md";
+
+const SIZE_STYLES: Record<
+  SelectSize,
+  {
+    height: string;
+    paddingX: string;
+    caret: string;
+    prefix: string;
+  }
+> = {
+  sm: {
+    height: "h-[var(--control-h-sm)]",
+    paddingX: "px-[var(--space-3)]",
+    caret: "size-[var(--space-4)]",
+    prefix: "size-[var(--space-4)]",
+  },
+  md: {
+    height: "h-[var(--control-h-md)]",
+    paddingX: "px-[var(--space-3)]",
+    caret: "size-[var(--space-5)]",
+    prefix: "size-[var(--space-5)]",
+  },
+  lg: {
+    height: "h-[var(--control-h-lg)]",
+    paddingX: "px-[var(--space-4)]",
+    caret: "size-[var(--space-6)]",
+    prefix: "size-[var(--space-6)]",
+  },
+};
+
 const AnimatedSelect = React.forwardRef<
   HTMLButtonElement,
   AnimatedSelectComponentProps
@@ -39,11 +72,13 @@ const AnimatedSelect = React.forwardRef<
       ariaLabel,
       align = "left",
       matchTriggerWidth = true,
+      size = DEFAULT_TRIGGER_SIZE,
       styles: stylesOverride,
     },
     ref,
   ) {
     const styles = stylesOverride ?? defaultStyles;
+    const sizeStyles = SIZE_STYLES[size] ?? SIZE_STYLES[DEFAULT_TRIGGER_SIZE];
     const mounted = useMounted();
 
     const [open, setOpen] = React.useState(false);
@@ -185,6 +220,11 @@ const AnimatedSelect = React.forwardRef<
         window.removeEventListener("scroll", handler);
       };
     }, [open, scheduleMeasure]);
+
+    React.useEffect(() => {
+      if (!open) return;
+      scheduleMeasure();
+    }, [open, scheduleMeasure, size]);
 
     React.useEffect(() => {
       if (!open) return;
@@ -372,7 +412,9 @@ const AnimatedSelect = React.forwardRef<
 
     const triggerCls = cn(
       styles.glitchTrigger,
-      "relative flex items-center h-[var(--control-h-sm)] rounded-[var(--radius-full)] px-[var(--space-3)] overflow-hidden",
+      "relative flex items-center rounded-[var(--radius-full)] overflow-hidden",
+      sizeStyles.height,
+      sizeStyles.paddingX,
       "bg-muted/12 hover:bg-muted/18",
       "focus:[outline:none] focus-visible:[outline:none]",
       "transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none",
@@ -381,7 +423,8 @@ const AnimatedSelect = React.forwardRef<
 
     const caretCls = cn(
       styles.caret,
-      "ml-auto size-[var(--space-4)] shrink-0 opacity-75",
+      "ml-auto shrink-0 opacity-75",
+      sizeStyles.caret,
       open && styles.caretOpen,
     );
 
@@ -422,7 +465,10 @@ const AnimatedSelect = React.forwardRef<
             {prefixLabel ? (
               <ChevronRight
                 aria-hidden="true"
-                className="h-[var(--space-4)] w-[var(--space-4)] shrink-0 opacity-70 transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none"
+                className={cn(
+                  "shrink-0 opacity-70 transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none",
+                  sizeStyles.prefix,
+                )}
               />
             ) : null}
 

--- a/src/components/ui/select/shared.ts
+++ b/src/components/ui/select/shared.ts
@@ -1,5 +1,7 @@
 import * as React from "react";
 
+import type { InputSize } from "../primitives/Input";
+
 export type SelectItem = {
   value: string;
   label: React.ReactNode;
@@ -30,6 +32,7 @@ export type AnimatedSelectProps = CommonSelectProps & {
   ariaLabel?: string;
   align?: Align;
   matchTriggerWidth?: boolean;
+  size?: InputSize;
 };
 
 export interface NativeSelectProps

--- a/src/components/ui/theme/BackgroundPicker.tsx
+++ b/src/components/ui/theme/BackgroundPicker.tsx
@@ -54,7 +54,8 @@ export default function BackgroundPicker({
       items={items}
       value={String(bg)}
       onChange={(v) => onBgChange(Number(v) as Background)}
-      buttonClassName="!h-[var(--control-h-sm)] !px-[var(--space-3)] !rounded-full !text-ui !shadow-neo-inset hover:ring-2 hover:ring-[var(--edge-iris)] focus-visible:ring-2 focus-visible:ring-[var(--edge-iris)]"
+      size="sm"
+      buttonClassName="!rounded-full !text-ui !shadow-neo-inset hover:ring-2 hover:ring-[var(--edge-iris)] focus-visible:ring-2 focus-visible:ring-[var(--edge-iris)]"
       matchTriggerWidth={false}
       className={className}
     />

--- a/src/components/ui/theme/ThemePicker.tsx
+++ b/src/components/ui/theme/ThemePicker.tsx
@@ -20,7 +20,8 @@ export default function ThemePicker({ variant, onVariantChange, className = "" }
       items={items}
       value={variant}
       onChange={v => onVariantChange(v as Variant)}
-      buttonClassName="!h-[var(--control-h-sm)] !px-[var(--space-3)] !rounded-full !text-ui !shadow-neo-inset hover:ring-2 hover:ring-[var(--edge-iris)] focus-visible:ring-2 focus-visible:ring-[var(--edge-iris)]"
+      size="sm"
+      buttonClassName="!rounded-full !text-ui !shadow-neo-inset hover:ring-2 hover:ring-[var(--edge-iris)] focus-visible:ring-2 focus-visible:ring-[var(--edge-iris)]"
       matchTriggerWidth={false}
       className={className}
     />

--- a/src/components/ui/theme/ThemeToggle.tsx
+++ b/src/components/ui/theme/ThemeToggle.tsx
@@ -145,7 +145,8 @@ export default function ThemeToggle({
         items={items}
         value={variant}
         onChange={handleChange}
-        buttonClassName="!h-[var(--control-h-sm)] !px-[var(--space-3)] !rounded-full !text-ui !w-auto"
+        size="sm"
+        buttonClassName="!rounded-full !text-ui !w-auto"
         matchTriggerWidth={false}
         align="right"
         className="shrink-0"

--- a/storybook/src/components/ui/AnimatedSelect.stories.tsx
+++ b/storybook/src/components/ui/AnimatedSelect.stories.tsx
@@ -5,6 +5,12 @@ import { AnimatedSelect } from "@/components/ui";
 const meta: Meta<typeof AnimatedSelect> = {
   title: "Primitives/AnimatedSelect",
   component: AnimatedSelect,
+  argTypes: {
+    size: {
+      options: ["sm", "md", "lg"],
+      control: { type: "inline-radio" },
+    },
+  },
   parameters: {
     layout: "fullscreen",
     docs: {
@@ -13,6 +19,9 @@ const meta: Meta<typeof AnimatedSelect> = {
           "AnimatedSelect automatically repositions the floating menu to stay visible within the viewport.",
       },
     },
+  },
+  args: {
+    size: "md",
   },
 };
 

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -295,7 +295,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                         aria-expanded="false"
                         aria-haspopup="listbox"
                         aria-label="Sort reviews"
-                        class="_glitchTrigger_843152 relative flex items-center h-[var(--control-h-sm)] rounded-[var(--radius-full)] px-[var(--space-3)] overflow-hidden bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none !h-[var(--control-h-lg)] !px-[var(--space-4)]"
+                        class="_glitchTrigger_843152 relative flex items-center rounded-[var(--radius-full)] overflow-hidden h-[var(--control-h-lg)] px-[var(--space-4)] bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none"
                         data-lit="true"
                         data-open="false"
                         type="button"
@@ -307,7 +307,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                         </span>
                         <svg
                           aria-hidden="true"
-                          class="lucide lucide-chevron-down _caret_843152 ml-auto size-[var(--space-4)] shrink-0 opacity-75"
+                          class="lucide lucide-chevron-down _caret_843152 ml-auto shrink-0 opacity-75 size-[var(--space-6)]"
                           fill="none"
                           height="24"
                           stroke="currentColor"


### PR DESCRIPTION
## Summary
- add an optional `size` prop to the animated select so the trigger height, padding, and caret sizing align with input tokens
- update theming pickers, the reviews sort control, and the component gallery to opt into small or large trigger heights and demonstrate the new variants
- expose the size options in the AnimatedSelect story for easier testing

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc766e2378832c8d0d23f413cba4d6