### PR TITLE
Align glitch hairlines with token

### DIFF
--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -938,8 +938,8 @@ html.bg-intense body::after {
 .pretty-border::before {
   content: "";
   position: absolute;
-  inset: -1px;
-  padding: 1px;
+  inset: calc(var(--hairline-w) * -1);
+  padding: var(--hairline-w);
   border-radius: inherit;
   pointer-events: none;
   background: conic-gradient(

--- a/src/components/ui/league/pillars/PillarBadge.tsx
+++ b/src/components/ui/league/pillars/PillarBadge.tsx
@@ -153,8 +153,8 @@ export default function PillarBadge({
         .lg-pillar-badge.active::before {
           content: "";
           position: absolute;
-          inset: 0;
-          padding: 1px;
+          inset: calc(var(--hairline-w) * -1);
+          padding: var(--hairline-w);
           border-radius: inherit;
           background: linear-gradient(90deg, var(--g1), var(--g2));
           -webkit-mask:

--- a/src/components/ui/select/Select.module.css
+++ b/src/components/ui/select/Select.module.css
@@ -46,13 +46,13 @@
 .gbFlicker,
 .gbScan {
   position: absolute;
-  inset: -1px;
+  inset: calc(var(--hairline-w) * -1);
   border-radius: var(--control-radius);
   pointer-events: none;
 }
 
 .gbIris {
-  padding: 1px;
+  padding: var(--hairline-w);
   background: conic-gradient(
     from 180deg,
     hsl(var(--ring) / 0),
@@ -77,7 +77,7 @@
 }
 
 .gbChroma {
-  padding: 1px;
+  padding: var(--hairline-w);
   background: conic-gradient(
     from 90deg,
     hsl(var(--ring) / 0),
@@ -116,7 +116,7 @@
 }
 
 .gbFlicker {
-  inset: -2px;
+  inset: calc(var(--hairline-w) * -2);
   border-radius: var(--control-radius);
   background: radial-gradient(
     120% 120% at 50% 50%,
@@ -169,7 +169,7 @@
 }
 
 .gbScan {
-  padding: 1px;
+  padding: var(--hairline-w);
   -webkit-mask:
     linear-gradient(hsl(var(--foreground)) 0 0) content-box,
     linear-gradient(hsl(var(--foreground)) 0 0);

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -840,8 +840,8 @@ exports[`ReviewEditor > renders default state 1`] = `
         .lg-pillar-badge.active::before {
           content: "";
           position: absolute;
-          inset: 0;
-          padding: 1px;
+          inset: calc(var(--hairline-w) * -1);
+          padding: var(--hairline-w);
           border-radius: inherit;
           background: linear-gradient(90deg, var(--g1), var(--g2));
           -webkit-mask:
@@ -977,8 +977,8 @@ exports[`ReviewEditor > renders default state 1`] = `
         .lg-pillar-badge.active::before {
           content: "";
           position: absolute;
-          inset: 0;
-          padding: 1px;
+          inset: calc(var(--hairline-w) * -1);
+          padding: var(--hairline-w);
           border-radius: inherit;
           background: linear-gradient(90deg, var(--g1), var(--g2));
           -webkit-mask:
@@ -1103,8 +1103,8 @@ exports[`ReviewEditor > renders default state 1`] = `
         .lg-pillar-badge.active::before {
           content: "";
           position: absolute;
-          inset: 0;
-          padding: 1px;
+          inset: calc(var(--hairline-w) * -1);
+          padding: var(--hairline-w);
           border-radius: inherit;
           background: linear-gradient(90deg, var(--g1), var(--g2));
           -webkit-mask:
@@ -1238,8 +1238,8 @@ exports[`ReviewEditor > renders default state 1`] = `
         .lg-pillar-badge.active::before {
           content: "";
           position: absolute;
-          inset: 0;
-          padding: 1px;
+          inset: calc(var(--hairline-w) * -1);
+          padding: var(--hairline-w);
           border-radius: inherit;
           background: linear-gradient(90deg, var(--g1), var(--g2));
           -webkit-mask:
@@ -1385,8 +1385,8 @@ exports[`ReviewEditor > renders default state 1`] = `
         .lg-pillar-badge.active::before {
           content: "";
           position: absolute;
-          inset: 0;
-          padding: 1px;
+          inset: calc(var(--hairline-w) * -1);
+          padding: var(--hairline-w);
           border-radius: inherit;
           background: linear-gradient(90deg, var(--g1), var(--g2));
           -webkit-mask:
@@ -1509,8 +1509,8 @@ exports[`ReviewEditor > renders default state 1`] = `
         .lg-pillar-badge.active::before {
           content: "";
           position: absolute;
-          inset: 0;
-          padding: 1px;
+          inset: calc(var(--hairline-w) * -1);
+          padding: var(--hairline-w);
           border-radius: inherit;
           background: linear-gradient(90deg, var(--g1), var(--g2));
           -webkit-mask:


### PR DESCRIPTION
## Summary
- align the PillarBadge active halo inset and padding with the shared hairline token
- refit select glitch border layers and pretty-border utility to pull spacing from --hairline-w
- refresh the ReviewEditor snapshot to capture the updated tokenized measurements

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cce19614e8832c98a3b27bf44d9f18