### PR TITLE
Add gallery metadata for core UI primitives

### DIFF
--- a/scripts/verify-prompts.ts
+++ b/scripts/verify-prompts.ts
@@ -29,7 +29,9 @@ async function getUiComponents(): Promise<string[]> {
     if (
       base === "index.ts" ||
       base === "index.tsx" ||
-      base.endsWith("Page.tsx")
+      base.endsWith("Page.tsx") ||
+      base.includes(".gallery.") ||
+      base.includes(".meta.")
     ) {
       continue;
     }

--- a/src/components/gallery/index.ts
+++ b/src/components/gallery/index.ts
@@ -1,0 +1,3 @@
+export * from "./registry";
+export * from "./loader";
+export * from "./runtime";

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -1,11 +1,12 @@
 import type { HeaderTab } from "@/components/ui";
-import { galleryPayload, getGalleryPreviewRenderer } from "@/components/gallery/runtime";
 import {
+  galleryPayload,
+  getGalleryPreviewRenderer,
   formatGallerySectionLabel,
   GALLERY_SECTION_IDS,
   type GallerySectionId,
   type GallerySerializableEntry,
-} from "@/components/gallery/registry";
+} from "@/components/gallery";
 import { COLOR_PALETTES } from "@/lib/theme";
 
 export type Section = GallerySectionId;
@@ -19,8 +20,6 @@ export const COLOR_SECTIONS = [
   { title: "Accents", tokens: COLOR_PALETTES.accents },
 ] as const;
 
-export const GALLERY_PAYLOAD = galleryPayload;
-
 const SECTION_ENTRIES = new Map<Section, readonly GallerySerializableEntry[]>(
   galleryPayload.sections.map((section) => [section.id, section.entries] as const),
 );
@@ -30,11 +29,6 @@ export function getGallerySectionEntries(
 ): readonly GallerySerializableEntry[] {
   return SECTION_ENTRIES.get(section) ?? [];
 }
-
-export const PRIMITIVE_ENTRIES = galleryPayload.byKind.primitive;
-export const COMPONENT_ENTRIES = galleryPayload.byKind.component;
-export const COMPLEX_ENTRIES = galleryPayload.byKind.complex;
-export const TOKEN_ENTRIES = galleryPayload.byKind.token;
 
 export const getGalleryPreview = getGalleryPreviewRenderer;
 

