### PR TITLE
Align home hero actions with grid columns

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -473,12 +473,8 @@ function HomePageContent() {
                       barVariant: "raised",
                       topClassName: "top-0",
                       actions: (
-                        <div
-                          className="flex w-full flex-col gap-[var(--space-3)] sm:flex-row sm:items-center sm:justify-end sm:gap-[var(--space-3)]"
-                        >
-                          <div
-                            className="flex w-full flex-wrap items-center justify-end gap-[var(--space-2)] sm:w-auto sm:flex-nowrap"
-                          >
+                        <div className="grid w-full grid-cols-12 gap-[var(--space-3)] sm:items-center">
+                          <div className="col-span-12 flex w-full flex-wrap items-center justify-end gap-[var(--space-2)] sm:flex-nowrap md:col-span-8 lg:col-span-7">
                             <ThemeToggle className="shrink-0" />
                             <Button
                               asChild
@@ -490,9 +486,7 @@ function HomePageContent() {
                               <Link href="/planner">Plan Week</Link>
                             </Button>
                           </div>
-                          <WelcomeHeroFigure
-                            className="flex w-full shrink-0 sm:max-w-[min(52vw,calc(var(--space-8) * 4))] md:basis-[33%] md:max-w-[34%] lg:basis-[42%] lg:max-w-[44%]"
-                          />
+                          <WelcomeHeroFigure className="col-span-12 md:col-span-4 lg:col-span-5" />
                         </div>
                       ),
                       children: (

--- a/src/components/home/WelcomeHeroFigure.tsx
+++ b/src/components/home/WelcomeHeroFigure.tsx
@@ -41,7 +41,7 @@ const haloSecondaryStyle: React.CSSProperties = {
 };
 
 const defaultSizes =
-  "(max-width: 639px) 100vw, (max-width: 1023px) 33vw, 40vw";
+  "(max-width: 767px) 100vw, (max-width: 1023px) calc(100vw / 3), calc(100vw * 5 / 12)";
 
 export interface WelcomeHeroFigureProps {
   className?: string;


### PR DESCRIPTION
## Summary
- move the home hero action cluster into the shared 12-column grid and remove bespoke max-width overrides
- tune the WelcomeHeroFigure default image sizes to better match the responsive column spans

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cca4acd15c832cb8b9df4cb0be4992