### PR TITLE
refactor: use spacing token for SectionCard body padding

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -725,7 +725,7 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
     backdrop-filter: blur(8px);
   }
   .section-b {
-    padding: 1.5rem;
+    padding: var(--space-5);
   }
 
   /* Sheen border utility */


### PR DESCRIPTION
## Summary
- replace the hard-coded SectionCard body padding with the design system spacing token to keep the layout aligned with tokens

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cca740d3f4832c9746dececee70517