### PR TITLE
Add dropdown shadow token for animated select menu

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,7 @@
     --shell-max: var(--shell-width);
     --accent-2-foreground: var(--background);
     --danger-foreground: var(--primary-foreground);
+    --shadow-dropdown: 0 12px 40px hsl(var(--shadow-color) / 0.55);
   }
 
   body {

--- a/src/components/ui/select/AnimatedSelect.tsx
+++ b/src/components/ui/select/AnimatedSelect.tsx
@@ -531,7 +531,7 @@ const AnimatedSelect = React.forwardRef<
                   className={cn(
                     "relative pointer-events-auto rounded-[var(--radius-2xl)] overflow-hidden",
                     "bg-card/92 backdrop-blur-xl",
-                    "shadow-[var(--shadow-raised)] ring-1 ring-ring/18",
+                    "shadow-dropdown ring-1 ring-ring/18",
                     "p-[var(--space-2)]",
                     "max-h-[60vh] min-w-[calc(var(--space-8)*3.5)] overflow-y-auto scrollbar-thin",
                     "scrollbar-thumb-foreground/12 scrollbar-track-transparent",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -124,6 +124,7 @@ const config: Config = {
         "outline-subtle": "var(--shadow-outline-subtle)",
         "outline-faint": "var(--shadow-outline-faint)",
         badge: "var(--shadow-badge)",
+        dropdown: "var(--shadow-dropdown)",
         "inset-contrast": "var(--shadow-inset-contrast)",
         "inset-hairline": "var(--shadow-inset-hairline)",
         "glow-current": "var(--shadow-glow-current)",


### PR DESCRIPTION
## Summary
- define a reusable `--shadow-dropdown` shadow token and expose it through the Tailwind config
- switch the animated select menu to the new `shadow-dropdown` utility so overlay depth is consistent with other surfaces

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cce51d2024832cacbc7a70af21090f