### PR TITLE
Add stable ids to quick action grid

### DIFF
--- a/src/components/home/QuickActionGrid.tsx
+++ b/src/components/home/QuickActionGrid.tsx
@@ -25,6 +25,7 @@ const buttonHoverLiftClassName =
   "motion-safe:hover:-translate-y-[var(--quick-actions-lift)] motion-reduce:transform-none";
 
 type QuickActionDefinition = {
+  id?: string;
   href: string;
   label: React.ReactNode;
   tone?: ButtonProps["tone"];
@@ -58,8 +59,9 @@ export default function QuickActionGrid({
 }: QuickActionGridProps) {
   return (
     <div className={cn(ROOT_CLASSNAME, layoutClassNames[layout], className)}>
-      {actions.map((action, index) => {
+      {actions.map((action) => {
         const {
+          id,
           href,
           label,
           tone,
@@ -69,7 +71,7 @@ export default function QuickActionGrid({
           variant,
           linkProps,
         } = action;
-        const key = `${href}-${index}`;
+        const key = id ?? href;
         const resolvedTone = tone ?? buttonTone;
         const resolvedSize = size ?? buttonSize;
         const resolvedVariant = variant ?? buttonVariant;

--- a/src/components/home/TeamPromptsCard.tsx
+++ b/src/components/home/TeamPromptsCard.tsx
@@ -6,16 +6,19 @@ import QuickActionGrid from "./QuickActionGrid";
 
 const teamQuickActions = [
   {
+    id: "team-archetypes",
     href: "/team",
     label: "Archetypes",
     asChild: true,
   },
   {
+    id: "team-builder",
     href: "/team",
     label: "Team Builder",
     asChild: true,
   },
   {
+    id: "team-jungle-clears",
     href: "/team",
     label: "Jungle Clears",
     asChild: true,


### PR DESCRIPTION
## Summary
- allow quick action definitions to specify an optional id and reuse hrefs when no id is provided
- use the stable identifier for each quick action button key instead of the array index
- add explicit ids to team quick actions so duplicate hrefs no longer collide

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cdd26bd0ac832c830d42ccb12673a4