### PR TITLE
Refactor glitch segmented glow tokens

### DIFF
--- a/src/components/ui/primitives/GlitchSegmented.module.css
+++ b/src/components/ui/primitives/GlitchSegmented.module.css
@@ -22,7 +22,7 @@
 
 .glitchScanlines:hover::after {
   opacity: 0.28;
-  filter: drop-shadow(0 0 6px hsl(var(--glow) / 0.5));
+  filter: drop-shadow(var(--shadow-glow-small));
   animation: crt-scan 4s linear infinite;
 }
 
@@ -30,7 +30,7 @@
 .glitchScanlines[aria-pressed="true"]::after,
 .glitchScanlines[data-selected="true"]::after {
   opacity: 0.45;
-  filter: drop-shadow(0 0 8px hsl(var(--glow)));
+  filter: drop-shadow(var(--shadow-glow-strong));
   animation:
     crt-scan 1s linear infinite,
     crt-jitter 200ms steps(2, end) infinite;
@@ -39,7 +39,7 @@
 .glitchScanlines::before {
   content: "";
   position: absolute;
-  inset: -2px;
+  inset: calc(-1 * var(--spacing-0-5));
   border-radius: inherit;
   pointer-events: none;
   background: radial-gradient(

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -120,6 +120,8 @@
   --shadow-ring: 0 0 var(--spacing-3) hsl(var(--ring));
   --shadow-neo-soft: 0 var(--spacing-1) var(--spacing-3) calc(var(--spacing-1) * -1)
       hsl(var(--shadow-color));
+  --shadow-glow-small: 0 0 calc(var(--spacing-3) / 2) hsl(var(--glow) / 0.5);
+  --shadow-glow-strong: 0 0 var(--spacing-2) hsl(var(--glow));
   --shadow-glow-sm: 0 0 var(--spacing-2) var(--glow-active);
   --shadow-glow-md: 0 0 var(--spacing-4) var(--glow-active);
   --shadow-glow-lg: 0 0 var(--spacing-5) var(--glow-active);

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -103,6 +103,9 @@ export default {
   shadowRing: "0 0 var(--spacing-3) hsl(var(--ring))",
   shadowNeoSoft:
     "0 var(--spacing-1) var(--spacing-3) calc(var(--spacing-1) * -1)\n      hsl(var(--shadow-color))",
+  shadowGlowSmall:
+    "0 0 calc(var(--spacing-3) / 2) hsl(var(--glow) / 0.5)",
+  shadowGlowStrong: "0 0 var(--spacing-2) hsl(var(--glow))",
   shadowGlowSm: "0 0 var(--spacing-2) var(--glow-active)",
   shadowGlowMd: "0 0 var(--spacing-4) var(--glow-active)",
   shadowGlowLg: "0 0 var(--spacing-5) var(--glow-active)",


### PR DESCRIPTION
## Summary
- replace the glitch segmented glow offsets with spacing and shadow tokens
- add reusable glow shadow aliases to the token bundle for hover and active states

## Testing
- npm run build-gallery-usage
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cdd76637b0832c8ad72806c07b9f6a