### PR TITLE
feat: add design token explorer

### DIFF
--- a/src/components/components/ComponentsPage.tsx
+++ b/src/components/components/ComponentsPage.tsx
@@ -1,7 +1,16 @@
 import ComponentsPageClient from "./ComponentsPageClient";
-import { loadGalleryNavigation } from "@/components/gallery/loader";
+import {
+  loadDesignTokenGroups,
+  loadGalleryNavigation,
+} from "@/components/gallery/loader";
 
 export default async function ComponentsPage() {
-  const navigation = await loadGalleryNavigation();
-  return <ComponentsPageClient navigation={navigation} />;
+  const [navigation, tokenGroups] = await Promise.all([
+    loadGalleryNavigation(),
+    loadDesignTokenGroups(),
+  ]);
+
+  return (
+    <ComponentsPageClient navigation={navigation} tokenGroups={tokenGroups} />
+  );
 }

--- a/src/components/components/ComponentsPageClient.tsx
+++ b/src/components/components/ComponentsPageClient.tsx
@@ -13,6 +13,7 @@ import {
   type GalleryNavigationData,
   type GalleryNavigationSection,
   type GallerySectionGroupKey,
+  type DesignTokenGroup,
 } from "@/components/gallery/loader";
 import { formatGallerySectionLabel } from "@/components/gallery";
 import type { GallerySerializableEntry } from "@/components/gallery";
