### PR TITLE
feat(theme): add token for card scanline overlay

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -99,16 +99,24 @@
   ) |
 | seg-active-base | hsl(var(--card)) |
 | shadow | 0 10px 30px hsl(250 30% 2% / 0.35) |
-| shadow-neo-sm | calc(var(--spacing-1)) calc(var(--spacing-1)) calc(var(--spacing-2)) hsl(var(--panel) / 0.72),
-    calc(var(--spacing-1) * -1) calc(var(--spacing-1) * -1) calc(var(--spacing-2)) hsl(var(--foreground) / 0.06) |
-| shadow-neo | calc(var(--spacing-3)) calc(var(--spacing-3)) var(--spacing-5) hsl(var(--panel) / 0.72),
-    calc(var(--spacing-3) * -1) calc(var(--spacing-3) * -1) var(--spacing-5) hsl(var(--foreground) / 0.06) |
+| shadow-neo-sm | calc(var(--spacing-1)) calc(var(--spacing-1)) calc(var(--spacing-2))
+      hsl(var(--panel) / 0.72),
+    calc(var(--spacing-1) * -1) calc(var(--spacing-1) * -1) calc(var(--spacing-2))
+      hsl(var(--foreground) / 0.06) |
+| shadow-neo | calc(var(--spacing-3)) calc(var(--spacing-3)) var(--spacing-5)
+      hsl(var(--panel) / 0.72),
+    calc(var(--spacing-3) * -1) calc(var(--spacing-3) * -1) var(--spacing-5)
+      hsl(var(--foreground) / 0.06) |
 | shadow-neo-strong | var(--spacing-4) var(--spacing-4) var(--spacing-6) hsl(var(--panel) / 0.72),
-    calc(var(--spacing-4) * -1) calc(var(--spacing-4) * -1) var(--spacing-6) hsl(var(--foreground) / 0.08) |
-| shadow-neo-inset | inset var(--spacing-1) var(--spacing-1) var(--spacing-3) hsl(var(--panel) / 0.85),
-    inset calc(var(--spacing-1) * -1) calc(var(--spacing-1) * -1) var(--spacing-3) hsl(var(--foreground) / 0.08) |
+    calc(var(--spacing-4) * -1) calc(var(--spacing-4) * -1) var(--spacing-6)
+      hsl(var(--foreground) / 0.08) |
+| shadow-neo-inset | inset var(--spacing-1) var(--spacing-1) var(--spacing-3)
+      hsl(var(--panel) / 0.85),
+    inset calc(var(--spacing-1) * -1) calc(var(--spacing-1) * -1) var(--spacing-3)
+      hsl(var(--foreground) / 0.08) |
 | shadow-ring | 0 0 var(--spacing-3) hsl(var(--ring)) |
-| shadow-neo-soft | 0 var(--spacing-1) var(--spacing-3) calc(var(--spacing-1) * -1) hsl(var(--shadow-color)) |
+| shadow-neo-soft | 0 var(--spacing-1) var(--spacing-3) calc(var(--spacing-1) * -1)
+      hsl(var(--shadow-color)) |
 | shadow-glow-sm | 0 0 var(--spacing-2) var(--glow-active) |
 | shadow-glow-md | 0 0 var(--spacing-4) var(--glow-active) |
 | shadow-glow-lg | 0 0 var(--spacing-5) var(--glow-active) |
@@ -123,8 +131,10 @@
 | shadow-inset-contrast | inset 0 0 0 var(--hairline-w) var(--ring-contrast) |
 | shadow-inset-hairline | inset 0 0 0 var(--hairline-w) hsl(var(--card-hairline)) |
 | shadow-glow-current | 0 0 var(--spacing-2) currentColor |
-| shadow-neon-soft | 0 0 var(--spacing-2) var(--neon), 0 0 var(--spacing-4) var(--neon-soft) |
-| shadow-neon-strong | 0 0 var(--spacing-3) var(--neon), 0 0 var(--spacing-5) var(--neon-soft) |
+| shadow-neon-soft | 0 0 var(--spacing-2) var(--neon),
+    0 0 var(--spacing-4) var(--neon-soft) |
+| shadow-neon-strong | 0 0 var(--spacing-3) var(--neon),
+    0 0 var(--spacing-5) var(--neon-soft) |
 | shadow-control | inset 0 var(--spacing-1) var(--spacing-2) 0 rgb(0 0 0 / 0.06),
     0 0 0 var(--hairline-w) hsl(var(--border) / 0.12) |
 | shadow-control-hover | 0 var(--spacing-1) var(--spacing-2) hsl(var(--shadow-color) / 0.3) |
