### PR TITLE
Adjust reminder textarea min height

### DIFF
--- a/src/components/goals/reminders/ReminderList.tsx
+++ b/src/components/goals/reminders/ReminderList.tsx
@@ -178,7 +178,7 @@ function RemTile({
               }
               className="rounded-[var(--radius-2xl)]"
               resize="resize-y"
-              textareaClassName="min-h-40 leading-relaxed"
+              textareaClassName="min-h-[calc(var(--space-8)*2_+_var(--space-3))] leading-relaxed"
             />
 
             <label className="text-label font-medium tracking-[0.02em] opacity-70">Tags</label>


### PR DESCRIPTION
## Summary
- replace the reminder editor textarea min-height utility with a token-based calc value so it scales with the spacing system

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cca866a3ac832c8f6ee066eda15010