### PR TITLE
Simplify planner day counts API

### DIFF
--- a/src/components/planner/useDay.ts
+++ b/src/components/planner/useDay.ts
@@ -35,7 +35,5 @@ export function useDay(iso: ISODate) {
     removeTaskImage: crud.removeTaskImage,
     doneCount,
     totalCount,
-    doneTasks: doneCount,
-    totalTasks: totalCount,
   } as const;
 }

--- a/tests/planner/usePlannerStore.test.tsx
+++ b/tests/planner/usePlannerStore.test.tsx
@@ -212,16 +212,12 @@ describe("usePlannerStore", () => {
     });
     expect(result.current.totalCount).toBe(2);
     expect(result.current.doneCount).toBe(0);
-    expect(result.current.totalTasks).toBe(2);
-    expect(result.current.doneTasks).toBe(0);
 
     act(() => result.current.toggleTask(t1));
     expect(result.current.doneCount).toBe(1);
-    expect(result.current.doneTasks).toBe(1);
 
     act(() => result.current.deleteTask(t1));
     expect(result.current.totalCount).toBe(1);
-    expect(result.current.totalTasks).toBe(1);
   });
 
   it("migrates legacy storage and stops syncing", async () => {


### PR DESCRIPTION
## Summary
- remove the redundant doneTasks/totalTasks aliases from the day hook
- update planner store tests to rely on the canonical doneCount/totalCount fields

## Testing
- npm test -- tests/planner/usePlannerStore.test.tsx
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccdfd77374832c81b698cf20e72366