### PR TITLE
Fix SideSelector indicator alignment

### DIFF
--- a/src/components/ui/league/SideSelector.tsx
+++ b/src/components/ui/league/SideSelector.tsx
@@ -95,9 +95,7 @@ export default function SideSelector({
         className="absolute top-[var(--space-1)] bottom-[var(--space-1)] left-[var(--space-1)] rounded-full transition-transform duration-200 ease-[var(--ease-out, cubic-bezier(.2,.8,.2,1))]"
         style={{
           width: "calc(50% - var(--space-1))",
-          transform: `translateX(${
-            isRight ? "calc(100% + var(--space-1) / 2)" : "0"
-          })`,
+          transform: `translateX(${isRight ? "100%" : "0"})`,
           background:
             "linear-gradient(90deg, hsl(var(--primary)/.35), hsl(var(--accent)/.35))",
           boxShadow: "0 10px 30px hsl(var(--shadow-color) / .25)",


### PR DESCRIPTION
## Summary
- align the SideSelector indicator translation to land flush against both rails

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cca1aafc90832c8b59d0be145ba053