### PR TITLE
Align OutlineGlow demo with focus tokens

### DIFF
--- a/src/components/prompts/OutlineGlowDemo.tsx
+++ b/src/components/prompts/OutlineGlowDemo.tsx
@@ -3,19 +3,19 @@ import * as React from "react";
 // Demos should represent all interactive states for clarity.
 export default function OutlineGlowDemo() {
   return (
-    <div className="mb-[var(--space-4)] space-x-[var(--space-2)]">
+    <div className="mb-[var(--space-4)] flex gap-[var(--space-2)]">
       <button
         type="button"
-        className="p-[var(--space-2)] border rounded-[var(--control-radius)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] hover:bg-surface-2 active:bg-surface"
-        style={{ "--focus": "var(--theme-ring)" } as React.CSSProperties}
+        className="inline-flex items-center justify-center rounded-card r-card-md border px-[var(--space-3)] py-[var(--space-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] hover:bg-surface-2 active:bg-surface"
+        style={{ "--focus": "var(--focus)" } as React.CSSProperties}
       >
         Focus me to see the glow
       </button>
       <button
         type="button"
         disabled
-        className="p-[var(--space-2)] border rounded-[var(--control-radius)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] hover:bg-surface-2 active:bg-surface disabled:cursor-not-allowed"
-        style={{ "--focus": "var(--theme-ring)" } as React.CSSProperties}
+        className="inline-flex items-center justify-center rounded-card r-card-md border px-[var(--space-3)] py-[var(--space-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] hover:bg-surface-2 active:bg-surface disabled:cursor-not-allowed"
+        style={{ "--focus": "var(--focus)" } as React.CSSProperties}
       >
         Disabled example
       </button>

--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -1251,19 +1251,19 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
       description: "Focus ring glow tokens and disabled outline states.",
       element: <OutlineGlowDemo />,
       tags: ["focus", "state", "demo"],
-      code: `<div className="space-x-2">
+      code: `<div className="flex gap-[var(--space-2)]">
   <button
     type="button"
-    className="p-2 border rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] hover:bg-surface-2 active:bg-surface"
-    style={{ "--focus": "var(--theme-ring)" }}
+    className="inline-flex items-center justify-center rounded-card r-card-md border px-[var(--space-3)] py-[var(--space-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] hover:bg-surface-2 active:bg-surface"
+    style={{ "--focus": "var(--focus)" }}
   >
     Focus me to see the glow
   </button>
   <button
     type="button"
-    aria-disabled="true"
-    className="p-2 border rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] hover:bg-surface-2 active:bg-surface disabled:cursor-not-allowed"
-    style={{ "--focus": "var(--theme-ring)" }}
+    disabled
+    className="inline-flex items-center justify-center rounded-card r-card-md border px-[var(--space-3)] py-[var(--space-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] hover:bg-surface-2 active:bg-surface disabled:cursor-not-allowed"
+    style={{ "--focus": "var(--focus)" }}
   >
     Disabled example
   </button>


### PR DESCRIPTION
## Summary
- switch the OutlineGlow demo buttons to token-backed spacing and radius utilities while using the unified focus token
- mirror the updated focus-ring example markup in the prompts gallery snippet

## Testing
- npm run build-gallery-usage
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cdd7aa491c832ca15a04ad552cbbca