--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -8,10 +8,6 @@ import {
 } from "@/components/gallery/registry";
 import {
   Button,
-  IconButton,
-  Input,
-  Textarea,
-  SegmentedButton,
   Card,
   NeoCard,
   CardHeader,
@@ -27,7 +23,6 @@ import {
   SettingsSelect,
   Progress,
   Split,
-  TabBar,
   TitleBar,
   AnimationToggle,
   CatCompanion,
@@ -36,30 +31,18 @@ import {
   SideSelector,
   PillarBadge,
   PillarSelector,
-  Header,
   Hero,
   NeomorphicHeroFrame,
   PageShell,
   SectionCard as UiSectionCard,
-  Field,
-  SearchBar,
-  Label,
-  type HeaderTab,
 } from "@/components/ui";
-import HeaderTabsControl, {
-  type HeaderTabItem as HeaderTabsItem,
-} from "@/components/tabs/HeaderTabs";
-import Badge from "@/components/ui/primitives/Badge";
-import ButtonShowcase from "./ButtonShowcase";
 import DemoHeader from "./DemoHeader";
 import GoalListDemo from "./GoalListDemo";
-import IconButtonShowcase from "./IconButtonShowcase";
 import OutlineGlowDemo from "./OutlineGlowDemo";
 import PromptList from "./PromptList";
 import PromptsComposePanel from "./PromptsComposePanel";
 import PromptsDemos from "./PromptsDemos";
 import PromptsHeader from "./PromptsHeader";
-import SelectShowcase from "./SelectShowcase";
 import SpinnerShowcase from "./SpinnerShowcase";
 import SnackbarShowcase from "./SnackbarShowcase";
 import SkeletonShowcase from "./SkeletonShowcase";
@@ -98,9 +81,6 @@ import {
 } from "@/components/goals";
 import { RemindersProvider } from "@/components/goals/reminders/useReminders";
 import { ProgressRingIcon, TimerRingIcon } from "@/icons";
-import { Circle, CircleDot, CircleCheck, Plus } from "lucide-react";
-
-const fieldStoryHref = "/storybook/?path=/story/primitives-field--state-gallery";
 
 type LegacySpec = {
   id: string;
@@ -247,95 +227,6 @@ function ChampListEditorDemo() {
   );
 }
 
-function HeaderTabsDemo() {
-  const tabs = React.useMemo<HeaderTab<string>[]>(
-    () => [
-      {
-        key: "summary",
-        label: "Summary",
-        icon: <Circle aria-hidden="true" className="h-[var(--space-4)] w-[var(--space-4)]" />,
-      },
-      {
-        key: "timeline",
-        label: "Timeline",
-        icon: <CircleDot aria-hidden="true" className="h-[var(--space-4)] w-[var(--space-4)]" />,
-      },
-      {
-        key: "insights",
-        label: "Insights",
-        icon: <CircleCheck aria-hidden="true" className="h-[var(--space-4)] w-[var(--space-4)]" />,
-        disabled: true,
-      },
-    ],
-    [],
-  );
-  const [tab, setTab] = React.useState<string>(
-    () => tabs.find((item) => !item.disabled)?.key ?? tabs[0]?.key ?? "",
-  );
-  const activeLabel = React.useMemo(
-    () => tabs.find((item) => item.key === tab)?.label ?? null,
-    [tab, tabs],
-  );
-
-  return (
-    <Header
-      heading="Header"
-      subtitle="Segmented navigation anchored to the header"
-      tabs={{
-        items: tabs,
-        value: tab,
-        onChange: setTab,
-        ariaLabel: "Header demo tabs",
-        size: "md",
-      }}
-      sticky={false}
-      topClassName="top-0"
-    >
-      <p className="text-ui text-muted-foreground">
-        Viewing
-        <span className="ml-[var(--space-1)] font-medium text-foreground">
-          {activeLabel}
-        </span>
-      </p>
-    </Header>
-  );
-}
-
-function HeaderTabsControlDemo() {
-  const [active, setActive] = React.useState("plan");
-  const items = React.useMemo<HeaderTabsItem<string>[]>(
-    () => [
-      {
-        key: "plan",
-        label: "Plan",
-        icon: <Circle aria-hidden />, 
-      },
-      {
-        key: "review",
-        label: "Review",
-        icon: <CircleDot aria-hidden />, 
-      },
-      {
-        key: "archive",
-        label: "Archive",
-        icon: <CircleCheck aria-hidden />, 
-        disabled: true,
-      },
-    ],
-    [],
-  );
-
-  return (
-    <HeaderTabsControl
-      items={items}
-      value={active}
-      onChange={setActive}
-      ariaLabel="Header tab demo"
-      idBase="header-tabs-demo"
-    />
-  );
-}
-
 function CardDemo() {
   return (
     <Card>
@@ -475,310 +366,8 @@ function DemoHeaderShowcase() {
   );
 }
 const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
-  buttons: [
-    {
-      id: "button",
-      name: "Button",
-      description: "Tone and size matrix",
-      element: <ButtonShowcase />,
-      tags: ["button", "action", "demo"],
-      props: [
-        { label: "tones", value: "primary accent info danger" },
-        { label: "sizes", value: "sm md lg" },
-      ],
-      code: `<div className="space-y-4">
-  <div className="flex flex-wrap gap-2">
-    <Button tone="primary">Primary tone</Button>
-    <Button tone="accent">Accent tone</Button>
-    <Button tone="info" variant="ghost">
-      Info ghost
-    </Button>
-    <Button tone="danger" variant="primary">
-      Danger primary
-    </Button>
-    <Button disabled>Disabled</Button>
-  </div>
-  <div className="flex flex-wrap items-center gap-2">
-    <Button size="sm">
-      <Plus />
-      Small
-    </Button>
-    <Button size="md">
-      <Plus />
-      Medium
-    </Button>
-    <Button size="lg">
-      <Plus />
-      Large
-    </Button>
-  </div>
-</div>`,
-    },
-    {
-      id: "button-states",
-      name: "Button States",
-      description: "State tokens",
-      element: (
-        <div className="flex flex-wrap gap-4">
-          <Button>Default</Button>
-          <Button className="bg-[--hover]">Hover</Button>
-          <Button className="ring-2 ring-[var(--focus)]">Focus</Button>
-          <Button className="bg-[--active]">Active</Button>
-          <Button disabled>Disabled</Button>
-          <Button loading>Loading</Button>
-        </div>
-      ),
-      tags: ["button", "states"],
-      code: `<div className="flex flex-wrap gap-4">
-  <Button>Default</Button>
-  <Button className="bg-[--hover]">Hover</Button>
-  <Button className="ring-2 ring-[var(--focus)]">Focus</Button>
-  <Button className="bg-[--active]">Active</Button>
-  <Button disabled>Disabled</Button>
-  <Button loading>Loading</Button>
-</div>`,
-    },
-    {
-      id: "segmented-button",
-      name: "SegmentedButton",
-      description: "Segmented control button",
-      element: (
-        <div className="flex gap-4">
-          <SegmentedButton>Default</SegmentedButton>
-          <SegmentedButton isActive>Active</SegmentedButton>
-        </div>
-      ),
-      tags: ["button", "segmented"],
-      code: `<div className="flex gap-4">
-  <SegmentedButton>Default</SegmentedButton>
-  <SegmentedButton isActive>Active</SegmentedButton>
-</div>`,
-    },
-    {
-      id: "icon-button",
-      name: "IconButton",
-      description: "Size and variant showcase",
-      element: <IconButtonShowcase />,
-      tags: ["icon", "button", "demo"],
-      props: [
-        { label: "sizes", value: "xs sm md lg xl" },
-        { label: "variants", value: "ring glow" },
-      ],
-      code: `<div className="flex flex-col gap-4">
-  <div className="flex gap-2">
-    <IconButton size="xs" variant="ring" aria-label="Add item xs">
-      <Plus aria-hidden />
-    </IconButton>
-    <IconButton size="sm" variant="ring" aria-label="Add item sm">
-      <Plus aria-hidden />
-    </IconButton>
-    <IconButton size="md" variant="ring" aria-label="Add item md">
-      <Plus aria-hidden />
-    </IconButton>
-    <IconButton size="lg" variant="ring" aria-label="Add item lg">
-      <Plus aria-hidden />
-    </IconButton>
-    <IconButton size="xl" variant="ring" aria-label="Add item xl">
-      <Plus aria-hidden />
-    </IconButton>
-    <IconButton size="md" variant="glow" aria-label="Add item glow">
-      <Plus aria-hidden />
-    </IconButton>
-  </div>
-  <div className="flex gap-2">
-    <IconButton
-      variant="ring"
-      size="md"
-      className="bg-[--active]"
-      aria-pressed
-      aria-label="Add item ring pressed"
-    >
-      <Plus aria-hidden />
-    </IconButton>
-    <IconButton
-      variant="glow"
-      size="md"
-      className="bg-[--active]"
-      aria-pressed
-      aria-label="Add item glow pressed"
-    >
-      <Plus aria-hidden />
-    </IconButton>
-  </div>
-</div>`,
-    },
-    {
-      id: "icon-button-states",
-      name: "IconButton States",
-      description: "State tokens",
-      element: (
-        <div className="flex flex-wrap gap-4">
-          <IconButton aria-label="Default">
-            <Plus />
-          </IconButton>
-          <IconButton className="bg-[--hover]" aria-label="Hover">
-            <Plus />
-          </IconButton>
-          <IconButton className="ring-2 ring-[var(--focus)]" aria-label="Focus">
-            <Plus />
-          </IconButton>
-          <IconButton className="bg-[--active]" aria-label="Active">
-            <Plus />
-          </IconButton>
-          <IconButton disabled aria-label="Disabled">
-            <Plus />
-          </IconButton>
-          <IconButton loading aria-label="Loading">
-            <Plus />
-          </IconButton>
-        </div>
-      ),
-      tags: ["icon", "button", "states"],
-      code: `<div className="flex flex-wrap gap-4">
-  <IconButton aria-label="Default">
-    <Plus />
-  </IconButton>
-  <IconButton className="bg-[--hover]" aria-label="Hover">
-    <Plus />
-  </IconButton>
-  <IconButton className="ring-2 ring-[var(--focus)]" aria-label="Focus">
-    <Plus />
-  </IconButton>
-  <IconButton className="bg-[--active]" aria-label="Active">
-    <Plus />
-  </IconButton>
-  <IconButton disabled aria-label="Disabled">
-    <Plus />
-  </IconButton>
-  <IconButton loading aria-label="Loading">
-    <Plus />
-  </IconButton>
-</div>`,
-    },
-  ],
-  inputs: [
-    {
-      id: "input",
-      name: "Input",
-      description: "Standard text input",
-      element: <Input placeholder="Type here" />,
-      tags: ["input", "text"],
-      code: `<Input placeholder="Type here" />`,
-    },
-    {
-      id: "input-states",
-      name: "Input States",
-      description: "State tokens",
-      element: (
-        <div className="flex flex-col gap-2">
-          <Input placeholder="Default" />
-          <Input placeholder="Hover" className="bg-[--hover]" />
-          <Input placeholder="Focus" className="ring-2 ring-[var(--focus)]" />
-          <Input placeholder="Active" className="bg-[--active]" />
-          <Input placeholder="Disabled" disabled />
-          <Input placeholder="Loading" data-loading="true" />
-        </div>
-      ),
-      tags: ["input", "states"],
-      code: `<div className="flex flex-col gap-2">
-  <Input placeholder="Default" />
-  <Input placeholder="Hover" className="bg-[--hover]" />
-  <Input placeholder="Focus" className="ring-2 ring-[var(--focus)]" />
-  <Input placeholder="Active" className="bg-[--active]" />
-  <Input placeholder="Disabled" disabled />
-  <Input placeholder="Loading" data-loading="true" />
-</div>`,
-    },
-    {
-      id: "select",
-      name: "Select",
-      description: "Animated and native select",
-      element: <SelectShowcase />,
-      tags: ["select", "input"],
-      code: `const items = [
-  { value: "one", label: "One" },
-  { value: "two", label: "Two" },
-];
-<>
-  <AnimatedSelect items={items} placeholder="Animated" />
-  <NativeSelect items={items} />
-  <Select items={items} disabled placeholder="Disabled" />
-</>`,
-    },
-    {
-      id: "textarea",
-      name: "Textarea",
-      description: "Multi-line text input",
-      element: (
-        <div className="flex flex-col gap-2">
-          <Textarea placeholder="Type here" />
-          <Textarea placeholder="Disabled" disabled />
-        </div>
-      ),
-      tags: ["textarea", "input"],
-      code: `<div className="flex flex-col gap-2">
-  <Textarea placeholder="Type here" />
-  <Textarea placeholder="Disabled" disabled />
-</div>`,
-    },
-    {
-      id: "field",
-      name: "Field",
-      description: "Primitive wrapper for custom inputs",
-      element: (
-        <div className="flex w-56 flex-col gap-[var(--space-2)]">
-          <Field.Root>
-            <Field.Input placeholder="Compose primitives" />
-          </Field.Root>
-          <a
-            href={fieldStoryHref}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center gap-[var(--space-1)] text-label font-medium text-accent-foreground transition-colors duration-[var(--dur-quick)] ease-out hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--bg))]"
-          >
-            Explore Field states in Storybook
-          </a>
-        </div>
-      ),
-      tags: ["field", "input"],
-      code: `<Field.Root>
-  <Field.Input placeholder="Compose primitives" />
-</Field.Root>`,
-    },
-    {
-      id: "label",
-      name: "Label",
-      element: (
-        <div className="flex w-56 flex-col gap-2">
-          <Label htmlFor="label-demo">Label</Label>
-          <Input id="label-demo" placeholder="With label" />
-        </div>
-      ),
-      tags: ["label", "input"],
-      code: `<div className="flex w-56 flex-col gap-2">
-  <Label htmlFor="label-demo">Label</Label>
-  <Input id="label-demo" placeholder="With label" />
-</div>`,
-    },
-    {
-      id: "search-bar",
-      name: "SearchBar",
-      description: "Debounced search input",
-      element: (
-        <SearchBar
-          value=""
-          placeholder="Search components"
-          className="w-56"
-        />
-      ),
-      tags: ["search", "input"],
-      code: `<SearchBar
-  value=""
-  placeholder="Search components"
-  className="w-56"
-/>`,
-    },
-  ],
+  buttons: [],
+  inputs: [],
   prompts: [
     {
       id: "prompt-list",
@@ -1086,88 +675,6 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
     },
   ],
   layout: [
-    {
-      id: "header-tabs-control",
-      name: "HeaderTabs",
-      description: "Neomorphic header tab control",
-      element: (
-        <div className="w-56">
-          <HeaderTabsControlDemo />
-        </div>
-      ),
-      tags: ["tabs", "navigation"],
-      code: `const tabs = [
-  { key: "plan", label: "Plan" },
-  { key: "review", label: "Review" },
-  { key: "archive", label: "Archive", disabled: true },
-];
-
-<HeaderTabs
-  items={tabs}
-  value="plan"
-  onChange={() => {}}
-  ariaLabel="Header tab demo"
-/>`,
-    },
-    {
-      id: "header-tabs",
-      name: "Header Tabs",
-      description: "Header with segmented tabs",
-      element: <HeaderTabsDemo />,
-      tags: ["header", "tabs"],
-      code: `<Header
-  heading="Header"
-  subtitle="Segmented navigation anchored to the header"
-  tabs={{
-    items: [
-      {
-        key: "summary",
-        label: "Summary",
-        icon: (
-          <Circle
-            aria-hidden="true"
-            className="h-[var(--space-4)] w-[var(--space-4)]"
-          />
-        ),
-      },
-      {
-        key: "timeline",
-        label: "Timeline",
-        icon: (
-          <CircleDot
-            aria-hidden="true"
-            className="h-[var(--space-4)] w-[var(--space-4)]"
-          />
-        ),
-      },
-      {
-        key: "insights",
-        label: "Insights",
-        icon: (
-          <CircleCheck
-            aria-hidden="true"
-            className="h-[var(--space-4)] w-[var(--space-4)]"
-          />
-        ),
-        disabled: true,
-      },
-    ],
-    value: "summary",
-    onChange: () => {},
-    ariaLabel: "Header demo tabs",
-    size: "md",
-  }}
-  sticky={false}
-  topClassName="top-0"
->
-  <p className="text-ui text-muted-foreground">
-    Viewing
-    <span className="ml-[var(--space-1)] font-medium text-foreground">
-      Summary
-    </span>
-  </p>
-</Header>`,
-    },
     {
       id: "page-shell",
       name: "PageShell",
@@ -1557,101 +1064,6 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
 <AnimationToggle loading />`,
     },
     {
-      id: "tab-bar-filters",
-      name: "TabBar (filters)",
-      description: "Preset filter tabs with icons",
-      element: (
-        <TabBar
-          items={[
-            { key: "all", label: "All", icon: <Circle aria-hidden="true" /> },
-            {
-              key: "active",
-              label: "Active",
-              icon: <CircleDot aria-hidden="true" />,
-            },
-            {
-              key: "done",
-              label: "Done",
-              icon: <CircleCheck aria-hidden="true" />,
-            },
-          ]}
-          defaultValue="active"
-          ariaLabel="Show active goals"
-        />
-      ),
-      tags: ["tab", "toggle"],
-      code: `<TabBar
-  items={[
-    { key: "all", label: "All", icon: <Circle aria-hidden="true" /> },
-    {
-      key: "active",
-      label: "Active",
-      icon: <CircleDot aria-hidden="true" />,
-    },
-    {
-      key: "done",
-      label: "Done",
-      icon: <CircleCheck aria-hidden="true" />,
-    },
-  ]}
-  defaultValue="active"
-  ariaLabel="Show active goals"
-/>`,
-    },
-    {
-      id: "tab-bar",
-      name: "TabBar",
-      element: (
-        <TabBar
-          items={[
-            { key: "a", label: "A" },
-            { key: "b", label: "B" },
-            { key: "c", label: "Disabled", disabled: true },
-            { key: "d", label: "Syncing", loading: true },
-          ]}
-          defaultValue="a"
-          ariaLabel="Example tabs"
-        />
-      ),
-      tags: ["tab", "toggle"],
-      code: `<TabBar
-  items={[
-    { key: "a", label: "A" },
-    { key: "b", label: "B" },
-    { key: "c", label: "Disabled", disabled: true },
-    { key: "d", label: "Syncing", loading: true },
-  ]}
-  defaultValue="a"
-  ariaLabel="Example tabs"
-/>`,
-    },
-    {
-      id: "tab-bar-app-nav",
-      name: "TabBar (app nav)",
-      description: "Controlled TabBar for section switching",
-      element: (
-        <TabBar
-          items={[
-            { key: "reviews", label: "Reviews" },
-            { key: "planner", label: "Planner" },
-            { key: "goals", label: "Goals" },
-          ]}
-          defaultValue="reviews"
-          ariaLabel="Planner areas"
-        />
-      ),
-      tags: ["tab", "toggle"],
-      code: `<TabBar
-  items={[
-    { key: "reviews", label: "Reviews" },
-    { key: "planner", label: "Planner" },
-    { key: "goals", label: "Goals" },
-  ]}
-  defaultValue="reviews"
-  ariaLabel="Planner areas"
-/>`,
-    },
-    {
       id: "theme-toggle",
       name: "ThemeToggle",
       element: <ThemeToggle />,
@@ -1759,13 +1171,6 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
   ],
   misc: [
     {
-      id: "badge",
-      name: "Badge",
-      element: <Badge>Badge</Badge>,
-      tags: ["badge"],
-      code: `<Badge>Badge</Badge>`,
-    },
-    {
       id: "theme-picker",
       name: "ThemePicker",
       element: <ThemePickerDemo />,
@@ -1815,23 +1220,6 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
       element: <ReviewListItem review={demoReview} />,
       tags: ["review", "list"],
       code: `<ReviewListItem review={demoReview} />`,
-    },
-    {
-      id: "badge-tones",
-      name: "Badge Tones",
-      element: (
-        <div className="flex flex-wrap gap-[var(--space-2)]">
-          <Badge tone="neutral">Neutral</Badge>
-          <Badge tone="accent">Accent</Badge>
-          <Badge tone="primary">Primary</Badge>
-        </div>
-      ),
-      tags: ["badge", "tone"],
-      code: `<div className="flex flex-wrap gap-[var(--space-2)]">
-  <Badge tone="neutral">Neutral</Badge>
-  <Badge tone="accent">Accent</Badge>
-  <Badge tone="primary">Primary</Badge>
-</div>`,
     },
     {
       id: "cat-companion",

--- a/src/components/tabs/HeaderTabs.gallery.tsx
+++ b/src/components/tabs/HeaderTabs.gallery.tsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+import { Circle, CircleCheck, CircleDot } from "lucide-react";
+
+import { createGalleryPreview, defineGallerySection } from "@/components/gallery";
+
+import HeaderTabs, { type HeaderTabItem } from "./HeaderTabs";
+
+type ItemKey = "plan" | "review" | "archive";
+
+const ITEMS: HeaderTabItem<ItemKey>[] = [
+  { key: "plan", label: "Plan", icon: <Circle aria-hidden="true" /> },
+  { key: "review", label: "Review", icon: <CircleDot aria-hidden="true" /> },
+  {
+    key: "archive",
+    label: "Archive",
+    icon: <CircleCheck aria-hidden="true" />,
+    disabled: true,
+  },
+];
+
+function HeaderTabsGalleryPreview() {
+  const [value, setValue] = React.useState<ItemKey>(
+    () => ITEMS.find((item) => !item.disabled)?.key ?? "plan",
+  );
+
+  return (
+    <HeaderTabs
+      items={ITEMS}
+      value={value}
+      onChange={setValue}
+      ariaLabel="Header tab demo"
+      idBase="header-tabs-gallery"
+    />
+  );
+}
+
+export default defineGallerySection({
+  id: "layout",
+  entries: [
+    {
+      id: "header-tabs",
+      name: "HeaderTabs",
+      description: "Neomorphic segmented control used within headers",
+      kind: "component",
+      tags: ["tabs", "navigation"],
+      axes: [
+        {
+          id: "state",
+          label: "State",
+          type: "state",
+          values: [
+            { value: "Active" },
+            { value: "Inactive" },
+            { value: "Disabled" },
+          ],
+        },
+      ],
+      preview: createGalleryPreview({
+        id: "ui:header-tabs:control",
+        render: () => <HeaderTabsGalleryPreview />,
+      }),
+      code: `<HeaderTabs
+  items={[
+    { key: "plan", label: "Plan", icon: <Circle aria-hidden="true" /> },
+    { key: "review", label: "Review", icon: <CircleDot aria-hidden="true" /> },
+    {
+      key: "archive",
+      label: "Archive",
+      icon: <CircleCheck aria-hidden="true" />,
+      disabled: true,
+    },
+  ]}
+  value="plan"
+  onChange={() => {}}
+  ariaLabel="Header tab demo"
+/>`,
+    },
+  ],
+});

--- a/src/components/ui/Label.gallery.tsx
+++ b/src/components/ui/Label.gallery.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+
+import { createGalleryPreview, defineGallerySection } from "@/components/gallery";
+import { Input } from "@/components/ui";
+
+import Label from "./Label";
+
+function LabelGalleryPreview() {
+  return (
+    <div className="flex w-64 flex-col gap-[var(--space-3)]">
+      <div>
+        <Label htmlFor="label-default">Email</Label>
+        <Input id="label-default" placeholder="player@example.gg" />
+      </div>
+      <div className="opacity-80">
+        <Label htmlFor="label-disabled">Disabled</Label>
+        <Input id="label-disabled" placeholder="Disabled input" disabled />
+      </div>
+    </div>
+  );
+}
+
+export default defineGallerySection({
+  id: "inputs",
+  entries: [
+    {
+      id: "label",
+      name: "Label",
+      description: "Text label paired with inputs for accessible forms",
+      kind: "primitive",
+      tags: ["label", "input"],
+      props: [
+        { name: "htmlFor", type: "string" },
+        { name: "className", type: "string" },
+      ],
+      axes: [
+        {
+          id: "state",
+          label: "State",
+          type: "state",
+          values: [
+            { value: "Default" },
+            { value: "Disabled" },
+          ],
+        },
+      ],
+      preview: createGalleryPreview({
+        id: "ui:label:pairing",
+        render: () => <LabelGalleryPreview />,
+      }),
+      code: `<div className="w-64 space-y-[var(--space-3)]">
+  <div>
+    <Label htmlFor="label-default">Email</Label>
+    <Input id="label-default" placeholder="player@example.gg" />
+  </div>
+  <div className="opacity-80">
+    <Label htmlFor="label-disabled">Disabled</Label>
+    <Input id="label-disabled" placeholder="Disabled input" disabled />
+  </div>
+</div>`,
+    },
+  ],
+});

--- a/src/components/ui/Select.gallery.tsx
+++ b/src/components/ui/Select.gallery.tsx
@@ -1,0 +1,95 @@
+import * as React from "react";
+
+import { createGalleryPreview, defineGallerySection } from "@/components/gallery";
+
+import Select from "./Select";
+
+const ITEMS = [
+  { value: "one", label: "One" },
+  { value: "two", label: "Two" },
+  { value: "three", label: "Three" },
+] as const;
+
+type ItemValue = (typeof ITEMS)[number]["value"];
+
+function SelectGalleryPreview() {
+  const [value, setValue] = React.useState<ItemValue>(ITEMS[0]?.value ?? "one");
+
+  return (
+    <div className="flex flex-col gap-[var(--space-3)]">
+      <Select
+        items={[...ITEMS]}
+        value={value}
+        onChange={(next) => setValue(next as ItemValue)}
+        placeholder="Animated select"
+      />
+      <Select
+        items={[...ITEMS]}
+        variant="native"
+        value={value}
+        onChange={(next) => setValue(next as ItemValue)}
+        aria-label="Native select"
+      />
+      <Select items={[...ITEMS]} disabled placeholder="Disabled select" />
+    </div>
+  );
+}
+
+export default defineGallerySection({
+  id: "inputs",
+  entries: [
+    {
+      id: "select",
+      name: "Select",
+      description: "Animated trigger with native fallback",
+      kind: "primitive",
+      tags: ["select", "input"],
+      props: [
+        {
+          name: "items",
+          type: "readonly { value: string; label: React.ReactNode }[]",
+          required: true,
+        },
+        { name: "value", type: "string | undefined" },
+        { name: "onChange", type: "(value: string) => void" },
+        { name: "placeholder", type: "string" },
+        { name: "variant", type: '"animated" | "native"', defaultValue: '"animated"' },
+        { name: "disabled", type: "boolean", defaultValue: "false" },
+      ],
+      axes: [
+        {
+          id: "variant",
+          label: "Variant",
+          type: "variant",
+          values: [
+            { value: "Animated" },
+            { value: "Native" },
+          ],
+        },
+        {
+          id: "state",
+          label: "State",
+          type: "state",
+          values: [
+            { value: "Default" },
+            { value: "Disabled" },
+          ],
+        },
+      ],
+      preview: createGalleryPreview({
+        id: "ui:select:variants",
+        render: () => <SelectGalleryPreview />,
+      }),
+      code: `const items = [
+  { value: "one", label: "One" },
+  { value: "two", label: "Two" },
+  { value: "three", label: "Three" },
+];
+const [value, setValue] = React.useState(items[0]?.value ?? "");
+
+<Select items={items} value={value} onChange={setValue} placeholder="Animated select" />
+<Select items={items} variant="native" value={value} onChange={setValue} />
+<Select items={items} disabled placeholder="Disabled select" />`,
+    },
+  ],
+});

--- a/src/components/ui/layout/Header.gallery.tsx
+++ b/src/components/ui/layout/Header.gallery.tsx
@@ -1,0 +1,154 @@
+import * as React from "react";
+import { Circle, CircleCheck, CircleDot } from "lucide-react";
+
+import { createGalleryPreview, defineGallerySection } from "@/components/gallery";
+
+import Header, { type HeaderTabsProps } from "./Header";
+
+const headerTabs: HeaderTabsProps<string>["items"] = [
+  {
+    key: "summary",
+    label: "Summary",
+    icon: (
+      <Circle
+        aria-hidden="true"
+        className="h-[var(--space-4)] w-[var(--space-4)]"
+      />
+    ),
+  },
+  {
+    key: "timeline",
+    label: "Timeline",
+    icon: (
+      <CircleDot
+        aria-hidden="true"
+        className="h-[var(--space-4)] w-[var(--space-4)]"
+      />
+    ),
+  },
+  {
+    key: "insights",
+    label: "Insights",
+    icon: (
+      <CircleCheck
+        aria-hidden="true"
+        className="h-[var(--space-4)] w-[var(--space-4)]"
+      />
+    ),
+    disabled: true,
+  },
+];
+
+function HeaderGalleryPreview() {
+  const [value, setValue] = React.useState<string>(
+    () => headerTabs.find((tab) => !tab.disabled)?.key ?? headerTabs[0]?.key ?? "",
+  );
+  const activeLabel = React.useMemo(
+    () => headerTabs.find((tab) => tab.key === value)?.label ?? null,
+    [value],
+  );
+
+  return (
+    <Header
+      heading="Header"
+      subtitle="Segmented navigation anchored to the header"
+      tabs={{
+        items: headerTabs,
+        value,
+        onChange: setValue,
+        ariaLabel: "Header demo tabs",
+        size: "md",
+      }}
+      sticky={false}
+      topClassName="top-0"
+    >
+      <p className="text-ui text-muted-foreground">
+        Viewing
+        <span className="ml-[var(--space-1)] font-medium text-foreground">
+          {activeLabel}
+        </span>
+      </p>
+    </Header>
+  );
+}
+
+export default defineGallerySection({
+  id: "layout",
+  entries: [
+    {
+      id: "header",
+      name: "Header",
+      description: "Workspace header with sticky support and segmented tabs",
+      kind: "component",
+      tags: ["header", "navigation"],
+      axes: [
+        {
+          id: "tab-state",
+          label: "Tab state",
+          type: "state",
+          values: [
+            { value: "Active" },
+            { value: "Inactive" },
+            { value: "Disabled" },
+          ],
+        },
+      ],
+      preview: createGalleryPreview({
+        id: "ui:header:tabs",
+        render: () => <HeaderGalleryPreview />,
+      }),
+      code: `<Header
+  heading="Header"
+  subtitle="Segmented navigation anchored to the header"
+  tabs={{
+    items: [
+      {
+        key: "summary",
+        label: "Summary",
+        icon: (
+          <Circle
+            aria-hidden="true"
+            className="h-[var(--space-4)] w-[var(--space-4)]"
+          />
+        ),
+      },
+      {
+        key: "timeline",
+        label: "Timeline",
+        icon: (
+          <CircleDot
+            aria-hidden="true"
+            className="h-[var(--space-4)] w-[var(--space-4)]"
+          />
+        ),
+      },
+      {
+        key: "insights",
+        label: "Insights",
+        icon: (
+          <CircleCheck
+            aria-hidden="true"
+            className="h-[var(--space-4)] w-[var(--space-4)]"
+          />
+        ),
+        disabled: true,
+      },
+    ],
+    value: "summary",
+    onChange: () => {},
+    ariaLabel: "Header demo tabs",
+    size: "md",
+  }}
+  sticky={false}
+  topClassName="top-0"
+>
+  <p className="text-ui text-muted-foreground">
+    Viewing
+    <span className="ml-[var(--space-1)] font-medium text-foreground">
+      Summary
+    </span>
+  </p>
+</Header>`,
+    },
+  ],
+});

--- a/src/components/ui/layout/TabBar.gallery.tsx
+++ b/src/components/ui/layout/TabBar.gallery.tsx
@@ -1,0 +1,128 @@
+import * as React from "react";
+import { Circle, CircleCheck, CircleDot } from "lucide-react";
+
+import { createGalleryPreview, defineGallerySection } from "@/components/gallery";
+
+import TabBar, { type TabItem } from "./TabBar";
+
+const filterItems: TabItem<string>[] = [
+  { key: "all", label: "All", icon: <Circle aria-hidden="true" /> },
+  { key: "active", label: "Active", icon: <CircleDot aria-hidden="true" /> },
+  { key: "done", label: "Done", icon: <CircleCheck aria-hidden="true" /> },
+];
+
+const defaultItems: TabItem<string>[] = [
+  { key: "a", label: "A" },
+  { key: "b", label: "B" },
+  { key: "c", label: "Disabled", disabled: true },
+  { key: "d", label: "Syncing", loading: true },
+];
+
+const navigationItems: TabItem<string>[] = [
+  { key: "reviews", label: "Reviews" },
+  { key: "planner", label: "Planner" },
+  { key: "goals", label: "Goals" },
+];
+
+function TabBarGalleryPreview() {
+  const [filterTab, setFilterTab] = React.useState<string>(filterItems[1]?.key ?? "all");
+  const [defaultTab, setDefaultTab] = React.useState<string>(defaultItems[0]?.key ?? "a");
+  const [navigationTab, setNavigationTab] = React.useState<string>(
+    navigationItems[0]?.key ?? "reviews",
+  );
+
+  return (
+    <div className="flex flex-col gap-[var(--space-4)]">
+      <TabBar
+        items={filterItems}
+        value={filterTab}
+        onValueChange={setFilterTab}
+        ariaLabel="Filter goals"
+      />
+      <TabBar
+        items={defaultItems}
+        value={defaultTab}
+        onValueChange={setDefaultTab}
+        ariaLabel="Example tabs"
+      />
+      <TabBar
+        items={navigationItems}
+        value={navigationTab}
+        onValueChange={setNavigationTab}
+        ariaLabel="Planner areas"
+      />
+    </div>
+  );
+}
+
+export default defineGallerySection({
+  id: "toggles",
+  entries: [
+    {
+      id: "tab-bar",
+      name: "TabBar",
+      description: "Segmented tab navigation with preset variants",
+      kind: "primitive",
+      tags: ["tabs", "navigation"],
+      axes: [
+        {
+          id: "variant",
+          label: "Variant",
+          type: "variant",
+          values: [
+            { value: "Filters" },
+            { value: "Default" },
+            { value: "Navigation" },
+          ],
+        },
+        {
+          id: "state",
+          label: "State",
+          type: "state",
+          values: [
+            { value: "Active" },
+            { value: "Disabled" },
+            { value: "Loading" },
+          ],
+        },
+      ],
+      preview: createGalleryPreview({
+        id: "ui:tab-bar:variants",
+        render: () => <TabBarGalleryPreview />,
+      }),
+      code: `<TabBar
+  items={[
+    { key: "all", label: "All", icon: <Circle aria-hidden="true" /> },
+    { key: "active", label: "Active", icon: <CircleDot aria-hidden="true" /> },
+    { key: "done", label: "Done", icon: <CircleCheck aria-hidden="true" /> },
+  ]}
+  value="active"
+  onValueChange={() => {}}
+  ariaLabel="Filter goals"
+/>
+
+<TabBar
+  items={[
+    { key: "a", label: "A" },
+    { key: "b", label: "B" },
+    { key: "c", label: "Disabled", disabled: true },
+    { key: "d", label: "Syncing", loading: true },
+  ]}
+  value="a"
+  onValueChange={() => {}}
+  ariaLabel="Example tabs"
+/>
+
+<TabBar
+  items={[
+    { key: "reviews", label: "Reviews" },
+    { key: "planner", label: "Planner" },
+    { key: "goals", label: "Goals" },
+  ]}
+  value="reviews"
+  onValueChange={() => {}}
+  ariaLabel="Planner areas"
+/>`,
+    },
+  ],
+});

--- a/src/components/ui/primitives/Badge.gallery.tsx
+++ b/src/components/ui/primitives/Badge.gallery.tsx
@@ -1,0 +1,129 @@
+import * as React from "react";
+
+import { createGalleryPreview, defineGallerySection } from "@/components/gallery";
+
+import Badge from "./Badge";
+
+const ROLE_BADGES = [
+  { tone: "top", label: "Top lane" },
+  { tone: "jungle", label: "Jungle" },
+  { tone: "mid", label: "Mid lane" },
+  { tone: "bot", label: "Bot lane" },
+  { tone: "support", label: "Support" },
+] as const;
+
+function BadgeGalleryPreview() {
+  return (
+    <div className="flex flex-col gap-[var(--space-3)]">
+      <div className="flex flex-wrap gap-[var(--space-2)]">
+        <Badge tone="neutral">Neutral</Badge>
+        <Badge tone="accent">Accent</Badge>
+        <Badge tone="primary">Primary</Badge>
+        <Badge tone="primary" interactive selected>
+          Selected
+        </Badge>
+        <Badge tone="accent" interactive disabled>
+          Disabled
+        </Badge>
+      </div>
+      <div className="flex flex-wrap gap-[var(--space-2)]">
+        {ROLE_BADGES.map(({ tone, label }) => (
+          <Badge key={tone} tone={tone} glitch>
+            {label}
+          </Badge>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default defineGallerySection({
+  id: "misc",
+  entries: [
+    {
+      id: "badge",
+      name: "Badge",
+      description: "Compact pill with tone-driven styles",
+      kind: "primitive",
+      tags: ["badge", "pill"],
+      props: [
+        {
+          name: "tone",
+          type:
+            '"neutral" | "primary" | "accent" | "top" | "jungle" | "mid" | "bot" | "support"',
+          defaultValue: '"neutral"',
+        },
+        {
+          name: "size",
+          type: '"xs" | "sm"',
+          defaultValue: '"sm"',
+        },
+        { name: "interactive", type: "boolean", defaultValue: "false" },
+        { name: "selected", type: "boolean", defaultValue: "false" },
+        { name: "glitch", type: "boolean", defaultValue: "false" },
+      ],
+      axes: [
+        {
+          id: "tone",
+          label: "Tone",
+          type: "variant",
+          values: [
+            { value: "Neutral" },
+            { value: "Accent" },
+            { value: "Primary" },
+            { value: "Top lane" },
+            { value: "Jungle" },
+            { value: "Mid lane" },
+            { value: "Bot lane" },
+            { value: "Support" },
+          ],
+        },
+        {
+          id: "state",
+          label: "State",
+          type: "state",
+          values: [
+            { value: "Default" },
+            { value: "Interactive" },
+            { value: "Selected" },
+            { value: "Disabled" },
+          ],
+        },
+      ],
+      preview: createGalleryPreview({
+        id: "ui:badge:tones",
+        render: () => <BadgeGalleryPreview />,
+      }),
+      code: `<div className="flex flex-col gap-[var(--space-3)]">
+  <div className="flex flex-wrap gap-[var(--space-2)]">
+    <Badge tone="neutral">Neutral</Badge>
+    <Badge tone="accent">Accent</Badge>
+    <Badge tone="primary">Primary</Badge>
+    <Badge tone="primary" interactive selected>
+      Selected
+    </Badge>
+    <Badge tone="accent" interactive disabled>
+      Disabled
+    </Badge>
+  </div>
+  <div className="flex flex-wrap gap-[var(--space-2)]">
+    <Badge tone="top" glitch>
+      Top lane
+    </Badge>
+    <Badge tone="jungle" glitch>
+      Jungle
+    </Badge>
+    <Badge tone="mid" glitch>
+      Mid lane
+    </Badge>
+    <Badge tone="bot" glitch>
+      Bot lane
+    </Badge>
+    <Badge tone="support" glitch>
+      Support
+    </Badge>
+  </div>
+</div>`,
+    },
+  ],
+});

--- a/src/components/ui/primitives/Button.gallery.tsx
+++ b/src/components/ui/primitives/Button.gallery.tsx
@@ -1,0 +1,166 @@
+import * as React from "react";
+import { Plus } from "lucide-react";
+
+import { createGalleryPreview, defineGallerySection } from "@/components/gallery";
+
+import Button from "./Button";
+
+const BUTTON_STATES = [
+  { label: "Default", className: undefined, props: { children: "Default" } },
+  {
+    label: "Hover",
+    className: "bg-[--hover]",
+    props: { children: "Hover" },
+  },
+  {
+    label: "Focus",
+    className: "ring-2 ring-[var(--focus)]",
+    props: { children: "Focus" },
+  },
+  {
+    label: "Active",
+    className: "bg-[--active]",
+    props: { children: "Active" },
+  },
+  {
+    label: "Disabled",
+    className: undefined,
+    props: { children: "Disabled", disabled: true },
+  },
+  {
+    label: "Loading",
+    className: undefined,
+    props: { children: "Loading", loading: true },
+  },
+] satisfies ReadonlyArray<{
+  label: string;
+  className?: string;
+  props: React.ComponentProps<typeof Button>;
+}>;
+
+function ButtonGalleryPreview() {
+  return (
+    <div className="flex flex-col gap-[var(--space-4)]">
+      <div className="flex flex-wrap gap-[var(--space-2)]">
+        <Button tone="primary">Primary tone</Button>
+        <Button tone="accent">Accent tone</Button>
+        <Button tone="info" variant="ghost">
+          Info ghost
+        </Button>
+        <Button tone="danger" variant="primary">
+          Danger primary
+        </Button>
+        <Button disabled>Disabled</Button>
+      </div>
+      <div className="flex flex-wrap items-center gap-[var(--space-2)]">
+        <Button size="sm">
+          <Plus aria-hidden />
+          Small
+        </Button>
+        <Button size="md">
+          <Plus aria-hidden />
+          Medium
+        </Button>
+        <Button size="lg">
+          <Plus aria-hidden />
+          Large
+        </Button>
+      </div>
+      <div className="flex flex-wrap gap-[var(--space-2)]">
+        {BUTTON_STATES.map(({ label, className, props }) => (
+          <Button key={label} className={className} {...props} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default defineGallerySection({
+  id: "buttons",
+  entries: [
+    {
+      id: "button",
+      name: "Button",
+      description: "Tone, size, and interaction states",
+      kind: "primitive",
+      tags: ["button", "action"],
+      props: [
+        {
+          name: "variant",
+          type: '"primary" | "secondary" | "ghost"',
+        },
+        {
+          name: "tone",
+          type: '"primary" | "accent" | "info" | "danger"',
+        },
+        {
+          name: "size",
+          type: '"sm" | "md" | "lg"',
+        },
+        {
+          name: "loading",
+          type: "boolean",
+          defaultValue: "false",
+        },
+      ],
+      axes: [
+        {
+          id: "tone",
+          label: "Tone",
+          type: "variant",
+          values: [
+            { value: "Primary" },
+            { value: "Accent" },
+            { value: "Info" },
+            { value: "Danger" },
+          ],
+        },
+        {
+          id: "state",
+          label: "State",
+          type: "state",
+          values: BUTTON_STATES.map(({ label }) => ({ value: label })),
+        },
+      ],
+      preview: createGalleryPreview({
+        id: "ui:button:matrix",
+        render: () => <ButtonGalleryPreview />,
+      }),
+      code: `<div className="flex flex-col gap-[var(--space-4)]">
+  <div className="flex flex-wrap gap-[var(--space-2)]">
+    <Button tone="primary">Primary tone</Button>
+    <Button tone="accent">Accent tone</Button>
+    <Button tone="info" variant="ghost">
+      Info ghost
+    </Button>
+    <Button tone="danger" variant="primary">
+      Danger primary
+    </Button>
+    <Button disabled>Disabled</Button>
+  </div>
+  <div className="flex flex-wrap items-center gap-[var(--space-2)]">
+    <Button size="sm">
+      <Plus />
+      Small
+    </Button>
+    <Button size="md">
+      <Plus />
+      Medium
+    </Button>
+    <Button size="lg">
+      <Plus />
+      Large
+    </Button>
+  </div>
+  <div className="flex flex-wrap gap-[var(--space-2)]">
+    <Button>Default</Button>
+    <Button className="bg-[--hover]">Hover</Button>
+    <Button className="ring-2 ring-[var(--focus)]">Focus</Button>
+    <Button className="bg-[--active]">Active</Button>
+    <Button disabled>Disabled</Button>
+    <Button loading>Loading</Button>
+  </div>
+</div>`,
+    },
+  ],
+});

--- a/src/components/ui/primitives/Field.gallery.tsx
+++ b/src/components/ui/primitives/Field.gallery.tsx
@@ -1,0 +1,149 @@
+import * as React from "react";
+
+import { createGalleryPreview, defineGallerySection } from "@/components/gallery";
+
+import Field from "./Field";
+
+const options = [
+  { value: "one", label: "One" },
+  { value: "two", label: "Two" },
+];
+
+function FieldGalleryPreview() {
+  const [search, setSearch] = React.useState("Scouting");
+
+  return (
+    <div className="flex flex-col gap-[var(--space-3)]">
+      <Field.Root helper="Compose primitives">
+        <Field.Input placeholder="Default field" />
+      </Field.Root>
+
+      <Field.Root invalid helper="Incorrect format" helperTone="danger">
+        <Field.Input placeholder="Invalid field" aria-invalid />
+      </Field.Root>
+
+      <Field.Root loading helper="Loading state">
+        <Field.Input placeholder="Loading field" />
+      </Field.Root>
+
+      <Field.Root disabled helper="Disabled field">
+        <Field.Input placeholder="Disabled field" disabled />
+      </Field.Root>
+
+      <Field.Root
+        counter="120 / 200"
+        counterId="field-counter"
+        helper="Helper with counter"
+        helperId="field-helper"
+      >
+        <Field.Textarea
+          aria-describedby="field-helper field-counter"
+          placeholder="Textarea within a field"
+          rows={3}
+        />
+      </Field.Root>
+
+      <Field.Root>
+        <Field.Select defaultValue="one">
+          {options.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </Field.Select>
+      </Field.Root>
+
+      <Field.Root>
+        <Field.Search
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search fields"
+          clearLabel="Clear search"
+        />
+      </Field.Root>
+    </div>
+  );
+}
+
+export default defineGallerySection({
+  id: "inputs",
+  entries: [
+    {
+      id: "field",
+      name: "Field",
+      description: "Composable shell for custom inputs, search, and selects",
+      kind: "primitive",
+      tags: ["field", "input"],
+      props: [
+        { name: "height", type: '"sm" | "md" | "lg" | number', defaultValue: '"md"' },
+        { name: "disabled", type: "boolean", defaultValue: "false" },
+        { name: "invalid", type: "boolean", defaultValue: "false" },
+        { name: "loading", type: "boolean", defaultValue: "false" },
+        { name: "readOnly", type: "boolean", defaultValue: "false" },
+        { name: "helper", type: "React.ReactNode" },
+        { name: "helperTone", type: '"muted" | "danger" | "success"' },
+        { name: "counter", type: "React.ReactNode" },
+      ],
+      axes: [
+        {
+          id: "state",
+          label: "State",
+          type: "state",
+          values: [
+            { value: "Default" },
+            { value: "Invalid" },
+            { value: "Loading" },
+            { value: "Disabled" },
+            { value: "With counter" },
+            { value: "Search" },
+            { value: "Select" },
+          ],
+        },
+      ],
+      preview: createGalleryPreview({
+        id: "ui:field:states",
+        render: () => <FieldGalleryPreview />,
+      }),
+      code: `const [search, setSearch] = React.useState("Scouting");
+
+<Field.Root helper="Compose primitives">
+  <Field.Input placeholder="Default field" />
+</Field.Root>
+<Field.Root invalid helper="Incorrect format" helperTone="danger">
+  <Field.Input placeholder="Invalid field" aria-invalid />
+</Field.Root>
+<Field.Root loading helper="Loading state">
+  <Field.Input placeholder="Loading field" />
+</Field.Root>
+<Field.Root disabled helper="Disabled field">
+  <Field.Input placeholder="Disabled field" disabled />
+</Field.Root>
+<Field.Root
+  counter="120 / 200"
+  counterId="field-counter"
+  helper="Helper with counter"
+  helperId="field-helper"
+>
+  <Field.Textarea
+    aria-describedby="field-helper field-counter"
+    placeholder="Textarea within a field"
+    rows={3}
+  />
+</Field.Root>
+<Field.Root>
+  <Field.Select defaultValue="one">
+    <option value="one">One</option>
+    <option value="two">Two</option>
+  </Field.Select>
+</Field.Root>
+<Field.Root>
+  <Field.Search
+    value={search}
+    onChange={(event) => setSearch(event.target.value)}
+    placeholder="Search fields"
+    clearLabel="Clear search"
+  />
+</Field.Root>`,
+    },
+  ],
+});

--- a/src/components/ui/primitives/IconButton.gallery.tsx
+++ b/src/components/ui/primitives/IconButton.gallery.tsx
@@ -1,0 +1,179 @@
+import * as React from "react";
+import { Plus } from "lucide-react";
+
+import { createGalleryPreview, defineGallerySection } from "@/components/gallery";
+
+import IconButton from "./IconButton";
+
+const ICON_BUTTON_STATES = [
+  {
+    label: "Default",
+    className: undefined,
+    props: { "aria-label": "Default", children: <Plus aria-hidden /> },
+  },
+  {
+    label: "Hover",
+    className: "bg-[--hover]",
+    props: { "aria-label": "Hover", children: <Plus aria-hidden /> },
+  },
+  {
+    label: "Focus",
+    className: "ring-2 ring-[var(--focus)]",
+    props: { "aria-label": "Focus", children: <Plus aria-hidden /> },
+  },
+  {
+    label: "Active",
+    className: "bg-[--active]",
+    props: {
+      "aria-label": "Active",
+      "aria-pressed": true,
+      children: <Plus aria-hidden />,
+    },
+  },
+  {
+    label: "Disabled",
+    className: undefined,
+    props: {
+      "aria-label": "Disabled",
+      children: <Plus aria-hidden />,
+      disabled: true,
+    },
+  },
+  {
+    label: "Loading",
+    className: undefined,
+    props: {
+      "aria-label": "Loading",
+      children: <Plus aria-hidden />,
+      loading: true,
+    },
+  },
+] satisfies ReadonlyArray<{
+  label: string;
+  className?: string;
+  props: React.ComponentProps<typeof IconButton>;
+}>;
+
+const ICON_BUTTON_SIZES = ["xs", "sm", "md", "lg", "xl"] as const;
+
+function IconButtonGalleryPreview() {
+  return (
+    <div className="flex flex-col gap-[var(--space-4)]">
+      <div className="flex flex-wrap gap-[var(--space-2)]">
+        {ICON_BUTTON_SIZES.map((size) => (
+          <IconButton
+            key={size}
+            size={size}
+            variant="ring"
+            aria-label={`Add item ${size}`}
+          >
+            <Plus aria-hidden />
+          </IconButton>
+        ))}
+        <IconButton size="md" variant="glow" aria-label="Add item glow">
+          <Plus aria-hidden />
+        </IconButton>
+      </div>
+      <div className="flex flex-wrap gap-[var(--space-2)]">
+        {ICON_BUTTON_STATES.map(({ label, className, props }) => (
+          <IconButton key={label} className={className} {...props} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default defineGallerySection({
+  id: "buttons",
+  entries: [
+    {
+      id: "icon-button",
+      name: "IconButton",
+      description: "Size, variant, and state coverage",
+      kind: "primitive",
+      tags: ["button", "icon"],
+      props: [
+        {
+          name: "variant",
+          type: '"ring" | "glow"',
+        },
+        {
+          name: "size",
+          type: '"xs" | "sm" | "md" | "lg" | "xl"',
+        },
+        {
+          name: "loading",
+          type: "boolean",
+          defaultValue: "false",
+        },
+      ],
+      axes: [
+        {
+          id: "variant",
+          label: "Variant",
+          type: "variant",
+          values: [
+            { value: "Ring" },
+            { value: "Glow" },
+          ],
+        },
+        {
+          id: "state",
+          label: "State",
+          type: "state",
+          values: ICON_BUTTON_STATES.map(({ label }) => ({ value: label })),
+        },
+      ],
+      preview: createGalleryPreview({
+        id: "ui:icon-button:matrix",
+        render: () => <IconButtonGalleryPreview />,
+      }),
+      code: `<div className="flex flex-col gap-[var(--space-4)]">
+  <div className="flex flex-wrap gap-[var(--space-2)]">
+    <IconButton size="xs" variant="ring" aria-label="Add item xs">
+      <Plus />
+    </IconButton>
+    <IconButton size="sm" variant="ring" aria-label="Add item sm">
+      <Plus />
+    </IconButton>
+    <IconButton size="md" variant="ring" aria-label="Add item md">
+      <Plus />
+    </IconButton>
+    <IconButton size="lg" variant="ring" aria-label="Add item lg">
+      <Plus />
+    </IconButton>
+    <IconButton size="xl" variant="ring" aria-label="Add item xl">
+      <Plus />
+    </IconButton>
+    <IconButton size="md" variant="glow" aria-label="Add item glow">
+      <Plus />
+    </IconButton>
+  </div>
+  <div className="flex flex-wrap gap-[var(--space-2)]">
+    <IconButton aria-label="Default">
+      <Plus />
+    </IconButton>
+    <IconButton className="bg-[--hover]" aria-label="Hover">
+      <Plus />
+    </IconButton>
+    <IconButton className="ring-2 ring-[var(--focus)]" aria-label="Focus">
+      <Plus />
+    </IconButton>
+    <IconButton
+      className="bg-[--active]"
+      aria-pressed
+      aria-label="Active"
+    >
+      <Plus />
+    </IconButton>
+    <IconButton disabled aria-label="Disabled">
+      <Plus />
+    </IconButton>
+    <IconButton loading aria-label="Loading">
+      <Plus />
+    </IconButton>
+  </div>
+</div>`,
+    },
+  ],
+});

--- a/src/components/ui/primitives/Input.gallery.tsx
+++ b/src/components/ui/primitives/Input.gallery.tsx
@@ -1,0 +1,91 @@
+import * as React from "react";
+
+import { createGalleryPreview, defineGallerySection } from "@/components/gallery";
+
+import Input from "./Input";
+
+const INPUT_STATES = [
+  {
+    label: "Default",
+    className: undefined,
+    props: { placeholder: "Default" },
+  },
+  {
+    label: "Hover",
+    className: "bg-[--hover]",
+    props: { placeholder: "Hover" },
+  },
+  {
+    label: "Focus",
+    className: "ring-2 ring-[var(--focus)]",
+    props: { placeholder: "Focus" },
+  },
+  {
+    label: "Active",
+    className: "bg-[--active]",
+    props: { placeholder: "Active" },
+  },
+  {
+    label: "Disabled",
+    className: undefined,
+    props: { placeholder: "Disabled", disabled: true },
+  },
+  {
+    label: "Loading",
+    className: undefined,
+    props: { placeholder: "Loading", "data-loading": true },
+  },
+] satisfies ReadonlyArray<{
+  label: string;
+  className?: string;
+  props: React.ComponentProps<typeof Input>;
+}>;
+
+function InputGalleryPreview() {
+  return (
+    <div className="flex flex-col gap-[var(--space-2)]">
+      {INPUT_STATES.map(({ label, className, props }) => (
+        <Input key={label} className={className} {...props} />
+      ))}
+    </div>
+  );
+}
+
+export default defineGallerySection({
+  id: "inputs",
+  entries: [
+    {
+      id: "input",
+      name: "Input",
+      description: "Standard text input with semantic states",
+      kind: "primitive",
+      tags: ["input", "text"],
+      props: [
+        { name: "placeholder", type: "string" },
+        { name: "height", type: '"sm" | "md" | "lg"', defaultValue: '"md"' },
+        { name: "disabled", type: "boolean", defaultValue: "false" },
+        { name: "data-loading", type: "boolean", defaultValue: "false" },
+      ],
+      axes: [
+        {
+          id: "state",
+          label: "State",
+          type: "state",
+          values: INPUT_STATES.map(({ label }) => ({ value: label })),
+        },
+      ],
+      preview: createGalleryPreview({
+        id: "ui:input:states",
+        render: () => <InputGalleryPreview />,
+      }),
+      code: `<div className="flex flex-col gap-[var(--space-2)]">
+  <Input placeholder="Default" />
+  <Input placeholder="Hover" className="bg-[--hover]" />
+  <Input placeholder="Focus" className="ring-2 ring-[var(--focus)]" />
+  <Input placeholder="Active" className="bg-[--active]" />
+  <Input placeholder="Disabled" disabled />
+  <Input placeholder="Loading" data-loading />
+</div>`,
+    },
+  ],
+});

--- a/src/components/ui/primitives/SearchBar.gallery.tsx
+++ b/src/components/ui/primitives/SearchBar.gallery.tsx
@@ -1,0 +1,109 @@
+import * as React from "react";
+
+import { createGalleryPreview, defineGallerySection } from "@/components/gallery";
+import { Button } from "@/components/ui";
+
+import SearchBar from "./SearchBar";
+
+function SearchBarGalleryPreview() {
+  const [query, setQuery] = React.useState("Champion counters");
+  const handleNoop = React.useCallback((_value: string) => {
+    void _value;
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-[var(--space-3)]">
+      <SearchBar
+        value={query}
+        onValueChange={setQuery}
+        placeholder="Search components"
+      />
+      <SearchBar
+        value=""
+        onValueChange={handleNoop}
+        label="Search library"
+        placeholder="With label"
+        right={<Button size="sm">Filters</Button>}
+      />
+      <SearchBar
+        value="Disabled"
+        onValueChange={handleNoop}
+        placeholder="Disabled"
+        disabled
+      />
+      <SearchBar
+        value="Loading"
+        onValueChange={handleNoop}
+        placeholder="Loading"
+        loading
+      />
+    </div>
+  );
+}
+
+export default defineGallerySection({
+  id: "inputs",
+  entries: [
+    {
+      id: "search-bar",
+      name: "SearchBar",
+      description: "Debounced search input with optional label and slots",
+      kind: "primitive",
+      tags: ["search", "input"],
+      props: [
+        { name: "value", type: "string", required: true },
+        { name: "onValueChange", type: "(value: string) => void" },
+        { name: "placeholder", type: "string" },
+        { name: "label", type: "React.ReactNode" },
+        { name: "right", type: "React.ReactNode" },
+        { name: "loading", type: "boolean", defaultValue: "false" },
+        { name: "disabled", type: "boolean", defaultValue: "false" },
+        { name: "variant", type: '"default" | "neo"', defaultValue: '"default"' },
+      ],
+      axes: [
+        {
+          id: "state",
+          label: "State",
+          type: "state",
+          values: [
+            { value: "Default" },
+            { value: "With label" },
+            { value: "Disabled" },
+            { value: "Loading" },
+          ],
+        },
+      ],
+      preview: createGalleryPreview({
+        id: "ui:search-bar:states",
+        render: () => <SearchBarGalleryPreview />,
+      }),
+      code: `const [query, setQuery] = React.useState("Champion counters");
+const handleNoop = React.useCallback((_value: string) => {}, []);
+
+<SearchBar
+  value={query}
+  onValueChange={setQuery}
+  placeholder="Search components"
+/>
+<SearchBar
+  value=""
+  onValueChange={handleNoop}
+  label="Search library"
+  placeholder="With label"
+  right={<Button size="sm">Filters</Button>}
+/>
+<SearchBar
+  value="Disabled"
+  onValueChange={handleNoop}
+  placeholder="Disabled"
+  disabled
+/>
+<SearchBar
+  value="Loading"
+  onValueChange={handleNoop}
+  placeholder="Loading"
+  loading
+/>`,
+    },
+  ],
+});

--- a/src/components/ui/primitives/SegmentedButton.gallery.tsx
+++ b/src/components/ui/primitives/SegmentedButton.gallery.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+
+import { createGalleryPreview, defineGallerySection } from "@/components/gallery";
+
+import SegmentedButton from "./SegmentedButton";
+
+const SEGMENTED_BUTTON_STATES = [
+  { label: "Default", props: { children: "Default" } },
+  { label: "Active", props: { children: "Active", isActive: true } },
+  { label: "Disabled", props: { children: "Disabled", disabled: true } },
+  { label: "Loading", props: { children: "Loading", loading: true } },
+] satisfies ReadonlyArray<{
+  label: string;
+  props: React.ComponentProps<typeof SegmentedButton>;
+}>;
+
+function SegmentedButtonGalleryPreview() {
+  return (
+    <div className="flex flex-wrap gap-[var(--space-2)]">
+      {SEGMENTED_BUTTON_STATES.map(({ label, props }) => (
+        <SegmentedButton key={label} {...props} />
+      ))}
+    </div>
+  );
+}
+
+export default defineGallerySection({
+  id: "buttons",
+  entries: [
+    {
+      id: "segmented-button",
+      name: "SegmentedButton",
+      description: "Inline segmented action with pressed and loading states",
+      kind: "primitive",
+      tags: ["button", "segmented"],
+      props: [
+        { name: "as", type: "React.ElementType" },
+        { name: "href", type: "string" },
+        { name: "isActive", type: "boolean", defaultValue: "false" },
+        { name: "loading", type: "boolean", defaultValue: "false" },
+        { name: "disabled", type: "boolean", defaultValue: "false" },
+      ],
+      axes: [
+        {
+          id: "state",
+          label: "State",
+          type: "state",
+          values: SEGMENTED_BUTTON_STATES.map(({ label }) => ({ value: label })),
+        },
+      ],
+      preview: createGalleryPreview({
+        id: "ui:segmented-button:states",
+        render: () => <SegmentedButtonGalleryPreview />,
+      }),
+      code: `<div className="flex flex-wrap gap-[var(--space-2)]">
+  <SegmentedButton>Default</SegmentedButton>
+  <SegmentedButton isActive>Active</SegmentedButton>
+  <SegmentedButton disabled>Disabled</SegmentedButton>
+  <SegmentedButton loading>Loading</SegmentedButton>
+</div>`,
+    },
+  ],
+});

--- a/src/components/ui/primitives/Textarea.gallery.tsx
+++ b/src/components/ui/primitives/Textarea.gallery.tsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+
+import { createGalleryPreview, defineGallerySection } from "@/components/gallery";
+
+import Textarea from "./Textarea";
+
+const TEXTAREA_STATES = [
+  { label: "Default", props: { placeholder: "Share your thoughts" } },
+  {
+    label: "Invalid",
+    props: { placeholder: "Needs attention", "aria-invalid": true },
+  },
+  {
+    label: "Read only",
+    props: { placeholder: "Read only", readOnly: true },
+  },
+  {
+    label: "Disabled",
+    props: { placeholder: "Disabled", disabled: true },
+  },
+] satisfies ReadonlyArray<{
+  label: string;
+  props: React.ComponentProps<typeof Textarea>;
+}>;
+
+function TextareaGalleryPreview() {
+  return (
+    <div className="flex flex-col gap-[var(--space-2)]">
+      {TEXTAREA_STATES.map(({ label, props }) => (
+        <Textarea key={label} {...props} />
+      ))}
+      <Textarea
+        placeholder="Resizable textarea"
+        resize="resize-y"
+        aria-label="Resizable textarea"
+      />
+    </div>
+  );
+}
+
+export default defineGallerySection({
+  id: "inputs",
+  entries: [
+    {
+      id: "textarea",
+      name: "Textarea",
+      description: "Multi-line text input with Field styling",
+      kind: "primitive",
+      tags: ["textarea", "input"],
+      props: [
+        { name: "placeholder", type: "string" },
+        { name: "disabled", type: "boolean", defaultValue: "false" },
+        { name: "readOnly", type: "boolean", defaultValue: "false" },
+        {
+          name: "aria-invalid",
+          type: 'boolean | "grammar" | "spelling" | undefined',
+        },
+        { name: "resize", type: "string" },
+      ],
+      axes: [
+        {
+          id: "state",
+          label: "State",
+          type: "state",
+          values: TEXTAREA_STATES.map(({ label }) => ({ value: label })),
+        },
+      ],
+      preview: createGalleryPreview({
+        id: "ui:textarea:states",
+        render: () => <TextareaGalleryPreview />,
+      }),
+      code: `<Textarea placeholder="Share your thoughts" />
+<Textarea placeholder="Needs attention" aria-invalid />
+<Textarea placeholder="Read only" readOnly />
+<Textarea placeholder="Disabled" disabled />
+<Textarea placeholder="Resizable textarea" resize="resize-y" aria-label="Resizable textarea" />`,
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- add gallery modules for core UI primitives and header components with updated state/variant metadata
- expose gallery utilities through a central index and clean up prompts constants/legacy specs
- update the verify-prompts script to ignore gallery/meta helper files

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ccf11d503c832cabc3a101827a2cc2