### PR TITLE
Ensure gradient swatch spans full width in ColorsView

### DIFF
--- a/src/components/prompts/ColorsView.tsx
+++ b/src/components/prompts/ColorsView.tsx
@@ -101,9 +101,9 @@ function Swatch({ token }: SwatchProps) {
 
 function GradientSwatch() {
   return (
-    <li className="col-span-full xl:col-span-6 flex flex-col items-center gap-[var(--space-2)]">
+    <li className="col-span-full flex flex-col items-center gap-[var(--space-2)]">
       <div className="h-16 w-full rounded-card r-card-md bg-gradient-to-r from-primary via-accent to-[hsl(var(--accent-2))]" />
-      <span className="text-label font-medium">
+      <span className="block w-full text-center text-label font-medium">
         from-primary via-accent to-[hsl(var(--accent-2))]
       </span>
     </li>


### PR DESCRIPTION
## Summary
- update the gradient swatch list item so it spans the full grid width across breakpoints
- align the gradient label styling with other swatches for consistent presentation

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc9e8c2d8c832c8dfa042359488dae