### PR TITLE
Refactor day focus/notes hooks to share text field logic

### DIFF
--- a/src/components/planner/createDayTextFieldHook.ts
+++ b/src/components/planner/createDayTextFieldHook.ts
@@ -1,0 +1,76 @@
+// src/components/planner/createDayTextFieldHook.ts
+"use client";
+
+import * as React from "react";
+
+import type { DayRecord, ISODate } from "./plannerStore";
+import { usePlannerStore } from "./usePlannerStore";
+
+type DayTextSelector = (day: DayRecord) => string | undefined;
+type DayTextMutator = (day: DayRecord, value: string) => DayRecord;
+
+type UseDayTextField = (iso: ISODate) => {
+  value: string;
+  setValue: React.Dispatch<React.SetStateAction<string>>;
+  saving: boolean;
+  isDirty: boolean;
+  lastSavedRef: React.MutableRefObject<string>;
+  commit: VoidFunction;
+};
+
+const scheduleSavingReset = (callback: VoidFunction) => {
+  if (typeof queueMicrotask === "function") {
+    queueMicrotask(callback);
+    return;
+  }
+
+  setTimeout(callback, 0);
+};
+
+export function createDayTextFieldHook({
+  selectValue,
+  applyValue,
+}: {
+  selectValue: DayTextSelector;
+  applyValue: DayTextMutator;
+}): UseDayTextField {
+  return function useDayTextField(iso: ISODate) {
+    const { getDay, upsertDay } = usePlannerStore();
+    const day = getDay(iso);
+    const persistedValue = selectValue(day) ?? "";
+
+    const applyForIso = React.useCallback(
+      (value: string) => {
+        upsertDay(iso, (d) => applyValue(d, value));
+      },
+      [iso, upsertDay],
+    );
+
+    const [value, setValue] = React.useState<string>(() => persistedValue);
+    const [saving, setSaving] = React.useState(false);
+    const lastSavedRef = React.useRef(persistedValue.trim());
+
+    const trimmed = React.useMemo(() => value.trim(), [value]);
+    const isDirty = trimmed !== lastSavedRef.current;
+
+    const commit = React.useCallback(() => {
+      if (!isDirty) return;
+      setSaving(true);
+      try {
+        applyForIso(trimmed);
+        lastSavedRef.current = trimmed;
+      } finally {
+        scheduleSavingReset(() => {
+          setSaving(false);
+        });
+      }
+    }, [applyForIso, isDirty, trimmed]);
+
+    React.useEffect(() => {
+      setValue(persistedValue);
+      lastSavedRef.current = persistedValue.trim();
+    }, [iso, persistedValue]);
+
+    return { value, setValue, saving, isDirty, lastSavedRef, commit } as const;
+  };
+}

--- a/src/components/planner/useDayFocus.ts
+++ b/src/components/planner/useDayFocus.ts
@@ -1,57 +1,10 @@
 // src/components/planner/useDayFocus.ts
 "use client";
 
-import * as React from "react";
-
+import { createDayTextFieldHook } from "./createDayTextFieldHook";
 import { setFocus as applyFocus } from "./plannerCrud";
-import { usePlannerStore } from "./usePlannerStore";
-import type { ISODate } from "./plannerStore";
 
-const scheduleSavingReset = (callback: VoidFunction) => {
-  if (typeof queueMicrotask === "function") {
-    queueMicrotask(callback);
-    return;
-  }
-
-  setTimeout(callback, 0);
-};
-
-export function useDayFocus(iso: ISODate) {
-  const { getDay, upsertDay } = usePlannerStore();
-  const day = getDay(iso);
-  const persistedFocus = day.focus ?? "";
-
-  const setFocusForIso = React.useCallback(
-    (focusValue: string) => {
-      upsertDay(iso, (d) => applyFocus(d, focusValue));
-    },
-    [iso, upsertDay],
-  );
-
-  const [value, setValue] = React.useState<string>(() => persistedFocus);
-  const [saving, setSaving] = React.useState(false);
-  const lastSavedRef = React.useRef(persistedFocus.trim());
-
-  const trimmed = React.useMemo(() => value.trim(), [value]);
-  const isDirty = trimmed !== lastSavedRef.current;
-
-  const commit = React.useCallback(() => {
-    if (!isDirty) return;
-    setSaving(true);
-    try {
-      setFocusForIso(trimmed);
-      lastSavedRef.current = trimmed;
-    } finally {
-      scheduleSavingReset(() => {
-        setSaving(false);
-      });
-    }
-  }, [isDirty, setFocusForIso, trimmed]);
-
-  React.useEffect(() => {
-    setValue(persistedFocus);
-    lastSavedRef.current = persistedFocus.trim();
-  }, [iso, persistedFocus]);
-
-  return { value, setValue, saving, isDirty, lastSavedRef, commit } as const;
-}
+export const useDayFocus = createDayTextFieldHook({
+  selectValue: (day) => day.focus,
+  applyValue: applyFocus,
+});

--- a/src/components/planner/useDayNotes.ts
+++ b/src/components/planner/useDayNotes.ts
@@ -1,57 +1,10 @@
 // src/components/planner/useDayNotes.ts
 "use client";
 
-import * as React from "react";
-
+import { createDayTextFieldHook } from "./createDayTextFieldHook";
 import { setNotes as applyNotes } from "./plannerCrud";
-import { usePlannerStore } from "./usePlannerStore";
-import type { ISODate } from "./plannerStore";
 
-const scheduleSavingReset = (callback: VoidFunction) => {
-  if (typeof queueMicrotask === "function") {
-    queueMicrotask(callback);
-    return;
-  }
-
-  setTimeout(callback, 0);
-};
-
-export function useDayNotes(iso: ISODate) {
-  const { getDay, upsertDay } = usePlannerStore();
-  const day = getDay(iso);
-  const persistedNotes = day.notes ?? "";
-
-  const setNotesForIso = React.useCallback(
-    (notes: string) => {
-      upsertDay(iso, (d) => applyNotes(d, notes));
-    },
-    [iso, upsertDay],
-  );
-
-  const [value, setValue] = React.useState<string>(() => persistedNotes);
-  const [saving, setSaving] = React.useState(false);
-  const lastSavedRef = React.useRef(persistedNotes.trim());
-
-  const trimmed = React.useMemo(() => value.trim(), [value]);
-  const isDirty = trimmed !== lastSavedRef.current;
-
-  const commit = React.useCallback(() => {
-    if (!isDirty) return;
-    setSaving(true);
-    try {
-      setNotesForIso(trimmed);
-      lastSavedRef.current = trimmed;
-    } finally {
-      scheduleSavingReset(() => {
-        setSaving(false);
-      });
-    }
-  }, [isDirty, setNotesForIso, trimmed]);
-
-  React.useEffect(() => {
-    setValue(persistedNotes);
-    lastSavedRef.current = persistedNotes.trim();
-  }, [iso, persistedNotes]);
-
-  return { value, setValue, saving, isDirty, lastSavedRef, commit } as const;
-}
+export const useDayNotes = createDayTextFieldHook({
+  selectValue: (day) => day.notes,
+  applyValue: applyNotes,
+});


### PR DESCRIPTION
## Summary
- add a reusable createDayTextFieldHook helper for planner text inputs
- refactor useDayFocus and useDayNotes to share the common persistence logic

## Testing
- npm test -- --run tests/planner
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ccd0e9a948832c952bcb7748d20f94