### PR TITLE
refactor: use spacing token for components spinner padding

### DIFF
--- a/src/app/components/page.tsx
+++ b/src/app/components/page.tsx
@@ -12,7 +12,7 @@ export default function ComponentsRoute() {
   return (
     <Suspense
       fallback={
-        <div className="flex justify-center p-6">
+        <div className="flex justify-center p-[var(--space-5)]">
           <Spinner />
         </div>
       }


### PR DESCRIPTION
## Summary
- swap the components route suspense fallback padding from `p-6` to `p-[var(--space-5)]`
- keep the spinner centered while aligning with the design token spacing scale

## Testing
- npm run check


------
https://chatgpt.com/codex/tasks/task_e_68ccb8d614f4832cb26a61d84f67b320