### PR TITLE
Align prompt demos with design tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,6 +8,9 @@
     --accent-2-foreground: var(--background);
     --danger-foreground: var(--primary-foreground);
     --shadow-dropdown: 0 12px 40px hsl(var(--shadow-color) / 0.55);
+    --settings-column-width: calc(var(--space-4) * 14);
+    --surface-overlay-soft: 0.12;
+    --surface-overlay-strong: 0.2;
   }
 
   body {
@@ -357,6 +360,16 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
     mix-blend-mode: soft-light;
     opacity: 0;
     transition: opacity var(--dur-quick) var(--ease-out);
+  }
+
+  .neo-card__overlay {
+    position: absolute;
+    inset: var(--neo-card-overlay-inset, 0);
+    pointer-events: none;
+    border-radius: inherit;
+    background: var(--accent-overlay);
+    mix-blend-mode: overlay;
+    opacity: var(--neo-card-overlay-opacity, var(--surface-overlay-strong));
   }
   /* HOVER: no translate */
   .card-neo:hover,

--- a/src/components/home/QuickActionGrid.tsx
+++ b/src/components/home/QuickActionGrid.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import Button, { type ButtonProps } from "@/components/ui/primitives/Button";
 import { cn } from "@/lib/utils";
 
-type QuickActionLayout = "stacked" | "grid";
+type QuickActionLayout = "stacked" | "grid" | "inline";
 
 const ROOT_CLASSNAME =
   "[--quick-actions-gap:var(--space-4)] [--quick-actions-column-width:calc(var(--space-4)*14)] [--quick-actions-lift:var(--spacing-0-5)]";
@@ -13,10 +13,15 @@ const ROOT_CLASSNAME =
 const layoutClassNames: Record<QuickActionLayout, string> = {
   stacked: "flex flex-col gap-[var(--quick-actions-gap)]",
   grid: "grid grid-cols-1 gap-[var(--quick-actions-gap)] sm:grid-cols-[repeat(auto-fit,minmax(var(--quick-actions-column-width),1fr))]",
+  inline:
+    "flex flex-col gap-[var(--quick-actions-gap)] md:flex-row md:items-center md:justify-between",
 };
 
 const buttonBaseClassName =
   "rounded-[var(--control-radius)] [--focus:var(--theme-ring)] focus-visible:ring-offset-0 transition-transform duration-[var(--dur-quick)] ease-out motion-reduce:transition-none";
