### PR TITLE
feat: add shared mobile nav to site chrome

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,16 @@
     --danger-foreground: var(--primary-foreground);
   }
 
+  body {
+    --header-stack: calc(var(--space-8) + var(--space-7));
+  }
+
+  @media (min-width: 48rem) {
+    body {
+      --header-stack: calc(var(--space-8) + var(--space-4));
+    }
+  }
+
   .page-shell {
     width: 100%;
     max-width: var(--shell-max, var(--shell-width));

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,6 @@ import {
   GoalsCard,
   ReviewsCard,
   TeamPromptsCard,
-  BottomNav,
   IsometricRoom,
   DashboardList,
   WelcomeHeroFigure,
@@ -553,9 +552,6 @@ function HomePageContent() {
                   <TeamPromptsCard />
                 </div>
               </section>
-              <div className="p-[var(--space-3)] md:hidden">
-                <BottomNav />
-              </div>
             </div>
           </div>
         </div>

--- a/src/components/chrome/BottomNav.tsx
+++ b/src/components/chrome/BottomNav.tsx
@@ -4,16 +4,30 @@ import * as React from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn, withoutBasePath } from "@/lib/utils";
-import { NAV_ITEMS, isNavActive } from "../chrome/nav-items";
+import { NAV_ITEMS, type NavItem, isNavActive } from "./nav-items";
 
-export default function BottomNav() {
+type BottomNavProps = {
+  className?: string;
+  items?: readonly NavItem[];
+};
+
+export default function BottomNav({
+  className,
+  items = NAV_ITEMS,
+}: BottomNavProps = {}) {
   const rawPathname = usePathname() ?? "/";
   const pathname = withoutBasePath(rawPathname);
-  const mobileItems = React.useMemo(() => NAV_ITEMS, []);
+
   return (
-    <nav aria-label="Primary" className="border-t border-border pt-[var(--space-4)] md:hidden">
+    <nav
+      aria-label="Primary"
+      className={cn(
+        "border-t border-border pt-[var(--space-4)] md:hidden",
+        className,
+      )}
+    >
       <ul className="flex justify-around">
-        {mobileItems.map(({ href, label, mobileIcon: Icon }) => {
+        {items.map(({ href, label, mobileIcon: Icon }) => {
           if (!Icon) {
             return null;
           }

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import NavBar from "@/components/chrome/NavBar";
+import BottomNav from "@/components/chrome/BottomNav";
 import ThemeToggle from "@/components/ui/theme/ThemeToggle";
 import AnimationToggle from "@/components/ui/AnimationToggle";
 import { PageShell } from "@/components/ui";
@@ -20,7 +21,7 @@ export default function SiteChrome() {
       {/* Bar content */}
       <PageShell
         grid
-        className="py-[var(--space-3)]"
+        className="pt-[var(--space-3)] pb-0 md:pb-[var(--space-3)]"
         contentClassName="items-center"
       >
         <Link
@@ -44,6 +45,10 @@ export default function SiteChrome() {
         <div className="col-span-full flex items-center justify-end gap-[var(--space-3)] md:col-span-3 md:justify-self-end">
           <ThemeToggle />
           <AnimationToggle />
+        </div>
+
+        <div className="col-span-full md:hidden">
+          <BottomNav />
         </div>
       </PageShell>
 

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -7,7 +7,7 @@ export { default as ReviewsCard } from "./ReviewsCard";
 export { default as QuickActions } from "./QuickActions";
 export { default as TeamPromptsCard } from "./TeamPromptsCard";
 export { default as QuickActionGrid } from "./QuickActionGrid";
-export { default as BottomNav } from "./BottomNav";
+export { default as BottomNav } from "../chrome/BottomNav";
 export { default as IsometricRoom } from "./IsometricRoom";
 export { default as HeroPortraitFrame } from "./HeroPortraitFrame";
 export { default as WelcomeHeroFigure } from "./WelcomeHeroFigure";

--- a/tests/chrome/SiteChrome.test.tsx
+++ b/tests/chrome/SiteChrome.test.tsx
@@ -5,6 +5,9 @@ import { describe, it, expect, vi } from "vitest";
 vi.mock("@/components/chrome/NavBar", () => ({
   default: () => <nav />,
 }));
+vi.mock("@/components/chrome/BottomNav", () => ({
+  default: () => <nav data-testid="mobile-nav" />,
+}));
 vi.mock("@/components/ui/theme/ThemeToggle", () => ({
   default: () => <button />,
 }));
@@ -20,5 +23,10 @@ describe("SiteChrome", () => {
     const link = screen.getByRole("link", { name: "Home" });
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute("href", "/");
+  });
+
+  it("renders the mobile navigation", () => {
+    render(<SiteChrome />);
+    expect(screen.getAllByTestId("mobile-nav")).not.toHaveLength(0);
   });
 });

--- a/tests/home/HomePage.test.tsx
+++ b/tests/home/HomePage.test.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import Page from "@/app/page";
+import SiteChrome from "@/components/chrome/SiteChrome";
 import { ThemeProvider } from "@/lib/theme-context";
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
@@ -14,22 +15,25 @@ describe("Home page", () => {
   it("renders navigation links", () => {
     render(
       <ThemeProvider>
-        <Suspense fallback="loading">
-          <Page />
-        </Suspense>
+        <React.Fragment>
+          <SiteChrome />
+          <Suspense fallback="loading">
+            <Page />
+          </Suspense>
+        </React.Fragment>
       </ThemeProvider>,
     );
-    const goals = screen.getByRole("link", { name: "Goals" });
-    const reviews = screen.getByRole("link", { name: "Reviews" });
-    const team = screen.getByRole("link", { name: "Team" });
-    const prompts = screen.getByRole("link", { name: "Prompts" });
-    const planner = screen
-      .getAllByRole("link", { name: "Planner" })
-      .find((l) => l.getAttribute("href") === "/planner");
-    expect(goals).toHaveAttribute("href", "/goals");
-    expect(planner).toHaveAttribute("href", "/planner");
-    expect(reviews).toHaveAttribute("href", "/reviews");
-    expect(team).toHaveAttribute("href", "/team");
-    expect(prompts).toHaveAttribute("href", "/prompts");
+    const expectLink = (label: string, href: string) => {
+      const match = (screen
+        .getAllByRole("link", { name: label }) as HTMLAnchorElement[])
+        .find((anchor) => anchor.getAttribute("href") === href);
+      expect(match?.getAttribute("href")).toBe(href);
+    };
+
+    expectLink("Goals", "/goals");
+    expectLink("Planner", "/planner");
+    expectLink("Reviews", "/reviews");
+    expectLink("Team", "/team");
+    expectLink("Prompts", "/prompts");
   });
 });

--- a/tests/ui/site-chrome.test.tsx
+++ b/tests/ui/site-chrome.test.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+vi.mock("@/components/chrome/BottomNav", () => ({
+  default: () => <nav />,
+}));
 import SiteChrome from "@/components/chrome/SiteChrome";
 import { ThemeProvider } from "@/lib/theme-context";
 


### PR DESCRIPTION
## Summary
- move the mobile BottomNav into the chrome package and reuse it from SiteChrome on small screens
- adjust the layout shell spacing and global header stack token for mobile to avoid overlap
- update the home page and related tests to rely on the shared navigation source

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccc2fe9844832ca69563efe8501fb4