### PR TITLE
Add test cleanup to prevent duplicate DOM nodes

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
-import { vi } from "vitest";
+import { afterEach, vi } from "vitest";
+import { cleanup } from "@testing-library/react";
 import type { ElementType, ReactNode } from "react";
 
 type ReactModule = typeof import("react");
@@ -78,6 +79,10 @@ Object.defineProperty(window, "matchMedia", {
     removeEventListener: vi.fn(),
     dispatchEvent: vi.fn(),
   }),
+});
+
+afterEach(() => {
+  cleanup();
 });
 
 export function resetLocalStorage() {


### PR DESCRIPTION
## Summary
- ensure Vitest cleans up rendered components between test cases by invoking testing-library cleanup in the global setup

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccc94fa228832c910889903bc9861a