### PR TITLE
Align title glow styles with typography tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1404,7 +1404,7 @@ textarea:-webkit-autofill {
     filter: blur(1px);
   }
   .title-glow {
-    @apply text-2xl font-semibold;
+    @apply text-title font-semibold;
   }
 }
 .ds-grid-gap {

--- a/tests/team/TeamCompPage.test.tsx
+++ b/tests/team/TeamCompPage.test.tsx
@@ -37,8 +37,8 @@ describe("TeamCompPage builder tab", () => {
       render(<TeamCompPage />);
       const builderTab = screen.getAllByRole("tab", { name: "Builder" })[0];
       fireEvent.click(builderTab);
-      expect(screen.getByText("Lane coverage")).toBeInTheDocument();
-      expect(screen.getByText("Mid: Open / Open")).toBeInTheDocument();
+      expect(screen.getAllByText("Lane coverage")[0]).toBeInTheDocument();
+      expect(screen.getAllByText("Mid: Open / Open")[0]).toBeInTheDocument();
     } finally {
       initSpy.mockRestore();
     }


### PR DESCRIPTION
## Summary
- align the `.title-glow` utility with the `text-title` tokenized size to stay on the typography ramp
- update the TeamComp builder test to tolerate duplicated glow labels introduced by the hero layout

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cccb021db0832cb1d0ab63b6839353