@@ -57,6 +58,7 @@ type ComponentsView = GallerySectionGroupKey;
 
 interface ComponentsPageClientProps {
   navigation: GalleryNavigationData;
+  tokenGroups: readonly DesignTokenGroup[];
 }
 
 const DEFAULT_FALLBACK_COPY: GalleryHeroCopy = {
@@ -67,6 +69,7 @@ const DEFAULT_FALLBACK_COPY: GalleryHeroCopy = {
 
 export default function ComponentsPageClient({
   navigation,
+  tokenGroups,
 }: ComponentsPageClientProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -574,7 +577,7 @@ export default function ComponentsPageClient({
           aria-hidden={view !== "tokens"}
           className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
-          <ColorsView />
+          <ColorsView groups={tokenGroups} />
         </div>
       </section>
     </PageShell>

--- a/src/components/gallery/loader.ts
+++ b/src/components/gallery/loader.ts
@@ -3,6 +3,7 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import fg from "fast-glob";
+import tokens from "../../../tokens/tokens.js";
 import {
   createGalleryRegistry,
   type GalleryEntryKind,
@@ -18,6 +19,12 @@ import {
   type GallerySectionGroupKey,
   type GallerySectionMeta,
 } from "./metadata";
+import {
+  buildDesignTokenGroups,
+  type DesignTokenGroup,
+} from "@/lib/design-token-registry";
+
+const DESIGN_TOKEN_GROUPS = buildDesignTokenGroups(tokens);
 
 interface GalleryModule {
   default: GallerySection | GallerySection[];
@@ -46,7 +53,7 @@ export interface GalleryLoaderSlices {
   primitives: readonly GallerySerializableEntry[];
   components: readonly GallerySerializableEntry[];
   complex: readonly GallerySerializableEntry[];
-  tokens: readonly GallerySerializableEntry[];
+  tokens: readonly DesignTokenGroup[];
 }
 
 export const loadGallerySlices = async (): Promise<GalleryLoaderSlices> => {
@@ -57,9 +64,13 @@ export const loadGallerySlices = async (): Promise<GalleryLoaderSlices> => {
     primitives: payload.byKind.primitive,
     components: payload.byKind.component,
     complex: payload.byKind.complex,
-    tokens: payload.byKind.token,
+    tokens: DESIGN_TOKEN_GROUPS,
   };
 };
+
+export const loadDesignTokenGroups = async (): Promise<
+  readonly DesignTokenGroup[]
+> => DESIGN_TOKEN_GROUPS;
 
 export const loadGalleryByKind = async (
   kind: GalleryEntryKind,
@@ -123,3 +134,4 @@ export const loadGalleryNavigation = async (): Promise<GalleryNavigationData> =>
 };
 
 export type { GalleryHeroCopy, GallerySectionGroupKey } from "./metadata";
+export type { DesignTokenGroup } from "@/lib/design-token-registry";

--- a/src/components/prompts/constants.tsx
+++ b/src/components/prompts/constants.tsx
@@ -7,18 +7,11 @@ import {
   type GallerySectionId,
   type GallerySerializableEntry,
 } from "@/components/gallery";
-import { COLOR_PALETTES } from "@/lib/theme";
 
 export type Section = GallerySectionId;
 export type GallerySpec = GallerySerializableEntry;
 
 export const SECTIONS = GALLERY_SECTION_IDS;
-
-export const COLOR_SECTIONS = [
-  { title: "Aurora", tokens: COLOR_PALETTES.aurora },
-  { title: "Neutrals", tokens: COLOR_PALETTES.neutrals },
-  { title: "Accents", tokens: COLOR_PALETTES.accents },
-] as const;
 
 const SECTION_ENTRIES = new Map<Section, readonly GallerySerializableEntry[]>(
   galleryPayload.sections.map((section) => [section.id, section.entries] as const),

--- a/src/lib/design-token-registry.ts
+++ b/src/lib/design-token-registry.ts
@@ -1,0 +1,180 @@
+export type DesignTokenCategory =
+  | "color"
+  | "spacing"
+  | "radius"
+  | "typography"
+  | "shadow"
+  | "z"
+  | "motion";
+
+export interface DesignTokenMeta {
+  readonly name: string;
+  readonly cssVar: string;
+  readonly originalName: string;
+  readonly value: string;
+  readonly category: DesignTokenCategory;
+  readonly search: string;
+}
+
+export interface DesignTokenGroup {
+  readonly id: DesignTokenCategory;
+  readonly label: string;
+  readonly tokens: readonly DesignTokenMeta[];
+}
+
+export const DESIGN_TOKEN_CATEGORY_ORDER: readonly DesignTokenCategory[] = [
+  "color",
+  "spacing",
+  "radius",
+  "typography",
+  "shadow",
+  "z",
+  "motion",
+] as const;
+
+export const DESIGN_TOKEN_CATEGORY_LABELS: Record<DesignTokenCategory, string> = {
+  color: "Color",
+  spacing: "Spacing",
+  radius: "Radius",
+  typography: "Typography",
+  shadow: "Shadow",
+  z: "Z-index",
+  motion: "Motion",
+};
+
+const EXACT_CATEGORY_OVERRIDES = new Map<string, DesignTokenCategory>([
+  ["shadow-color", "color"],
+  ["glow-strong", "color"],
+  ["glow-soft", "color"],
+]);
+
+const SPACING_SPECIFIC_NAMES = new Set<string>([
+  "control-px",
+  "header-stack",
+  "hairline-w",
+]);
+
+const MOTION_PREFIXES = ["ease-", "dur-", "motion-"];
+
+const TYPOGRAPHY_SUFFIXES = ["-fs"];
+
+const SHADOW_NAMES = new Set<string>(["shadow"]);
+
+const toCssVarIdentifier = (original: string): string => {
+  const hyphenated = original
+    .replace(/([A-Z])/g, "-$1")
+    .replace(/([0-9]+)/g, "-$1")
+    .replace(/^-/, "")
+    .toLowerCase();
+
+  return hyphenated
+    .replace(/-0([0-9]+)/g, (_match, digits: string) => `-0-${digits}`)
+    .replace(/-{2,}/g, "-")
+    .replace(/^-/, "");
+};
+
+const categorizeDesignToken = (
+  name: string,
+  value: string,
+): DesignTokenCategory => {
+  const exact = EXACT_CATEGORY_OVERRIDES.get(name);
+  if (exact) {
+    return exact;
+  }
+
+  if (MOTION_PREFIXES.some((prefix) => name.startsWith(prefix))) {
+    return "motion";
+  }
+
+  if (name.startsWith("z-")) {
+    return "z";
+  }
+
+  if (name.startsWith("radius-") || name.endsWith("-radius")) {
+    return "radius";
+  }
+
+  if (
+    name.startsWith("spacing-") ||
+    name.startsWith("space-") ||
+    name.startsWith("control-h") ||
+    SPACING_SPECIFIC_NAMES.has(name)
+  ) {
+    return "spacing";
+  }
+
+  if (
+    name.startsWith("font-") ||
+    TYPOGRAPHY_SUFFIXES.some((suffix) => name.endsWith(suffix))
+  ) {
+    return "typography";
+  }
+
+  if (
+    SHADOW_NAMES.has(name) ||
+    name.startsWith("shadow-") ||
+    name.endsWith("-shadow")
+  ) {
+    return "shadow";
+  }
+
+  if (value.includes("cubic-bezier") || value.includes("ms")) {
+    return "motion";
+  }
+
+  return "color";
+};
+
+export const buildDesignTokenGroups = (
+  tokens: Record<string, string>,
+): readonly DesignTokenGroup[] => {
+  const groups = new Map<DesignTokenCategory, DesignTokenMeta[]>();
+
+  for (const category of DESIGN_TOKEN_CATEGORY_ORDER) {
+    groups.set(category, []);
+  }
+
+  for (const [originalName, rawValue] of Object.entries(tokens)) {
+    const value = rawValue.trim();
+    const name = toCssVarIdentifier(originalName);
+    const category = categorizeDesignToken(name, value);
+    const cssVar = `--${name}`;
+    const search = [name, cssVar, value, originalName, category]
+      .join(" ")
+      .toLowerCase();
+
+    const bucket = groups.get(category);
+    if (!bucket) {
+      continue;
+    }
+
+    bucket.push({
+      name,
+      cssVar,
+      originalName,
+      value,
+      category,
+      search,
+    });
+  }
+
+  const result: DesignTokenGroup[] = [];
+
+  for (const category of DESIGN_TOKEN_CATEGORY_ORDER) {
+    const bucket = groups.get(category);
+    if (!bucket || bucket.length === 0) {
+      continue;
+    }
+
+    bucket.sort((a, b) => a.name.localeCompare(b.name));
+
+    result.push({
+      id: category,
+      label: DESIGN_TOKEN_CATEGORY_LABELS[category],
+      tokens: bucket as readonly DesignTokenMeta[],
+    });
+  }
+
+  return result;
+};
+


### PR DESCRIPTION
## Summary
- add a design token registry helper and surface its data through the gallery loader
- replace the prompts ColorsView with a searchable token explorer that supports copy-to-clipboard and contextual previews
- load token groups on the components page and drop the static COLOR_SECTIONS constant

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cd3d8feac0832caac54cbdf8de6f3e