### PR TITLE
Adjust OutlineGlowDemo spacing and disabled state

### DIFF
--- a/src/components/prompts/OutlineGlowDemo.tsx
+++ b/src/components/prompts/OutlineGlowDemo.tsx
@@ -3,18 +3,18 @@ import * as React from "react";
 // Demos should represent all interactive states for clarity.
 export default function OutlineGlowDemo() {
   return (
-    <div className="mb-4 space-x-2">
+    <div className="mb-[var(--space-4)] space-x-[var(--space-2)]">
       <button
         type="button"
-        className="p-2 border rounded-[var(--control-radius)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] hover:bg-surface-2 active:bg-surface"
+        className="p-[var(--space-2)] border rounded-[var(--control-radius)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] hover:bg-surface-2 active:bg-surface"
         style={{ "--focus": "var(--theme-ring)" } as React.CSSProperties}
       >
         Focus me to see the glow
       </button>
       <button
         type="button"
-        aria-disabled="true"
-        className="p-2 border rounded-[var(--control-radius)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] hover:bg-surface-2 active:bg-surface disabled:cursor-not-allowed"
+        disabled
+        className="p-[var(--space-2)] border rounded-[var(--control-radius)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] hover:bg-surface-2 active:bg-surface disabled:cursor-not-allowed"
         style={{ "--focus": "var(--theme-ring)" } as React.CSSProperties}
       >
         Disabled example


### PR DESCRIPTION
## Summary
- update the outline glow demo container to use spacing tokens
- replace button padding with the space-2 token and mark the disabled example with the native attribute

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccceb238dc832c836c1895606e708b