### PR TITLE
Use spacing token for GoalListDemo margin

### DIFF
--- a/src/components/prompts/GoalListDemo.tsx
+++ b/src/components/prompts/GoalListDemo.tsx
@@ -8,7 +8,7 @@ import { GOAL_DEMO_ITEMS } from "./demoData";
 export default function GoalListDemo() {
   const [items, setItems] = React.useState<Goal[]>(GOAL_DEMO_ITEMS);
   return (
-    <div className="mb-8">
+    <div className="mb-[var(--space-8)]">
       <GoalList
         goals={items}
         onToggleDone={(id) =>


### PR DESCRIPTION
## Summary
- replace the GoalList demo wrapper margin utility with the design token variant

## Testing
- npm run check *(fails: tests/team/TeamCompPage.test.tsx > TeamCompPage builder tab > handles missing lane entries gracefully)*

------
https://chatgpt.com/codex/tasks/task_e_68ccca7a1320832ca8211ca25df0896a