### PR TITLE
Use tokenized radius for snackbar action focus ring

### DIFF
--- a/src/components/ui/feedback/Snackbar.tsx
+++ b/src/components/ui/feedback/Snackbar.tsx
@@ -36,7 +36,7 @@ export default function Snackbar({
             type="button"
             className={cn(
               "inline-flex items-center font-medium text-accent-3 underline underline-offset-4 transition-colors",
-              "hover:text-accent-foreground focus-visible:rounded-sm focus-visible:outline-none",
+              "hover:text-accent-foreground focus-visible:rounded-[var(--radius-md)] focus-visible:outline-none",
               "focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--surface-2))]",
               "active:text-accent-3 active:opacity-80 disabled:text-muted-foreground disabled:no-underline disabled:pointer-events-none",
             )}


### PR DESCRIPTION
## Summary
- update the snackbar action button to use the design token radius when focused to stay on scale

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccb7172e78832cb85adea5824320a2