### PR TITLE
Add required attribute to goal title input

### DIFF
--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -81,6 +81,7 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
               className="h-10 text-ui font-medium"
               value={title}
               onChange={(e) => onTitleChange(e.target.value)}
+              required
               aria-required="true"
               aria-describedby={describedBy || undefined}
             />


### PR DESCRIPTION
## Summary
- add the HTML required attribute to the goal title input while preserving existing aria wiring

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cda4276a34832c9da8e554cae39081