+
+const buttonHoverLiftClassName =
+  "motion-safe:hover:-translate-y-[var(--quick-actions-lift)] motion-reduce:transform-none";
 
 type QuickActionDefinition = {
   href: string;
@@ -37,6 +42,7 @@ type QuickActionGridProps = {
   buttonSize?: ButtonProps["size"];
   buttonTone?: ButtonProps["tone"];
   buttonVariant?: ButtonProps["variant"];
+  hoverLift?: boolean;
 };
 
 export default function QuickActionGrid({
@@ -47,6 +53,7 @@ export default function QuickActionGrid({
   buttonSize = "md",
   buttonTone = "primary",
   buttonVariant = "secondary",
+  hoverLift = false,
 }: QuickActionGridProps) {
   return (
     <div className={cn(ROOT_CLASSNAME, layoutClassNames[layout], className)}>
@@ -67,6 +74,7 @@ export default function QuickActionGrid({
         const resolvedVariant = variant ?? buttonVariant;
         const mergedClassName = cn(
           buttonBaseClassName,
+          hoverLift && buttonHoverLiftClassName,
           buttonClassName,
           actionClassName,
         );

--- a/src/components/home/QuickActions.tsx
+++ b/src/components/home/QuickActions.tsx
@@ -25,8 +25,8 @@ export default function QuickActions() {
     <section aria-label="Quick actions" className="grid gap-[var(--space-4)]">
       <QuickActionGrid
         actions={actions}
-        className="md:flex-row md:items-center md:justify-between"
-        buttonClassName="motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none"
+        layout="inline"
+        hoverLift
       />
     </section>
   );

--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -10,6 +10,7 @@ import {
   Button,
   Card,
   NeoCard,
+  neoCardOverlayClassName,
   CardHeader,
   CardTitle,
   CardDescription,
@@ -298,8 +299,8 @@ function CardErrorState() {
           message="Sync failed"
           actionLabel="Retry"
           onAction={() => {}}
-          className="mx-0 w-full justify-between"
           tone="danger"
+          width="full"
         />
       </CardContent>
     </Card>
@@ -310,7 +311,7 @@ function NeoCardDemo() {
   return (
     <NeoCard
       overlay={
-        <div className="pointer-events-none absolute inset-0 rounded-[inherit] bg-[var(--accent-overlay)] mix-blend-overlay [--neo-card-overlay-opacity:0.2] opacity-[var(--neo-card-overlay-opacity)]" />
+        <div className={neoCardOverlayClassName} />
       }
     >
       <p className="text-ui">Body</p>
@@ -364,8 +365,8 @@ function NeoCardErrorState() {
           message="Sync failed"
           actionLabel="Retry"
           onAction={() => {}}
-          className="mx-0 w-full justify-between"
           tone="danger"
+          width="full"
         />
       </div>
     </NeoCard>
@@ -584,9 +585,9 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
             { href: "/goals", label: "New Goal", tone: "accent" },
             { href: "/reviews", label: "New Review", tone: "accent" },
           ]}
-          className="md:flex-row md:items-center md:justify-between"
+          layout="inline"
           buttonSize="lg"
-          buttonClassName="motion-safe:hover:-translate-y-[var(--quick-actions-lift)] motion-reduce:transform-none"
+          hoverLift
         />
       ),
       tags: ["actions", "planner"],
@@ -596,9 +597,9 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
     { href: "/goals", label: "New Goal", tone: "accent" },
     { href: "/reviews", label: "New Review", tone: "accent" },
   ]}
-  className="md:flex-row md:items-center md:justify-between"
+  layout="inline"
   buttonSize="lg"
-  buttonClassName="motion-safe:hover:-translate-y-[var(--quick-actions-lift)] motion-reduce:transform-none"
+  hoverLift
 />`,
     },
     {
@@ -760,7 +761,8 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
       message="Sync failed"
       actionLabel="Retry"
       onAction={() => {}}
-      className="mx-0 w-full justify-between border-danger/40 bg-danger/15 text-danger-foreground"
+      tone="danger"
+      width="full"
     />
   </CardContent>
 </Card>`,
@@ -793,8 +795,7 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
       element: <NeoCardDemo />,
       tags: ["card", "overlay", "layout"],
       code: `<NeoCard
-  className="p-4"
-  overlay={<div className="pointer-events-none absolute inset-0 rounded-[inherit] bg-[var(--accent-overlay)] mix-blend-overlay opacity-20" />}
+  overlay={<div className="neo-card__overlay" />}
 >
   <p className="text-ui">Body</p>
 </NeoCard>`,
@@ -851,7 +852,8 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
       message="Sync failed"
       actionLabel="Retry"
       onAction={() => {}}
-      className="mx-0 w-full justify-between border-danger/40 bg-danger/15 text-danger-foreground"
+      tone="danger"
+      width="full"
     />
   </div>
 </NeoCard>`,
@@ -1456,20 +1458,18 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
       name: "SettingsSelect",
       element: <SettingsSelectDemo />,
       tags: ["select", "settings"],
-      code: `<div className="space-y-[var(--space-2)]">
+      code: `<div className="stack-sm">
   <SettingsSelect
     ariaLabel="Theme"
     prefixLabel="Theme"
     items={[{ value: "lg", label: "Glitch" }]}
     value="lg"
-    className="w-56"
   />
   <SettingsSelect
     ariaLabel="Theme (disabled)"
     prefixLabel="Theme (disabled)"
     items={[{ value: "lg", label: "Glitch" }]}
     value="lg"
-    className="w-56"
     disabled
   />
 </div>`,

--- a/src/components/ui/feedback/Snackbar.tsx
+++ b/src/components/ui/feedback/Snackbar.tsx
@@ -11,10 +11,16 @@ interface SnackbarProps extends React.HTMLAttributes<HTMLDivElement> {
   actionAriaLabel?: string;
   onAction?: () => void;
   tone?: SnackbarTone;
+  width?: "auto" | "full";
 }
 
 const BASE_CLASSNAME =
-  "mx-auto w-fit rounded-card r-card-lg [--snackbar-border:hsl(var(--border))] [--snackbar-background:hsl(var(--surface-2))] [--snackbar-foreground:hsl(var(--foreground))] border border-[var(--snackbar-border)] bg-[var(--snackbar-background)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-[var(--snackbar-foreground)] shadow-sm transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none";
+  "inline-flex items-center justify-between gap-[var(--space-3)] rounded-card r-card-lg [--snackbar-border:hsl(var(--border))] [--snackbar-background:hsl(var(--surface-2))] [--snackbar-foreground:hsl(var(--foreground))] border border-[var(--snackbar-border)] bg-[var(--snackbar-background)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-[var(--snackbar-foreground)] shadow-sm transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none";
+
+const widthClassNames: Record<NonNullable<SnackbarProps["width"]>, string> = {
+  auto: "mx-auto w-fit",
+  full: "w-full",
+};
 
 const toneClassNames: Record<SnackbarTone, string> = {
   default: "",
@@ -29,34 +35,34 @@ export default function Snackbar({
   onAction,
   className,
   tone = "default",
+  width = "auto",
   ...props
 }: SnackbarProps) {
   const toneClassName = toneClassNames[tone] ?? toneClassNames.default;
+  const widthClassName = widthClassNames[width] ?? widthClassNames.auto;
   return (
     <div
       role="status"
       aria-live="polite"
-      className={cn(BASE_CLASSNAME, toneClassName, className)}
+      className={cn(BASE_CLASSNAME, widthClassName, toneClassName, className)}
       {...props}
     >
-      {message}
+      <span className="flex-1 text-left leading-snug">{message}</span>
       {actionLabel && onAction ? (
-        <>
-          {" "}
-          <button
-            type="button"
-            className={cn(
-              "inline-flex items-center font-medium text-accent-3 underline underline-offset-4 transition-colors",
-              "hover:text-[var(--text-on-accent)] focus-visible:rounded-[var(--radius-md)] focus-visible:outline-none",
-              "focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--surface-2))]",
-              "active:text-accent-3 active:opacity-80 disabled:text-muted-foreground disabled:no-underline disabled:pointer-events-none",
-            )}
-            onClick={onAction}
-            aria-label={actionAriaLabel ?? actionLabel}
-          >
-            {actionLabel}
-          </button>
-        </>
+        <button
+          type="button"
+          className={cn(
+            "inline-flex items-center font-medium text-accent-3 underline underline-offset-4 transition-colors",
+            "hover:text-[var(--text-on-accent)] focus-visible:rounded-[var(--radius-md)] focus-visible:outline-none",
+            "focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent))] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--surface-2))]",
+            "active:text-accent-3 active:opacity-80 disabled:text-muted-foreground disabled:no-underline disabled:pointer-events-none",
+            "flex-shrink-0",
+          )}
+          onClick={onAction}
+          aria-label={actionAriaLabel ?? actionLabel}
+        >
+          {actionLabel}
+        </button>
       ) : null}
     </div>
   );

--- a/src/components/ui/primitives/NeoCard.tsx
+++ b/src/components/ui/primitives/NeoCard.tsx
@@ -6,11 +6,16 @@ export type NeoCardProps = CardProps & {
   overlay?: React.ReactNode;
 };
 
+const NEO_CARD_BASE_CLASSNAME =
+  "relative overflow-hidden card-neo-soft [--neo-card-overlay-inset:0px] [--neo-card-overlay-opacity:var(--surface-overlay-strong,0.2)]";
+
+export const neoCardOverlayClassName = "neo-card__overlay";
+
 const NeoCard = React.forwardRef<React.ElementRef<"div">, NeoCardProps>(
   ({ className, children, overlay, ...props }, ref) => (
     <Card
       ref={ref}
-      className={cn("relative overflow-hidden card-neo-soft", className)}
+      className={cn(NEO_CARD_BASE_CLASSNAME, className)}
       {...props}
     >
       {children}

--- a/src/components/ui/theme/SettingsSelect.tsx
+++ b/src/components/ui/theme/SettingsSelect.tsx
@@ -6,7 +6,7 @@ import type { AnimatedSelectProps } from "../select/shared";
 import { cn } from "@/lib/utils";
 
 const SETTINGS_SELECT_BUTTON_CLASS =
-  "!rounded-full !text-ui !shadow-neo-inset [--settings-select-width:var(--settings-column-width,calc(var(--space-4)*14))] min-w-[var(--settings-select-width)] hover:ring-2 hover:ring-[var(--edge-iris)] focus-visible:ring-2 focus-visible:ring-[var(--edge-iris)]";
+  "!rounded-full !text-ui !shadow-neo-inset [--settings-select-width:var(--settings-column-width)] min-w-[var(--settings-select-width)] hover:ring-2 hover:ring-[var(--edge-iris)] focus-visible:ring-2 focus-visible:ring-[var(--edge-iris)]";
 
 export type SettingsSelectProps = Omit<
   AnimatedSelectProps,


### PR DESCRIPTION
## Summary
- add global tokens for settings select width and overlay intensity, plus a reusable neo card overlay utility
- extend QuickActionGrid and snackbar primitives so demos can rely on layout, hover, and width tokens
- refresh prompts gallery demos (settings select, neo card, quick actions) to consume the new utilities

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cd7db6aed4832c9ec89fffff71d74f