### PR TITLE
Ensure ChampListEditor emits empty arrays for empty lists

### DIFF
--- a/src/components/team/ChampListEditor.tsx
+++ b/src/components/team/ChampListEditor.tsx
@@ -44,12 +44,13 @@ export default function ChampListEditor({
   const workingList = sanitized.length ? sanitized : [""];
 
   function commit(next: string[]) {
-    onChange(sanitizeList(next));
+    const sanitizedNext = sanitizeList(next);
+    onChange(sanitizedNext.length ? sanitizedNext : []);
   }
 
   function commitWithoutBlanks(next: string[]) {
     const cleaned = sanitizeList(next).filter((item) => item.trim().length);
-    onChange(cleaned);
+    onChange(cleaned.length ? cleaned : []);
   }
 
   function setAt(index: number, value: string) {


### PR DESCRIPTION
## Summary
- update ChampListEditor commit helpers to return true empty arrays when all champs are cleared

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccc6a17294832c8bab20241a87641a