### PR TITLE
Adjust loss toggle translation

### DIFF
--- a/src/components/reviews/ResultScoreSection.tsx
+++ b/src/components/reviews/ResultScoreSection.tsx
@@ -88,7 +88,7 @@ function ResultScoreSection(
             className="absolute top-1 bottom-1 left-1 rounded-xl transition-transform duration-300"
             style={{
               width: "calc(50% - var(--space-1))",
-              transform: `translate3d(${result === "Win" ? "0" : "calc(100% + var(--space-1) / 2)"},0,0)`,
+              transform: `translate3d(${result === "Win" ? "0" : "100%"},0,0)`,
               transitionTimingFunction: "cubic-bezier(.22,1,.36,1)",
               background:
                 result === "Win"


### PR DESCRIPTION
## Summary
- center the result toggle highlight by translating the Loss state by 100%
- retained the existing gradient and shadow styling for the sliding indicator

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cca24115ac832caaaec9c69abee771