### PR TITLE
chore: remove unused React import from TodayHero

### DIFF
--- a/src/components/planner/TodayHero.tsx
+++ b/src/components/planner/TodayHero.tsx
@@ -19,7 +19,6 @@ import IconButton from "@/components/ui/primitives/IconButton";
 import GlitchProgress from "@/components/ui/primitives/GlitchProgress";
 import Button from "@/components/ui/primitives/Button";
 import { Pencil, Trash2, Calendar } from "lucide-react";
-import type React from "react";
 
 type DateInputWithPicker = HTMLInputElement & { showPicker?: () => void };
 type Props = { iso?: ISODate };


### PR DESCRIPTION
## Summary
- remove the unused React type import from `TodayHero`

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cce6e775a0832c8694d7f5bdeca542