### PR TITLE
Rename TabBar tile label in component gallery

### DIFF
--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -244,7 +244,7 @@ export default function ComponentGallery() {
         ),
       },
       {
-        label: "Tabs",
+        label: "TabBar (default)",
         element: (
           <TabBar
             items={[


### PR DESCRIPTION
## Summary
- rename the default TabBar gallery tile to "TabBar (default)" so it is distinct from the Tabs primitive tile

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cdd98c86b4832cae5ca5f4dc43917b