### PR TITLE
refactor(modal): use non-interactive backdrop

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -33,10 +33,11 @@ export default function Modal({
   if (!open || !mounted) return null;
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center">
-      <button
-        type="button"
-        aria-label="Close modal"
-        className="absolute inset-0 bg-background/80 transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[hsl(var(--background)/0.86)] active:bg-[hsl(var(--background)/0.92)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)]"
+      <div
+        role="presentation"
+        aria-hidden="true"
+        tabIndex={-1}
+        className="absolute inset-0 bg-background/80 transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[hsl(var(--background)/0.86)] active:bg-[hsl(var(--background)/0.92)]"
         onClick={onClose}
       />
       <Card


### PR DESCRIPTION
## Summary
- replace the modal backdrop button with a presentational div to keep it out of the accessibility tree
- ensure the backdrop remains clickable while marking it aria-hidden and removing it from the tab order

## Testing
- npm run check *(fails: snapshot mismatches in baseline tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cd90c607a8832c97912027a63cad60