### PR TITLE
fix: generate unique prompt demo ids

### DIFF
--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -162,6 +162,8 @@ export default function ComponentGallery() {
   const [tactilePrimaryActive, setTactilePrimaryActive] = React.useState(false);
   const [tactileSecondaryActive, setTactileSecondaryActive] = React.useState(false);
 
+  const labelDemoId = React.useId();
+
   const buttonItems = React.useMemo(
     () => [
       { label: "Button", element: <Button className="w-56">Click me</Button> },
@@ -437,8 +439,8 @@ export default function ComponentGallery() {
         label: "Label",
         element: (
           <div className="w-56">
-            <Label htmlFor="label-demo">Label</Label>
-            <Input id="label-demo" placeholder="With spacing" />
+            <Label htmlFor={labelDemoId}>Label</Label>
+            <Input id={labelDemoId} placeholder="With spacing" />
           </div>
         ),
       },
@@ -589,6 +591,7 @@ export default function ComponentGallery() {
       selectValue,
       defaultVariantSelectValue,
       successVariantSelectValue,
+      labelDemoId,
     ],
   );
 

--- a/src/components/prompts/PromptsDemos.tsx
+++ b/src/components/prompts/PromptsDemos.tsx
@@ -39,6 +39,8 @@ import {
 } from "./demoData";
 
 export default function PromptsDemos() {
+  const labelDemoId = React.useId();
+
   return (
     <>
       <OutlineGlowDemo />
@@ -109,8 +111,8 @@ export default function PromptsDemos() {
         <h3 className="type-title">Label</h3>
         <div className="space-y-[var(--space-3)]">
           <div>
-            <Label htmlFor="label-demo">Label</Label>
-            <Input id="label-demo" placeholder="With spacing" />
+            <Label htmlFor={labelDemoId}>Label</Label>
+            <Input id={labelDemoId} placeholder="With spacing" />
           </div>
         </div>
       </Card>


### PR DESCRIPTION
## Summary
- ensure the Prompts demo label uses a React-generated id so its label/input association is unique across renders
- reuse a memoized id inside the ComponentGallery label example to avoid duplicate htmlFor values in Storybook snapshots

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cd8244ad04832ca85a3fb1184919f7