### PR TITLE
Align Card header spacing with tokens

### DIFF
--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -845,6 +845,8 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
     {
       id: "card-demo",
       name: "Card",
+      description:
+        "Standard card surface with header spacing set to the space-2 token for consistent vertical rhythm.",
       element: <CardDemo />,
       tags: ["card", "layout"],
       code: `<Card>

--- a/src/components/ui/primitives/Card.tsx
+++ b/src/components/ui/primitives/Card.tsx
@@ -31,7 +31,7 @@ export const CardHeader = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "flex flex-col space-y-[calc(var(--space-3)/2)]",
+      "flex flex-col space-y-[var(--space-2)]",
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary
- replace the CardHeader calc spacing with the space-2 token to match the design scale
- document the new rhythm in the Card component gallery entry

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cca4b55eb8832ca0cc2ea1c5a6006b