### PR TITLE
Extract shared planner saving reset helper

### DIFF
--- a/src/components/planner/createDayTextFieldHook.ts
+++ b/src/components/planner/createDayTextFieldHook.ts
@@ -4,6 +4,7 @@
 import * as React from "react";
 
 import type { DayRecord, ISODate } from "./plannerStore";
+import { scheduleSavingReset as defaultScheduleSavingReset } from "./scheduleSavingReset";
 import { usePlannerStore } from "./usePlannerStore";
 
 type DayTextSelector = (day: DayRecord) => string | undefined;
@@ -18,21 +19,14 @@ type UseDayTextField = (iso: ISODate) => {
   commit: VoidFunction;
 };
 
-const scheduleSavingReset = (callback: VoidFunction) => {
-  if (typeof queueMicrotask === "function") {
-    queueMicrotask(callback);
-    return;
-  }
-
-  setTimeout(callback, 0);
-};
-
 export function createDayTextFieldHook({
   selectValue,
   applyValue,
+  scheduleSavingReset = defaultScheduleSavingReset,
 }: {
   selectValue: DayTextSelector;
   applyValue: DayTextMutator;
+  scheduleSavingReset?: typeof defaultScheduleSavingReset;
 }): UseDayTextField {
   return function useDayTextField(iso: ISODate) {
     const { getDay, upsertDay } = usePlannerStore();

--- a/src/components/planner/scheduleSavingReset.ts
+++ b/src/components/planner/scheduleSavingReset.ts
@@ -1,0 +1,10 @@
+// src/components/planner/scheduleSavingReset.ts
+
+export function scheduleSavingReset(callback: VoidFunction): void {
+  if (typeof queueMicrotask === "function") {
+    queueMicrotask(callback);
+    return;
+  }
+
+  setTimeout(callback, 0);
+}

--- a/src/components/planner/useDayFocus.ts
+++ b/src/components/planner/useDayFocus.ts
@@ -2,9 +2,11 @@
 "use client";
 
 import { createDayTextFieldHook } from "./createDayTextFieldHook";
+import { scheduleSavingReset } from "./scheduleSavingReset";
 import { setFocus as applyFocus } from "./plannerCrud";
 
 export const useDayFocus = createDayTextFieldHook({
   selectValue: (day) => day.focus,
   applyValue: applyFocus,
+  scheduleSavingReset,
 });

--- a/src/components/planner/useDayNotes.ts
+++ b/src/components/planner/useDayNotes.ts
@@ -2,9 +2,11 @@
 "use client";
 
 import { createDayTextFieldHook } from "./createDayTextFieldHook";
+import { scheduleSavingReset } from "./scheduleSavingReset";
 import { setNotes as applyNotes } from "./plannerCrud";
 
 export const useDayNotes = createDayTextFieldHook({
   selectValue: (day) => day.notes,
   applyValue: applyNotes,
+  scheduleSavingReset,
 });


### PR DESCRIPTION
## Summary
- add a planner `scheduleSavingReset` utility that preserves the existing microtask fallback behavior
- allow `createDayTextFieldHook` to consume an injectable scheduler and wire `useDayFocus`/`useDayNotes` to the shared helper

## Testing
- npm test -- --run tests/planner/useFocusDate.test.tsx
- npm test -- --run tests/planner/usePlannerStore.test.tsx
- npm test -- --run tests/planner/usePlannerStore.integration.test.tsx
- npm test -- --run tests/planner/useSelection.test.tsx
- npm test -- --run tests/planner/pruneOldDays.test.ts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccdf8cef74832cab458b6239ba4801