### PR TITLE
Handle missing team builder entries

### DIFF
--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -286,8 +286,8 @@ export default function TeamCompPage() {
     }
     if (tab === "builder") {
       const laneSummaries = BUILDER_LANES.map((lane) => {
-        const ally = builderState.allies[lane.key].trim();
-        const enemy = builderState.enemies[lane.key].trim();
+        const ally = (builderState.allies[lane.key] ?? "").trim();
+        const enemy = (builderState.enemies[lane.key] ?? "").trim();
         return {
           ...lane,
           ally,

--- a/tests/team/TeamCompPage.test.tsx
+++ b/tests/team/TeamCompPage.test.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import TeamCompPage from "@/components/team/TeamCompPage";
+import * as BuilderModule from "@/components/team/Builder";
+import type { TeamState } from "@/components/team/Builder";
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -15,12 +17,31 @@ afterEach(() => {
 describe("TeamCompPage builder tab", () => {
   it("shows builder hero with spacing", () => {
     render(<TeamCompPage />);
-    const builderTab = screen.getByRole("tab", { name: "Builder" });
+    const builderTab = screen.getAllByRole("tab", { name: "Builder" })[0];
     fireEvent.click(builderTab);
     const heroHeading = screen.getByRole("heading", { name: "Builder" });
     expect(heroHeading).toBeInTheDocument();
     const cardParent = screen.getByText("Allies").closest("section")?.parentElement;
     expect(cardParent).toHaveClass("mt-6");
+  });
+
+  it("handles missing lane entries gracefully", () => {
+    const partialState = {
+      allies: { top: "Garen" },
+      enemies: {},
+    } as unknown as TeamState;
+    const initSpy = vi
+      .spyOn(BuilderModule, "createInitialTeamState")
+      .mockReturnValue(partialState);
+    try {
+      render(<TeamCompPage />);
+      const builderTab = screen.getAllByRole("tab", { name: "Builder" })[0];
+      fireEvent.click(builderTab);
+      expect(screen.getByText("Lane coverage")).toBeInTheDocument();
+      expect(screen.getByText("Mid: Open / Open")).toBeInTheDocument();
+    } finally {
+      initSpy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- guard builder lane hero calculations by defaulting to empty strings before trimming
- add a team builder test that mocks missing lane data to ensure the hero renders without crashing

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccc4961d24832ca20acad070fc37ee