### PR TITLE
Refine components gallery layout and categorization

### DIFF
--- a/src/components/components/ComponentsPage.tsx
+++ b/src/components/components/ComponentsPage.tsx
@@ -274,11 +274,13 @@ export default function ComponentsPage() {
   return (
     <PageShell
       as="main"
-      className="space-y-[var(--space-6)] py-[var(--space-6)]"
+      grid
       aria-labelledby="components-header"
+      className="py-[var(--space-6)] md:py-[var(--space-7)] lg:py-[var(--space-8)]"
+      contentClassName="gap-y-[var(--space-6)] md:gap-y-[var(--space-7)] lg:gap-y-[var(--space-8)]"
     >
       <PageHeader
-        containerClassName="relative isolate"
+        containerClassName="relative isolate col-span-full"
         header={{
           id: "components-header",
           heading: "Component Gallery",
@@ -292,7 +294,10 @@ export default function ComponentsPage() {
             idBase: "components",
             linkPanels: true,
             variant: "neo",
-            tablistClassName: NEO_TABLIST_SHARED_CLASSES,
+            tablistClassName: cn(
+              NEO_TABLIST_SHARED_CLASSES,
+              "w-full md:w-auto",
+            ),
           },
         }}
         frameProps={{
@@ -323,8 +328,11 @@ export default function ComponentsPage() {
                   size: "sm",
                   variant: "default",
                   showBaseline: true,
-                  tablistClassName: "max-w-full shadow-neo-inset",
-                  className: "max-w-full",
+                  tablistClassName: cn(
+                    "max-w-full shadow-neo-inset",
+                    "w-full md:w-auto",
+                  ),
+                  className: "max-w-full w-full md:w-auto",
                   renderItem: ({ item, props, ref, disabled }) => {
                     const {
                       className: baseClassName,
@@ -402,7 +410,9 @@ export default function ComponentsPage() {
               : undefined,
         }}
       />
-      <section className="grid gap-[var(--space-6)]">
+      <section
+        className="col-span-full grid gap-[var(--space-6)] md:gap-[var(--space-7)] lg:gap-[var(--space-8)]"
+      >
         <div
           id="components-components-panel"
           role="tabpanel"

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -542,76 +542,6 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
 </div>`,
     },
     {
-      id: "tab-bar-filters",
-      name: "TabBar (filters)",
-      description: "Preset filter tabs with icons",
-      element: (
-        <TabBar
-          items={[
-            { key: "all", label: "All", icon: <Circle aria-hidden="true" /> },
-            {
-              key: "active",
-              label: "Active",
-              icon: <CircleDot aria-hidden="true" />,
-            },
-            {
-              key: "done",
-              label: "Done",
-              icon: <CircleCheck aria-hidden="true" />,
-            },
-          ]}
-          defaultValue="active"
-          ariaLabel="Show active goals"
-        />
-      ),
-      tags: ["button", "segmented"],
-      code: `<TabBar
-  items={[
-    { key: "all", label: "All", icon: <Circle aria-hidden="true" /> },
-    {
-      key: "active",
-      label: "Active",
-      icon: <CircleDot aria-hidden="true" />,
-    },
-    {
-      key: "done",
-      label: "Done",
-      icon: <CircleCheck aria-hidden="true" />,
-    },
-  ]}
-  defaultValue="active"
-  ariaLabel="Show active goals"
-/>`,
-    },
-    {
-      id: "quick-action-grid",
-      name: "QuickActionGrid",
-      description: "Maps quick action configs to styled buttons",
-      element: (
-        <QuickActionGrid
-          actions={[
-            { href: "/planner", label: "Planner Today" },
-            { href: "/goals", label: "New Goal", tone: "accent" },
-            { href: "/reviews", label: "New Review", tone: "accent" },
-          ]}
-          className="md:flex-row md:items-center md:justify-between"
-          buttonSize="lg"
-          buttonClassName="motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
-        />
-      ),
-      tags: ["button", "layout"],
-      code: `<QuickActionGrid
-  actions={[
-    { href: "/planner", label: "Planner Today" },
-    { href: "/goals", label: "New Goal", tone: "accent" },
-    { href: "/reviews", label: "New Review", tone: "accent" },
-  ]}
-  className="md:flex-row md:items-center md:justify-between"
-  buttonSize="lg"
-  buttonClassName="motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
-/>`,
-    },
-    {
       id: "icon-button",
       name: "IconButton",
       description: "Size and variant showcase",
@@ -846,13 +776,6 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       code: `<PromptList prompts={demoPrompts} query="" />`,
     },
     {
-      id: "goal-list-demo",
-      name: "GoalListDemo",
-      element: <GoalListDemo />,
-      tags: ["goal", "list"],
-      code: `<GoalListDemo />`,
-    },
-    {
       id: "prompts-header",
       name: "PromptsHeader",
       description: "Prompts workspace header with search, chips, and save action.",
@@ -925,6 +848,41 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       element: <GoalsProgress total={3} pct={50} />,
       tags: ["goals", "progress"],
       code: `<GoalsProgress total={3} pct={50} />`,
+    },
+    {
+      id: "goal-list-demo",
+      name: "GoalListDemo",
+      element: <GoalListDemo />,
+      tags: ["goal", "list"],
+      code: `<GoalListDemo />`,
+    },
+    {
+      id: "quick-action-grid",
+      name: "QuickActionGrid",
+      description: "Maps quick action configs to styled planner shortcuts",
+      element: (
+        <QuickActionGrid
+          actions={[
+            { href: "/planner", label: "Planner Today" },
+            { href: "/goals", label: "New Goal", tone: "accent" },
+            { href: "/reviews", label: "New Review", tone: "accent" },
+          ]}
+          className="md:flex-row md:items-center md:justify-between"
+          buttonSize="lg"
+          buttonClassName="motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
+        />
+      ),
+      tags: ["actions", "planner"],
+      code: `<QuickActionGrid
+  actions={[
+    { href: "/planner", label: "Planner Today" },
+    { href: "/goals", label: "New Goal", tone: "accent" },
+    { href: "/reviews", label: "New Review", tone: "accent" },
+  ]}
+  className="md:flex-row md:items-center md:justify-between"
+  buttonSize="lg"
+  buttonClassName="motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
+/>`,
     },
     {
       id: "reminders-tab",
@@ -1274,14 +1232,6 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
 </Modal>`,
     },
     {
-      id: "toast-demo",
-      name: "Toast",
-      element: <ToastDemo />,
-      tags: ["toast", "feedback"],
-      code: `<Button size="sm">Show</Button>
-<Toast open closable showProgress><p className="text-ui">Toast message</p></Toast>`,
-    },
-    {
       id: "split",
       name: "Split",
       element: (
@@ -1292,52 +1242,6 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       ),
       tags: ["split", "layout"],
       code: `<Split left={<div>Left</div>} right={<div>Right</div>} />`,
-    },
-    {
-      id: "tab-bar",
-      name: "TabBar",
-      element: (
-        <TabBar
-          items={[
-            { key: "a", label: "A" },
-            { key: "b", label: "B" },
-          ]}
-          defaultValue="a"
-          ariaLabel="Example tabs"
-        />
-      ),
-      tags: ["tabs"],
-      code: `<TabBar
-  items={[{ key: "a", label: "A" }, { key: "b", label: "B" }]}
-  defaultValue="a"
-  ariaLabel="Example tabs"
-/>`,
-    },
-    {
-      id: "tab-bar-app-nav",
-      name: "TabBar (app nav)",
-      description: "Controlled TabBar for section switching",
-      element: (
-        <TabBar
-          items={[
-            { key: "reviews", label: "Reviews" },
-            { key: "planner", label: "Planner" },
-            { key: "goals", label: "Goals" },
-          ]}
-          defaultValue="reviews"
-          ariaLabel="Planner areas"
-        />
-      ),
-      tags: ["tabs"],
-      code: `<TabBar
-  items={[
-    { key: "reviews", label: "Reviews" },
-    { key: "planner", label: "Planner" },
-    { key: "goals", label: "Goals" },
-  ]}
-  defaultValue="reviews"
-  ariaLabel="Planner areas"
-/>`,
     },
     {
       id: "title-bar",
@@ -1584,6 +1488,14 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       code: `<Snackbar message="Saved" actionLabel="Undo" onAction={() => {}} />`,
     },
     {
+      id: "toast-demo",
+      name: "Toast",
+      element: <ToastDemo />,
+      tags: ["toast", "feedback"],
+      code: `<Button size="sm">Show</Button>
+<Toast open closable showProgress><p className="text-ui">Toast message</p></Toast>`,
+    },
+    {
       id: "skeleton",
       name: "Skeleton",
       description: "Shimmer placeholder for loading layouts.",
@@ -1630,6 +1542,94 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       tags: ["toggle", "animation"],
       code: `<AnimationToggle />
 <AnimationToggle loading />`,
+    },
+    {
+      id: "tab-bar-filters",
+      name: "TabBar (filters)",
+      description: "Preset filter tabs with icons",
+      element: (
+        <TabBar
+          items={[
+            { key: "all", label: "All", icon: <Circle aria-hidden="true" /> },
+            {
+              key: "active",
+              label: "Active",
+              icon: <CircleDot aria-hidden="true" />,
+            },
+            {
+              key: "done",
+              label: "Done",
+              icon: <CircleCheck aria-hidden="true" />,
+            },
+          ]}
+          defaultValue="active"
+          ariaLabel="Show active goals"
+        />
+      ),
+      tags: ["tab", "toggle"],
+      code: `<TabBar
+  items={[
+    { key: "all", label: "All", icon: <Circle aria-hidden="true" /> },
+    {
+      key: "active",
+      label: "Active",
+      icon: <CircleDot aria-hidden="true" />,
+    },
+    {
+      key: "done",
+      label: "Done",
+      icon: <CircleCheck aria-hidden="true" />,
+    },
+  ]}
+  defaultValue="active"
+  ariaLabel="Show active goals"
+/>`,
+    },
+    {
+      id: "tab-bar",
+      name: "TabBar",
+      element: (
+        <TabBar
+          items={[
+            { key: "a", label: "A" },
+            { key: "b", label: "B" },
+          ]}
+          defaultValue="a"
+          ariaLabel="Example tabs"
+        />
+      ),
+      tags: ["tab", "toggle"],
+      code: `<TabBar
+  items={[{ key: "a", label: "A" }, { key: "b", label: "B" }]}
+  defaultValue="a"
+  ariaLabel="Example tabs"
+/>`,
+    },
+    {
+      id: "tab-bar-app-nav",
+      name: "TabBar (app nav)",
+      description: "Controlled TabBar for section switching",
+      element: (
+        <TabBar
+          items={[
+            { key: "reviews", label: "Reviews" },
+            { key: "planner", label: "Planner" },
+            { key: "goals", label: "Goals" },
+          ]}
+          defaultValue="reviews"
+          ariaLabel="Planner areas"
+        />
+      ),
+      tags: ["tab", "toggle"],
+      code: `<TabBar
+  items={[
+    { key: "reviews", label: "Reviews" },
+    { key: "planner", label: "Planner" },
+    { key: "goals", label: "Goals" },
+  ]}
+  defaultValue="reviews"
+  ariaLabel="Planner areas"
+/>`,
     },
     {
       id: "theme-toggle",


### PR DESCRIPTION
## Summary
- align the components gallery shell with the design grid, including responsive spacing and tab sizing updates
- move miscategorized specs (quick actions, goal list, toast, tab bars) into their correct component sections for accurate sub-tabs

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccceffb5a0832cb6ee696f1f2d61c4