### PR TITLE
Adopt nonce-based Content Security Policy

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,12 +1,73 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { securityHeaders } from "./security-headers.mjs";
+import { createContentSecurityPolicy, createSecurityHeaders } from "./security-headers.mjs";
 
-export function middleware(_request: NextRequest) {
-  const response = NextResponse.next();
+const NONCE_BYTE_LENGTH = 16;
+const REQUEST_CSP_HEADER = "content-security-policy";
+const NONCE_HEADER = "x-nonce";
+
+const BASE64_CHARS =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+const encodeBase64 = (bytes: Uint8Array): string => {
+  let output = "";
+  for (let index = 0; index < bytes.length; index += 3) {
+    const remaining = bytes.length - index;
+    const byteOne = bytes[index];
+    const byteTwo = remaining > 1 ? bytes[index + 1] : 0;
+    const byteThree = remaining > 2 ? bytes[index + 2] : 0;
+
+    output += BASE64_CHARS[byteOne >> 2];
+
+    if (remaining === 1) {
+      output += BASE64_CHARS[(byteOne & 0b11) << 4];
+      output += "==";
+      break;
+    }
+
+    output += BASE64_CHARS[((byteOne & 0b11) << 4) | (byteTwo >> 4)];
+
+    if (remaining === 2) {
+      output += BASE64_CHARS[(byteTwo & 0b1111) << 2];
+      output += "=";
+      break;
+    }
+
+    output += BASE64_CHARS[((byteTwo & 0b1111) << 2) | (byteThree >> 6)];
+    output += BASE64_CHARS[byteThree & 0b111111];
+  }
+  return output;
+};
+
+const createNonce = (): string => {
+  const randomValues = globalThis.crypto.getRandomValues(
+    new Uint8Array(NONCE_BYTE_LENGTH),
+  );
+  return encodeBase64(randomValues);
+};
+
+export function middleware(request: NextRequest) {
+  const nonce = createNonce();
+  const securityHeaders = createSecurityHeaders(nonce);
+  const cspHeader = securityHeaders.find(
+    (header) => header.key === "Content-Security-Policy",
+  );
+  const cspValue = cspHeader?.value ?? createContentSecurityPolicy(nonce);
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set(NONCE_HEADER, nonce);
+  requestHeaders.set(REQUEST_CSP_HEADER, cspValue);
+
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+
   for (const { key, value } of securityHeaders) {
     response.headers.set(key, value);
   }
+
   return response;
 }
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,6 @@
 import path from "path";
 import { fileURLToPath } from "url";
-import { securityHeaders } from "./security-headers.mjs";
+import { baseSecurityHeaders } from "./security-headers.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -49,7 +49,7 @@ const nextConfig = {
     return [
       {
         source: "/:path*",
-        headers: securityHeaders.map((header) => ({ ...header })),
+        headers: baseSecurityHeaders.map((header) => ({ ...header })),
       },
     ];
   },

--- a/security-headers.d.mts
+++ b/security-headers.d.mts
@@ -3,5 +3,7 @@ export interface SecurityHeader {
   readonly value: string;
 }
 
-export declare const securityHeadersMap: Readonly<Record<string, string>>;
-export declare const securityHeaders: ReadonlyArray<SecurityHeader>;
+export declare const baseSecurityHeadersMap: Readonly<Record<string, string>>;
+export declare const baseSecurityHeaders: ReadonlyArray<SecurityHeader>;
+export declare const createContentSecurityPolicy: (nonce: string) => string;
+export declare const createSecurityHeaders: (nonce: string) => ReadonlyArray<SecurityHeader>;

--- a/security-headers.mjs
+++ b/security-headers.mjs
@@ -3,8 +3,7 @@
  */
 
 /** @type {Readonly<Record<string, string>>} */
-export const securityHeadersMap = Object.freeze({
-  "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; media-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; manifest-src 'self'; worker-src 'self' blob:; frame-src 'none'",
+export const baseSecurityHeadersMap = Object.freeze({
   "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
   "Referrer-Policy": "strict-origin-when-cross-origin",
   "X-Frame-Options": "DENY",
@@ -13,8 +12,43 @@ export const securityHeadersMap = Object.freeze({
 });
 
 /** @type {ReadonlyArray<SecurityHeader>} */
-export const securityHeaders = Object.freeze(
-  Object.entries(securityHeadersMap).map(([key, value]) =>
+export const baseSecurityHeaders = Object.freeze(
+  Object.entries(baseSecurityHeadersMap).map(([key, value]) =>
     Object.freeze({ key, value }),
   ),
 );
+
+/**
+ * @param {string} nonce
+ * @returns {string}
+ */
+export const createContentSecurityPolicy = (nonce) =>
+  [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
+    `style-src 'self' 'nonce-${nonce}'`,
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "media-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    "manifest-src 'self'",
+    "worker-src 'self' blob:",
+    "frame-src 'none'",
+  ].join("; ");
+
+/**
+ * @param {string} nonce
+ * @returns {ReadonlyArray<SecurityHeader>}
+ */
+export const createSecurityHeaders = (nonce) =>
+  Object.freeze([
+    Object.freeze({
+      key: "Content-Security-Policy",
+      value: createContentSecurityPolicy(nonce),
+    }),
+    ...baseSecurityHeaders,
+  ]);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import "./themes.css";
 
 import type { CSSProperties } from "react";
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import SiteChrome from "@/components/chrome/SiteChrome";
 import { CatCompanion } from "@/components/ui";
 import { withBasePath } from "@/lib/utils";
@@ -31,11 +32,13 @@ const htmlStyle = {
   "--asset-glitch-gif-url": `url('${withBasePath("/glitch-gif.gif")}')`,
 } as CSSProperties;
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const nonceHeader = await headers();
+  const nonce = nonceHeader.get("x-nonce") ?? undefined;
   return (
     // Default SSR state: LG (dark). The no-flash script will tweak immediately.
     <html
@@ -48,6 +51,7 @@ export default function RootLayout({
         <Script
           id="theme-bootstrap"
           strategy="beforeInteractive"
+          nonce={nonce}
           src={withBasePath(THEME_BOOTSTRAP_SCRIPT_PATH)}
         />
       </head>


### PR DESCRIPTION
## Summary
- replace the static CSP map with nonce-aware helpers while preserving the other security headers
- mint a per-request nonce in middleware, forward it through the request, and attach it to the bootstrap script during SSR
- use the shared base headers in `next.config.mjs` so middleware owns the CSP enforcement

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cccdf57d64832ca76291dbc7647d4e