### PR TITLE
Fix components section page params typing

### DIFF
--- a/src/app/components/[section]/page.tsx
+++ b/src/app/components/[section]/page.tsx
@@ -15,13 +15,14 @@ export function generateStaticParams() {
 }
 
 interface ComponentsSectionPageProps {
-  params: { section: string };
+  params: Promise<{ section: string }>;
 }
 
-export default function ComponentsSectionPage({
+export default async function ComponentsSectionPage({
   params,
 }: ComponentsSectionPageProps) {
-  const resolved = resolveComponentsSlug(params.section);
+  const { section } = await params;
+  const resolved = resolveComponentsSlug(section);
   if (!resolved) {
     notFound();
   }


### PR DESCRIPTION
## Summary
- treat the components section page `params` as asynchronous to satisfy the updated Next.js 15 `PageProps` constraint
- await the section parameter before resolving the slug so the redirect target stays consistent

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cda467a8d0832cabf0b534bbee271b