### PR TITLE
Add slug resolver for components page deep links

### DIFF
--- a/src/app/components/[section]/page.tsx
+++ b/src/app/components/[section]/page.tsx
@@ -1,0 +1,50 @@
+import { notFound, redirect } from "next/navigation";
+
+import {
+  DEFAULT_COMPONENTS_VIEW,
+  getAllComponentSlugs,
+  resolveComponentsSlug,
+} from "@/components/components/slug";
+
+export { metadata } from "../page";
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return getAllComponentSlugs().map((section) => ({ section }));
+}
+
+interface ComponentsSectionPageProps {
+  params: { section: string };
+}
+
+export default function ComponentsSectionPage({
+  params,
+}: ComponentsSectionPageProps) {
+  const resolved = resolveComponentsSlug(params.section);
+  if (!resolved) {
+    notFound();
+  }
+
+  const searchParams = new URLSearchParams();
+
+  if (resolved.section) {
+    searchParams.set("section", resolved.section);
+  }
+
+  if (
+    resolved.view &&
+    (resolved.viewExplicit || resolved.view !== DEFAULT_COMPONENTS_VIEW)
+  ) {
+    searchParams.set("view", resolved.view);
+  }
+
+  if (resolved.query) {
+    searchParams.set("q", resolved.query);
+  }
+
+  const query = searchParams.toString();
+  const target = query ? `/components?${query}` : "/components";
+
+  redirect(target);
+}

--- a/src/components/components/slug.ts
+++ b/src/components/components/slug.ts
@@ -1,0 +1,250 @@
+import { galleryPayload, GALLERY_SECTION_IDS } from "@/components/gallery";
+import {
+  GALLERY_SECTION_GROUPS,
+  type GallerySectionGroupKey,
+} from "@/components/gallery/metadata";
+import type {
+  GallerySectionId,
+  GallerySerializableEntry,
+} from "@/components/gallery/registry";
+
+function normalizeSlug(value: string | null | undefined): string {
+  if (!value) {
+    return "";
+  }
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\s_-]/gu, "-")
+    .replace(/[\s_]+/gu, "-")
+    .replace(/-+/gu, "-")
+    .replace(/^-+|-+$/gu, "");
+}
+
+const DEFAULT_VIEW: GallerySectionGroupKey =
+  GALLERY_SECTION_GROUPS[0]?.id ?? "primitives";
+
+const SECTION_SLUG_TO_ID = new Map<string, GallerySectionId>();
+for (const id of GALLERY_SECTION_IDS) {
+  const normalized = normalizeSlug(id);
+  if (normalized) {
+    SECTION_SLUG_TO_ID.set(normalized, id);
+  }
+}
+
+const SECTION_TO_GROUP = new Map<GallerySectionId, GallerySectionGroupKey>();
+for (const group of GALLERY_SECTION_GROUPS) {
+  for (const section of group.sections) {
+    SECTION_TO_GROUP.set(section.id, group.id);
+    const normalized = normalizeSlug(section.id);
+    if (normalized) {
+      SECTION_SLUG_TO_ID.set(normalized, section.id);
+    }
+  }
+}
+
+const GROUP_SLUG_TO_ID = new Map<string, GallerySectionGroupKey>();
+for (const group of GALLERY_SECTION_GROUPS) {
+  const normalized = normalizeSlug(group.id);
+  if (normalized) {
+    GROUP_SLUG_TO_ID.set(normalized, group.id);
+  }
+}
+
+const VIEW_ALIAS = new Map<string, GallerySectionGroupKey>([
+  ["colors", "tokens"],
+]);
+
+interface EntryMetadata {
+  slug: string;
+  section: GallerySectionId;
+  view: GallerySectionGroupKey | undefined;
+  name: string;
+  keywords: Set<string>;
+}
+
+const entrySlugMap = new Map<string, EntryMetadata>();
+const directEntrySlugs = new Set<string>();
+const aliasEntrySlugs = new Set<string>();
+const entryMetadataList: EntryMetadata[] = [];
+
+function addKeyword(set: Set<string>, value: string | null | undefined) {
+  const normalized = normalizeSlug(value);
+  if (!normalized) {
+    return;
+  }
+  set.add(normalized);
+  const parts = normalized.split("-");
+  for (const part of parts) {
+    if (part) {
+      set.add(part);
+    }
+  }
+}
+
+function registerDirectSlug(slug: string, metadata: EntryMetadata) {
+  if (!slug) {
+    return;
+  }
+  entrySlugMap.set(slug, metadata);
+  directEntrySlugs.add(slug);
+}
+
+function registerAliasSlug(slug: string, metadata: EntryMetadata) {
+  if (!slug) {
+    return;
+  }
+  if (entrySlugMap.has(slug)) {
+    return;
+  }
+  if (SECTION_SLUG_TO_ID.has(slug)) {
+    return;
+  }
+  entrySlugMap.set(slug, metadata);
+  aliasEntrySlugs.add(slug);
+}
+
+function buildEntryMetadata(entry: GallerySerializableEntry, section: GallerySectionId) {
+  const view = SECTION_TO_GROUP.get(section);
+  const slug = normalizeSlug(entry.id);
+  if (!slug) {
+    return;
+  }
+  const keywords = new Set<string>();
+  addKeyword(keywords, entry.id);
+  addKeyword(keywords, entry.name);
+  if (entry.tags) {
+    for (const tag of entry.tags) {
+      addKeyword(keywords, tag);
+    }
+  }
+  const metadata: EntryMetadata = {
+    slug,
+    section,
+    view,
+    name: entry.name,
+    keywords,
+  };
+  entryMetadataList.push(metadata);
+  registerDirectSlug(slug, metadata);
+
+  const tagSlugs = new Set<string>();
+  if (entry.tags) {
+    for (const tag of entry.tags) {
+      const normalized = normalizeSlug(tag);
+      if (normalized) {
+        tagSlugs.add(normalized);
+      }
+    }
+  }
+  for (const tag of tagSlugs) {
+    registerAliasSlug(normalizeSlug(`${tag}-${slug}`), metadata);
+    registerAliasSlug(normalizeSlug(`${slug}-${tag}`), metadata);
+    if (!slug.endsWith("s")) {
+      registerAliasSlug(normalizeSlug(`${tag}-${slug}s`), metadata);
+      registerAliasSlug(normalizeSlug(`${slug}s-${tag}`), metadata);
+    }
+    if (!tag.endsWith("s")) {
+      registerAliasSlug(normalizeSlug(`${tag}s-${slug}`), metadata);
+      registerAliasSlug(normalizeSlug(`${tag}s-${slug}s`), metadata);
+    }
+  }
+}
+
+for (const section of galleryPayload.sections) {
+  for (const entry of section.entries) {
+    buildEntryMetadata(entry, section.id);
+  }
+}
+
+const ALL_KNOWN_SLUGS = [
+  ...new Set([
+    ...Array.from(VIEW_ALIAS.keys()),
+    ...Array.from(GROUP_SLUG_TO_ID.keys()),
+    ...Array.from(SECTION_SLUG_TO_ID.keys()),
+    ...Array.from(directEntrySlugs.values()),
+    ...Array.from(aliasEntrySlugs.values()),
+  ]),
+];
+
+export interface ResolvedComponentsSlug {
+  section?: GallerySectionId;
+  view?: GallerySectionGroupKey;
+  query?: string;
+  viewExplicit?: boolean;
+}
+
+export function resolveComponentsSlug(
+  rawSlug: string,
+): ResolvedComponentsSlug | null {
+  const normalized = normalizeSlug(rawSlug);
+  if (!normalized) {
+    return null;
+  }
+
+  const aliasView = VIEW_ALIAS.get(normalized);
+  if (aliasView) {
+    return { view: aliasView, viewExplicit: true };
+  }
+
+  const group = GROUP_SLUG_TO_ID.get(normalized);
+  if (group) {
+    return { view: group, viewExplicit: true };
+  }
+
+  const section = SECTION_SLUG_TO_ID.get(normalized);
+  if (section) {
+    const view = SECTION_TO_GROUP.get(section);
+    return { section, view, viewExplicit: false };
+  }
+
+  const directEntry = entrySlugMap.get(normalized);
+  if (directEntry) {
+    return {
+      section: directEntry.section,
+      view: directEntry.view,
+      query: directEntry.name,
+      viewExplicit: false,
+    };
+  }
+
+  const words = normalized.split("-").filter(Boolean);
+  let bestMatch: EntryMetadata | null = null;
+  let bestScore = 0;
+
+  for (const metadata of entryMetadataList) {
+    let score = 0;
+    for (const word of words) {
+      if (
+        metadata.keywords.has(word) ||
+        (word.endsWith("s") && metadata.keywords.has(word.slice(0, -1)))
+      ) {
+        score += 1;
+      } else {
+        score = 0;
+        break;
+      }
+    }
+    if (score > bestScore) {
+      bestScore = score;
+      bestMatch = metadata;
+    }
+  }
+
+  if (bestMatch && bestScore > 0) {
+    return {
+      section: bestMatch.section,
+      view: bestMatch.view,
+      query: bestMatch.name,
+      viewExplicit: false,
+    };
+  }
+
+  return null;
+}
+
+export function getAllComponentSlugs(): readonly string[] {
+  return ALL_KNOWN_SLUGS;
+}
+
+export { DEFAULT_VIEW as DEFAULT_COMPONENTS_VIEW };

