### PR TITLE
Use high-contrast token for IconButton accent/info variants

### DIFF
--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -81,24 +81,24 @@ const variantBase: Record<Variant, string> = {
 const toneClasses: Record<Variant, Record<Tone, string>> = {
   ring: {
     primary: "border-line/35 text-foreground",
-    accent: "border-accent/35 text-accent-foreground",
-    info: "border-accent-2/35 text-accent-2-foreground",
+    accent: "border-accent/35 text-[var(--text-on-accent)]",
+    info: "border-accent-2/35 text-[var(--text-on-accent)]",
     danger: "border-danger/35 text-danger",
   },
   solid: {
     primary:
       "border-transparent bg-foreground/15 text-foreground [--hover:hsl(var(--foreground)/0.12)] [--active:hsl(var(--foreground)/0.08)]",
     accent:
-      "border-transparent bg-accent/30 text-accent-foreground [--hover:hsl(var(--accent)/0.4)] [--active:hsl(var(--accent)/0.5)]",
+      "border-transparent bg-accent/30 text-[var(--text-on-accent)] [--hover:hsl(var(--accent)/0.4)] [--active:hsl(var(--accent)/0.5)]",
     info:
-      "border-transparent bg-accent-2/30 text-accent-2-foreground [--hover:hsl(var(--accent-2)/0.2)] [--active:hsl(var(--accent-2)/0.15)]",
+      "border-transparent bg-accent-2/30 text-[var(--text-on-accent)] [--hover:hsl(var(--accent-2)/0.2)] [--active:hsl(var(--accent-2)/0.15)]",
     danger:
       "border-transparent bg-danger/20 text-danger-foreground [--hover:theme('colors.interaction.danger.surfaceHover')] [--active:theme('colors.interaction.danger.surfaceActive')]",
   },
   glow: {
     primary: "border-foreground/35 text-foreground",
-    accent: "border-accent/35 text-accent-foreground",
-    info: "border-accent-2/35 text-accent-2-foreground",
+    accent: "border-accent/35 text-[var(--text-on-accent)]",
+    info: "border-accent-2/35 text-[var(--text-on-accent)]",
     danger: "border-danger/35 text-danger",
   },
 };

--- a/tests/primitives/icon-button.test.tsx
+++ b/tests/primitives/icon-button.test.tsx
@@ -107,7 +107,7 @@ describe("IconButton", () => {
     const classes = getByRole("button").className;
     expect(classes).toContain("border");
     expect(classes).toContain(
-      "border-transparent bg-accent/30 text-accent-foreground",
+      "border-transparent bg-accent/30 text-[var(--text-on-accent)]",
     );
     expect(classes).toContain("[--hover:hsl(var(--accent)/0.4)]");
     expect(classes).toContain("[--active:hsl(var(--accent)/0.5)]");
@@ -122,7 +122,9 @@ describe("IconButton", () => {
     expect(classes).toContain("hover:bg-[--hover]");
     expect(classes).toContain("shadow-glow-current");
     expect(classes).toContain("[--hover:hsl(var(--panel)/0.45)]");
-    expect(classes).toContain("border-accent-2/35 text-accent-2");
+    expect(classes).toContain(
+      "border-accent-2/35 text-[var(--text-on-accent)]",
+    );
   });
 
   it("applies ring variant with danger tone", () => {


### PR DESCRIPTION
## Summary
- switch IconButton accent and info tones to use the bright text-on-accent token across ring, solid, and glow variants
- update IconButton unit tests to check for the new foreground utility and maintain hover/active expectations

## Testing
- `npm test -- --run tests/primitives/icon-button.test.tsx`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68ccb708fa18832c8f394a1720a8a252