### PR TITLE
Add palette state demos to ColorsView

### DIFF
--- a/src/components/prompts/ColorsView.tsx
+++ b/src/components/prompts/ColorsView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { SectionCard as UiSectionCard } from "@/components/ui";
+import { SectionCard as UiSectionCard, Skeleton } from "@/components/ui";
 import { COLOR_SECTIONS } from "./constants";
 
 const CHECKERBOARD_STYLE: React.CSSProperties = {
@@ -10,6 +10,9 @@ const CHECKERBOARD_STYLE: React.CSSProperties = {
   backgroundPosition: "0 0, var(--space-2) var(--space-2)",
   backgroundSize: "calc(var(--space-2) * 2) calc(var(--space-2) * 2)",
 };
+
+const PALETTE_GRID_CLASSNAME =
+  "grid grid-cols-2 gap-[var(--space-3)] sm:grid-cols-3 md:grid-cols-4 md:gap-[var(--space-4)] xl:grid-cols-12 xl:gap-[var(--space-5)]";
 
 type SectionCardProps = {
   title: string;
@@ -99,6 +102,17 @@ function Swatch({ token }: SwatchProps) {
   );
 }
 
+function SkeletonSwatch() {
+  return (
+    <li className="flex flex-col items-center gap-[var(--space-2)] xl:col-span-3">
+      <div className="relative h-[var(--space-8)] w-full overflow-hidden rounded-card r-card-md border border-[var(--card-hairline)]">
+        <Skeleton radius="card" className="h-full w-full" />
+      </div>
+      <Skeleton radius="sm" className="h-[var(--space-3)] w-3/4" />
+    </li>
+  );
+}
+
 function GradientSwatch() {
   return (
     <li className="col-span-full flex flex-col items-center gap-[var(--space-2)]">
@@ -115,7 +129,7 @@ export default function ColorsView() {
     <div className="space-y-[var(--space-6)]">
       {COLOR_SECTIONS.map((p) => (
         <SectionCard key={p.title} title={p.title}>
-          <ul className="grid grid-cols-2 gap-[var(--space-3)] sm:grid-cols-3 md:grid-cols-4 md:gap-[var(--space-4)] xl:grid-cols-12 xl:gap-[var(--space-5)]">
+          <ul className={PALETTE_GRID_CLASSNAME}>
             {p.tokens.map((t) => (
               <Swatch key={t} token={t} />
             ))}
@@ -123,9 +137,51 @@ export default function ColorsView() {
         </SectionCard>
       ))}
       <SectionCard title="Gradients">
-        <ul className="grid grid-cols-2 gap-[var(--space-3)] sm:grid-cols-3 md:grid-cols-4 md:gap-[var(--space-4)] xl:grid-cols-12 xl:gap-[var(--space-5)]">
+        <ul className={PALETTE_GRID_CLASSNAME}>
           <GradientSwatch />
         </ul>
+      </SectionCard>
+      <SectionCard title="Palette Loading State">
+        <UiSectionCard>
+          <UiSectionCard.Header title="Loading swatches" />
+          <UiSectionCard.Body>
+            <ul className={PALETTE_GRID_CLASSNAME}>
+              {Array.from({ length: 8 }).map((_, index) => (
+                <SkeletonSwatch key={index} />
+              ))}
+            </ul>
+          </UiSectionCard.Body>
+        </UiSectionCard>
+      </SectionCard>
+      <SectionCard title="Palette Error State">
+        <UiSectionCard>
+          <UiSectionCard.Header title="Palette failed to load" />
+          <UiSectionCard.Body>
+            <div className="flex flex-col items-center gap-[var(--space-2)] rounded-card r-card-md border border-danger/45 bg-danger/10 p-[var(--space-5)] text-center">
+              <p className="text-body font-semibold text-danger">
+                We couldn&apos;t fetch the swatches.
+              </p>
+              <p className="text-label text-danger/80">
+                Check your connection and try again.
+              </p>
+            </div>
+          </UiSectionCard.Body>
+        </UiSectionCard>
+      </SectionCard>
+      <SectionCard title="Palette Empty State">
+        <UiSectionCard>
+          <UiSectionCard.Header title="No swatches yet" />
+          <UiSectionCard.Body>
+            <div className="flex flex-col items-center gap-[var(--space-2)] rounded-card r-card-md border border-dashed border-border/60 bg-muted/20 p-[var(--space-5)] text-center">
+              <p className="text-body font-semibold text-foreground">
+                No tokens in this palette.
+              </p>
+              <p className="text-label text-muted-foreground">
+                Add tokens to see them appear here.
+              </p>
+            </div>
+          </UiSectionCard.Body>
+        </UiSectionCard>
       </SectionCard>
       <SectionCard title="SectionCard Variants">
         <div className="flex flex-col gap-[var(--space-4)]">


### PR DESCRIPTION
## Summary
- add a reusable grid class and skeleton swatch for palette examples
- showcase loading, error, and empty palette states using SectionCard primitives and semantic tokens

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccc45d2758832c81e83962ceca4803