### PR TITLE
Align page shell padding with layout rhythm

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -23,6 +23,9 @@ This project ships with a small design system based on Tailwind CSS and CSS vari
 
 - Use a 12‑column grid with 24px gutters.
 - Spacing tokens: `1`=4px, `2`=8px, `3`=12px, `4`=16px, `5`=24px, `6`=32px, `7`=48px, `8`=64px.
+- Wrap page-level content with `.page-shell` or the `<PageShell />` component to get the shared container rhythm: `space-6` on
+  small screens, `space-7` at `md`, and `space-8` at `lg`. Add vertical padding per view instead of redefining horizontal
+  gutters.
 
 ## Typography
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,7 +13,7 @@
     width: 100%;
     max-width: var(--shell-max, var(--shell-width));
     margin-inline: auto;
-    padding-inline: clamp(var(--space-3), 2.5vw, var(--space-6));
+    @apply px-[var(--space-6)] md:px-[var(--space-7)] lg:px-[var(--space-8)];
   }
 
   .page-backdrop {


### PR DESCRIPTION
## Summary
- swap the page shell clamp padding for spacing tokens applied per breakpoint
- note the shared page shell container rhythm in the layout guidelines so downstream shells reuse it

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cca499ac6c832cb7d2a3d5bea08901