### PR TITLE
Remove redundant aria label from focus input

### DIFF
--- a/src/components/planner/FocusPanel.tsx
+++ b/src/components/planner/FocusPanel.tsx
@@ -42,7 +42,6 @@ export default function FocusPanel({ iso }: Props) {
             name={`focus-${iso}`}
             autoComplete="off"
             className="flex-1"
-            aria-label="Daily focus"
             aria-labelledby={headerId}
           />
           <Button


### PR DESCRIPTION
## Summary
- rely on the SectionCard header to label the focus input by removing its redundant aria-label

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cccfcc5f08832cb3faee9cbf34f373