### PR TITLE
Guard nonce lookup during static exports

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,8 +37,16 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const nonceHeader = await headers();
-  const nonce = nonceHeader.get("x-nonce") ?? undefined;
+  let nonce: string | undefined;
+
+  if (process.env.GITHUB_PAGES === "true") {
+    // Static exports (GitHub Pages) do not provide response headers,
+    // so skip reading the nonce in that environment.
+    nonce = undefined;
+  } else {
+    const nonceHeader = await headers();
+    nonce = nonceHeader.get("x-nonce") ?? undefined;
+  }
   return (
     // Default SSR state: LG (dark). The no-flash script will tweak immediately.
     <html


### PR DESCRIPTION
## Summary
- skip reading the CSP nonce from request headers when building for GitHub Pages exports
- retain nonce support for runtime environments that provide the x-nonce header

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cce1ced01c832ca13a268530770324