### PR TITLE
Limit ChampListEditor editing to active card

### DIFF
--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -391,7 +391,7 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
                           <ChampListEditor
                             list={list}
                             onChange={setList}
-                            editing={editing}
+                            editing={editing && editingCard}
                             emptyLabel="-"
                             viewClassName="champ-badges mt-1 flex flex-wrap gap-2"
                           />


### PR DESCRIPTION
## Summary
- update MyComps to gate ChampListEditor editing mode behind the active card selection

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccb854a1c4832c9ace1c42d278e472