### PR TITLE
Use interaction tokens for IconButton hover states

### DIFF
--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -72,10 +72,35 @@ const getSizeClass = (s: IconButtonSize) => {
   return sizeMap[s];
 };
 
-const variantBase: Record<Variant, string> = {
-  ring: "border bg-card/35 hover:bg-[--hover] [--hover:hsl(var(--panel)/0.45)] [--active:hsl(var(--panel)/0.55)]",
-  solid: "border",
-  glow: "border bg-card/35 hover:bg-[--hover] [--hover:hsl(var(--panel)/0.45)] [--active:hsl(var(--panel)/0.55)] shadow-glow-current",
+const toneTintTokens = {
+  primary:
+    "[--hover:theme('colors.interaction.foreground.tintHover')] [--active:theme('colors.interaction.foreground.tintActive')]",
+  accent:
+    "[--hover:theme('colors.interaction.accent.tintHover')] [--active:theme('colors.interaction.accent.tintActive')]",
+  info:
+    "[--hover:theme('colors.interaction.info.tintHover')] [--active:theme('colors.interaction.info.tintActive')]",
+  danger:
+    "[--hover:theme('colors.interaction.danger.tintHover')] [--active:theme('colors.interaction.danger.tintActive')]",
+} satisfies Record<Tone, string>;
+
+const surfaceInteractionTokens = {
+  accent:
+    "[--hover:theme('colors.interaction.accent.surfaceHover')] [--active:theme('colors.interaction.accent.surfaceActive')]",
+  info:
+    "[--hover:theme('colors.interaction.info.surfaceHover')] [--active:theme('colors.interaction.info.surfaceActive')]",
+  danger:
+    "[--hover:theme('colors.interaction.danger.surfaceHover')] [--active:theme('colors.interaction.danger.surfaceActive')]",
+} satisfies Record<Exclude<Tone, "primary">, string>;
+
+const variantBase: Record<Variant, (tone: Tone) => string> = {
+  ring: (tone) =>
+    cn("border bg-card/35 hover:bg-[--hover]", toneTintTokens[tone]),
+  solid: () => "border",
+  glow: (tone) =>
+    cn(
+      "border bg-card/35 hover:bg-[--hover] shadow-glow-current",
+      toneTintTokens[tone],
+    ),
 };
 
 const toneClasses: Record<Variant, Record<Tone, string>> = {
@@ -86,14 +111,22 @@ const toneClasses: Record<Variant, Record<Tone, string>> = {
     danger: "border-danger/35 text-danger",
   },
   solid: {
-    primary:
-      "border-transparent bg-foreground/15 text-foreground [--hover:hsl(var(--foreground)/0.12)] [--active:hsl(var(--foreground)/0.08)]",
-    accent:
-      "border-transparent bg-accent/30 text-[var(--text-on-accent)] [--hover:hsl(var(--accent)/0.4)] [--active:hsl(var(--accent)/0.5)]",
-    info:
-      "border-transparent bg-accent-2/30 text-[var(--text-on-accent)] [--hover:hsl(var(--accent-2)/0.2)] [--active:hsl(var(--accent-2)/0.15)]",
-    danger:
-      "border-transparent bg-danger/20 text-danger-foreground [--hover:theme('colors.interaction.danger.surfaceHover')] [--active:theme('colors.interaction.danger.surfaceActive')]",
+    primary: cn(
+      "border-transparent bg-foreground/15 text-foreground",
+      toneTintTokens.primary,
+    ),
+    accent: cn(
+      "border-transparent bg-accent/30 text-[var(--text-on-accent)]",
+      surfaceInteractionTokens.accent,
+    ),
+    info: cn(
+      "border-transparent bg-accent-2/30 text-[var(--text-on-accent)]",
+      surfaceInteractionTokens.info,
+    ),
+    danger: cn(
+      "border-transparent bg-danger/20 text-danger-foreground",
+      surfaceInteractionTokens.danger,
+    ),
   },
   glow: {
     primary: "border-foreground/35 text-foreground",
@@ -164,7 +197,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
         type="button"
         className={cn(
           "inline-flex items-center justify-center select-none rounded-full transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)]",
-          variantBase[variant],
+          variantBase[variant](tone),
           toneClasses[variant][tone],
           sizeClass,
           iconMap[appliedIconSize],

--- a/tests/primitives/icon-button.test.tsx
+++ b/tests/primitives/icon-button.test.tsx
@@ -96,7 +96,12 @@ describe("IconButton", () => {
     );
     const classes = getByRole("button").className;
     expect(classes).toContain("border bg-card/35 hover:bg-[--hover]");
-    expect(classes).toContain("[--hover:hsl(var(--panel)/0.45)]");
+    expect(classes).toContain(
+      "[--hover:theme('colors.interaction.foreground.tintHover')]",
+    );
+    expect(classes).toContain(
+      "[--active:theme('colors.interaction.foreground.tintActive')]",
+    );
     expect(classes).toContain("border-line/35 text-foreground");
   });
 
@@ -109,8 +114,12 @@ describe("IconButton", () => {
     expect(classes).toContain(
       "border-transparent bg-accent/30 text-[var(--text-on-accent)]",
     );
-    expect(classes).toContain("[--hover:hsl(var(--accent)/0.4)]");
-    expect(classes).toContain("[--active:hsl(var(--accent)/0.5)]");
+    expect(classes).toContain(
+      "[--hover:theme('colors.interaction.accent.surfaceHover')]",
+    );
+    expect(classes).toContain(
+      "[--active:theme('colors.interaction.accent.surfaceActive')]",
+    );
   });
 
   it("applies glow variant with info tone", () => {
@@ -121,7 +130,12 @@ describe("IconButton", () => {
     expect(classes).toContain("border bg-card/35");
     expect(classes).toContain("hover:bg-[--hover]");
     expect(classes).toContain("shadow-glow-current");
-    expect(classes).toContain("[--hover:hsl(var(--panel)/0.45)]");
+    expect(classes).toContain(
+      "[--hover:theme('colors.interaction.info.tintHover')]",
+    );
+    expect(classes).toContain(
+      "[--active:theme('colors.interaction.info.tintActive')]",
+    );
     expect(classes).toContain(
       "border-accent-2/35 text-[var(--text-on-accent)]",
     );
@@ -133,7 +147,12 @@ describe("IconButton", () => {
     );
     const classes = getByRole("button").className;
     expect(classes).toContain("border bg-card/35 hover:bg-[--hover]");
-    expect(classes).toContain("[--hover:hsl(var(--panel)/0.45)]");
+    expect(classes).toContain(
+      "[--hover:theme('colors.interaction.danger.tintHover')]",
+    );
+    expect(classes).toContain(
+      "[--active:theme('colors.interaction.danger.tintActive')]",
+    );
     expect(classes).toContain("border-danger/35 text-danger");
     expect(classes).not.toContain("shadow-glow-current");
   });

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -1906,7 +1906,7 @@ exports[`ReviewEditor > renders default state 1`] = `
             </div>
             <button
               aria-label="Add timestamp"
-              class="inline-flex items-center justify-center select-none rounded-full transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] border border-transparent bg-foreground/15 text-foreground [--hover:hsl(var(--foreground)/0.12)] [--active:hsl(var(--foreground)/0.08)] h-[var(--control-h-md)] w-[var(--control-h-md)] [&_svg]:size-[var(--space-4)]"
+              class="inline-flex items-center justify-center select-none rounded-full transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] border border-transparent bg-foreground/15 text-foreground [--hover:theme('colors.interaction.foreground.tintHover')] [--active:theme('colors.interaction.foreground.tintActive')] h-[var(--control-h-md)] w-[var(--control-h-md)] [&_svg]:size-[var(--space-4)]"
               disabled=""
               tabindex="0"
               title="Enter details"
@@ -2011,7 +2011,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           </div>
           <button
             aria-label="Add tag"
-            class="inline-flex items-center justify-center select-none rounded-full transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] border border-transparent bg-foreground/15 text-foreground [--hover:hsl(var(--foreground)/0.12)] [--active:hsl(var(--foreground)/0.08)] h-[var(--control-h-md)] w-[var(--control-h-md)] [&_svg]:size-[var(--space-4)]"
+            class="inline-flex items-center justify-center select-none rounded-full transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] border border-transparent bg-foreground/15 text-foreground [--hover:theme('colors.interaction.foreground.tintHover')] [--active:theme('colors.interaction.foreground.tintActive')] h-[var(--control-h-md)] w-[var(--control-h-md)] [&_svg]:size-[var(--space-4)]"
             tabindex="0"
             title="Add tag"
             type="button"

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -233,7 +233,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                       />
                       <button
                         aria-label="Clear"
-                        class="inline-flex items-center justify-center select-none rounded-full duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] border bg-card/35 hover:bg-[--hover] [--hover:hsl(var(--panel)/0.45)] [--active:hsl(var(--panel)/0.55)] border-line/35 text-foreground h-[var(--control-h-sm)] w-[var(--control-h-sm)] [&_svg]:size-[var(--space-4)] absolute right-[var(--space-3)] top-1/2 -translate-y-1/2 transition-opacity pointer-events-none opacity-0"
+                        class="inline-flex items-center justify-center select-none rounded-full duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] border bg-card/35 hover:bg-[--hover] [--hover:theme('colors.interaction.foreground.tintHover')] [--active:theme('colors.interaction.foreground.tintActive')] border-line/35 text-foreground h-[var(--control-h-sm)] w-[var(--control-h-sm)] [&_svg]:size-[var(--space-4)] absolute right-[var(--space-3)] top-1/2 -translate-y-1/2 transition-opacity pointer-events-none opacity-0"
                         tabindex="0"
                         title="Clear"
                         type="button"


### PR DESCRIPTION
## Summary
- use tone-aware interaction token helpers for IconButton ring and glow variants instead of hard-coded HSL values
- apply the same helpers to solid tone classes and refresh affected tests and snapshots

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cdd77fe1c8832cb9ba78b15324f034