### PR TITLE
Use tokenized shadow for segmented buttons

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -649,10 +649,7 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
     color: hsl(var(--foreground));
     background: color-mix(in oklab, hsl(var(--card)) 75%, transparent);
     border-color: hsl(var(--ring));
-    box-shadow:
-      0 0 0 var(--spacing-0-5) hsl(var(--ring) / 0.35),
-      0 var(--space-3) calc(var(--space-5) + var(--space-1))
-        hsl(var(--ring) / 0.25);
+    box-shadow: var(--shadow-nav-active);
   }
 
   .btn-glitch {


### PR DESCRIPTION
## Summary
- replace the segmented button active shadow in globals.css with the shared nav shadow token so the state uses design tokens

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cdd76ac9b0832c8fdd17bc3c57feb5