### PR TITLE
Fix Hero rail styling and tests

### DIFF
--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -152,7 +152,7 @@ function Hero<Key extends string = string>({
     : "gap-[var(--space-2)] md:gap-[var(--space-4)]";
 
   const labelClusterClass = cx(
-    "col-span-full md:col-span-8 flex min-w-0 flex-wrap items-start md:flex-nowrap",
+    "relative col-span-full md:col-span-8 flex min-w-0 flex-wrap items-start md:flex-nowrap",
     isRaisedBar ? "md:items-stretch" : "md:items-center",
     clusterGapClass,
   );
@@ -286,7 +286,12 @@ function Hero<Key extends string = string>({
 
         <div className={cx(barSpacingClass, barClassName)}>
           <div className={labelClusterClass}>
-            {rail ? <span aria-hidden className="rail shrink-0 self-stretch" /> : null}
+            {rail ? (
+              <span
+                aria-hidden
+                className="header-rail pointer-events-none absolute left-0 top-[var(--space-1)] bottom-[var(--space-1)] w-[var(--space-2)] rounded-l-2xl"
+              />
+            ) : null}
             {isRaisedBar ? (
               <div className={raisedLabelBarClass}>
                 {iconNode}

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -134,11 +134,11 @@ exports[`ReviewsPage > renders default state 1`] = `
                   class="relative z-[2] grid grid-cols-1 md:grid-cols-12 items-start md:items-center gap-y-[var(--space-2)] md:gap-y-0 md:gap-x-[var(--space-4)] lg:gap-x-[var(--space-5)] py-[var(--space-4)] md:py-[var(--space-5)]"
                 >
                   <div
-                    class="col-span-full md:col-span-8 flex min-w-0 flex-wrap items-start md:flex-nowrap md:items-center gap-[var(--space-2)] md:gap-[var(--space-4)]"
+                    class="relative col-span-full md:col-span-8 flex min-w-0 flex-wrap items-start md:flex-nowrap md:items-center gap-[var(--space-2)] md:gap-[var(--space-4)]"
                   >
                     <span
                       aria-hidden="true"
-                      class="rail shrink-0 self-stretch"
+                      class="header-rail pointer-events-none absolute left-0 top-[var(--space-1)] bottom-[var(--space-1)] w-[var(--space-2)] rounded-l-2xl"
                     />
                     <div
                       class="min-w-0"

--- a/tests/ui/tab-bar.test.tsx
+++ b/tests/ui/tab-bar.test.tsx
@@ -52,4 +52,17 @@ describe("navigation tabs", () => {
     );
     expect(screen.getByRole("tab", { name: "Buttons" })).toBeInTheDocument();
   });
+
+  it("renders the animated header rail when enabled", () => {
+    const { container } = render(<Hero heading="Components" rail />);
+    const rail = container.querySelector(".header-rail");
+    expect(rail).not.toBeNull();
+    expect(rail).toHaveAttribute("aria-hidden", "true");
+    expect(rail?.className).toContain("pointer-events-none");
+  });
+
+  it("omits the decorative rail when disabled", () => {
+    const { container } = render(<Hero heading="Components" rail={false} />);
+    expect(container.querySelector(".header-rail")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- reuse the header rail styling in the Hero layout so the decorative spine inherits the global animations
- add targeted tests for the Hero rail toggle and update the reviews snapshot to match the new markup

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cca37fabf8832c8cd84f96a1306f01