### PR TITLE
Ensure ComponentGallery external link uses safe rel

### DIFF
--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -425,7 +425,7 @@ export default function ComponentGallery() {
             <a
               href={fieldStoryHref}
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="inline-flex items-center gap-[var(--space-1)] text-label font-medium text-accent-foreground transition-colors duration-[var(--dur-quick)] ease-out hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--bg))]"
             >
               Explore Field states


### PR DESCRIPTION
## Summary
- include `noopener noreferrer` on the ComponentGallery storybook link when it opens in a new tab to avoid opener leaks

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cd823f6338832cb94d84397ff66723