### PR TITLE
feat: add grid option to page shell

### DIFF
--- a/src/components/chrome/Banner.tsx
+++ b/src/components/chrome/Banner.tsx
@@ -32,16 +32,22 @@ export default function Banner({
         className
       )}
     >
-      <PageShell className="py-[var(--space-3)]">
-        {title || actions ? (
-          <div className="flex items-center justify-between gap-[var(--space-4)]">
-            <div className="font-mono text-ui text-muted-foreground">
-              {title}
-            </div>
-            <div className="flex items-center gap-[var(--space-3)]">{actions}</div>
+      <PageShell
+        grid
+        className="py-[var(--space-3)]"
+        contentClassName="items-center"
+      >
+        {title ? (
+          <div className="col-span-full font-mono text-ui text-muted-foreground md:col-span-8 lg:col-span-9">
+            {title}
           </div>
         ) : null}
-        {children}
+        {actions ? (
+          <div className="col-span-full flex items-center justify-end gap-[var(--space-3)] md:col-span-4 md:justify-self-end lg:col-span-3">
+            {actions}
+          </div>
+        ) : null}
+        {children ? <div className="col-span-full">{children}</div> : null}
       </PageShell>
     </header>
   );

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -18,11 +18,15 @@ export default function SiteChrome() {
   return (
     <header role="banner" className="sticky top-0 z-50 sticky-blur">
       {/* Bar content */}
-      <PageShell className="flex items-center justify-between py-[var(--space-3)]">
+      <PageShell
+        grid
+        className="py-[var(--space-3)]"
+        contentClassName="items-center"
+      >
         <Link
           href="/"
           aria-label="Home"
-          className="flex items-center gap-[var(--space-3)]"
+          className="col-span-full flex items-center gap-[var(--space-3)] md:col-span-4"
         >
           <span
             className="h-[var(--space-2)] w-[var(--space-2)] rounded-full animate-pulse bg-[hsl(var(--accent-overlay))] shadow-[0_0_6px_hsl(var(--glow-active))]"
@@ -33,10 +37,11 @@ export default function SiteChrome() {
           </span>
         </Link>
 
-        <div className="flex items-center gap-[var(--space-3)]">
-          <div className="hidden min-w-0 items-center md:flex md:flex-1">
-            <NavBar />
-          </div>
+        <div className="col-span-full hidden min-w-0 items-center md:col-span-5 md:flex">
+          <NavBar />
+        </div>
+
+        <div className="col-span-full flex items-center justify-end gap-[var(--space-3)] md:col-span-3 md:justify-self-end">
           <ThemeToggle />
           <AnimationToggle />
         </div>

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -850,14 +850,18 @@ export default function ComponentGallery() {
       {
         label: "PageShell",
         element: (
-          <PageShell className="space-y-3 rounded-card border border-border/40 bg-surface/60 py-6">
-            <div className="text-label font-semibold tracking-[0.02em] text-muted-foreground">
+          <PageShell
+            grid
+            className="rounded-card border border-border/40 bg-surface/60 py-6"
+            contentClassName="items-start"
+          >
+            <div className="col-span-full text-label font-semibold tracking-[0.02em] text-muted-foreground md:col-span-7">
               PageShell
             </div>
-            <p className="text-ui text-muted-foreground">
+            <p className="col-span-full text-ui text-muted-foreground md:col-span-7">
               Constrains page content to the shell width.
             </p>
-            <div className="flex flex-wrap gap-2">
+            <div className="col-span-full flex flex-wrap justify-end gap-2 md:col-span-5 md:justify-self-end">
               <Button size="sm">Primary</Button>
               <Button size="sm" variant="ghost">
                 Ghost

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -1027,21 +1027,40 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
     {
       id: "page-shell",
       name: "PageShell",
-      description: "Responsive page container",
+      description:
+        "Responsive page container. Enable the grid prop and wrap sections in col-span-* to align to the shell template.",
       element: (
-        <PageShell className="space-y-3 py-6">
-          <div className="text-label font-semibold tracking-[0.02em] text-muted-foreground">
+        <PageShell
+          grid
+          className="py-6"
+          contentClassName="items-start"
+        >
+          <div className="col-span-full text-label font-semibold tracking-[0.02em] text-muted-foreground md:col-span-7">
             Page shell content
           </div>
-          <Button size="sm">Action</Button>
+          <div className="col-span-full flex items-center justify-end gap-[var(--space-3)] md:col-span-5 md:justify-self-end">
+            <Button size="sm">Primary</Button>
+            <Button size="sm" variant="ghost">
+              Secondary
+            </Button>
+          </div>
         </PageShell>
       ),
       tags: ["layout", "shell"],
-      code: `<PageShell className="space-y-3 py-6">
-  <div className="text-label font-semibold tracking-[0.02em] text-muted-foreground">
+      code: `<PageShell
+  grid
+  className="py-6"
+  contentClassName="items-start"
+>
+  <div className="col-span-full text-label font-semibold tracking-[0.02em] text-muted-foreground md:col-span-7">
     Page shell content
   </div>
-  <Button size="sm">Action</Button>
+  <div className="col-span-full flex items-center justify-end gap-[var(--space-3)] md:col-span-5 md:justify-self-end">
+    <Button size="sm">Primary</Button>
+    <Button size="sm" variant="ghost">
+      Secondary
+    </Button>
+  </div>
 </PageShell>`,
     },
     {

--- a/src/components/ui/layout/PageShell.tsx
+++ b/src/components/ui/layout/PageShell.tsx
@@ -10,6 +10,13 @@ type PageShellOwnProps<T extends PageShellElement = "div"> = {
   /** Semantic element for the shell container. Defaults to a <div>. */
   as?: T;
   className?: string;
+  /**
+   * Enables the standardized 12-column grid within the page shell.
+   * When set, children should define their own col-span wrappers.
+   */
+  grid?: boolean;
+  /** Additional classes for the inner grid container when `grid` is enabled. */
+  contentClassName?: string;
 };
 
 export type PageShellProps<T extends PageShellElement = "div"> =
@@ -18,10 +25,13 @@ export type PageShellProps<T extends PageShellElement = "div"> =
 
 /**
  * PageShell — width-constrained wrapper that applies the global `page-shell` class.
+ * Use the `grid` prop to opt into the standard 12-column layout inside the shell.
  */
 export default function PageShell<T extends PageShellElement = "div">({
   as,
   className,
+  grid = false,
+  contentClassName,
   children,
   ...rest
 }: PageShellProps<T>) {
@@ -29,7 +39,18 @@ export default function PageShell<T extends PageShellElement = "div">({
 
   return (
     <Component className={cn("page-shell", className)} {...rest}>
-      {children}
+      {grid ? (
+        <div
+          className={cn(
+            "grid gap-[var(--space-4)] md:grid-cols-12 lg:gap-[var(--space-5)]",
+            contentClassName
+          )}
+        >
+          {children}
+        </div>
+      ) : (
+        children
+      )}
     </Component>
   );
 }


### PR DESCRIPTION
## Summary
- add a `grid` mode to `PageShell` so layouts can opt into the shared 12-column template
- refactor `Banner` and `SiteChrome` to rely on `col-span-*` wrappers instead of bespoke flex containers
- document the migration in the prompts gallery so teams know to wrap content in grid spans

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cca4f75eb8832c8342fbf9e6be71a0