### PR TITLE
Add useReviews hook and adopt shared persistence hooks

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,15 +31,15 @@ import {
   useWeek,
   useWeekData,
 } from "@/components/planner";
+import { useGoals } from "@/components/goals";
+import { useReviews } from "@/components/reviews";
+import { useChatPrompts } from "@/components/prompts";
 import { useTheme } from "@/lib/theme-context";
 import { useThemeQuerySync } from "@/lib/theme-hooks";
-import { usePersistentState } from "@/lib/db";
-import type { Goal, Review } from "@/lib/types";
+import type { Goal } from "@/lib/types";
 import { formatWeekRangeLabel, fromISODate } from "@/lib/date";
 import { LOCALE, cn } from "@/lib/utils";
 import ProgressRingIcon from "@/icons/ProgressRingIcon";
-import { CHAT_PROMPTS_STORAGE_KEY } from "@/components/prompts/useChatPrompts";
-import type { Prompt } from "@/components/prompts/types";
 
 type WeeklyHighlight = {
   id: string;
@@ -110,12 +110,9 @@ function HeroPlannerCards() {
     [toggleTask],
   );
 
-  const [goals] = usePersistentState<Goal[]>("goals.v2", []);
-  const [reviews] = usePersistentState<Review[]>("reviews.v1", []);
-  const [prompts] = usePersistentState<Prompt[]>(
-    CHAT_PROMPTS_STORAGE_KEY,
-    [],
-  );
+  const { goals } = useGoals();
+  const { totalCount: reviewCount, flaggedReviewCount } = useReviews();
+  const { prompts } = useChatPrompts();
   const goalStats = React.useMemo(() => {
     let completed = 0;
     const active: Goal[] = [];
@@ -138,12 +135,6 @@ function HeroPlannerCards() {
     const pct = (goalStats.completed / goalStats.total) * 100;
     return Math.max(0, Math.min(100, Math.round(pct)));
   }, [goalStats.completed, goalStats.total]);
-
-  const flaggedReviewCount = React.useMemo(
-    () => reviews.filter((review) => review.focusOn).length,
-    [reviews],
-  );
-  const reviewCount = reviews.length;
   const promptCount = prompts.length;
 
   const heroSummaryItems = React.useMemo(

--- a/src/components/home/ReviewsCard.tsx
+++ b/src/components/home/ReviewsCard.tsx
@@ -3,16 +3,11 @@
 import * as React from "react";
 import DashboardCard from "./DashboardCard";
 import DashboardList from "./DashboardList";
-import { usePersistentState } from "@/lib/db";
-import type { Review } from "@/lib/types";
+import { useReviews } from "@/components/reviews";
 import { LOCALE } from "@/lib/utils";
 
 export default function ReviewsCard() {
-  const [reviews] = usePersistentState<Review[]>("reviews.v1", []);
-  const recentReviews = React.useMemo(
-    () => [...reviews].sort((a, b) => b.createdAt - a.createdAt).slice(0, 3),
-    [reviews],
-  );
+  const { recentReviews } = useReviews();
 
   return (
     <DashboardCard

--- a/src/components/reviews/ReviewPage.tsx
+++ b/src/components/reviews/ReviewPage.tsx
@@ -2,16 +2,17 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Review } from "@/lib/types";
-import { usePersistentState, uid } from "@/lib/db";
+import { uid } from "@/lib/db";
 import ReviewsPage from "./ReviewsPage";
 import { primeReviewSearch } from "./reviewSearch";
+import { useReviews } from "./useReviews";
 
 /**
  * ReviewPage — container with local-first persistence.
  * Hydration-safe: usePersistentState returns initial value on first render, then loads.
 */
 export default function ReviewPage() {
-  const [reviews, setReviews] = usePersistentState<Review[]>("reviews.v1", []);
+  const { reviews, setReviews } = useReviews();
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
   // After local DB hydration, select the first review if none is chosen

--- a/src/components/reviews/index.ts
+++ b/src/components/reviews/index.ts
@@ -21,3 +21,4 @@ export { default as TimestampMarkers } from "./TimestampMarkers";
 export { default as ReviewSurface } from "./ReviewSurface";
 export { default as ReviewSliderTrack } from "./ReviewSliderTrack";
 export { default as ScoreMeter } from "./ScoreMeter";
+export { useReviews } from "./useReviews";

--- a/src/components/reviews/useReviews.ts
+++ b/src/components/reviews/useReviews.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import * as React from "react";
+import { usePersistentState } from "@/lib/db";
+import type { Review } from "@/lib/types";
+
+const REVIEWS_STORAGE_KEY = "reviews.v1" as const;
+
+export function useReviews() {
+  const [reviews, setReviews] = usePersistentState<Review[]>(
+    REVIEWS_STORAGE_KEY,
+    [],
+  );
+
+  const totalCount = reviews.length;
+
+  const flaggedReviews = React.useMemo(
+    () => reviews.filter((review) => review.focusOn),
+    [reviews],
+  );
+
+  const flaggedReviewCount = flaggedReviews.length;
+
+  const recentReviews = React.useMemo(
+    () =>
+      [...reviews]
+        .sort((a, b) => b.createdAt - a.createdAt)
+        .slice(0, 3),
+    [reviews],
+  );
+
+  return {
+    reviews,
+    setReviews,
+    totalCount,
+    flaggedReviews,
+    flaggedReviewCount,
+    recentReviews,
+  } as const;
+}


### PR DESCRIPTION
## Summary
- add a useReviews feature hook that wraps persistent storage with derived helpers
- refactor review and home surfaces to consume the new hook instead of raw persistence keys
- update HeroPlannerCards to use centralized goals, reviews, and prompts hooks

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cce37e8018832cb867a69e65c3700e