### PR TITLE
Extract planner hero cards into reusable components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,14 @@ import {
   IsometricRoom,
   DashboardList,
   WelcomeHeroFigure,
+  HeroSummaryList,
+  FocusDayCard,
+  GoalMomentumCard,
+  WeeklyCalendarCard,
+  useHeroSummaryItems,
+  useFocusDayCard,
+  useGoalMomentumCard,
+  useWeeklyCalendarCard,
 } from "@/components/home";
 import {
   PageHeader,
@@ -21,25 +29,11 @@ import {
   Button,
   ThemeToggle,
   Spinner,
-  NeoCard,
-  CheckCircle,
 } from "@/components/ui";
-import {
-  PlannerProvider,
-  useDay,
-  useFocusDate,
-  useWeek,
-  useWeekData,
-} from "@/components/planner";
+import { PlannerProvider } from "@/components/planner";
 import { useTheme } from "@/lib/theme-context";
 import { useThemeQuerySync } from "@/lib/theme-hooks";
-import { usePersistentState } from "@/lib/db";
-import type { Goal, Review } from "@/lib/types";
-import { formatWeekRangeLabel, fromISODate } from "@/lib/date";
-import { LOCALE, cn } from "@/lib/utils";
-import ProgressRingIcon from "@/icons/ProgressRingIcon";
-import { CHAT_PROMPTS_STORAGE_KEY } from "@/components/prompts/useChatPrompts";
-import type { Prompt } from "@/components/prompts/types";
+import { cn } from "@/lib/utils";
 
 type WeeklyHighlight = {
   id: string;
@@ -69,361 +63,31 @@ const weeklyHighlights = [
   },
 ] as const satisfies readonly WeeklyHighlight[];
 
-const focusDayFormatter = new Intl.DateTimeFormat(LOCALE, {
-  weekday: "long",
-  month: "long",
-  day: "numeric",
-});
-
-const calendarWeekdayFormatter = new Intl.DateTimeFormat(LOCALE, {
-  weekday: "short",
-});
-
-const calendarDayFormatter = new Intl.DateTimeFormat(LOCALE, {
-  day: "2-digit",
-});
-
-function HeroPlannerCards() {
-  const { iso, setIso } = useFocusDate();
-  const { projects, tasks, toggleTask, doneCount, totalCount } = useDay(iso);
-  const tasksPreview = React.useMemo(() => tasks.slice(0, 4), [tasks]);
-  const remainingTasks = Math.max(tasks.length - tasksPreview.length, 0);
-
-  const projectNames = React.useMemo(() => {
-    const map = new Map<string, string>();
-    for (const project of projects) {
-      map.set(project.id, project.name);
-    }
-    return map;
-  }, [projects]);
-
-  const focusDate = React.useMemo(() => fromISODate(iso), [iso]);
-  const focusLabel = React.useMemo(() => {
-    if (!focusDate) return iso;
-    return focusDayFormatter.format(focusDate);
-  }, [focusDate, iso]);
-
-  const handleToggleTask = React.useCallback(
-    (taskId: string) => {
-      toggleTask(taskId);
-    },
-    [toggleTask],
-  );
-
-  const [goals] = usePersistentState<Goal[]>("goals.v2", []);
-  const [reviews] = usePersistentState<Review[]>("reviews.v1", []);
-  const [prompts] = usePersistentState<Prompt[]>(
-    CHAT_PROMPTS_STORAGE_KEY,
-    [],
-  );
-  const goalStats = React.useMemo(() => {
-    let completed = 0;
-    const active: Goal[] = [];
-    for (const goal of goals) {
-      if (goal.done) {
-        completed += 1;
-      } else if (active.length < 2) {
-        active.push(goal);
-      }
-    }
-    return {
-      total: goals.length,
-      completed,
-      active,
-    } as const;
-  }, [goals]);
-
-  const goalPct = React.useMemo(() => {
-    if (goalStats.total === 0) return 0;
-    const pct = (goalStats.completed / goalStats.total) * 100;
-    return Math.max(0, Math.min(100, Math.round(pct)));
-  }, [goalStats.completed, goalStats.total]);
-
-  const flaggedReviewCount = React.useMemo(
-    () => reviews.filter((review) => review.focusOn).length,
-    [reviews],
-  );
-  const reviewCount = reviews.length;
-  const promptCount = prompts.length;
-
-  const heroSummaryItems = React.useMemo(
-    () => {
-      const reviewValue =
-        flaggedReviewCount > 0
-          ? `${flaggedReviewCount} review${flaggedReviewCount === 1 ? "" : "s"}`
-          : reviewCount > 0
-            ? "All caught up"
-            : "No reviews yet";
-      const promptValue =
-        promptCount > 0 ? `${promptCount} saved` : "Start a prompt";
-      return [
-        {
-          key: "focus" as const,
-          label: "Next focus",
-          value: focusLabel,
-          href: "/planner",
-          cta: "Open planner",
-        },
-        {
-          key: "reviews" as const,
-          label: "Open reviews",
-          value: reviewValue,
-          href: "/reviews",
-          cta: flaggedReviewCount > 0 ? "Review now" : "View reviews",
-        },
-        {
-          key: "prompts" as const,
-          label: "Team prompts",
-          value: promptValue,
-          href: "/prompts",
-          cta: promptCount > 0 ? "View prompts" : "Browse prompts",
-        },
-      ] as const;
-    },
-    [flaggedReviewCount, focusLabel, promptCount, reviewCount],
-  );
-
-  const heroSummary = (
-    <div className="col-span-12 md:col-span-6 lg:col-span-4 flex flex-col gap-[var(--space-3)]">
-      <div className="space-y-[var(--space-1)]">
-        <p className="text-label text-muted-foreground">Highlights</p>
-        <h3 className="text-body font-semibold text-card-foreground tracking-[-0.01em]">
-          Quick summary
-        </h3>
-      </div>
-      <ul className="grid gap-[var(--space-2)]" role="list">
-        {heroSummaryItems.map((item) => (
-          <li key={item.key}>
-            <Link
-              href={item.href}
-              className={cn(
-                "group flex items-center justify-between gap-[var(--space-3)] rounded-card r-card-md border border-border/60 bg-card/70 px-[var(--space-3)] py-[var(--space-2)] transition",
-                "hover:border-primary/40 hover:bg-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
-              )}
-            >
-              <div className="flex min-w-0 flex-col gap-[var(--space-1)]">
-                <span className="text-label text-muted-foreground">{item.label}</span>
-                <span className="text-ui font-semibold text-card-foreground text-balance">
-                  {item.value}
-                </span>
-              </div>
-              <span className="shrink-0 text-label font-medium text-primary transition-colors group-hover:text-primary-foreground">
-                {item.cta}
-              </span>
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-
-  const { start, end, days, isToday } = useWeek(iso);
-  const { per, weekDone, weekTotal } = useWeekData(days);
-  const weekLabel = React.useMemo(
-    () => formatWeekRangeLabel(start, end),
-    [start, end],
-  );
-
-  const handleSelectDay = React.useCallback(
-    (nextIso: string) => {
-      setIso(nextIso);
-    },
-    [setIso],
-  );
+function HeroPlannerSection() {
+  const heroSummaryItems = useHeroSummaryItems();
+  const focusDayCard = useFocusDayCard();
+  const goalMomentumCard = useGoalMomentumCard();
+  const weeklyCalendarCard = useWeeklyCalendarCard();
 
   return (
-    <div className="grid grid-cols-12 gap-[var(--space-4)]">
-      {heroSummary}
-      <div className="col-span-12 md:col-span-6 lg:col-span-4">
-        <NeoCard className="flex h-full flex-col gap-[var(--space-4)] p-[var(--space-4)] md:p-[var(--space-5)]">
-          <header className="flex items-start justify-between gap-[var(--space-3)]">
-            <div className="space-y-[var(--space-1)]">
-              <p className="text-label text-muted-foreground">Focus day</p>
-              <h3 className="text-body font-semibold text-card-foreground tracking-[-0.01em]">
-                {focusLabel}
-              </h3>
-            </div>
-            <div className="text-right">
-              <p className="text-label text-muted-foreground">Progress</p>
-              <p className="text-ui font-medium tabular-nums text-card-foreground">
-                {doneCount}/{totalCount}
-              </p>
-            </div>
-          </header>
-          <ul className="flex flex-col gap-[var(--space-3)]" aria-live="polite">
-            {tasksPreview.length > 0 ? (
-              tasksPreview.map((task) => {
-                const projectName = task.projectId
-                  ? projectNames.get(task.projectId) ?? null
-                  : null;
-                return (
-                  <li key={task.id} className="flex items-start gap-[var(--space-3)]">
-                    <CheckCircle
-                      checked={task.done}
-                      onChange={() => handleToggleTask(task.id)}
-                      aria-label={
-                        task.done
-                          ? `Mark ${task.title} as not done`
-                          : `Mark ${task.title} as done`
-                      }
-                      size="sm"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => handleToggleTask(task.id)}
-                      className={cn(
-                        "flex flex-col items-start gap-[var(--space-1)] rounded-card r-card-sm px-[var(--space-1)] py-[var(--space-1)] text-left transition",
-                        "hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
-                        "active:text-foreground/80",
-                      )}
-                    >
-                      <span
-                        className={cn(
-                          "text-ui font-medium text-card-foreground",
-                          task.done && "line-through-soft text-muted-foreground",
-                        )}
-                      >
-                        {task.title}
-                      </span>
-                      {projectName ? (
-                        <span className="text-label text-muted-foreground">{projectName}</span>
-                      ) : null}
-                    </button>
-                  </li>
-                );
-              })
-            ) : (
-              <li className="rounded-card r-card-md border border-dashed border-border px-[var(--space-3)] py-[var(--space-3)] text-label text-muted-foreground">
-                No tasks captured for this day.
-              </li>
-            )}
-          </ul>
-          {remainingTasks > 0 ? (
-            <p className="text-label text-muted-foreground">
-              +{remainingTasks} more task{remainingTasks === 1 ? "" : "s"} in planner
-            </p>
-          ) : null}
-        </NeoCard>
-      </div>
-      <div className="col-span-12 md:col-span-6 lg:col-span-4">
-        <NeoCard className="flex h-full flex-col gap-[var(--space-4)] p-[var(--space-4)] md:p-[var(--space-5)]">
-          <header className="flex items-start justify-between gap-[var(--space-3)]">
-            <div className="space-y-[var(--space-1)]">
-              <p className="text-label text-muted-foreground">Goals overview</p>
-              <h3 className="text-body font-semibold text-card-foreground tracking-[-0.01em]">
-                Momentum
-              </h3>
-            </div>
-            <div className="text-right">
-              <p className="text-label text-muted-foreground">Completed</p>
-              <p className="text-ui font-medium tabular-nums text-card-foreground">
-                {goalStats.completed}/{goalStats.total}
-              </p>
-            </div>
-          </header>
-          <div className="flex flex-col gap-[var(--space-4)] md:flex-row md:items-center md:gap-[var(--space-5)]">
-            <div className="flex items-center justify-center">
-              <div className="relative flex h-[var(--space-8)] w-[var(--space-8)] items-center justify-center">
-                <ProgressRingIcon pct={goalPct} size={64} />
-                <span className="absolute text-ui font-semibold tabular-nums text-card-foreground">
-                  {goalStats.total === 0 ? "0%" : `${goalPct}%`}
-                </span>
-              </div>
-            </div>
-            <div className="flex-1 space-y-[var(--space-3)]">
-              {goalStats.total === 0 ? (
-                <p className="text-label text-muted-foreground">
-                  No goals tracked yet. Capture one in the goals workspace to see it here.
-                </p>
-              ) : goalStats.active.length > 0 ? (
-                goalStats.active.map((goal) => (
-                  <div key={goal.id} className="space-y-[var(--space-1)]">
-                    <p className="text-ui font-medium text-card-foreground">{goal.title}</p>
-                    {goal.metric ? (
-                      <p className="text-label text-muted-foreground">{goal.metric}</p>
-                    ) : goal.notes ? (
-                      <p className="text-label text-muted-foreground">{goal.notes}</p>
-                    ) : null}
-                  </div>
-                ))
-              ) : (
-                <p className="text-label text-muted-foreground">
-                  All active goals are complete. Great work!
-                </p>
-              )}
-            </div>
-          </div>
-        </NeoCard>
-      </div>
-      <div className="col-span-12 md:col-span-12 lg:col-span-4">
-        <NeoCard className="flex h-full flex-col gap-[var(--space-4)] p-[var(--space-4)] md:p-[var(--space-5)]">
-          <header className="space-y-[var(--space-1)]">
-            <p className="text-label text-muted-foreground">Weekly calendar</p>
-            <h3 className="text-body font-semibold text-card-foreground tracking-[-0.01em]">
-              {weekLabel}
-            </h3>
-            <p className="text-label text-muted-foreground">
-              {weekTotal > 0 ? (
-                <span className="tabular-nums text-card-foreground">
-                  {weekDone}/{weekTotal}
-                </span>
-              ) : (
-                "No tasks scheduled this week"
-              )}
-            </p>
-          </header>
-          <div className="flex overflow-x-auto rounded-card r-card-lg border border-border/60 p-[var(--space-2)]">
-            <ul className="flex w-full min-w-0 gap-[var(--space-2)]" role="listbox" aria-label="Select focus day">
-              {per.map((day) => {
-                const dayDate = fromISODate(day.iso);
-                const weekday = dayDate
-                  ? calendarWeekdayFormatter.format(dayDate)
-                  : day.iso;
-                const dayNumber = dayDate
-                  ? calendarDayFormatter.format(dayDate)
-                  : "--";
-                const selected = day.iso === iso;
-                const todayMarker = isToday(day.iso);
-                return (
-                  <li
-                    key={day.iso}
-                    className="flex-1 min-w-[calc(var(--space-8)+var(--space-2))]"
-                  >
-                    <button
-                      type="button"
-                      role="option"
-                      aria-selected={selected}
-                      aria-current={todayMarker ? "date" : undefined}
-                      onClick={() => handleSelectDay(day.iso)}
-                      className={cn(
-                        "flex w-full flex-col items-start gap-[var(--space-1)] rounded-card r-card-md border px-[var(--space-3)] py-[var(--space-2)] text-left transition",
-                        "border-card-hairline bg-card/70 hover:border-primary/40 hover:bg-card/80",
-                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
-                        "active:bg-card/90",
-                        selected && "border-primary/70 bg-card",
-                      )}
-                    >
-                      <span
-                        className={cn(
-                          "text-label text-muted-foreground",
-                          todayMarker && "text-accent-3",
-                        )}
-                      >
-                        {weekday}
-                      </span>
-                      <span className="text-ui font-semibold tabular-nums text-card-foreground">
-                        {dayNumber}
-                      </span>
-                      <span className="text-label text-muted-foreground tabular-nums">
-                        {day.done}/{day.total}
-                      </span>
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
-        </NeoCard>
+    <div className="pt-[var(--space-4)]">
+      <div className="grid grid-cols-12 gap-[var(--space-4)]">
+        <HeroSummaryList
+          className="col-span-12 md:col-span-6 lg:col-span-4"
+          items={heroSummaryItems}
+        />
+        <FocusDayCard
+          className="col-span-12 md:col-span-6 lg:col-span-4"
+          {...focusDayCard}
+        />
+        <GoalMomentumCard
+          className="col-span-12 md:col-span-6 lg:col-span-4"
+          {...goalMomentumCard}
+        />
+        <WeeklyCalendarCard
+          className="col-span-12 md:col-span-12 lg:col-span-4"
+          {...weeklyCalendarCard}
+        />
       </div>
     </div>
   );
@@ -489,9 +153,7 @@ function HomePageContent() {
                         </div>
                       ),
                       children: (
-                        <div className="pt-[var(--space-4)]">
-                          <HeroPlannerCards />
-                        </div>
+                        <HeroPlannerSection />
                     ),
                   }}
                 />
@@ -569,7 +231,9 @@ export default function Page() {
         </div>
       }
     >
-      <HomePageContent />
+      <React.Fragment>
+        <HomePageContent />
+      </React.Fragment>
     </Suspense>
   );
 }

--- a/src/components/home/hero/FocusDayCard.tsx
+++ b/src/components/home/hero/FocusDayCard.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import * as React from "react";
+import { NeoCard, CheckCircle } from "@/components/ui";
+import { cn } from "@/lib/utils";
+import { useDay, useFocusDate } from "@/components/planner";
+import type { ISODate } from "@/components/planner/plannerStore";
+import {
+  useFocusDayLabel,
+  useProjectNameMap,
+  useTaskPreview,
+} from "./useHeroPlanner";
+
+export type FocusDayTask = {
+  id: string;
+  title: string;
+  done: boolean;
+  projectName: string | null;
+};
+
+export type FocusDayCardProps = {
+  focusLabel: string;
+  doneCount: number;
+  totalCount: number;
+  tasks: readonly FocusDayTask[];
+  remainingTasks: number;
+  onToggleTask: (taskId: string) => void;
+  className?: string;
+};
+
+function useFocusIso(): ISODate {
+  const { iso } = useFocusDate();
+  return iso;
+}
+
+export function useFocusDayCard(limit = 4): Omit<FocusDayCardProps, "className"> {
+  const iso = useFocusIso();
+  const { projects, tasks, toggleTask, doneCount, totalCount } = useDay(iso);
+  const focusLabel = useFocusDayLabel(iso);
+  const projectNames = useProjectNameMap(projects);
+  const { preview, remaining } = useTaskPreview(tasks, limit);
+
+  const taskItems = React.useMemo<FocusDayTask[]>(() => {
+    return preview.map((task) => ({
+      id: task.id,
+      title: task.title,
+      done: task.done,
+      projectName: task.projectId
+        ? projectNames.get(task.projectId) ?? null
+        : null,
+    }));
+  }, [preview, projectNames]);
+
+  const handleToggleTask = React.useCallback(
+    (taskId: string) => {
+      toggleTask(taskId);
+    },
+    [toggleTask],
+  );
+
+  return {
+    focusLabel,
+    doneCount,
+    totalCount,
+    tasks: taskItems,
+    remainingTasks: remaining,
+    onToggleTask: handleToggleTask,
+  } as const;
+}
+
+function FocusDayCard({
+  focusLabel,
+  doneCount,
+  totalCount,
+  tasks,
+  remainingTasks,
+  onToggleTask,
+  className,
+}: FocusDayCardProps) {
+  return (
+    <div className={className}>
+      <NeoCard className="flex h-full flex-col gap-[var(--space-4)] p-[var(--space-4)] md:p-[var(--space-5)]">
+        <header className="flex items-start justify-between gap-[var(--space-3)]">
+          <div className="space-y-[var(--space-1)]">
+            <p className="text-label text-muted-foreground">Focus day</p>
+            <h3 className="text-body font-semibold text-card-foreground tracking-[-0.01em]">
+              {focusLabel}
+            </h3>
+          </div>
+          <div className="text-right">
+            <p className="text-label text-muted-foreground">Progress</p>
+            <p className="text-ui font-medium tabular-nums text-card-foreground">
+              {doneCount}/{totalCount}
+            </p>
+          </div>
+        </header>
+        <ul className="flex flex-col gap-[var(--space-3)]" aria-live="polite">
+          {tasks.length > 0 ? (
+            tasks.map((task) => (
+              <li key={task.id} className="flex items-start gap-[var(--space-3)]">
+                <CheckCircle
+                  checked={task.done}
+                  onChange={() => onToggleTask(task.id)}
+                  aria-label={
+                    task.done
+                      ? `Mark ${task.title} as not done`
+                      : `Mark ${task.title} as done`
+                  }
+                  size="sm"
+                />
+                <button
+                  type="button"
+                  onClick={() => onToggleTask(task.id)}
+                  className={cn(
+                    "flex flex-col items-start gap-[var(--space-1)] rounded-card r-card-sm px-[var(--space-1)] py-[var(--space-1)] text-left transition",
+                    "hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
+                    "active:text-foreground/80",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "text-ui font-medium text-card-foreground",
+                      task.done && "line-through-soft text-muted-foreground",
+                    )}
+                  >
+                    {task.title}
+                  </span>
+                  {task.projectName ? (
+                    <span className="text-label text-muted-foreground">
+                      {task.projectName}
+                    </span>
+                  ) : null}
+                </button>
+              </li>
+            ))
+          ) : (
+            <li className="rounded-card r-card-md border border-dashed border-border px-[var(--space-3)] py-[var(--space-3)] text-label text-muted-foreground">
+              No tasks captured for this day.
+            </li>
+          )}
+        </ul>
+        {remainingTasks > 0 ? (
+          <p className="text-label text-muted-foreground">
+            +{remainingTasks} more task{remainingTasks === 1 ? "" : "s"} in planner
+          </p>
+        ) : null}
+      </NeoCard>
+    </div>
+  );
+}
+
+export default FocusDayCard;

--- a/src/components/home/hero/GoalMomentumCard.tsx
+++ b/src/components/home/hero/GoalMomentumCard.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import * as React from "react";
+import { NeoCard } from "@/components/ui";
+import ProgressRingIcon from "@/icons/ProgressRingIcon";
+import { usePersistentState } from "@/lib/db";
+import type { Goal } from "@/lib/types";
+
+export type GoalMomentumActiveGoal = {
+  id: string;
+  title: string;
+  metric?: string | null;
+  notes?: string | null;
+};
+
+export type GoalMomentumCardProps = {
+  total: number;
+  completed: number;
+  pct: number;
+  activeGoals: readonly GoalMomentumActiveGoal[];
+  className?: string;
+};
+
+type GoalStats = {
+  total: number;
+  completed: number;
+  active: GoalMomentumActiveGoal[];
+};
+
+function computeGoalStats(
+  goals: readonly Goal[],
+  maxActive: number,
+): GoalStats {
+  let completed = 0;
+  const active: GoalMomentumActiveGoal[] = [];
+  for (const goal of goals) {
+    if (goal.done) {
+      completed += 1;
+      continue;
+    }
+    if (active.length >= maxActive) continue;
+    active.push({
+      id: goal.id,
+      title: goal.title,
+      metric: goal.metric ?? null,
+      notes: goal.notes ?? null,
+    });
+  }
+  return {
+    total: goals.length,
+    completed,
+    active,
+  };
+}
+
+function computeGoalPct(total: number, completed: number): number {
+  if (total === 0) return 0;
+  const pct = (completed / total) * 100;
+  return Math.max(0, Math.min(100, Math.round(pct)));
+}
+
+export function useGoalMomentumCard(
+  maxActive = 2,
+): Omit<GoalMomentumCardProps, "className"> {
+  const [goals] = usePersistentState<Goal[]>("goals.v2", []);
+
+  const stats = React.useMemo(
+    () => computeGoalStats(goals, maxActive),
+    [goals, maxActive],
+  );
+
+  const pct = React.useMemo(
+    () => computeGoalPct(stats.total, stats.completed),
+    [stats.completed, stats.total],
+  );
+
+  return {
+    total: stats.total,
+    completed: stats.completed,
+    pct,
+    activeGoals: stats.active,
+  } as const;
+}
+
+function GoalMomentumCard({
+  total,
+  completed,
+  pct,
+  activeGoals,
+  className,
+}: GoalMomentumCardProps) {
+  const hasGoals = total > 0;
+  const hasActive = activeGoals.length > 0;
+
+  return (
+    <div className={className}>
+      <NeoCard className="flex h-full flex-col gap-[var(--space-4)] p-[var(--space-4)] md:p-[var(--space-5)]">
+        <header className="flex items-start justify-between gap-[var(--space-3)]">
+          <div className="space-y-[var(--space-1)]">
+            <p className="text-label text-muted-foreground">Goals overview</p>
+            <h3 className="text-body font-semibold text-card-foreground tracking-[-0.01em]">
+              Momentum
+            </h3>
+          </div>
+          <div className="text-right">
+            <p className="text-label text-muted-foreground">Completed</p>
+            <p className="text-ui font-medium tabular-nums text-card-foreground">
+              {completed}/{total}
+            </p>
+          </div>
+        </header>
+        <div className="flex flex-col gap-[var(--space-4)] md:flex-row md:items-center md:gap-[var(--space-5)]">
+          <div className="flex items-center justify-center">
+            <div className="relative flex h-[var(--space-8)] w-[var(--space-8)] items-center justify-center">
+              <ProgressRingIcon pct={pct} size={64} />
+              <span className="absolute text-ui font-semibold tabular-nums text-card-foreground">
+                {hasGoals ? `${pct}%` : "0%"}
+              </span>
+            </div>
+          </div>
+          <div className="flex-1 space-y-[var(--space-3)]">
+            {!hasGoals ? (
+              <p className="text-label text-muted-foreground">
+                No goals tracked yet. Capture one in the goals workspace to see it here.
+              </p>
+            ) : hasActive ? (
+              activeGoals.map((goal) => (
+                <div key={goal.id} className="space-y-[var(--space-1)]">
+                  <p className="text-ui font-medium text-card-foreground">
+                    {goal.title}
+                  </p>
+                  {goal.metric ? (
+                    <p className="text-label text-muted-foreground">{goal.metric}</p>
+                  ) : goal.notes ? (
+                    <p className="text-label text-muted-foreground">{goal.notes}</p>
+                  ) : null}
+                </div>
+              ))
+            ) : (
+              <p className="text-label text-muted-foreground">
+                All active goals are complete. Great work!
+              </p>
+            )}
+          </div>
+        </div>
+      </NeoCard>
+    </div>
+  );
+}
+
+export default GoalMomentumCard;

--- a/src/components/home/hero/HeroSummaryList.tsx
+++ b/src/components/home/hero/HeroSummaryList.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import { useFocusDate } from "@/components/planner";
+import { usePersistentState } from "@/lib/db";
+import type { Review } from "@/lib/types";
+import { CHAT_PROMPTS_STORAGE_KEY } from "@/components/prompts/useChatPrompts";
+import type { Prompt } from "@/components/prompts/types";
+import { useFocusDayLabel } from "./useHeroPlanner";
+
+export type HeroSummaryItem = {
+  key: "focus" | "reviews" | "prompts";
+  label: string;
+  value: string;
+  href: string;
+  cta: string;
+};
+
+export type HeroSummaryListProps = {
+  items: readonly HeroSummaryItem[];
+  className?: string;
+};
+
+type ReviewSummary = {
+  reviewCount: number;
+  flaggedCount: number;
+};
+
+type PromptSummary = {
+  promptCount: number;
+};
+
+function useReviewSummary(): ReviewSummary {
+  const [reviews] = usePersistentState<Review[]>("reviews.v1", []);
+  return React.useMemo(() => {
+    let flagged = 0;
+    for (const review of reviews) {
+      if (review.focusOn) flagged += 1;
+    }
+    return { reviewCount: reviews.length, flaggedCount: flagged };
+  }, [reviews]);
+}
+
+function usePromptSummary(): PromptSummary {
+  const [prompts] = usePersistentState<Prompt[]>(
+    CHAT_PROMPTS_STORAGE_KEY,
+    [],
+  );
+  return React.useMemo(
+    () => ({ promptCount: prompts.length }),
+    [prompts.length],
+  );
+}
+
+export function useHeroSummaryItems(): readonly HeroSummaryItem[] {
+  const { iso } = useFocusDate();
+  const focusLabel = useFocusDayLabel(iso);
+  const { reviewCount, flaggedCount } = useReviewSummary();
+  const { promptCount } = usePromptSummary();
+
+  return React.useMemo(() => {
+    const reviewValue =
+      flaggedCount > 0
+        ? `${flaggedCount} review${flaggedCount === 1 ? "" : "s"}`
+        : reviewCount > 0
+          ? "All caught up"
+          : "No reviews yet";
+    const promptValue =
+      promptCount > 0 ? `${promptCount} saved` : "Start a prompt";
+
+    return [
+      {
+        key: "focus" as const,
+        label: "Next focus",
+        value: focusLabel,
+        href: "/planner",
+        cta: "Open planner",
+      },
+      {
+        key: "reviews" as const,
+        label: "Open reviews",
+        value: reviewValue,
+        href: "/reviews",
+        cta: flaggedCount > 0 ? "Review now" : "View reviews",
+      },
+      {
+        key: "prompts" as const,
+        label: "Team prompts",
+        value: promptValue,
+        href: "/prompts",
+        cta: promptCount > 0 ? "View prompts" : "Browse prompts",
+      },
+    ] as const;
+  }, [flaggedCount, focusLabel, promptCount, reviewCount]);
+}
+
+function HeroSummaryList({ items, className }: HeroSummaryListProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-[var(--space-3)]",
+        className,
+      )}
+    >
+      <div className="space-y-[var(--space-1)]">
+        <p className="text-label text-muted-foreground">Highlights</p>
+        <h3 className="text-body font-semibold text-card-foreground tracking-[-0.01em]">
+          Quick summary
+        </h3>
+      </div>
+      <ul className="grid gap-[var(--space-2)]" role="list">
+        {items.map((item) => (
+          <li key={item.key}>
+            <Link
+              href={item.href}
+              className={cn(
+                "group flex items-center justify-between gap-[var(--space-3)] rounded-card r-card-md border border-border/60 bg-card/70 px-[var(--space-3)] py-[var(--space-2)] transition",
+                "hover:border-primary/40 hover:bg-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
+              )}
+            >
+              <div className="flex min-w-0 flex-col gap-[var(--space-1)]">
+                <span className="text-label text-muted-foreground">{item.label}</span>
+                <span className="text-ui font-semibold text-card-foreground text-balance">
+                  {item.value}
+                </span>
+              </div>
+              <span className="shrink-0 text-label font-medium text-primary transition-colors group-hover:text-primary-foreground">
+                {item.cta}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default HeroSummaryList;

--- a/src/components/home/hero/WeeklyCalendarCard.tsx
+++ b/src/components/home/hero/WeeklyCalendarCard.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import * as React from "react";
+import { NeoCard } from "@/components/ui";
+import { cn } from "@/lib/utils";
+import { useFocusDate, useWeek, useWeekData } from "@/components/planner";
+import { formatWeekRangeLabel } from "@/lib/date";
+import { formatCalendarDayParts } from "./useHeroPlanner";
+
+export type WeeklyCalendarDay = {
+  iso: string;
+  weekday: string;
+  dayNumber: string;
+  done: number;
+  total: number;
+  isToday: boolean;
+  isSelected: boolean;
+};
+
+export type WeeklyCalendarCardProps = {
+  weekLabel: string;
+  done: number;
+  total: number;
+  days: readonly WeeklyCalendarDay[];
+  onSelectDay: (iso: string) => void;
+  className?: string;
+};
+
+export function useWeeklyCalendarCard(): Omit<WeeklyCalendarCardProps, "className"> {
+  const { iso, setIso } = useFocusDate();
+  const { start, end, days, isToday } = useWeek(iso);
+  const { per, weekDone, weekTotal } = useWeekData(days);
+
+  const weekLabel = React.useMemo(
+    () => formatWeekRangeLabel(start, end),
+    [start, end],
+  );
+
+  const calendarDays = React.useMemo<WeeklyCalendarDay[]>(() => {
+    return per.map((day) => {
+      const { weekday, dayNumber } = formatCalendarDayParts(day.iso);
+      return {
+        iso: day.iso,
+        weekday,
+        dayNumber,
+        done: day.done,
+        total: day.total,
+        isToday: isToday(day.iso),
+        isSelected: day.iso === iso,
+      };
+    });
+  }, [iso, isToday, per]);
+
+  const handleSelectDay = React.useCallback(
+    (nextIso: string) => {
+      setIso(nextIso);
+    },
+    [setIso],
+  );
+
+  return {
+    weekLabel,
+    done: weekDone,
+    total: weekTotal,
+    days: calendarDays,
+    onSelectDay: handleSelectDay,
+  } as const;
+}
+
+function WeeklyCalendarCard({
+  weekLabel,
+  done,
+  total,
+  days,
+  onSelectDay,
+  className,
+}: WeeklyCalendarCardProps) {
+  return (
+    <div className={className}>
+      <NeoCard className="flex h-full flex-col gap-[var(--space-4)] p-[var(--space-4)] md:p-[var(--space-5)]">
+        <header className="space-y-[var(--space-1)]">
+          <p className="text-label text-muted-foreground">Weekly calendar</p>
+          <h3 className="text-body font-semibold text-card-foreground tracking-[-0.01em]">
+            {weekLabel}
+          </h3>
+          <p className="text-label text-muted-foreground">
+            {total > 0 ? (
+              <span className="tabular-nums text-card-foreground">
+                {done}/{total}
+              </span>
+            ) : (
+              "No tasks scheduled this week"
+            )}
+          </p>
+        </header>
+        <div className="flex overflow-x-auto rounded-card r-card-lg border border-border/60 p-[var(--space-2)]">
+          <ul
+            className="flex w-full min-w-0 gap-[var(--space-2)]"
+            role="listbox"
+            aria-label="Select focus day"
+          >
+            {days.map((day) => (
+              <li
+                key={day.iso}
+                className="flex-1 min-w-[calc(var(--space-8)+var(--space-2))]"
+              >
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={day.isSelected}
+                  aria-current={day.isToday ? "date" : undefined}
+                  onClick={() => onSelectDay(day.iso)}
+                  className={cn(
+                    "flex w-full flex-col items-start gap-[var(--space-1)] rounded-card r-card-md border px-[var(--space-3)] py-[var(--space-2)] text-left transition",
+                    "border-card-hairline bg-card/70 hover:border-primary/40 hover:bg-card/80",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
+                    "active:bg-card/90",
+                    day.isSelected && "border-primary/70 bg-card",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "text-label text-muted-foreground",
+                      day.isToday && "text-accent-3",
+                    )}
+                  >
+                    {day.weekday}
+                  </span>
+                  <span className="text-ui font-semibold tabular-nums text-card-foreground">
+                    {day.dayNumber}
+                  </span>
+                  <span className="text-label text-muted-foreground tabular-nums">
+                    {day.done}/{day.total}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </NeoCard>
+    </div>
+  );
+}
+
+export default WeeklyCalendarCard;

--- a/src/components/home/hero/index.ts
+++ b/src/components/home/hero/index.ts
@@ -1,0 +1,28 @@
+export { default as HeroSummaryList } from "./HeroSummaryList";
+export type { HeroSummaryItem, HeroSummaryListProps } from "./HeroSummaryList";
+export { useHeroSummaryItems } from "./HeroSummaryList";
+
+export { default as FocusDayCard } from "./FocusDayCard";
+export type { FocusDayTask, FocusDayCardProps } from "./FocusDayCard";
+export { useFocusDayCard } from "./FocusDayCard";
+
+export { default as GoalMomentumCard } from "./GoalMomentumCard";
+export type {
+  GoalMomentumActiveGoal,
+  GoalMomentumCardProps,
+} from "./GoalMomentumCard";
+export { useGoalMomentumCard } from "./GoalMomentumCard";
+
+export { default as WeeklyCalendarCard } from "./WeeklyCalendarCard";
+export type {
+  WeeklyCalendarDay,
+  WeeklyCalendarCardProps,
+} from "./WeeklyCalendarCard";
+export { useWeeklyCalendarCard } from "./WeeklyCalendarCard";
+
+export {
+  useFocusDayLabel,
+  useProjectNameMap,
+  useTaskPreview,
+  formatCalendarDayParts,
+} from "./useHeroPlanner";

--- a/src/components/home/hero/useHeroPlanner.ts
+++ b/src/components/home/hero/useHeroPlanner.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import * as React from "react";
+import { fromISODate } from "@/lib/date";
+import { LOCALE } from "@/lib/utils";
+import type { DayTask, Project } from "@/components/planner/plannerStore";
+
+const focusDayFormatter = new Intl.DateTimeFormat(LOCALE, {
+  weekday: "long",
+  month: "long",
+  day: "numeric",
+});
+
+const calendarWeekdayFormatter = new Intl.DateTimeFormat(LOCALE, {
+  weekday: "short",
+});
+
+const calendarDayFormatter = new Intl.DateTimeFormat(LOCALE, {
+  day: "2-digit",
+});
+
+export function useFocusDayLabel(iso: string): string {
+  return React.useMemo(() => {
+    const date = fromISODate(iso);
+    if (!date) return iso;
+    return focusDayFormatter.format(date);
+  }, [iso]);
+}
+
+export function useProjectNameMap(projects: readonly Project[]) {
+  return React.useMemo(() => {
+    const map = new Map<string, string>();
+    for (const project of projects) {
+      map.set(project.id, project.name);
+    }
+    return map as ReadonlyMap<string, string>;
+  }, [projects]);
+}
+
+export function useTaskPreview(tasks: readonly DayTask[], limit: number) {
+  return React.useMemo(() => {
+    const preview = tasks.slice(0, Math.max(0, limit));
+    const remaining = Math.max(tasks.length - preview.length, 0);
+    return { preview, remaining } as const;
+  }, [tasks, limit]);
+}
+
+export function formatCalendarDayParts(iso: string) {
+  const date = fromISODate(iso);
+  if (!date) {
+    return { weekday: iso, dayNumber: "--" } as const;
+  }
+
+  return {
+    weekday: calendarWeekdayFormatter.format(date),
+    dayNumber: calendarDayFormatter.format(date),
+  } as const;
+}

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -11,3 +11,4 @@ export { default as BottomNav } from "../chrome/BottomNav";
 export { default as IsometricRoom } from "./IsometricRoom";
 export { default as HeroPortraitFrame } from "./HeroPortraitFrame";
 export { default as WelcomeHeroFigure } from "./WelcomeHeroFigure";
+export * from "./hero";

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -67,6 +67,16 @@ import {
   QuickActionGrid,
   HeroPortraitFrame,
   WelcomeHeroFigure,
+  HeroSummaryList,
+  FocusDayCard,
+  GoalMomentumCard,
+  WeeklyCalendarCard,
+} from "@/components/home";
+import type {
+  HeroSummaryItem,
+  FocusDayCardProps,
+  GoalMomentumCardProps,
+  WeeklyCalendarCardProps,
 } from "@/components/home";
 import ChampListEditor from "@/components/team/ChampListEditor";
 import {
@@ -144,6 +154,107 @@ export const demoReview: Review = {
   role: "MID",
   score: 8,
   result: "Win",
+};
+
+const HERO_SUMMARY_DEMO_ITEMS: HeroSummaryItem[] = [
+  {
+    key: "focus",
+    label: "Next focus",
+    value: "Tuesday · 14 May",
+    href: "/planner",
+    cta: "Open planner",
+  },
+  {
+    key: "reviews",
+    label: "Open reviews",
+    value: "2 reviews",
+    href: "/reviews",
+    cta: "Review now",
+  },
+  {
+    key: "prompts",
+    label: "Team prompts",
+    value: "6 saved",
+    href: "/prompts",
+    cta: "View prompts",
+  },
+];
+
+const FOCUS_DAY_CARD_DEMO: FocusDayCardProps = {
+  focusLabel: "Tuesday, May 14",
+  doneCount: 2,
+  totalCount: 4,
+  tasks: [
+    { id: "t1", title: "Ship sprint plan", done: false, projectName: "Aurora" },
+    { id: "t2", title: "Sync with research", done: true, projectName: "Pulse" },
+    { id: "t3", title: "Review backlog", done: false, projectName: null },
+  ],
+  remainingTasks: 3,
+  onToggleTask: () => {},
+};
+
+const GOAL_MOMENTUM_CARD_DEMO: GoalMomentumCardProps = {
+  total: 4,
+  completed: 2,
+  pct: 50,
+  activeGoals: [
+    { id: "g1", title: "Launch planner beta", metric: "Ship invite list" },
+    { id: "g2", title: "Improve retention", notes: "Draft success brief" },
+  ],
+};
+
+const WEEKLY_CALENDAR_CARD_DEMO: WeeklyCalendarCardProps = {
+  weekLabel: "May 13 – May 19",
+  done: 8,
+  total: 12,
+  days: [
+    {
+      iso: "2024-05-13",
+      weekday: "Mon",
+      dayNumber: "13",
+      done: 1,
+      total: 2,
+      isToday: false,
+      isSelected: false,
+    },
+    {
+      iso: "2024-05-14",
+      weekday: "Tue",
+      dayNumber: "14",
+      done: 2,
+      total: 3,
+      isToday: false,
+      isSelected: true,
+    },
+    {
+      iso: "2024-05-15",
+      weekday: "Wed",
+      dayNumber: "15",
+      done: 1,
+      total: 2,
+      isToday: false,
+      isSelected: false,
+    },
+    {
+      iso: "2024-05-16",
+      weekday: "Thu",
+      dayNumber: "16",
+      done: 3,
+      total: 3,
+      isToday: false,
+      isSelected: false,
+    },
+    {
+      iso: "2024-05-17",
+      weekday: "Fri",
+      dayNumber: "17",
+      done: 1,
+      total: 2,
+      isToday: false,
+      isSelected: false,
+    },
+  ],
+  onSelectDay: () => {},
 };
 
 function RoleSelectorDemo() {
@@ -893,6 +1004,82 @@ export const SPEC_DATA: Record<Section, Spec[]> = {
   className="md:flex-row md:items-center md:justify-between"
   buttonSize="lg"
   buttonClassName="motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
+/>`,
+    },
+    {
+      id: "hero-summary-list",
+      name: "HeroSummaryList",
+      element: (
+        <HeroSummaryList
+          className="max-w-xl"
+          items={HERO_SUMMARY_DEMO_ITEMS}
+        />
+      ),
+      tags: ["hero", "summary"],
+      code: `<HeroSummaryList
+  items={[
+    { key: "focus", label: "Next focus", value: "Tuesday · 14 May", href: "/planner", cta: "Open planner" },
+  ]}
+/>`,
+    },
+    {
+      id: "focus-day-card",
+      name: "FocusDayCard",
+      element: (
+        <FocusDayCard
+          {...FOCUS_DAY_CARD_DEMO}
+          className="max-w-xl"
+        />
+      ),
+      tags: ["hero", "tasks"],
+      code: `<FocusDayCard
+  focusLabel="Tuesday, May 14"
+  doneCount={2}
+  totalCount={4}
+  tasks={[
+    { id: "t1", title: "Ship sprint plan", done: false, projectName: "Aurora" },
+  ]}
+  remainingTasks={3}
+  onToggleTask={() => {}}
+/>`,
+    },
+    {
+      id: "goal-momentum-card",
+      name: "GoalMomentumCard",
+      element: (
+        <GoalMomentumCard
+          {...GOAL_MOMENTUM_CARD_DEMO}
+          className="max-w-xl"
+        />
+      ),
+      tags: ["hero", "goals"],
+      code: `<GoalMomentumCard
+  total={4}
+  completed={2}
+  pct={50}
+  activeGoals={[
+    { id: "g1", title: "Launch planner beta", metric: "Ship invite list" },
+  ]}
+/>`,
+    },
+    {
+      id: "weekly-calendar-card",
+      name: "WeeklyCalendarCard",
+      element: (
+        <WeeklyCalendarCard
+          {...WEEKLY_CALENDAR_CARD_DEMO}
+          className="max-w-2xl"
+        />
+      ),
+      tags: ["hero", "calendar"],
+      code: `<WeeklyCalendarCard
+  weekLabel="May 13 – May 19"
+  done={8}
+  total={12}
+  days={[
+    { iso: "2024-05-13", weekday: "Mon", dayNumber: "13", done: 1, total: 2, isToday: false, isSelected: false },
+  ]}
+  onSelectDay={() => {}}
 />`,
     },
     {


### PR DESCRIPTION
## Summary
- extract the planner hero summary, focus day, momentum, and calendar views into dedicated components with typed props and selector hooks
- wire the home page hero to the new modular components while keeping the rest of the layout intact
- register the new hero building blocks in the prompts gallery with demo data so they appear in the component catalog

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cce373d558832cb0307b9d5cb45f38