### PR TITLE
Use instance ids for goal form aria helpers

### DIFF
--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -39,8 +39,9 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
   ref
 ) {
   const titleRef = React.useRef<HTMLInputElement>(null);
-  const helpId = "goal-form-help";
-  const errorId = "goal-form-error";
+  const id = React.useId();
+  const helpId = `${id}-help`;
+  const errorId = `${id}-error`;
   const describedBy = [helpId, err ? errorId : null].filter(Boolean).join(" ");
   const trimmedTitle = title.trim();
   const isAtCap = activeCount >= activeCap;


### PR DESCRIPTION
## Summary
- derive stable goal form help and error identifiers from React.useId
- continue wiring aria-describedby to the generated identifiers for the help and error messages

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cd9b54d5f4832c8af3ee45b73d5b53