### PR TITLE
Add disabled and loading TabBar showcase items

### DIFF
--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -1593,6 +1593,8 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
           items={[
             { key: "a", label: "A" },
             { key: "b", label: "B" },
+            { key: "c", label: "Disabled", disabled: true },
+            { key: "d", label: "Syncing", loading: true },
           ]}
           defaultValue="a"
           ariaLabel="Example tabs"
@@ -1600,7 +1602,12 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       ),
       tags: ["tab", "toggle"],
       code: `<TabBar
-  items={[{ key: "a", label: "A" }, { key: "b", label: "B" }]}
+  items={[
+    { key: "a", label: "A" },
+    { key: "b", label: "B" },
+    { key: "c", label: "Disabled", disabled: true },
+    { key: "d", label: "Syncing", loading: true },
+  ]}
   defaultValue="a"
   ariaLabel="Example tabs"
 />`,


### PR DESCRIPTION
## Summary
- add disabled and loading entries to the TabBar prompts showcase
- update the embedded code example to match the new items

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cce0c24940832c9350c98e08658388