### PR TITLE
Fix ReviewList semantics

### DIFF
--- a/src/components/reviews/ReviewList.tsx
+++ b/src/components/reviews/ReviewList.tsx
@@ -44,7 +44,7 @@ export default function ReviewList({
 
   return (
     <Card className={containerClass}>
-      <ul className="flex flex-col gap-3" role="listbox">
+      <ul className="flex flex-col gap-3">
         {reviews.map((r) => (
           <li key={r.id}>
             <ReviewListItem

--- a/src/components/reviews/ReviewListItem.tsx
+++ b/src/components/reviews/ReviewListItem.tsx
@@ -72,11 +72,9 @@ export default function ReviewListItem({
     <button
       data-scope="reviews"
       type="button"
-      role="option"
       disabled={disabled}
       onClick={onClick}
       aria-label={`Open review: ${title}`}
-      aria-selected={selected}
       aria-current={selected ? "true" : undefined}
       data-selected={selected ? "true" : undefined}
       className={shellBase}

--- a/tests/reviews/ReviewsPage.test.tsx
+++ b/tests/reviews/ReviewsPage.test.tsx
@@ -94,10 +94,19 @@ describe("ReviewsPage", () => {
       />,
     );
 
-    const list = screen.getAllByRole("listbox")[0];
+    const list = screen
+      .getAllByRole("list")
+      .find(
+        (candidate) =>
+          within(candidate).queryAllByRole("button", { name: /Open review:/i })
+            .length > 0,
+      );
+
+    expect(list).toBeDefined();
+
     const getTitles = () =>
-      within(list)
-        .getAllByRole("option")
+      within(list!)
+        .getAllByRole("button", { name: /Open review:/i })
         .map((b) => b.getAttribute("aria-label")?.replace("Open review: ", ""));
 
     expect(getTitles()).toEqual(["Alpha", "Gamma", "Beta"]);

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -4,10 +4,8 @@ exports[`ReviewListItem > renders default state 1`] = `
 <div>
   <button
     aria-label="Open review: Sample Review"
-    aria-selected="false"
     class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
     data-scope="reviews"
-    role="option"
     type="button"
   >
     <div
@@ -60,11 +58,9 @@ exports[`ReviewListItem > renders disabled state 1`] = `
 <div>
   <button
     aria-label="Open review: Sample Review"
-    aria-selected="false"
     class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
     data-scope="reviews"
     disabled=""
-    role="option"
     type="button"
   >
     <div
@@ -134,11 +130,9 @@ exports[`ReviewListItem > renders selected state 1`] = `
   <button
     aria-current="true"
     aria-label="Open review: Sample Review"
-    aria-selected="true"
     class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
     data-scope="reviews"
     data-selected="true"
-    role="option"
     type="button"
   >
     <div
@@ -191,10 +185,8 @@ exports[`ReviewListItem > renders untitled state 1`] = `
 <div>
   <button
     aria-label="Open review: Untitled Review"
-    aria-selected="false"
     class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
     data-scope="reviews"
-    role="option"
     type="button"
   >
     <div

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -409,15 +409,12 @@ exports[`ReviewsPage > renders default state 1`] = `
             >
               <ul
                 class="flex flex-col gap-3"
-                role="listbox"
               >
                 <li>
                   <button
                     aria-label="Open review: Alpha"
-                    aria-selected="false"
                     class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
                     data-scope="reviews"
-                    role="option"
                     type="button"
                   >
                     <div
@@ -460,10 +457,8 @@ exports[`ReviewsPage > renders default state 1`] = `
                 <li>
                   <button
                     aria-label="Open review: Gamma"
-                    aria-selected="false"
                     class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
                     data-scope="reviews"
-                    role="option"
                     type="button"
                   >
                     <div
@@ -506,10 +501,8 @@ exports[`ReviewsPage > renders default state 1`] = `
                 <li>
                   <button
                     aria-label="Open review: Beta"
-                    aria-selected="false"
                     class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
                     data-scope="reviews"
-                    role="option"
                     type="button"
                   >
                     <div


### PR DESCRIPTION
## Summary
- remove the faux listbox role from `ReviewList` so it uses native list semantics
- update `ReviewListItem` to drop the option role and invalid `aria-selected` attribute while keeping selection styling
- align review tests and snapshots with the native list structure

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cd9f25e200832c8b964cfeb80d5ee2