### PR TITLE
Use select dropdown shadow token

### DIFF
--- a/src/components/ui/select/AnimatedSelect.tsx
+++ b/src/components/ui/select/AnimatedSelect.tsx
@@ -531,7 +531,7 @@ const AnimatedSelect = React.forwardRef<
                   className={cn(
                     "relative pointer-events-auto rounded-[var(--radius-2xl)] overflow-hidden",
                     "bg-card/92 backdrop-blur-xl",
-                    "shadow-[0_12px_40px_hsl(var(--shadow-color)/0.55)] ring-1 ring-ring/18",
+                    "shadow-[var(--shadow-raised)] ring-1 ring-ring/18",
                     "p-[var(--space-2)]",
                     "max-h-[60vh] min-w-[calc(var(--space-8)*3.5)] overflow-y-auto scrollbar-thin",
                     "scrollbar-thumb-foreground/12 scrollbar-track-transparent",


### PR DESCRIPTION
## Summary
- replace the AnimatedSelect dropdown shadow utility class with the shared raised shadow token

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cce286e78c832c8091fb59aaefed5b