### PR TITLE
Use NeoCard in Card Neo gallery sample

### DIFF
--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -26,6 +26,7 @@ import {
   SearchBar,
   Snackbar,
   Card,
+  NeoCard,
   CheckCircle,
   NeonIcon,
   Toggle,
@@ -1190,9 +1191,9 @@ export default function ComponentGallery() {
       {
         label: "Card Neo",
         element: (
-          <div className="card-neo w-56 h-8 flex items-center justify-center">
+          <NeoCard className="w-56 flex items-center justify-center text-center">
             Card Neo
-          </div>
+          </NeoCard>
         ),
       },
       {


### PR DESCRIPTION
## Summary
- replace the Card Neo gallery sample’s manual div with the NeoCard primitive to rely on shared neumorphic styling
- trim redundant utility classes while preserving centered copy in the demo card

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cdd9a668d4832ca9a525bc2449bcb9