### PR TITLE
Use glow token for SiteChrome brand mark shadow

### DIFF
--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -30,7 +30,7 @@ export default function SiteChrome() {
           className="col-span-full flex items-center gap-[var(--space-3)] md:col-span-4"
         >
           <span
-            className="h-[var(--space-2)] w-[var(--space-2)] rounded-full animate-pulse bg-[hsl(var(--accent-overlay))] shadow-[0_0_6px_hsl(var(--glow-active))]"
+            className="h-[var(--space-2)] w-[var(--space-2)] rounded-full animate-pulse bg-[hsl(var(--accent-overlay))] shadow-glow-sm"
             aria-hidden
           />
           <span className="font-mono tracking-wide text-muted-foreground">


### PR DESCRIPTION
## Summary
- swap the SiteChrome brand mark glow to the existing `shadow-glow-sm` token for semantic styling

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cce4c22344832cb2573370d380246f