### PR TITLE
Handle CI flag truthy values in regen script

### DIFF
--- a/scripts/regen-if-needed.ts
+++ b/scripts/regen-if-needed.ts
@@ -93,8 +93,16 @@ function run(cmd: string): void {
   execSync(cmd, { stdio: "inherit" });
 }
 
+const isCiEnvironment = (() => {
+  const value = process.env.CI;
+  if (!value) {
+    return false;
+  }
+  return value !== "false" && value !== "0";
+})();
+
 async function main() {
-  if (process.env.CI === "true") {
+  if (isCiEnvironment) {
     console.log("Skipping regeneration tasks");
     return;
   }


### PR DESCRIPTION
## Summary
- skip regeneration scripts whenever CI is set to a truthy value so install hooks do not run in hosted pipelines

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cd637864b4832c97e5f7ac3f344aad