### PR TITLE
Adjust CTA hover contrast

### DIFF
--- a/src/components/home/DashboardList.tsx
+++ b/src/components/home/DashboardList.tsx
@@ -72,7 +72,7 @@ export default function DashboardList<T>({
               {cta ? (
                 <Link
                   href={cta.href}
-                  className="inline-flex items-center text-label font-medium text-accent-3 underline underline-offset-4 transition-colors hover:text-accent-foreground active:text-accent-foreground active:bg-interaction-accent-tintActive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] focus-visible:ring-offset-0 motion-reduce:transition-none"
+                  className="inline-flex items-center text-label font-medium text-accent-3 underline underline-offset-4 transition-colors hover:text-[var(--text-on-accent)] active:text-[var(--text-on-accent)] active:bg-interaction-accent-tintActive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] focus-visible:ring-offset-0 motion-reduce:transition-none"
                 >
                   {cta.label}
                 </Link>

--- a/src/components/ui/feedback/Snackbar.tsx
+++ b/src/components/ui/feedback/Snackbar.tsx
@@ -36,7 +36,7 @@ export default function Snackbar({
             type="button"
             className={cn(
               "inline-flex items-center font-medium text-accent-3 underline underline-offset-4 transition-colors",
-              "hover:text-accent-foreground focus-visible:rounded-[var(--radius-md)] focus-visible:outline-none",
+              "hover:text-[var(--text-on-accent)] focus-visible:rounded-[var(--radius-md)] focus-visible:outline-none",
               "focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--surface-2))]",
               "active:text-accent-3 active:opacity-80 disabled:text-muted-foreground disabled:no-underline disabled:pointer-events-none",
             )}


### PR DESCRIPTION
## Summary
- update Snackbar action hover color to use the bright accent text token for stronger contrast in Hardstuck
- align DashboardList CTA link hover and active text colors with the bright accent token while retaining existing focus treatments

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccbb970720832c85a7f36c3f9e8e77