### PR TITLE
Refactor TodayHero into modular components

### DIFF
--- a/src/components/planner/TodayHeroHeader.tsx
+++ b/src/components/planner/TodayHeroHeader.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useMemo, useRef, useCallback } from "react";
+import type { ChangeEvent } from "react";
+import { Calendar } from "lucide-react";
+
+import { toISODate } from "@/lib/date";
+import IconButton from "@/components/ui/primitives/IconButton";
+import type { ISODate } from "./plannerStore";
+
+const HEADER_TITLE = "Today";
+
+type DateInputWithPicker = HTMLInputElement & { showPicker?: () => void };
+
+type TodayHeroHeaderProps = {
+  viewIso: ISODate;
+  isToday: boolean;
+  onChange: (nextIso: ISODate) => void;
+};
+
+export default function TodayHeroHeader({
+  viewIso,
+  isToday,
+  onChange,
+}: TodayHeroHeaderProps) {
+  const fallbackIso = useMemo(() => toISODate(), []);
+  const dateRef = useRef<HTMLInputElement>(null);
+
+  const openPicker = useCallback(() => {
+    const el = dateRef.current as DateInputWithPicker | null;
+    if (el?.showPicker) {
+      el.showPicker();
+      return;
+    }
+    dateRef.current?.focus();
+  }, []);
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onChange(event.target.value as ISODate);
+    },
+    [onChange],
+  );
+
+  const title = isToday ? HEADER_TITLE : viewIso;
+  const inputValue = viewIso || fallbackIso;
+
+  return (
+    <div className="mb-[var(--space-4)] flex flex-col gap-[var(--space-2)] md:flex-row md:items-center md:justify-between">
+      <div className="flex items-center gap-[var(--space-3)]">
+        <h2 className="glitch text-title font-semibold tracking-[-0.01em]" data-text={title}>
+          {title}
+        </h2>
+      </div>
+
+      <div className="flex items-center gap-[var(--space-2)]">
+        <input
+          ref={dateRef}
+          type="date"
+          value={inputValue}
+          onChange={handleChange}
+          aria-label="Change focused date"
+          className="sr-only"
+        />
+        <IconButton
+          aria-label="Open calendar"
+          title={viewIso}
+          onClick={openPicker}
+          size="md"
+          variant="ring"
+          iconSize="md"
+        >
+          <Calendar />
+        </IconButton>
+      </div>
+    </div>
+  );
+}

