### PR TITLE
Use shared shadow tokens for slider indicators

### DIFF
--- a/src/components/reviews/ResultScoreSection.tsx
+++ b/src/components/reviews/ResultScoreSection.tsx
@@ -19,6 +19,10 @@ type ResultScoreSectionProps = {
   onScoreEnter?: () => void;
 };
 
+type ResultIndicatorStyle = React.CSSProperties & {
+  "--result-indicator-gradient"?: string;
+};
+
 function ResultScoreSection(
   {
     result: result0 = "Win",
@@ -51,6 +55,15 @@ function ResultScoreSection(
   const pool = SCORE_POOLS[score] ?? SCORE_POOLS[5];
   const msg = pool[msgIndex];
   const { Icon: ScoreIcon, cls: scoreIconCls } = scoreIcon(score);
+  const resultIndicatorStyle: ResultIndicatorStyle = {
+    width: "calc(50% - var(--space-1))",
+    transform: `translate3d(${result === "Win" ? "0" : "100%"},0,0)`,
+    transitionTimingFunction: "cubic-bezier(.22,1,.36,1)",
+    "--result-indicator-gradient":
+      result === "Win"
+        ? "linear-gradient(90deg, hsl(var(--success)/0.22), hsl(var(--accent)/0.18))"
+        : "linear-gradient(90deg, hsl(var(--danger)/0.24), hsl(var(--primary)/0.20))",
+  };
 
   return (
     <>
@@ -85,17 +98,8 @@ function ResultScoreSection(
         >
           <span
             aria-hidden
-            className="absolute top-1 bottom-1 left-1 rounded-[var(--control-radius)] transition-transform duration-300"
-            style={{
-              width: "calc(50% - var(--space-1))",
-              transform: `translate3d(${result === "Win" ? "0" : "100%"},0,0)`,
-              transitionTimingFunction: "cubic-bezier(.22,1,.36,1)",
-              background:
-                result === "Win"
-                  ? "linear-gradient(90deg, hsl(var(--success)/0.22), hsl(var(--accent)/0.18))"
-                  : "linear-gradient(90deg, hsl(var(--danger)/0.24), hsl(var(--primary)/0.20))",
-              boxShadow: "0 10px 30px hsl(var(--shadow-color) / .25)",
-            }}
+            className="absolute top-1 bottom-1 left-1 rounded-[var(--control-radius)] transition-transform duration-300 [background:var(--result-indicator-gradient)] shadow-[var(--shadow-neo-soft)]"
+            style={resultIndicatorStyle}
           />
           <div className="relative z-10 grid w-full grid-cols-2 text-ui font-mono">
             <div

--- a/src/components/ui/league/SideSelector.tsx
+++ b/src/components/ui/league/SideSelector.tsx
@@ -6,6 +6,10 @@ import { cn } from "@/lib/utils";
 
 export type GameSide = "Blue" | "Red";
 
+type SideIndicatorStyle = React.CSSProperties & {
+  "--side-indicator-gradient"?: string;
+};
+
 type Props = {
   value?: GameSide;
   onChange?: (v: GameSide) => void;
@@ -32,6 +36,12 @@ export default function SideSelector({
 }: Props) {
   const isRight = value === "Red";
   const [flick, setFlick] = React.useState(false);
+  const indicatorStyle: SideIndicatorStyle = {
+    width: "calc(50% - var(--space-1))",
+    transform: `translateX(${isRight ? "100%" : "0"})`,
+    "--side-indicator-gradient":
+      "linear-gradient(90deg, hsl(var(--primary)/0.35), hsl(var(--accent)/0.35))",
+  };
 
   function toggle() {
     if (disabled || loading) return;
@@ -92,14 +102,8 @@ export default function SideSelector({
       {/* Sliding indicator */}
       <span
         aria-hidden
-        className="absolute top-[var(--space-1)] bottom-[var(--space-1)] left-[var(--space-1)] rounded-full transition-transform duration-200 ease-[var(--ease-out, cubic-bezier(.2,.8,.2,1))]"
-        style={{
-          width: "calc(50% - var(--space-1))",
-          transform: `translateX(${isRight ? "100%" : "0"})`,
-          background:
-            "linear-gradient(90deg, hsl(var(--primary)/.35), hsl(var(--accent)/.35))",
-          boxShadow: "0 10px 30px hsl(var(--shadow-color) / .25)",
-        }}
+        className="absolute top-[var(--space-1)] bottom-[var(--space-1)] left-[var(--space-1)] rounded-full transition-transform duration-200 ease-[var(--ease-out, cubic-bezier(.2,.8,.2,1))] [background:var(--side-indicator-gradient)] shadow-[var(--shadow-neo-soft)]"
+        style={indicatorStyle}
       />
 
       {/* Labels */}

--- a/src/components/ui/league/pillars/PillarSelector.tsx
+++ b/src/components/ui/league/pillars/PillarSelector.tsx
@@ -7,6 +7,10 @@ import type { Pillar } from "@/lib/types";
 
 const ORDER: Pillar[] = ["Wave", "Trading", "Vision", "Tempo", "Positioning", "Comms"];
 
+type PillarHighlightStyle = React.CSSProperties & {
+  "--pillar-indicator-gradient"?: string;
+};
+
 export default function PillarSelector({
   value = [],
   onChange,
@@ -33,22 +37,24 @@ export default function PillarSelector({
       <div className="flex flex-wrap gap-[var(--space-2)]">
         {ORDER.map((p) => {
           const active = set.has(p);
+          const activeStyle: PillarHighlightStyle | undefined = active
+            ? {
+                "--pillar-indicator-gradient":
+                  "linear-gradient(90deg, hsl(var(--primary)/0.18), hsl(var(--accent)/0.18))",
+              }
+            : undefined;
           return (
             <button
               key={p}
               type="button"
               aria-pressed={active}
               onClick={() => toggle(p)}
-              className={cn("pill transition", active ? "pill--medium text-foreground" : "")}
-              style={
-                active
-                  ? {
-                      background:
-                        "linear-gradient(90deg, hsl(var(--primary)/.18), hsl(var(--accent)/.18))",
-                      boxShadow: "0 10px 30px hsl(var(--shadow-color) / .25)",
-                    }
-                  : undefined
-              }
+              className={cn(
+                "pill transition",
+                active &&
+                  "pill--medium text-foreground shadow-[var(--shadow-neo-soft)] [background:var(--pillar-indicator-gradient)]",
+              )}
+              style={activeStyle}
             >
               <span
                 aria-hidden

--- a/src/components/ui/toggles/Toggle.tsx
+++ b/src/components/ui/toggles/Toggle.tsx
@@ -7,11 +7,15 @@ import Spinner from "../feedback/Spinner";
 
 type Side = "Left" | "Right";
 
-type ToggleStyle = CSSProperties & {
+type ToggleLabelStyle = CSSProperties & {
   "--glow-active"?: string;
 };
 
-const createLabelGlow = (color: string): ToggleStyle => ({
+type ToggleIndicatorStyle = CSSProperties & {
+  "--toggle-indicator-gradient"?: string;
+};
+
+const createLabelGlow = (color: string): ToggleLabelStyle => ({
   "--glow-active": color,
   textShadow: "var(--shadow-glow-md)",
 });
@@ -37,10 +41,10 @@ export default function Toggle({
   const id = React.useId();
   const leftId = `${id}-left`;
   const rightId = `${id}-right`;
-  const indicatorStyle: ToggleStyle = {
+  const indicatorStyle: ToggleIndicatorStyle = {
     width: "calc(50% - var(--space-1))",
     transform: `translateX(${isRight ? "100%" : "0"})`,
-    "--glow-active": "hsl(var(--shadow-color) / 0.25)",
+    "--toggle-indicator-gradient": "var(--seg-active-grad)",
   };
   const leftLabelStyle = !isRight
     ? createLabelGlow("hsl(var(--team-blue) / 0.35)")
@@ -96,7 +100,7 @@ export default function Toggle({
       {/* Sliding indicator */}
       <span
         aria-hidden
-        className="absolute top-[var(--space-1)] bottom-[var(--space-1)] left-[var(--space-1)] rounded-full transition-transform duration-[var(--dur-quick)] ease-snap motion-reduce:transition-none group-active:scale-95 group-disabled:opacity-[var(--disabled)] group-data-[loading=true]:opacity-[var(--loading)] group-focus-visible:ring-2 group-focus-visible:ring-ring bg-[var(--seg-active-grad)] shadow-[var(--shadow-glow-xl)]"
+        className="absolute top-[var(--space-1)] bottom-[var(--space-1)] left-[var(--space-1)] rounded-full transition-transform duration-[var(--dur-quick)] ease-snap motion-reduce:transition-none group-active:scale-95 group-disabled:opacity-[var(--disabled)] group-data-[loading=true]:opacity-[var(--loading)] group-focus-visible:ring-2 group-focus-visible:ring-ring [background:var(--toggle-indicator-gradient,var(--seg-active-grad))] shadow-[var(--shadow-neo-soft)]"
         style={indicatorStyle}
       />
 

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -427,8 +427,8 @@ exports[`ReviewEditor > renders default state 1`] = `
         >
           <span
             aria-hidden="true"
-            class="absolute top-1 bottom-1 left-1 rounded-[var(--control-radius)] transition-transform duration-300"
-            style="width: calc(50% - var(--space-1)); transform: translate3d(0,0,0); transition-timing-function: cubic-bezier(.22,1,.36,1); background: linear-gradient(90deg, hsl(var(--success)/0.22), hsl(var(--accent)/0.18)); box-shadow: 0 10px 30px hsl(var(--shadow-color) / .25);"
+            class="absolute top-1 bottom-1 left-1 rounded-[var(--control-radius)] transition-transform duration-300 [background:var(--result-indicator-gradient)] shadow-[var(--shadow-neo-soft)]"
+            style="width: calc(50% - var(--space-1)); transform: translate3d(0,0,0); transition-timing-function: cubic-bezier(.22,1,.36,1); --result-indicator-gradient: linear-gradient(90deg, hsl(var(--success)/0.22), hsl(var(--accent)/0.18));"
           />
           <div
             class="relative z-10 grid w-full grid-cols-2 text-ui font-mono"


### PR DESCRIPTION
## Summary
- update slider highlight spans to use the `var(--shadow-neo-soft)` token instead of hard-coded shadows
- expose CSS custom properties so gradients remain configurable while consuming the shared shadow token
- align toggle indicator shadow usage with the rest of the selectors

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cd801845f4832c9c78d79afee680ec