### PR TITLE
Fix usePersistentState initial value handling

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -323,7 +323,7 @@ export function usePersistentState<T>(
   initial: T,
   options?: PersistentStateOptions<T>,
 ): [T, React.Dispatch<React.SetStateAction<T>>] {
-  const [state, setState] = React.useState<T>(initial);
+  const [state, setState] = React.useState<T>(() => initial);
 
   const initialRef = React.useRef(initial);
   const stateRef = React.useRef(state);
@@ -331,7 +331,9 @@ export function usePersistentState<T>(
     stateRef.current = state;
   }, [state]);
   React.useEffect(() => {
-    initialRef.current = initial;
+    if (!Object.is(initialRef.current, initial)) {
+      initialRef.current = initial;
+    }
   }, [initial]);
 
   const decodeRef = React.useRef<PersistentStateDecode<T> | null>(


### PR DESCRIPTION
## Summary
- initialize persistent state lazily so new renders do not retrigger default writes
- ignore redundant initial value updates by guarding the ref assignment

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cda65c07e8832c886d2c9bc5a684cc