### PR TITLE
Fix gallery select controls

### DIFF
--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -152,6 +152,11 @@ export default function ComponentGallery() {
   const [side, setSide] = React.useState<GameSide>("Blue");
   const [pillars, setPillars] = React.useState<Pillar[]>([]);
   const [selectValue, setSelectValue] = React.useState<string | undefined>();
+  const [nativeSelectValue, setNativeSelectValue] = React.useState("");
+  const [defaultVariantSelectValue, setDefaultVariantSelectValue] =
+    React.useState("");
+  const [successVariantSelectValue, setSuccessVariantSelectValue] =
+    React.useState("");
   const [view, setView] = React.useState<View>("buttons");
   const [headerTab, setHeaderTab] = React.useState("one");
   const [tactilePrimaryActive, setTactilePrimaryActive] = React.useState(false);
@@ -467,7 +472,8 @@ export default function ComponentGallery() {
               { value: "orange", label: "Orange" },
               { value: "pear", label: "Pear" },
             ]}
-            value=""
+            value={nativeSelectValue}
+            onChange={setNativeSelectValue}
           />
         ),
       },
@@ -495,7 +501,8 @@ export default function ComponentGallery() {
                 { value: "a", label: "A" },
                 { value: "b", label: "B" },
               ]}
-              value=""
+              value={defaultVariantSelectValue}
+              onChange={setDefaultVariantSelectValue}
               aria-label="Default native select demo"
             />
             <Select
@@ -505,7 +512,8 @@ export default function ComponentGallery() {
                 { value: "", label: "Choose…" },
                 { value: "a", label: "A" },
               ]}
-              value=""
+              value={successVariantSelectValue}
+              onChange={setSuccessVariantSelectValue}
               aria-label="Success native select demo"
             />
           </div>
@@ -575,7 +583,13 @@ export default function ComponentGallery() {
         ),
       },
     ],
-    [query, selectValue],
+    [
+      query,
+      nativeSelectValue,
+      selectValue,
+      defaultVariantSelectValue,
+      successVariantSelectValue,
+    ],
   );
 
   const promptItems = React.useMemo(


### PR DESCRIPTION
## Summary
- add local state for the gallery select demos so each control is controlled intentionally
- wire the Select examples to their respective state and include the dependencies required for updates

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccc1df3008832cb85008092cab8581