### PR TITLE
Align segmented tab radius with control token

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -576,7 +576,7 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
   }
 
   .btn-like-segmented {
-    @apply inline-flex items-center rounded-[var(--radius-2xl)] border px-4 py-2 text-ui font-medium tracking-[0.02em] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none;
+    @apply inline-flex items-center rounded-[var(--control-radius)] border px-4 py-2 text-ui font-medium tracking-[0.02em] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none;
     position: relative;
     overflow: hidden;
     border-color: hsl(var(--card-hairline));
@@ -636,7 +636,7 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
   }
 
   .btn-glitch {
-    border-radius: var(--radius-2xl);
+    border-radius: var(--control-radius);
     color: hsl(var(--primary-foreground));
     background-color: var(--seg-active-base);
     background-image: var(--seg-active-grad);
@@ -653,7 +653,7 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
   }
 
   .btn-lift {
-    border-radius: var(--radius-2xl);
+    border-radius: var(--control-radius);
     background: hsl(var(--card));
     border: 1px solid hsl(var(--card-hairline));
     box-shadow: 0 calc(var(--space-2) - var(--spacing-0-5))

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -220,7 +220,7 @@ export default function TabBar<
     "inline-flex max-w-full items-center overflow-x-auto",
     isGlitch
       ? "gap-[var(--space-2)] py-[var(--space-2)]"
-      : "gap-[var(--space-1)] rounded-full border p-[var(--space-1)]",
+      : "gap-[var(--space-1)] rounded-[var(--control-radius)] border p-[var(--space-1)]",
     containerVariant,
     tablistClassName,
   );
@@ -298,7 +298,7 @@ export default function TabBar<
                   item.className,
                 )
               : cn(
-                  "relative inline-flex items-center justify-center select-none rounded-full transition-[background,box-shadow,color] duration-[var(--dur-quick)] ease-out",
+                  "relative inline-flex items-center justify-center select-none rounded-[var(--control-radius)] transition-[background,box-shadow,color] duration-[var(--dur-quick)] ease-out",
                   s.h,
                   s.px,
                   s.text,


### PR DESCRIPTION
## Summary
- switch segmented button, glitch button, and lift surface radii to use the shared control radius token
- update TabBar containers and tabs to inherit the control radius in non-glitch variants
- confirm page tabs continue to rely on the glitch variant without reintroducing larger radii

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccb56e5738832c9cde3d642176f9a4