### PR TITLE
Use spacing tokens on not found page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -16,11 +16,11 @@ export default function NotFound() {
 
   return (
     <main
-      className="flex min-h-screen flex-col items-center justify-center gap-4 p-6 text-center"
+      className="flex min-h-screen flex-col items-center justify-center gap-[var(--space-3)] px-[var(--space-4)] py-[var(--space-5)] text-center"
       aria-labelledby={headerId}
     >
       <PageHeader
-        className="rounded-card r-card-lg px-4 py-4"
+        className="rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-5)]"
         header={{
           id: headerId,
           heading: "Page not found",
@@ -31,7 +31,7 @@ export default function NotFound() {
           heading: "This page does not exist",
           actions: (
             <Link href="/">
-              <Button className="px-4">Go home</Button>
+              <Button>Go home</Button>
             </Link>
           ),
           children: (


### PR DESCRIPTION
## Summary
- align the not-found page layout and header padding with design tokens
- rely on the button's default token padding to remove raw spacing overrides

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cca6d1cb7c832ca223cd9a01708527