@@ -134,10 +144,6 @@
 | lg-black | var(--background) |
 | glow-strong | var(--ring) / 0.55 |
 | glow-soft | var(--accent) / 0.25 |
-| spacing-0-125 | calc(var(--spacing-1) / 8) |
-| spacing-0-25 | calc(var(--spacing-1) / 4) |
-| spacing-0-5 | calc(var(--spacing-1) / 2) |
-| spacing-0-75 | calc(var(--spacing-1) * 0.75) |
 | space-1 | var(--spacing-1) |
 | space-2 | var(--spacing-2) |
 | space-3 | var(--spacing-3) |
@@ -178,6 +184,17 @@
 | pillar-comms-start | 286 90% 68% |
 | pillar-comms-end | 312 88% 66% |
 | pillar-comms-shadow | 300 80% 36% / 0.35 |
+| card-overlay-scanlines | repeating-linear-gradient(
+    to bottom,
+    hsl(var(--foreground) / 0.035) 0,
+    hsl(var(--foreground) / 0.035) var(--spacing-0-25),
+    transparent var(--spacing-0-5),
+    transparent calc(var(--spacing-0-5) + var(--spacing-0-25))
+  ) |
+| spacing-0-125 | calc(var(--spacing-1) / 8) |
+| spacing-0-25 | calc(var(--spacing-1) / 4) |
+| spacing-0-5 | calc(var(--spacing-1) / 2) |
+| spacing-0-75 | calc(var(--spacing-1) * 0.75) |
 | spacing-1 | 4px |
 | spacing-2 | 8px |
 | spacing-3 | 12px |

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -342,13 +342,7 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
     inset: 0;
     border-radius: inherit;
     pointer-events: none;
-    background: repeating-linear-gradient(
-      to bottom,
-      hsl(var(--foreground) / 0.035) 0,
-      hsl(var(--foreground) / 0.035) var(--spacing-0-25),
-      transparent var(--spacing-0-5),
-      transparent calc(var(--spacing-0-5) + var(--spacing-0-25))
-    );
+    background: var(--card-overlay-scanlines);
     mix-blend-mode: soft-light;
     opacity: 0;
     transition: opacity var(--dur-quick) var(--ease-out);

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -22,6 +22,17 @@
     calc(-1 * var(--space-1) / 4) hsl(var(--accent) / 0.25);
   --btn-primary-active-shadow: inset 0 0 0 calc(var(--space-1) / 4)
     hsl(var(--accent) / 0.6);
+  --card-overlay-scanlines: repeating-linear-gradient(
+    to bottom,
+    hsl(var(--foreground) / 0.035) 0,
+    hsl(var(--foreground) / 0.035) var(--spacing-0-25),
+    transparent var(--spacing-0-5),
+    transparent calc(var(--spacing-0-5) + var(--spacing-0-25))
+  );
+  --spacing-0-125: calc(var(--spacing-1) / 8);
+  --spacing-0-25: calc(var(--spacing-1) / 4);
+  --spacing-0-5: calc(var(--spacing-1) / 2);
+  --spacing-0-75: calc(var(--spacing-1) * 0.75);
   --pillar-wave-start: 257 90% 70%;
   --pillar-wave-end: 198 90% 62%;
   --pillar-wave-shadow: 258 90% 38% / 0.35;

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -102,41 +102,33 @@
   );
   --seg-active-base: hsl(var(--card));
   --shadow: 0 10px 30px hsl(250 30% 2% / 0.35);
-  --shadow-neo-sm:
-    calc(var(--spacing-1)) calc(var(--spacing-1)) calc(var(--spacing-2))
+  --shadow-neo-sm: calc(var(--spacing-1)) calc(var(--spacing-1)) calc(var(--spacing-2))
       hsl(var(--panel) / 0.72),
     calc(var(--spacing-1) * -1) calc(var(--spacing-1) * -1) calc(var(--spacing-2))
       hsl(var(--foreground) / 0.06);
