### PR TITLE
Use tokenized spacing and tone utilities in demos

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1884,6 +1884,36 @@ a:active .lucide {
 }
 
 @layer utilities {
+  .stack-xs {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .stack-sm {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .stack-md {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+
+  .stack-lg {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
+  .stack-xl {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+  }
+
   .text-muted-foreground {
     color: hsl(var(--muted-foreground));
   }

--- a/src/components/home/QuickActionGrid.tsx
+++ b/src/components/home/QuickActionGrid.tsx
@@ -7,13 +7,16 @@ import { cn } from "@/lib/utils";
 
 type QuickActionLayout = "stacked" | "grid";
 
+const ROOT_CLASSNAME =
+  "[--quick-actions-gap:var(--space-4)] [--quick-actions-column-width:calc(var(--space-4)*14)] [--quick-actions-lift:var(--spacing-0-5)]";
+
 const layoutClassNames: Record<QuickActionLayout, string> = {
-  stacked: "flex flex-col gap-[var(--space-4)]",
-  grid: "grid gap-[var(--space-4)]",
+  stacked: "flex flex-col gap-[var(--quick-actions-gap)]",
+  grid: "grid grid-cols-1 gap-[var(--quick-actions-gap)] sm:grid-cols-[repeat(auto-fit,minmax(var(--quick-actions-column-width),1fr))]",
 };
 
 const buttonBaseClassName =
-  "rounded-[var(--control-radius)] [--focus:var(--theme-ring)] focus-visible:ring-offset-0";
+  "rounded-[var(--control-radius)] [--focus:var(--theme-ring)] focus-visible:ring-offset-0 transition-transform duration-[var(--dur-quick)] ease-out motion-reduce:transition-none";
 
 type QuickActionDefinition = {
   href: string;
@@ -46,7 +49,7 @@ export default function QuickActionGrid({
   buttonVariant = "secondary",
 }: QuickActionGridProps) {
   return (
-    <div className={cn(layoutClassNames[layout], className)}>
+    <div className={cn(ROOT_CLASSNAME, layoutClassNames[layout], className)}>
       {actions.map((action, index) => {
         const {
           href,

--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -170,14 +170,13 @@ function SettingsSelectDemo() {
   );
 
   return (
-    <div className="space-y-[var(--space-2)]">
+    <div className="stack-sm">
       <SettingsSelect
         ariaLabel="Theme"
         prefixLabel="Theme"
         items={items}
         value={value}
         onChange={setValue}
-        className="w-56"
       />
       <SettingsSelect
         ariaLabel="Theme (disabled)"
@@ -185,7 +184,6 @@ function SettingsSelectDemo() {
         items={items}
         value={value}
         onChange={setValue}
-        className="w-56"
         disabled
       />
     </div>
@@ -287,8 +285,8 @@ function CardLoadingState() {
 function CardErrorState() {
   return (
     <Card>
-      <CardContent className="space-y-[var(--space-3)]">
-        <div className="space-y-[var(--space-1)]">
+      <CardContent className="stack-md">
+        <div className="stack-xs">
           <h4 className="text-ui font-semibold tracking-[-0.01em]">
             Data unavailable
           </h4>
@@ -300,7 +298,8 @@ function CardErrorState() {
           message="Sync failed"
           actionLabel="Retry"
           onAction={() => {}}
-          className="mx-0 w-full justify-between border-danger/40 bg-danger/15 text-danger-foreground"
+          className="mx-0 w-full justify-between"
+          tone="danger"
         />
       </CardContent>
     </Card>
@@ -310,9 +309,8 @@ function CardErrorState() {
 function NeoCardDemo() {
   return (
     <NeoCard
-      className="p-4"
       overlay={
-        <div className="pointer-events-none absolute inset-0 rounded-[inherit] bg-[var(--accent-overlay)] mix-blend-overlay opacity-20" />
+        <div className="pointer-events-none absolute inset-0 rounded-[inherit] bg-[var(--accent-overlay)] mix-blend-overlay [--neo-card-overlay-opacity:0.2] opacity-[var(--neo-card-overlay-opacity)]" />
       }
     >
       <p className="text-ui">Body</p>
@@ -322,9 +320,9 @@ function NeoCardDemo() {
 
 function NeoCardLoadingState() {
   return (
-    <NeoCard className="p-[var(--space-4)]">
-      <div className="space-y-[var(--space-4)]">
-        <div className="space-y-[var(--space-2)]">
+    <NeoCard>
+      <div className="stack-lg">
+        <div className="stack-sm">
           <Skeleton
             ariaHidden={false}
             role="status"
@@ -340,7 +338,7 @@ function NeoCardLoadingState() {
             className="h-[var(--space-7)] w-[var(--space-7)] flex-none"
             radius="full"
           />
-          <div className="flex-1 space-y-[var(--space-2)]">
+          <div className="flex-1 stack-sm">
             <Skeleton className="w-3/4" />
             <Skeleton className="w-2/3" />
           </div>
@@ -352,9 +350,9 @@ function NeoCardLoadingState() {
 
 function NeoCardErrorState() {
   return (
-    <NeoCard className="p-[var(--space-4)]">
-      <div className="space-y-[var(--space-3)]">
-        <div className="space-y-[var(--space-1)]">
+    <NeoCard>
+      <div className="stack-md">
+        <div className="stack-xs">
           <h4 className="text-ui font-semibold tracking-[-0.01em]">
             Overlay unavailable
           </h4>
@@ -366,7 +364,8 @@ function NeoCardErrorState() {
           message="Sync failed"
           actionLabel="Retry"
           onAction={() => {}}
-          className="mx-0 w-full justify-between border-danger/40 bg-danger/15 text-danger-foreground"
+          className="mx-0 w-full justify-between"
+          tone="danger"
         />
       </div>
     </NeoCard>
@@ -587,7 +586,7 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
           ]}
           className="md:flex-row md:items-center md:justify-between"
           buttonSize="lg"
-          buttonClassName="motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
+          buttonClassName="motion-safe:hover:-translate-y-[var(--quick-actions-lift)] motion-reduce:transform-none"
         />
       ),
       tags: ["actions", "planner"],
@@ -599,7 +598,7 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
   ]}
   className="md:flex-row md:items-center md:justify-between"
   buttonSize="lg"
-  buttonClassName="motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
+  buttonClassName="motion-safe:hover:-translate-y-[var(--quick-actions-lift)] motion-reduce:transform-none"
 />`,
     },
     {

--- a/src/components/ui/feedback/Snackbar.tsx
+++ b/src/components/ui/feedback/Snackbar.tsx
@@ -3,12 +3,24 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
+type SnackbarTone = "default" | "danger";
+
 interface SnackbarProps extends React.HTMLAttributes<HTMLDivElement> {
   message: React.ReactNode;
   actionLabel?: string;
   actionAriaLabel?: string;
   onAction?: () => void;
+  tone?: SnackbarTone;
 }
+
+const BASE_CLASSNAME =
+  "mx-auto w-fit rounded-card r-card-lg [--snackbar-border:hsl(var(--border))] [--snackbar-background:hsl(var(--surface-2))] [--snackbar-foreground:hsl(var(--foreground))] border border-[var(--snackbar-border)] bg-[var(--snackbar-background)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-[var(--snackbar-foreground)] shadow-sm transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none";
+
+const toneClassNames: Record<SnackbarTone, string> = {
+  default: "",
+  danger:
+    "[--snackbar-border:hsl(var(--danger)/0.45)] [--snackbar-background:theme('colors.interaction.danger.surfaceHover')] [--snackbar-foreground:hsl(var(--danger-foreground))] shadow-[var(--shadow-glow-sm)]",
+};
 
 export default function Snackbar({
   message,
@@ -16,16 +28,15 @@ export default function Snackbar({
   actionAriaLabel,
   onAction,
   className,
+  tone = "default",
   ...props
 }: SnackbarProps) {
+  const toneClassName = toneClassNames[tone] ?? toneClassNames.default;
   return (
     <div
       role="status"
       aria-live="polite"
-      className={cn(
-        "mx-auto w-fit rounded-card r-card-lg border border-border bg-surface-2 px-[var(--space-4)] py-[var(--space-2)] text-ui shadow-sm",
-        className,
-      )}
+      className={cn(BASE_CLASSNAME, toneClassName, className)}
       {...props}
     >
       {message}

--- a/src/components/ui/theme/SettingsSelect.tsx
+++ b/src/components/ui/theme/SettingsSelect.tsx
@@ -6,7 +6,7 @@ import type { AnimatedSelectProps } from "../select/shared";
 import { cn } from "@/lib/utils";
 
 const SETTINGS_SELECT_BUTTON_CLASS =
-  "!rounded-full !text-ui !shadow-neo-inset hover:ring-2 hover:ring-[var(--edge-iris)] focus-visible:ring-2 focus-visible:ring-[var(--edge-iris)]";
+  "!rounded-full !text-ui !shadow-neo-inset [--settings-select-width:var(--settings-column-width,calc(var(--space-4)*14))] min-w-[var(--settings-select-width)] hover:ring-2 hover:ring-[var(--edge-iris)] focus-visible:ring-2 focus-visible:ring-[var(--edge-iris)]";
 
 export type SettingsSelectProps = Omit<
   AnimatedSelectProps,


### PR DESCRIPTION
## Summary
- add stack spacing utilities and apply them across the settings select and neo card demos
- expose token-based width, column, and motion variables on SettingsSelect, QuickActionGrid, and Snackbar tone handling
- update QuickActionGrid and snackbar error demos to consume the new tokens while preserving neumorphic styling

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cd4e2e2828832cbbd5defea5de5a6e