### PR TITLE
Improve team card action accessibility

### DIFF
--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -3,7 +3,7 @@
 import "./style.css";
 
 /**
- * CheatSheet — hover-only edit per card, write-through persistence.
+ * CheatSheet — edit per card with persistent controls, write-through persistence.
  * Titles use Lavender-Glitch (glitch-title + glitch-flicker + title-glow).
  * Lane labels (TOP/JUNGLE/MID/BOT/SUPPORT) also flicker via team scope.
  * Scoped with data-scope="team" to avoid global glitch leakage.
@@ -479,9 +479,9 @@ export default function CheatSheet({
                 : "p-5",
             ].join(" ")}
           >
-            {/* Hover-only top-right edit/save button */}
+            {/* Top-right edit/save control */}
             {editing && (
-              <div className="absolute right-2 top-2 z-10 opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto">
+              <div className="absolute right-2 top-2 z-10 flex items-center gap-1 opacity-100 pointer-events-auto">
                 {!isEditing ? (
                   <IconButton
                     title="Edit"

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -5,7 +5,7 @@
  * MyComps — CRUD for custom comps, single-panel version.
  * - One SectionCard: header + add bar + cards grid inside the same panel
  * - Add comp (title), edit per-role champs (inline chips), notes
- * - Hover-only actions: Copy / Edit / Delete; Save when editing
+ * - Actions stay reachable on touch: Copy / Edit / Delete; Save when editing
  * - Local-first via usePersistentState("team:mycomps.v1")
  * - Scoped with data-scope="team" so glitch effects don't bleed globally
  */
@@ -16,6 +16,7 @@ import * as React from "react";
 import { usePersistentState, uid } from "@/lib/db";
 import { isRecord, isStringArray, safeNumber } from "@/lib/validators";
 import { copyText } from "@/lib/clipboard";
+import { useCoarsePointer } from "@/lib/useCoarsePointer";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import IconButton from "@/components/ui/primitives/IconButton";
 import Input from "@/components/ui/primitives/Input";
@@ -164,6 +165,7 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
   const [editingId, setEditingId] = React.useState<string | null>(null);
   const copyTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMountedRef = React.useRef(true);
+  const isCoarsePointer = useCoarsePointer();
 
   React.useEffect(() => {
     isMountedRef.current = true;
@@ -287,14 +289,21 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
           <div className="grid grid-cols-12 gap-4">
             {filtered.map((c) => {
               const editingCard = editingId === c.id;
+              const showActions = isCoarsePointer || editing || editingCard;
+              const actionClasses = [
+                "absolute right-2 top-2 z-10 flex items-center gap-1 transition-opacity",
+                showActions
+                  ? "opacity-100 pointer-events-auto"
+                  : "opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto",
+              ].join(" ");
 
               return (
                 <article
                   key={c.id}
                   className="col-span-12 md:col-span-6 xl:col-span-4 group card-neo glitch-card relative p-7"
                 >
-                  {/* hover edit/save + delete + copy */}
-                  <div className="absolute right-2 top-2 z-10 flex items-center gap-1 opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto">
+                  {/* Action controls: copy, edit, delete, save */}
+                  <div className={actionClasses}>
                     {!editingCard ? (
                       <>
                         <IconButton

--- a/src/lib/useCoarsePointer.ts
+++ b/src/lib/useCoarsePointer.ts
@@ -1,0 +1,73 @@
+import * as React from "react";
+
+function detectCoarsePointer() {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const nav = window.navigator as Navigator & {
+    maxTouchPoints?: number;
+    msMaxTouchPoints?: number;
+  };
+
+  if (typeof nav.maxTouchPoints === "number" && nav.maxTouchPoints > 0) {
+    return true;
+  }
+
+  if (typeof nav.msMaxTouchPoints === "number" && nav.msMaxTouchPoints > 0) {
+    return true;
+  }
+
+  if (typeof window.matchMedia !== "function") {
+    return false;
+  }
+
+  try {
+    return ["(pointer: coarse)", "(hover: none)"].some((query) =>
+      window.matchMedia(query).matches,
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detects whether the current pointer prefers coarse interactions (e.g. touch).
+ * Falls back to hover heuristics when matchMedia isn't available.
+ */
+export function useCoarsePointer() {
+  const [isCoarse, setIsCoarse] = React.useState(() => detectCoarsePointer());
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    setIsCoarse(detectCoarsePointer());
+
+    if (typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const media = window.matchMedia("(hover: none)");
+    const handleChange = (event: MediaQueryListEvent) => {
+      setIsCoarse(event.matches || detectCoarsePointer());
+    };
+
+    if (typeof media.addEventListener === "function") {
+      media.addEventListener("change", handleChange);
+      return () => {
+        media.removeEventListener("change", handleChange);
+      };
+    }
+
+    if (typeof media.addListener === "function") {
+      media.addListener(handleChange);
+      return () => {
+        media.removeListener(handleChange);
+      };
+    }
+
+    return;
+  }, []);
+
+  return isCoarse;
+}


### PR DESCRIPTION
## Summary
- keep the CheatSheet edit/save button visible whenever editing is enabled so touch users can activate it
- add a coarse pointer detector and use it to expose MyComps copy/edit/delete actions without hover while preserving desktop hover/focus behavior

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccc13465a8832c8131c45214016724