--- a/src/components/planner/TodayHeroProjects.tsx
+++ b/src/components/planner/TodayHeroProjects.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { Pencil, Trash2 } from "lucide-react";
+import type { FormEvent } from "react";
+
+import { cn } from "@/lib/utils";
+import Button from "@/components/ui/primitives/Button";
+import IconButton from "@/components/ui/primitives/IconButton";
+import Input from "@/components/ui/primitives/Input";
+import CheckCircle from "@/components/ui/toggles/CheckCircle";
+import type { Project } from "./plannerStore";
+
+export type TodayHeroProjectsProps = {
+  projects: Project[];
+  selectedProjectId: string;
+  projectsListId: string;
+  projectName: string;
+  editingProjectId: string | null;
+  editingProjectName: string;
+  showAllProjects: boolean;
+  visibleProjects: Project[];
+  hiddenProjectsCount: number;
+  shouldShowProjectToggle: boolean;
+  onProjectNameChange: (value: string) => void;
+  onProjectFormSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onProjectSelect: (projectId: string) => void;
+  onProjectToggle: (projectId: string) => void;
+  onProjectDelete: (projectId: string) => void;
+  onProjectEditOpen: (projectId: string, name: string) => void;
+  onProjectRenameChange: (value: string) => void;
+  onProjectRenameCommit: (projectId: string, fallbackName: string) => void;
+  onProjectRenameCancel: () => void;
+  onToggleShowAllProjects: () => void;
+};
+
+export default function TodayHeroProjects({
+  projects,
+  selectedProjectId,
+  projectsListId,
+  projectName,
+  editingProjectId,
+  editingProjectName,
+  showAllProjects,
+  visibleProjects,
+  hiddenProjectsCount,
+  shouldShowProjectToggle,
+  onProjectNameChange,
+  onProjectFormSubmit,
+  onProjectSelect,
+  onProjectToggle,
+  onProjectDelete,
+  onProjectEditOpen,
+  onProjectRenameChange,
+  onProjectRenameCommit,
+  onProjectRenameCancel,
+  onToggleShowAllProjects,
+}: TodayHeroProjectsProps) {
+  return (
+    <div className="mt-[var(--space-4)] space-y-[var(--space-4)]">
+      <form onSubmit={onProjectFormSubmit}>
+        <Input
+          name="new-project"
+          placeholder="> new project…"
+          value={projectName}
+          onChange={(event) => onProjectNameChange(event.target.value)}
+          aria-label="New project"
+          className="w-full"
+        />
+      </form>
+
+      {projects.length > 0 && (
+        <>
+          <ul
+            id={projectsListId}
+            className="space-y-[var(--space-2)]"
+            role="list"
+            aria-label="Projects"
+          >
+            {visibleProjects.map((project) => {
+              const isEditing = editingProjectId === project.id;
+              const isSelected = selectedProjectId === project.id;
+              return (
+                <li
+                  key={project.id}
+                  className={cn(
+                    "group flex select-none items-center justify-between rounded-card r-card-lg border px-[var(--space-3)] py-[var(--space-2)] text-ui font-medium transition",
+                    "border-border bg-card/55 hover:bg-card/70",
+                    isSelected && "ring-1 ring-ring",
+                  )}
+                  onClick={() => {
+                    if (!isEditing) onProjectSelect(project.id);
+                  }}
+                  title={
+                    isEditing
+                      ? "Editing…"
+                      : isSelected
+                        ? "Selected"
+                        : "Click to select"
+                  }
+                  role="listitem"
+                >
+                  {isEditing ? (
+                    <Input
+                      name={`rename-project-${project.id}`}
+                      autoFocus
+                      value={editingProjectName}
+                      onChange={(event) => onProjectRenameChange(event.target.value)}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter") {
+                          onProjectRenameCommit(project.id, project.name);
+                        }
+                        if (event.key === "Escape") onProjectRenameCancel();
+                      }}
+                      onBlur={() => {
+                        onProjectRenameCommit(project.id, project.name);
+                      }}
+                      aria-label={`Rename project ${project.name}`}
+                      onClick={(event) => event.stopPropagation()}
+                    />
+                  ) : (
+                    <div className="flex min-w-0 items-center gap-[var(--space-3)]">
+                      <span
+                        className="shrink-0"
+                        onMouseDown={(event) => event.stopPropagation()}
+                        onClick={(event) => event.stopPropagation()}
+                      >
+                        <CheckCircle
+                          size="sm"
+                          checked={project.done}
+                          onChange={() => onProjectToggle(project.id)}
+                          aria-label={`Toggle completion for ${project.name}`}
+                        />
+                      </span>
+                      <span
+                        className={cn(
+                          "truncate",
+                          project.done && "line-through-soft text-muted-foreground",
+                        )}
+                      >
+                        {project.name}
+                      </span>
+                    </div>
+                  )}
+
+                  <div className="flex items-center gap-[var(--space-2)]">
+                    <IconButton
+                      aria-label={`Edit project ${project.name}`}
+                      title="Edit"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onProjectEditOpen(project.id, project.name);
+                      }}
+                      size="sm"
+                      variant="ring"
+                      iconSize="xs"
+                    >
+                      <Pencil />
+                    </IconButton>
+                    <IconButton
+                      aria-label={`Remove project ${project.name}`}
+                      title="Remove"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onProjectDelete(project.id);
+                      }}
+                      size="sm"
+                      variant="ring"
+                      iconSize="xs"
+                    >
+                      <Trash2 />
+                    </IconButton>
+                  </div>
+                </li>
+              );
+            })}
+            {hiddenProjectsCount > 0 && (
+              <li className="pr-[var(--space-1)] text-right text-label font-medium tracking-[0.02em] opacity-70">
+                + {hiddenProjectsCount} more…
+              </li>
+            )}
+          </ul>
+          {shouldShowProjectToggle && (
+            <div className="flex justify-end">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={onToggleShowAllProjects}
+                aria-expanded={showAllProjects}
+                aria-controls={projectsListId}
+              >
+                {showAllProjects ? "Show less" : "Show more"}
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/planner/TodayHeroTasks.tsx
+++ b/src/components/planner/TodayHeroTasks.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { Pencil, Trash2 } from "lucide-react";
+import type { FormEvent } from "react";
+
+import { cn } from "@/lib/utils";
+import Button from "@/components/ui/primitives/Button";
+import IconButton from "@/components/ui/primitives/IconButton";
+import Input from "@/components/ui/primitives/Input";
+import CheckCircle from "@/components/ui/toggles/CheckCircle";
+import type { DayTask } from "./plannerStore";
+
+export type TodayHeroTasksProps = {
+  projectId: string;
+  projectName: string;
+  tasksListId: string;
+  taskInputName: string;
+  visibleTasks: DayTask[];
+  totalTaskCount: number;
+  showAllTasks: boolean;
+  shouldShowTaskToggle: boolean;
+  editingTaskId: string | null;
+  editingTaskText: string;
+  taskAnnouncementText: string;
+  onTaskFormSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onTaskSelect: (taskId: string) => void;
+  onTaskToggle: (taskId: string) => void;
+  onTaskDelete: (taskId: string) => void;
+  onTaskEditOpen: (taskId: string, title: string, options?: { select?: boolean }) => void;
+  onTaskRenameChange: (value: string) => void;
+  onTaskRenameCommit: (taskId: string, fallbackTitle: string) => void;
+  onTaskRenameCancel: () => void;
+  onToggleShowAllTasks: () => void;
+};
+
+export default function TodayHeroTasks({
+  projectId,
+  projectName,
+  tasksListId,
+  taskInputName,
+  visibleTasks,
+  totalTaskCount,
+  showAllTasks,
+  shouldShowTaskToggle,
+  editingTaskId,
+  editingTaskText,
+  taskAnnouncementText,
+  onTaskFormSubmit,
+  onTaskSelect,
+  onTaskToggle,
+  onTaskDelete,
+  onTaskEditOpen,
+  onTaskRenameChange,
+  onTaskRenameCommit,
+  onTaskRenameCancel,
+  onToggleShowAllTasks,
+}: TodayHeroTasksProps) {
+  if (!projectId) {
+    return (
+      <div className="mt-[var(--space-4)] text-ui font-medium text-muted-foreground">
+        Select a project to add and view tasks.
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-[var(--space-4)] space-y-[var(--space-4)]">
+      <form onSubmit={onTaskFormSubmit}>
+        <Input
+          name={taskInputName}
+          placeholder={`> task for "${projectName || "Project"}"`}
+          aria-label="New task"
+          className="w-full"
+        />
+      </form>
+
+      <div aria-live="polite" className="sr-only">
+        {taskAnnouncementText}
+      </div>
+
+      {totalTaskCount === 0 ? (
+        <div className="tasks-placeholder">No tasks yet.</div>
+      ) : (
+        <div className="space-y-[var(--space-2)]">
+          <ul
+            id={tasksListId}
+            className="space-y-[var(--space-2)]"
+            role="list"
+            aria-label="Tasks"
+          >
+            {visibleTasks.map((task) => {
+              const isEditing = editingTaskId === task.id;
+              return (
+                <li
+                  key={task.id}
+                  className={cn(
+                    "task-tile flex items-center justify-between rounded-card r-card-lg border px-[var(--space-3)] py-[var(--space-2)]",
+                    "border-border bg-card/55 hover:bg-card/70",
+                  )}
+                  role="listitem"
+                  onClick={() => onTaskSelect(task.id)}
+                >
+                  <div className="flex items-center gap-[var(--space-3)]">
+                    <CheckCircle
+                      checked={task.done}
+                      onChange={() => {
+                        onTaskToggle(task.id);
+                      }}
+                      size="sm"
+                    />
+                    {isEditing ? (
+                      <Input
+                        name={`rename-task-${task.id}`}
+                        autoFocus
+                        value={editingTaskText}
+                        onChange={(event) => onTaskRenameChange(event.target.value)}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter") {
+                            onTaskRenameCommit(task.id, task.title);
+                          }
+                          if (event.key === "Escape") onTaskRenameCancel();
+                        }}
+                        onBlur={() => {
+                          onTaskRenameCommit(task.id, task.title);
+                        }}
+                        aria-label={`Rename task ${task.title}`}
+                      />
+                    ) : (
+                      <button
+                        type="button"
+                        className={cn(
+                          "task-tile__text",
+                          task.done && "line-through-soft",
+                        )}
+                        onClick={() => {
+                          onTaskEditOpen(task.id, task.title);
+                        }}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter" || event.key === " ") {
+                            event.preventDefault();
+                            onTaskEditOpen(task.id, task.title);
+                          }
+                        }}
+                        aria-label={`Edit task ${task.title}`}
+                        title="Edit task"
+                      >
+                        {task.title}
+                      </button>
+                    )}
+                  </div>
+
+                  <div className="flex items-center gap-[var(--space-2)]">
+                    <IconButton
+                      aria-label={`Edit task ${task.title}`}
+                      title="Edit"
+                      onClick={() => {
+                        onTaskEditOpen(task.id, task.title, { select: true });
+                      }}
+                      size="sm"
+                      variant="ring"
+                      iconSize="xs"
+                    >
+                      <Pencil />
+                    </IconButton>
+                    <IconButton
+                      aria-label="Remove task"
+                      title="Remove"
+                      onClick={() => {
+                        onTaskDelete(task.id);
+                      }}
+                      size="sm"
+                      variant="ring"
+                      iconSize="xs"
+                    >
+                      <Trash2 />
+                    </IconButton>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+          {shouldShowTaskToggle && (
+            <div className="flex justify-end">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={onToggleShowAllTasks}
+                aria-expanded={showAllTasks}
+                aria-controls={tasksListId}
+              >
+                {showAllTasks ? "Show less" : "Show more"}
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/planner/useTodayHeroProjects.ts
+++ b/src/components/planner/useTodayHeroProjects.ts
@@ -1,0 +1,190 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { FormEvent } from "react";
+
+import type { Project } from "./plannerStore";
+
+const PROJECT_PREVIEW_LIMIT = 12;
+
+type UseTodayHeroProjectsParams = {
+  projects: Project[];
+  selectedProjectId: string;
+  setSelectedProjectId: (projectId: string) => void;
+  addProject: (name: string) => string | void;
+  renameProject: (id: string, name: string) => void;
+  deleteProject: (id: string) => void;
+  toggleProject: (id: string) => void;
+};
+
+type UseTodayHeroProjectsResult = {
+  projectsListId: string;
+  projectName: string;
+  editingProjectId: string | null;
+  editingProjectName: string;
+  showAllProjects: boolean;
+  visibleProjects: Project[];
+  hiddenProjectsCount: number;
+  shouldShowProjectToggle: boolean;
+  handleProjectNameChange: (value: string) => void;
+  handleProjectFormSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  handleProjectSelect: (projectId: string) => void;
+  handleProjectToggle: (projectId: string) => void;
+  handleProjectDelete: (projectId: string) => void;
+  openProjectEditor: (projectId: string, name: string) => void;
+  handleProjectRenameChange: (value: string) => void;
+  commitProjectRename: (projectId: string, fallbackName: string) => void;
+  cancelProjectRename: () => void;
+  toggleShowAllProjects: () => void;
+};
+
+export function useTodayHeroProjects({
+  projects,
+  selectedProjectId,
+  setSelectedProjectId,
+  addProject,
+  renameProject,
+  deleteProject,
+  toggleProject,
+}: UseTodayHeroProjectsParams): UseTodayHeroProjectsResult {
+  const [projectName, setProjectName] = useState("");
+  const [editingProjectId, setEditingProjectId] = useState<string | null>(null);
+  const [editingProjectName, setEditingProjectName] = useState("");
+  const [showAllProjects, setShowAllProjects] = useState(false);
+
+  const projectsListId = "today-hero-project-list";
+
+  const visibleProjects = useMemo(
+    () =>
+      showAllProjects
+        ? projects
+        : projects.slice(0, PROJECT_PREVIEW_LIMIT),
+    [projects, showAllProjects],
+  );
+
+  const hiddenProjectsCount = useMemo(
+    () => Math.max(projects.length - visibleProjects.length, 0),
+    [projects.length, visibleProjects.length],
+  );
+
+  const shouldShowProjectToggle = projects.length > PROJECT_PREVIEW_LIMIT;
+
+  const handleProjectNameChange = useCallback((value: string) => {
+    setProjectName(value);
+  }, []);
+
+  const handleProjectFormSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const title = projectName.trim();
+      if (!title) return;
+      const id = addProject(title);
+      setProjectName("");
+      if (id) setSelectedProjectId(id);
+    },
+    [addProject, projectName, setSelectedProjectId],
+  );
+
+  const handleProjectSelect = useCallback(
+    (projectId: string) => {
+      setSelectedProjectId(projectId);
+    },
+    [setSelectedProjectId],
+  );
+
+  const handleProjectToggle = useCallback(
+    (projectId: string) => {
+      toggleProject(projectId);
+    },
+    [toggleProject],
+  );
+
+  const handleProjectDelete = useCallback(
+    (projectId: string) => {
+      deleteProject(projectId);
+      if (selectedProjectId === projectId) {
+        setSelectedProjectId("");
+      }
+      if (editingProjectId === projectId) {
+        setEditingProjectId(null);
+        setEditingProjectName("");
+      }
+    },
+    [deleteProject, editingProjectId, selectedProjectId, setSelectedProjectId],
+  );
+
+  const openProjectEditor = useCallback((projectId: string, name: string) => {
+    setEditingProjectId(projectId);
+    setEditingProjectName(name);
+  }, []);
+
+  const handleProjectRenameChange = useCallback((value: string) => {
+    setEditingProjectName(value);
+  }, []);
+
+  const commitProjectRename = useCallback(
+    (projectId: string, fallbackName: string) => {
+      const nextName = editingProjectName.trim() || fallbackName;
+      renameProject(projectId, nextName);
+      setEditingProjectId(null);
+    },
+    [editingProjectName, renameProject],
+  );
+
+  const cancelProjectRename = useCallback(() => {
+    setEditingProjectId(null);
+  }, []);
+
+  const toggleShowAllProjects = useCallback(() => {
+    setShowAllProjects((prev) => !prev);
+  }, []);
+
+  useEffect(() => {
+    if (showAllProjects && projects.length <= PROJECT_PREVIEW_LIMIT) {
+      setShowAllProjects(false);
+    }
+  }, [projects.length, showAllProjects]);
+
+  useEffect(() => {
+    if (!selectedProjectId || showAllProjects) return;
+    if (projects.length <= PROJECT_PREVIEW_LIMIT) return;
+
+    const isSelectedVisible = projects
+      .slice(0, PROJECT_PREVIEW_LIMIT)
+      .some((project) => project.id === selectedProjectId);
+
+    if (!isSelectedVisible) {
+      setShowAllProjects(true);
+    }
+  }, [projects, selectedProjectId, showAllProjects]);
+
+  useEffect(() => {
+    if (!editingProjectId) return;
+    const stillExists = projects.some((project) => project.id === editingProjectId);
+    if (!stillExists) {
+      setEditingProjectId(null);
+      setEditingProjectName("");
+    }
+  }, [editingProjectId, projects]);
+
+  return {
+    projectsListId,
+    projectName,
+    editingProjectId,
+    editingProjectName,
+    showAllProjects,
+    visibleProjects,
+    hiddenProjectsCount,
+    shouldShowProjectToggle,
+    handleProjectNameChange,
+    handleProjectFormSubmit,
+    handleProjectSelect,
+    handleProjectToggle,
+    handleProjectDelete,
+    openProjectEditor,
+    handleProjectRenameChange,
+    commitProjectRename,
+    cancelProjectRename,
+    toggleShowAllProjects,
+  };
+}

--- a/src/components/planner/useTodayHeroTasks.ts
+++ b/src/components/planner/useTodayHeroTasks.ts
@@ -1,0 +1,278 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { FormEvent } from "react";
+
+import type { DayTask } from "./plannerStore";
+
+type TodayHeroTaskAnnouncement = {
+  text: string;
+  toggleMarker: boolean;
+};
+
+type UseTodayHeroTasksParams = {
+  scopedTasks: DayTask[];
+  projectId: string;
+  projectName: string;
+  addTask: (title: string, projectId?: string) => string | void;
+  renameTask: (taskId: string, title: string) => void;
+  deleteTask: (taskId: string) => void;
+  toggleTask: (taskId: string) => void;
+  setSelectedTaskId: (taskId: string) => void;
+};
+
+type UseTodayHeroTasksResult = {
+  tasksListId: string;
+  taskInputName: string;
+  visibleTasks: DayTask[];
+  totalTaskCount: number;
+  showAllTasks: boolean;
+  shouldShowTaskToggle: boolean;
+  editingTaskId: string | null;
+  editingTaskText: string;
+  taskAnnouncementText: string;
+  handleTaskFormSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  handleTaskSelect: (taskId: string) => void;
+  handleTaskToggle: (taskId: string) => void;
+  handleTaskDelete: (taskId: string) => void;
+  openTaskEditor: (taskId: string, title: string, options?: { select?: boolean }) => void;
+  handleTaskRenameChange: (value: string) => void;
+  commitTaskRename: (taskId: string, fallbackTitle: string) => void;
+  cancelTaskRename: () => void;
+  toggleShowAllTasks: () => void;
+};
+
+const TASK_PREVIEW_LIMIT = 12;
+
+export function useTodayHeroTasks({
+  scopedTasks,
+  projectId,
+  projectName,
+  addTask,
+  renameTask,
+  deleteTask,
+  toggleTask,
+  setSelectedTaskId,
+}: UseTodayHeroTasksParams): UseTodayHeroTasksResult {
+  const [showAllTasks, setShowAllTasks] = useState(false);
+  const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
+  const [editingTaskText, setEditingTaskText] = useState("");
+  const [taskAnnouncement, setTaskAnnouncement] = useState<TodayHeroTaskAnnouncement>({
+    text: "",
+    toggleMarker: false,
+  });
+
+  const prevProjectIdRef = useRef<string | null>(null);
+  const prevTasksRef = useRef<Map<string, { title: string; done: boolean }>>(
+    new Map(),
+  );
+
+  const tasksListId = useMemo(
+    () => `today-hero-task-list-${projectId || "none"}`,
+    [projectId],
+  );
+
+  const taskInputName = useMemo(
+    () => `new-task-${projectId || "none"}`,
+    [projectId],
+  );
+
+  const totalTaskCount = scopedTasks.length;
+
+  const visibleTasks = useMemo(
+    () =>
+      showAllTasks
+        ? scopedTasks
+        : scopedTasks.slice(0, TASK_PREVIEW_LIMIT),
+    [scopedTasks, showAllTasks],
+  );
+
+  const shouldShowTaskToggle = totalTaskCount > TASK_PREVIEW_LIMIT;
+
+  const handleTaskFormSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      if (!projectId) {
+        event.preventDefault();
+        return;
+      }
+      event.preventDefault();
+      const input = event.currentTarget.elements.namedItem(
+        taskInputName,
+      ) as HTMLInputElement | null;
+      const value = input?.value ?? "";
+      const title = value.trim();
+      if (!title) return;
+      const id = addTask(title, projectId);
+      if (input) input.value = "";
+      if (id) setSelectedTaskId(id);
+    },
+    [addTask, projectId, setSelectedTaskId, taskInputName],
+  );
+
+  const handleTaskSelect = useCallback(
+    (taskId: string) => {
+      setSelectedTaskId(taskId);
+    },
+    [setSelectedTaskId],
+  );
+
+  const handleTaskToggle = useCallback(
+    (taskId: string) => {
+      toggleTask(taskId);
+      setSelectedTaskId(taskId);
+    },
+    [setSelectedTaskId, toggleTask],
+  );
+
+  const handleTaskDelete = useCallback(
+    (taskId: string) => {
+      deleteTask(taskId);
+      setSelectedTaskId("");
+      if (editingTaskId === taskId) {
+        setEditingTaskId(null);
+        setEditingTaskText("");
+      }
+    },
+    [deleteTask, editingTaskId, setSelectedTaskId],
+  );
+
+  const openTaskEditor = useCallback(
+    (taskId: string, title: string, options?: { select?: boolean }) => {
+      setEditingTaskText(title);
+      setEditingTaskId(taskId);
+      if (options?.select) setSelectedTaskId(taskId);
+    },
+    [setSelectedTaskId],
+  );
+
+  const handleTaskRenameChange = useCallback((value: string) => {
+    setEditingTaskText(value);
+  }, []);
+
+  const commitTaskRename = useCallback(
+    (taskId: string, fallbackTitle: string) => {
+      const nextTitle = editingTaskText.trim() || fallbackTitle;
+      renameTask(taskId, nextTitle);
+      setEditingTaskId(null);
+    },
+    [editingTaskText, renameTask],
+  );
+
+  const cancelTaskRename = useCallback(() => {
+    setEditingTaskId(null);
+  }, []);
+
+  const toggleShowAllTasks = useCallback(() => {
+    setShowAllTasks((prev) => !prev);
+  }, []);
+
+  useEffect(() => {
+    setShowAllTasks(false);
+  }, [projectId]);
+
+  useEffect(() => {
+    if (showAllTasks && totalTaskCount <= TASK_PREVIEW_LIMIT) {
+      setShowAllTasks(false);
+    }
+  }, [showAllTasks, totalTaskCount]);
+
+  useEffect(() => {
+    if (editingTaskId && !scopedTasks.some((task) => task.id === editingTaskId)) {
+      setEditingTaskId(null);
+      setEditingTaskText("");
+    }
+  }, [editingTaskId, scopedTasks]);
+
+  useEffect(() => {
+    if (!projectId) {
+      prevProjectIdRef.current = null;
+      prevTasksRef.current = new Map();
+      setTaskAnnouncement((prev) =>
+        prev.text ? { text: "", toggleMarker: prev.toggleMarker } : prev,
+      );
+      return;
+    }
+
+    const currentTasksMap = new Map<string, { title: string; done: boolean }>(
+      scopedTasks.map((task) => [task.id, { title: task.title, done: task.done }]),
+    );
+
+    if (prevProjectIdRef.current !== projectId) {
+      prevProjectIdRef.current = projectId;
+      prevTasksRef.current = currentTasksMap;
+      setTaskAnnouncement((prev) =>
+        prev.text ? { text: "", toggleMarker: prev.toggleMarker } : prev,
+      );
+      return;
+    }
+
+    const prevTasksMap = prevTasksRef.current;
+    let message: string | null = null;
+    const projectSuffix = projectName ? ` in project "${projectName}"` : "";
+
+    for (const [id, task] of currentTasksMap) {
+      if (!prevTasksMap.has(id)) {
+        message = `Task "${task.title}" added${projectSuffix}.`;
+        break;
+      }
+    }
+
+    if (!message) {
+      for (const [id, prevTask] of prevTasksMap) {
+        if (!currentTasksMap.has(id)) {
+          message = `Task "${prevTask.title}" removed${projectSuffix}.`;
+          break;
+        }
+      }
+    }
+
+    if (!message) {
+      for (const [id, task] of currentTasksMap) {
+        const prevTask = prevTasksMap.get(id);
+        if (!prevTask) continue;
+
+        if (prevTask.title !== task.title) {
+          message = `Task "${prevTask.title}" renamed to "${task.title}"${projectSuffix}.`;
+          break;
+        }
+
+        if (prevTask.done !== task.done) {
+          message = task.done
+            ? `Task "${task.title}" marked complete${projectSuffix}.`
+            : `Task "${task.title}" marked incomplete${projectSuffix}.`;
+          break;
+        }
+      }
+    }
+
+    if (message) {
+      setTaskAnnouncement((prev) => ({
+        text: `${message}${prev.toggleMarker ? "" : "\u200B"}`,
+        toggleMarker: !prev.toggleMarker,
+      }));
+    }
+
+    prevTasksRef.current = currentTasksMap;
+  }, [projectId, projectName, scopedTasks]);
+
+  return {
+    tasksListId,
+    taskInputName,
+    visibleTasks,
+    totalTaskCount,
+    showAllTasks,
+    shouldShowTaskToggle,
+    editingTaskId,
+    editingTaskText,
+    taskAnnouncementText: taskAnnouncement.text,
+    handleTaskFormSubmit,
+    handleTaskSelect,
+    handleTaskToggle,
+    handleTaskDelete,
+    openTaskEditor,
+    handleTaskRenameChange,
+    commitTaskRename,
+    cancelTaskRename,
+    toggleShowAllTasks,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the Today hero header into a reusable header component with a calendar picker
- split project and task sections into dedicated components backed by new hooks for state and preview logic
- simplify TodayHero to compose the new hooks/components while keeping progress calculations intact

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cdd6d1ce2c832c815f71827a0d61b7