### PR TITLE
Fix Button asChild type forwarding

### DIFF
--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -357,7 +357,10 @@ export const Button = React.forwardRef<
   if (asChild) {
     const slotProps = {
       ...(props as ButtonAsChildProps),
-    } as Record<string, unknown> & { tabIndex?: number };
+    } as Record<string, unknown> & {
+      tabIndex?: number;
+      type?: HTMLMotionProps<"button">["type"];
+    };
     const tabIndex = slotProps.tabIndex;
     delete slotProps.tabIndex;
     delete slotProps.asChild;
@@ -369,7 +372,6 @@ export const Button = React.forwardRef<
     delete slotProps.className;
     delete slotProps.children;
     delete slotProps.style;
-    delete slotProps.type;
     delete slotProps.disabled;
     const baseProps = {
       className: mergedClassName,

--- a/tests/primitives/button.test.tsx
+++ b/tests/primitives/button.test.tsx
@@ -22,6 +22,16 @@ describe("Button", () => {
     expect(getByRole("button")).toHaveClass("btn-primary");
   });
 
+  it("keeps child button type when rendered asChild", () => {
+    const { getByRole } = render(
+      <Button asChild>
+        <button type="submit">Submit</button>
+      </Button>,
+    );
+
+    expect(getByRole("button")).toHaveAttribute("type", "submit");
+  });
+
   it("has no outline when focused", () => {
     const { getByRole } = render(<Button>Focus</Button>);
     const btn = getByRole("button");


### PR DESCRIPTION
## Summary
- keep the type attribute when Button renders children via `asChild`
- add a regression test ensuring the type is forwarded to the rendered button

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cdc765ecf8832c9fe6b11eb6ab9171