-  --shadow-neo:
-    calc(var(--spacing-3)) calc(var(--spacing-3)) var(--spacing-5)
+  --shadow-neo: calc(var(--spacing-3)) calc(var(--spacing-3)) var(--spacing-5)
       hsl(var(--panel) / 0.72),
     calc(var(--spacing-3) * -1) calc(var(--spacing-3) * -1) var(--spacing-5)
       hsl(var(--foreground) / 0.06);
-  --shadow-neo-strong:
-    var(--spacing-4) var(--spacing-4) var(--spacing-6) hsl(var(--panel) / 0.72),
+  --shadow-neo-strong: var(--spacing-4) var(--spacing-4) var(--spacing-6) hsl(var(--panel) / 0.72),
     calc(var(--spacing-4) * -1) calc(var(--spacing-4) * -1) var(--spacing-6)
       hsl(var(--foreground) / 0.08);
-  --shadow-neo-inset:
-    inset var(--spacing-1) var(--spacing-1) var(--spacing-3)
+  --shadow-neo-inset: inset var(--spacing-1) var(--spacing-1) var(--spacing-3)
       hsl(var(--panel) / 0.85),
     inset calc(var(--spacing-1) * -1) calc(var(--spacing-1) * -1) var(--spacing-3)
       hsl(var(--foreground) / 0.08);
   --shadow-ring: 0 0 var(--spacing-3) hsl(var(--ring));
-  --shadow-neo-soft:
-    0 var(--spacing-1) var(--spacing-3) calc(var(--spacing-1) * -1)
+  --shadow-neo-soft: 0 var(--spacing-1) var(--spacing-3) calc(var(--spacing-1) * -1)
       hsl(var(--shadow-color));
   --shadow-glow-sm: 0 0 var(--spacing-2) var(--glow-active);
   --shadow-glow-md: 0 0 var(--spacing-4) var(--glow-active);
   --shadow-glow-lg: 0 0 var(--spacing-5) var(--glow-active);
-  --shadow-glow-xl:
-    0 var(--spacing-2) var(--spacing-6) var(--glow-active);
-  --shadow-nav-active:
-    0 0 0 var(--hairline-w) hsl(var(--ring) / 0.35),
+  --shadow-glow-xl: 0 var(--spacing-2) var(--spacing-6) var(--glow-active);
+  --shadow-nav-active: 0 0 0 var(--hairline-w) hsl(var(--ring) / 0.35),
     0 var(--spacing-2) var(--spacing-6) hsl(var(--ring) / 0.2);
   --shadow-outline-subtle: 0 0 0 var(--hairline-w) hsl(var(--border) / 0.12);
   --shadow-outline-faint: 0 0 0 var(--hairline-w) hsl(var(--border) / 0.08);
-  --shadow-badge:
-    inset 0 var(--hairline-w) 0 hsl(var(--foreground) / 0.06),
+  --shadow-badge: inset 0 var(--hairline-w) 0 hsl(var(--foreground) / 0.06),
     0 0 0 var(--hairline-w) hsl(var(--card-hairline) / 0.35),
     0 var(--spacing-3) var(--spacing-4) hsl(var(--shadow-color) / 0.18);
   --shadow-inset-contrast: inset 0 0 0 var(--hairline-w) var(--ring-contrast);
@@ -146,21 +138,15 @@
     0 0 var(--spacing-4) var(--neon-soft);
   --shadow-neon-strong: 0 0 var(--spacing-3) var(--neon),
     0 0 var(--spacing-5) var(--neon-soft);
-  --shadow-control:
-    inset 0 var(--spacing-1) var(--spacing-2) 0 rgb(0 0 0 / 0.06),
+  --shadow-control: inset 0 var(--spacing-1) var(--spacing-2) 0 rgb(0 0 0 / 0.06),
     0 0 0 var(--hairline-w) hsl(var(--border) / 0.12);
-  --shadow-control-hover:
-    0 var(--spacing-1) var(--spacing-2) hsl(var(--shadow-color) / 0.3);
+  --shadow-control-hover: 0 var(--spacing-1) var(--spacing-2) hsl(var(--shadow-color) / 0.3);
   --lg-violet: var(--ring);
   --lg-cyan: var(--accent-2);
   --lg-pink: var(--lav-deep);
   --lg-black: var(--background);
   --glow-strong: var(--ring) / 0.55;
   --glow-soft: var(--accent) / 0.25;
