### PR TITLE
Adjust quick action button sizing

### DIFF
--- a/src/components/home/QuickActionGrid.tsx
+++ b/src/components/home/QuickActionGrid.tsx
@@ -41,7 +41,7 @@ export default function QuickActionGrid({
   layout = "stacked",
   className,
   buttonClassName,
-  buttonSize = "md",
+  buttonSize = "lg",
   buttonTone = "primary",
   buttonVariant = "secondary",
 }: QuickActionGridProps) {
@@ -60,10 +60,11 @@ export default function QuickActionGrid({
         } = action;
         const key = `${href}-${index}`;
         const resolvedTone = tone ?? buttonTone;
-        const resolvedSize = size ?? buttonSize;
+        const resolvedSize = (size ?? buttonSize) ?? "lg";
         const resolvedVariant = variant ?? buttonVariant;
         const mergedClassName = cn(
           buttonBaseClassName,
+          resolvedSize === "lg" && "min-h-[length:var(--control-h-lg)]",
           buttonClassName,
           actionClassName,
         );


### PR DESCRIPTION
## Summary
- default `QuickActionGrid` buttons to the large control height token so base actions meet the 44 px guideline
- add a guard min-height class when the resolved size is large so overriding class names still respect the control size

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccaf6137a8832cab23a55a46e091fe