### PR TITLE
Show disabled SettingsSelect variant

### DIFF
--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -178,14 +178,25 @@ function SettingsSelectDemo() {
   );
 
   return (
-    <SettingsSelect
-      ariaLabel="Theme"
-      prefixLabel="Theme"
-      items={items}
-      value={value}
-      onChange={setValue}
-      className="w-56"
-    />
+    <div className="space-y-[var(--space-2)]">
+      <SettingsSelect
+        ariaLabel="Theme"
+        prefixLabel="Theme"
+        items={items}
+        value={value}
+        onChange={setValue}
+        className="w-56"
+      />
+      <SettingsSelect
+        ariaLabel="Theme (disabled)"
+        prefixLabel="Theme (disabled)"
+        items={items}
+        value={value}
+        onChange={setValue}
+        className="w-56"
+        disabled
+      />
+    </div>
   );
 }
 
@@ -1764,7 +1775,23 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
       name: "SettingsSelect",
       element: <SettingsSelectDemo />,
       tags: ["select", "settings"],
-      code: `<SettingsSelect ariaLabel="Theme" prefixLabel="Theme" items={[{ value: "lg", label: "Glitch" }]} value="lg" />`,
+      code: `<div className="space-y-[var(--space-2)]">
+  <SettingsSelect
+    ariaLabel="Theme"
+    prefixLabel="Theme"
+    items={[{ value: "lg", label: "Glitch" }]}
+    value="lg"
+    className="w-56"
+  />
+  <SettingsSelect
+    ariaLabel="Theme (disabled)"
+    prefixLabel="Theme (disabled)"
+    items={[{ value: "lg", label: "Glitch" }]}
+    value="lg"
+    className="w-56"
+    disabled
+  />
+</div>`,
     },
     {
       id: "role-selector",


### PR DESCRIPTION
## Summary
- stack the SettingsSelect demo controls to show spacing and layout
- add a disabled SettingsSelect variant and mirror it in the code snippet

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cce0c58960832c987624ab5fbd1793