### PR TITLE
Keep spec code panel mounted for aria controls

### DIFF
--- a/src/components/prompts/ComponentsView.tsx
+++ b/src/components/prompts/ComponentsView.tsx
@@ -192,9 +192,11 @@ function SpecCard({
         </p>
       ) : null}
       <div className={frameClassName}>{element}</div>
-      {showCode && code ? (
+      {code ? (
         <pre
           id={codeId}
+          hidden={!showCode}
+          aria-hidden={showCode ? undefined : true}
           className="rounded-card r-card-md bg-muted/80 p-4 text-label overflow-x-auto shadow-[var(--shadow-inset)]"
         >
           <code>{code}</code>


### PR DESCRIPTION
## Summary
- keep the spec code panel mounted and toggle hidden/aria-hidden so the button's aria-controls always has a live target

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccc61cf41c832ca0289c29b200f9ac