### PR TITLE
Respect goal cap when submitting

### DIFF
--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -42,6 +42,9 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
   const helpId = "goal-form-help";
   const errorId = "goal-form-error";
   const describedBy = [helpId, err ? errorId : null].filter(Boolean).join(" ");
+  const trimmedTitle = title.trim();
+  const isAtCap = activeCount >= activeCap;
+  const canSubmit = Boolean(trimmedTitle) && !isAtCap;
 
   React.useImperativeHandle(ref, () => ({
     focus: (options?: FocusOptions) => titleRef.current?.focus(options),
@@ -51,6 +54,9 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
     <form
       onSubmit={(e) => {
         e.preventDefault();
+        if (!canSubmit) {
+          return;
+        }
         onSubmit();
       }}
     >
@@ -60,7 +66,7 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
           title="Add Goal"
           titleClassName="text-title font-semibold tracking-[-0.01em]"
           actions={
-            <Button type="submit" size="sm" disabled={!title.trim()}>
+            <Button type="submit" size="sm" disabled={!canSubmit}>
               Add Goal
             </Button>
           }
@@ -102,7 +108,7 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
           </Label>
 
           <div id={helpId} className="text-label font-medium tracking-[0.02em] text-muted-foreground">
-            {activeCount >= activeCap ? (
+            {isAtCap ? (
               <span className="text-danger">
                 Cap reached. Finish one to add more.
               </span>
@@ -115,12 +121,12 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
           </div>
 
           {err ? (
-              <p
-                id={errorId}
-                role="status"
-                aria-live="polite"
-                className="text-label font-medium tracking-[0.02em] text-danger"
-              >
+            <p
+              id={errorId}
+              role="status"
+              aria-live="polite"
+              className="text-label font-medium tracking-[0.02em] text-danger"
+            >
               {err}
             </p>
           ) : null}

--- a/tests/goals/goals-page.test.tsx
+++ b/tests/goals/goals-page.test.tsx
@@ -150,10 +150,12 @@ describe("GoalsPage", () => {
 
     await Promise.all(goalCreationPromises);
 
-    // Attempt to add a fourth active goal, expect cap error
+    // Attempt to add a fourth active goal, expect disabled state and help text
     fireEvent.change(titleInput, { target: { value: "Goal 4" } });
-    fireEvent.click(addButton);
-    expect(screen.getByRole("status")).toHaveTextContent("Cap reached");
+    expect(addButton).toBeDisabled();
+    expect(
+      screen.getByText(/Cap reached\. Finish one to add more\./),
+    ).toBeInTheDocument();
 
     // Mark the first goal as done
     const goal1Article = screen
@@ -173,10 +175,18 @@ describe("GoalsPage", () => {
 
     // Now adding another goal should succeed
     fireEvent.change(titleInput, { target: { value: "Goal 4" } });
+    await waitFor(() => expect(addButton).not.toBeDisabled());
+    await waitFor(() =>
+      expect(screen.getByText(/1 active slot left/)).toBeInTheDocument(),
+    );
     fireEvent.click(addButton);
-    await waitFor(() => expect(screen.queryByRole("status")).toBeNull());
     const goal4 = await screen.findByText("Goal 4");
     expect(goal4).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Cap reached\. Finish one to add more\./),
+      ).toBeInTheDocument(),
+    );
 
     // Remove the new goal and then undo
     const goal4Article = goal4.closest("article") as HTMLElement;


### PR DESCRIPTION
## Summary
- reuse a single guard to prevent submitting goals when the active cap is reached, including form keyboard submits
- keep the capacity help text visible while disabled so users still see the cap warning
- refresh the GoalsPage test to assert the disabled button state and help copy

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccbf6d10cc832c9e02e86fb12cdd37