--- a/tests/components/components-slug.test.ts
+++ b/tests/components/components-slug.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getAllComponentSlugs,
+  resolveComponentsSlug,
+} from "@/components/components/slug";
+
+describe("components slug resolution", () => {
+  it("resolves known section slugs", () => {
+    const result = resolveComponentsSlug("buttons");
+    expect(result).toMatchObject({ section: "buttons" });
+    expect(result?.view).toBe("primitives");
+  });
+
+  it("resolves entry slugs", () => {
+    const result = resolveComponentsSlug("button");
+    expect(result).toMatchObject({ section: "buttons" });
+    expect(result?.query).toBe("Button");
+  });
+
+  it("resolves tagged alias slugs", () => {
+    const result = resolveComponentsSlug("action-buttons");
+    expect(result).toMatchObject({ section: "buttons" });
+    expect(result?.query).toBe("Button");
+  });
+
+  it("maps view aliases", () => {
+    const result = resolveComponentsSlug("colors");
+    expect(result).toMatchObject({ view: "tokens" });
+    expect(result?.section).toBeUndefined();
+  });
+
+  it("returns null for unknown slugs", () => {
+    expect(resolveComponentsSlug("unknown")).toBeNull();
+  });
+
+  it("exposes all static params", () => {
+    const slugs = getAllComponentSlugs();
+    expect(slugs).toContain("buttons");
+    expect(slugs).toContain("button");
+    expect(slugs).toContain("action-buttons");
+    expect(slugs).toContain("colors");
+  });
+});


### PR DESCRIPTION
## Summary
- add a slug resolution helper for the components gallery to map section, entry, and alias slugs
- add a catch-all components/[section] route that redirects to the main gallery with the appropriate query params
- cover slug resolution behaviour with unit tests, including aliases such as action-buttons and colors

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cd9cbaba78832c9afc88dc875d8b02