### PR TITLE
Use spacing tokens in onboarding tabs

### DIFF
--- a/src/components/prompts/OnboardingTabs.tsx
+++ b/src/components/prompts/OnboardingTabs.tsx
@@ -38,7 +38,7 @@ export default function OnboardingTabs() {
   }, [role]);
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-[var(--space-4)]">
       <TabBar
         items={ROLE_TABS}
         value={role}
@@ -56,17 +56,17 @@ export default function OnboardingTabs() {
         tabIndex={role === "designer" ? 0 : -1}
         ref={designerRef}
       >
-        <ul className="pl-6 space-y-1 list-none text-foreground">
-          <li className="flex gap-2">
-            <span className="mt-2 h-2 w-2 rounded-full bg-current" />
+        <ul className="pl-[var(--space-6)] space-y-[var(--space-1)] list-none text-foreground">
+          <li className="flex gap-[var(--space-2)]">
+            <span className="mt-[var(--space-2)] h-[var(--space-2)] w-[var(--space-2)] rounded-full bg-current" />
             <span>Review design system guidelines</span>
           </li>
-          <li className="flex gap-2">
-            <span className="mt-2 h-2 w-2 rounded-full bg-current" />
+          <li className="flex gap-[var(--space-2)]">
+            <span className="mt-[var(--space-2)] h-[var(--space-2)] w-[var(--space-2)] rounded-full bg-current" />
             <span>Audit existing components for consistency</span>
           </li>
-          <li className="flex gap-2">
-            <span className="mt-2 h-2 w-2 rounded-full bg-current" />
+          <li className="flex gap-[var(--space-2)]">
+            <span className="mt-[var(--space-2)] h-[var(--space-2)] w-[var(--space-2)] rounded-full bg-current" />
             <span>Collaborate with developers on UI implementation</span>
           </li>
         </ul>
@@ -79,65 +79,65 @@ export default function OnboardingTabs() {
         tabIndex={role === "developer" ? 0 : -1}
         ref={developerRef}
       >
-        <ul className="pl-6 space-y-1 list-none text-foreground">
-          <li className="flex gap-2">
-            <span className="mt-2 h-2 w-2 rounded-full bg-current" />
+        <ul className="pl-[var(--space-6)] space-y-[var(--space-1)] list-none text-foreground">
+          <li className="flex gap-[var(--space-2)]">
+            <span className="mt-[var(--space-2)] h-[var(--space-2)] w-[var(--space-2)] rounded-full bg-current" />
             <span>
               Global styles are now modularized into <code>animations.css</code>,
               <code>overlays.css</code>, and <code>utilities.css</code>.
             </span>
           </li>
-          <li className="flex gap-2">
-            <span className="mt-2 h-2 w-2 rounded-full bg-current" />
+          <li className="flex gap-[var(--space-2)]">
+            <span className="mt-[var(--space-2)] h-[var(--space-2)] w-[var(--space-2)] rounded-full bg-current" />
             <span>
               Control height token <code>--control-h</code> now snaps to 44px to
               align with the 4px spacing grid.
             </span>
           </li>
-          <li className="flex gap-2">
-            <span className="mt-2 h-2 w-2 rounded-full bg-current" />
+          <li className="flex gap-[var(--space-2)]">
+            <span className="mt-[var(--space-2)] h-[var(--space-2)] w-[var(--space-2)] rounded-full bg-current" />
             <span>
               Buttons now default to the 40px <code>md</code> size and follow a
               36/40/44px scale.
             </span>
           </li>
-          <li className="flex gap-2">
-            <span className="mt-2 h-2 w-2 rounded-full bg-current" />
+          <li className="flex gap-[var(--space-2)]">
+            <span className="mt-[var(--space-2)] h-[var(--space-2)] w-[var(--space-2)] rounded-full bg-current" />
             <span>
               WeekPicker scrolls horizontally with snap points, showing 2–3 days
               at a time on smaller screens.
             </span>
           </li>
-          <li className="flex gap-2">
-            <span className="mt-2 h-2 w-2 rounded-full bg-current" />
+          <li className="flex gap-[var(--space-2)]">
+            <span className="mt-[var(--space-2)] h-[var(--space-2)] w-[var(--space-2)] rounded-full bg-current" />
             <span>Review status dots blink to highlight wins and losses.</span>
           </li>
-          <li className="flex gap-2">
-            <span className="mt-2 h-2 w-2 rounded-full bg-current" />
+          <li className="flex gap-[var(--space-2)]">
+            <span className="mt-[var(--space-2)] h-[var(--space-2)] w-[var(--space-2)] rounded-full bg-current" />
             <span>
               Hero dividers now use <code>var(--space-4)</code> top padding and
               tokenized side offsets via <code>var(--space-2)</code>.
             </span>
           </li>
-          <li className="flex gap-2">
-            <span className="mt-2 h-2 w-2 rounded-full bg-current" />
+          <li className="flex gap-[var(--space-2)]">
+            <span className="mt-[var(--space-2)] h-[var(--space-2)] w-[var(--space-2)] rounded-full bg-current" />
             <span>
               IconButton adds a compact <code>xs</code> size.
             </span>
           </li>
-          <li className="flex gap-2">
-            <span className="mt-2 h-2 w-2 rounded-full bg-current" />
+          <li className="flex gap-[var(--space-2)]">
+            <span className="mt-[var(--space-2)] h-[var(--space-2)] w-[var(--space-2)] rounded-full bg-current" />
             <span>DurationSelector active state uses accent color tokens.</span>
           </li>
-          <li className="flex gap-2">
-            <span className="mt-2 h-2 w-2 rounded-full bg-current" />
+          <li className="flex gap-[var(--space-2)]">
+            <span className="mt-[var(--space-2)] h-[var(--space-2)] w-[var(--space-2)] rounded-full bg-current" />
             <span>
               Color gallery groups tokens into Aurora, Neutrals, and Accents
               palettes with tabs.
             </span>
           </li>
-          <li className="flex gap-2">
-            <span className="mt-2 h-2 w-2 rounded-full bg-current" />
+          <li className="flex gap-[var(--space-2)]">
+            <span className="mt-[var(--space-2)] h-[var(--space-2)] w-[var(--space-2)] rounded-full bg-current" />
             <span>Prompts page refactored into playground.</span>
           </li>
         </ul>


### PR DESCRIPTION
## Summary
- replace Tailwind spacing utilities in OnboardingTabs with spacing tokens to follow the design system

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccaa4009ac832ca18a9d1dd1bb9569