### PR TITLE
Use spacing tokens in button showcase

### DIFF
--- a/src/components/prompts/ButtonShowcase.tsx
+++ b/src/components/prompts/ButtonShowcase.tsx
@@ -4,8 +4,8 @@ import { Plus } from "lucide-react";
 
 export default function ButtonShowcase() {
   return (
-    <div className="mb-8 space-y-4">
-      <div className="flex flex-wrap gap-2">
+    <div className="mb-[var(--space-8)] space-y-[var(--space-4)]">
+      <div className="flex flex-wrap gap-[var(--space-2)]">
         <Button tone="primary">Primary tone</Button>
         <Button tone="accent">Accent tone</Button>
         <Button tone="info" variant="ghost">
@@ -16,7 +16,7 @@ export default function ButtonShowcase() {
         </Button>
         <Button disabled>Disabled</Button>
       </div>
-      <div className="flex flex-wrap items-center gap-2">
+      <div className="flex flex-wrap items-center gap-[var(--space-2)]">
         <Button size="sm">
           <Plus />
           Small


### PR DESCRIPTION
## Summary
- replace the prompt button showcase spacing utilities with the corresponding spacing tokens

## Testing
- npm run check *(fails: tests/team/TeamCompPage.test.tsx > TeamCompPage builder tab > handles missing lane entries gracefully due to duplicate "Lane coverage" labels)*

------
https://chatgpt.com/codex/tasks/task_e_68ccca6b6bf4832c936638c7b9027440