-  --spacing-0-125: calc(var(--spacing-1) / 8);
-  --spacing-0-25: calc(var(--spacing-1) / 4);
-  --spacing-0-5: calc(var(--spacing-1) / 2);
-  --spacing-0-75: calc(var(--spacing-1) * 0.75);
   --space-1: var(--spacing-1);
   --space-2: var(--spacing-2);
   --space-3: var(--spacing-3);
@@ -201,6 +187,17 @@
   --pillar-comms-start: 286 90% 68%;
   --pillar-comms-end: 312 88% 66%;
   --pillar-comms-shadow: 300 80% 36% / 0.35;
+  --card-overlay-scanlines: repeating-linear-gradient(
+    to bottom,
+    hsl(var(--foreground) / 0.035) 0,
+    hsl(var(--foreground) / 0.035) var(--spacing-0-25),
+    transparent var(--spacing-0-5),
+    transparent calc(var(--spacing-0-5) + var(--spacing-0-25))
+  );
+  --spacing-0-125: calc(var(--spacing-1) / 8);
+  --spacing-0-25: calc(var(--spacing-1) / 4);
+  --spacing-0-5: calc(var(--spacing-1) / 2);
+  --spacing-0-75: calc(var(--spacing-1) * 0.75);
   --spacing-1: 4px;
   --spacing-2: 8px;
   --spacing-3: 12px;

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -93,21 +93,20 @@ export default {
   segActiveBase: "hsl(var(--card))",
   shadow: "0 10px 30px hsl(250 30% 2% / 0.35)",
   shadowNeoSm:
-    "calc(var(--spacing-1)) calc(var(--spacing-1)) calc(var(--spacing-2)) hsl(var(--panel) / 0.72),\n    calc(var(--spacing-1) * -1) calc(var(--spacing-1) * -1) calc(var(--spacing-2)) hsl(var(--foreground) / 0.06)",
+    "calc(var(--spacing-1)) calc(var(--spacing-1)) calc(var(--spacing-2))\n      hsl(var(--panel) / 0.72),\n    calc(var(--spacing-1) * -1) calc(var(--spacing-1) * -1) calc(var(--spacing-2))\n      hsl(var(--foreground) / 0.06)",
   shadowNeo:
-    "calc(var(--spacing-3)) calc(var(--spacing-3)) var(--spacing-5) hsl(var(--panel) / 0.72),\n    calc(var(--spacing-3) * -1) calc(var(--spacing-3) * -1) var(--spacing-5) hsl(var(--foreground) / 0.06)",
+    "calc(var(--spacing-3)) calc(var(--spacing-3)) var(--spacing-5)\n      hsl(var(--panel) / 0.72),\n    calc(var(--spacing-3) * -1) calc(var(--spacing-3) * -1) var(--spacing-5)\n      hsl(var(--foreground) / 0.06)",
   shadowNeoStrong:
-    "var(--spacing-4) var(--spacing-4) var(--spacing-6) hsl(var(--panel) / 0.72),\n    calc(var(--spacing-4) * -1) calc(var(--spacing-4) * -1) var(--spacing-6) hsl(var(--foreground) / 0.08)",
+    "var(--spacing-4) var(--spacing-4) var(--spacing-6) hsl(var(--panel) / 0.72),\n    calc(var(--spacing-4) * -1) calc(var(--spacing-4) * -1) var(--spacing-6)\n      hsl(var(--foreground) / 0.08)",
   shadowNeoInset:
-    "inset var(--spacing-1) var(--spacing-1) var(--spacing-3) hsl(var(--panel) / 0.85),\n    inset calc(var(--spacing-1) * -1) calc(var(--spacing-1) * -1) var(--spacing-3) hsl(var(--foreground) / 0.08)",
+    "inset var(--spacing-1) var(--spacing-1) var(--spacing-3)\n      hsl(var(--panel) / 0.85),\n    inset calc(var(--spacing-1) * -1) calc(var(--spacing-1) * -1) var(--spacing-3)\n      hsl(var(--foreground) / 0.08)",
   shadowRing: "0 0 var(--spacing-3) hsl(var(--ring))",
   shadowNeoSoft:
-    "0 var(--spacing-1) var(--spacing-3) calc(var(--spacing-1) * -1) hsl(var(--shadow-color))",
+    "0 var(--spacing-1) var(--spacing-3) calc(var(--spacing-1) * -1)\n      hsl(var(--shadow-color))",
   shadowGlowSm: "0 0 var(--spacing-2) var(--glow-active)",
   shadowGlowMd: "0 0 var(--spacing-4) var(--glow-active)",
   shadowGlowLg: "0 0 var(--spacing-5) var(--glow-active)",
-  shadowGlowXl:
-    "0 var(--spacing-2) var(--spacing-6) var(--glow-active)",
+  shadowGlowXl: "0 var(--spacing-2) var(--spacing-6) var(--glow-active)",
   shadowNavActive:
     "0 0 0 var(--hairline-w) hsl(var(--ring) / 0.35),\n    0 var(--spacing-2) var(--spacing-6) hsl(var(--ring) / 0.2)",
   shadowOutlineSubtle: "0 0 0 var(--hairline-w) hsl(var(--border) / 0.12)",
@@ -115,10 +114,13 @@ export default {
   shadowBadge:
     "inset 0 var(--hairline-w) 0 hsl(var(--foreground) / 0.06),\n    0 0 0 var(--hairline-w) hsl(var(--card-hairline) / 0.35),\n    0 var(--spacing-3) var(--spacing-4) hsl(var(--shadow-color) / 0.18)",
   shadowInsetContrast: "inset 0 0 0 var(--hairline-w) var(--ring-contrast)",
-  shadowInsetHairline: "inset 0 0 0 var(--hairline-w) hsl(var(--card-hairline))",
+  shadowInsetHairline:
+    "inset 0 0 0 var(--hairline-w) hsl(var(--card-hairline))",
   shadowGlowCurrent: "0 0 var(--spacing-2) currentColor",
-  shadowNeonSoft: "0 0 var(--spacing-2) var(--neon), 0 0 var(--spacing-4) var(--neon-soft)",
-  shadowNeonStrong: "0 0 var(--spacing-3) var(--neon), 0 0 var(--spacing-5) var(--neon-soft)",
+  shadowNeonSoft:
+    "0 0 var(--spacing-2) var(--neon),\n    0 0 var(--spacing-4) var(--neon-soft)",
+  shadowNeonStrong:
+    "0 0 var(--spacing-3) var(--neon),\n    0 0 var(--spacing-5) var(--neon-soft)",
   shadowControl:
     "inset 0 var(--spacing-1) var(--spacing-2) 0 rgb(0 0 0 / 0.06),\n    0 0 0 var(--hairline-w) hsl(var(--border) / 0.12)",
   shadowControlHover:
@@ -129,10 +131,6 @@ export default {
   lgBlack: "var(--background)",
   glowStrong: "var(--ring) / 0.55",
   glowSoft: "var(--accent) / 0.25",
-  spacing0125: "calc(var(--spacing-1) / 8)",
-  spacing025: "calc(var(--spacing-1) / 4)",
-  spacing05: "calc(var(--spacing-1) / 2)",
-  spacing075: "calc(var(--spacing-1) * 0.75)",
   space1: "var(--spacing-1)",
   space2: "var(--spacing-2)",
   space3: "var(--spacing-3)",
@@ -172,6 +170,12 @@ export default {
   pillarCommsStart: "286 90% 68%",
   pillarCommsEnd: "312 88% 66%",
   pillarCommsShadow: "300 80% 36% / 0.35",
+  cardOverlayScanlines:
+    "repeating-linear-gradient(\n    to bottom,\n    hsl(var(--foreground) / 0.035) 0,\n    hsl(var(--foreground) / 0.035) var(--spacing-0-25),\n    transparent var(--spacing-0-5),\n    transparent calc(var(--spacing-0-5) + var(--spacing-0-25))\n  )",
+  spacing0125: "calc(var(--spacing-1) / 8)",
+  spacing025: "calc(var(--spacing-1) / 4)",
+  spacing05: "calc(var(--spacing-1) / 2)",
+  spacing075: "calc(var(--spacing-1) * 0.75)",
   spacing1: "4px",
   spacing2: "8px",
   spacing3: "12px",


### PR DESCRIPTION
## Summary
- add a `--card-overlay-scanlines` token and fractional spacing aliases in the shared theme root
- wire the neo card overlays to the new texture token and regenerate token artifacts

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccc1d0e594832cba56ccd9efcb7e4a