### PR TITLE
Use control radius for quick action buttons

### DIFF
--- a/src/components/home/QuickActionGrid.tsx
+++ b/src/components/home/QuickActionGrid.tsx
@@ -13,7 +13,7 @@ const layoutClassNames: Record<QuickActionLayout, string> = {
 };
 
 const buttonBaseClassName =
-  "rounded-[var(--radius-2xl)] [--focus:var(--theme-ring)] focus-visible:ring-offset-0";
+  "rounded-[var(--control-radius)] [--focus:var(--theme-ring)] focus-visible:ring-offset-0";
 
 type QuickActionDefinition = {
   href: string;


### PR DESCRIPTION
## Summary
- update QuickActionGrid quick action base class to use the standardized control radius token
- verified the component does not define conflicting radius overrides

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccc649c884832c9ccb15157d412991