### PR TITLE
Add xl control height and update gallery inputs

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -62,7 +62,7 @@ This project ships with a small design system based on Tailwind CSS and CSS vari
 - `Input` fields reuse their generated `id` as the default `name` to avoid
   collisions when several fields share the same label. Supply a custom `name`
   (or `id`) if you need specific form field identifiers.
-- Control height is set via a `height` prop that accepts `"sm" | "md" | "lg"`
+- Control height is set via a `height` prop that accepts `"sm" | "md" | "lg" | "xl"`
   or a numeric Tailwind token (e.g. `12` for `h-12`). The native `size`
   attribute remains available for setting character width.
 - `Button` automatically sizes any `svg` icons based on the `size` option

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -78,6 +78,7 @@
 | control-h-sm | 32px |
 | control-h-md | 40px |
 | control-h-lg | 48px |
+| control-h-xl | 56px |
 | control-h | var(--control-h-md) |
 | control-radius | var(--radius-xl) |
 | control-fs | var(--font-ui) |

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -400,7 +400,7 @@ export default function ComponentGallery() {
           <Input
             aria-label="Demo input"
             placeholder="Type here"
-            className="w-56 rounded-full"
+            className="w-56"
           />
         ),
       },
@@ -537,7 +537,7 @@ export default function ComponentGallery() {
             <Input aria-label="Small input demo" height="sm" placeholder="Small" />
             <Input aria-label="Medium input demo" placeholder="Medium" />
             <Input aria-label="Large input demo" height="lg" placeholder="Large" />
-            <Input aria-label="Tall input demo" height={12} placeholder="h-12" />
+            <Input aria-label="Tall input demo" height="xl" placeholder="Extra large" />
             <Input aria-label="Input with icon demo" placeholder="With icon" hasEndSlot>
               <Plus className="absolute right-[var(--space-3)] top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
             </Input>

--- a/src/components/ui/primitives/Field.gallery.tsx
+++ b/src/components/ui/primitives/Field.gallery.tsx
@@ -75,7 +75,7 @@ export default defineGallerySection({
       kind: "primitive",
       tags: ["field", "input"],
       props: [
-        { name: "height", type: '"sm" | "md" | "lg" | number', defaultValue: '"md"' },
+        { name: "height", type: '"sm" | "md" | "lg" | "xl" | number', defaultValue: '"md"' },
         { name: "disabled", type: "boolean", defaultValue: "false" },
         { name: "invalid", type: "boolean", defaultValue: "false" },
         { name: "loading", type: "boolean", defaultValue: "false" },

--- a/src/components/ui/primitives/Field.tsx
+++ b/src/components/ui/primitives/Field.tsx
@@ -8,12 +8,13 @@ import { cn } from "@/lib/utils";
 import Spinner from "../feedback/Spinner";
 import IconButton from "./IconButton";
 
-export type FieldHeight = "sm" | "md" | "lg";
+export type FieldHeight = "sm" | "md" | "lg" | "xl";
 
 const HEIGHT_MAP: Record<FieldHeight, string> = {
   sm: "var(--control-h-sm)",
   md: "var(--control-h-md)",
   lg: "var(--control-h-lg)",
+  xl: "var(--control-h-xl)",
 };
 
 const FIELD_ROOT_BASE = cn(

--- a/src/components/ui/primitives/Input.gallery.tsx
+++ b/src/components/ui/primitives/Input.gallery.tsx
@@ -62,7 +62,7 @@ export default defineGallerySection({
       tags: ["input", "text"],
       props: [
         { name: "placeholder", type: "string" },
-        { name: "height", type: '"sm" | "md" | "lg"', defaultValue: '"md"' },
+        { name: "height", type: '"sm" | "md" | "lg" | "xl"', defaultValue: '"md"' },
         { name: "disabled", type: "boolean", defaultValue: "false" },
         { name: "data-loading", type: "boolean", defaultValue: "false" },
       ],

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 import { useFieldIds } from "@/lib/useFieldIds";
 import Field from "./Field";
 
-export type InputSize = "sm" | "md" | "lg";
+export type InputSize = "sm" | "md" | "lg" | "xl";
 
 export type InputProps = Omit<
   React.InputHTMLAttributes<HTMLInputElement>,

--- a/src/components/ui/select/AnimatedSelect.tsx
+++ b/src/components/ui/select/AnimatedSelect.tsx
@@ -49,6 +49,12 @@ const SIZE_STYLES: Record<
     caret: "size-[var(--space-6)]",
     prefix: "size-[var(--space-6)]",
   },
+  xl: {
+    height: "h-[var(--control-h-xl)]",
+    paddingX: "px-[var(--space-4)]",
+    caret: "size-[var(--space-6)]",
+    prefix: "size-[var(--space-6)]",
+  },
 };
 
 const AnimatedSelect = React.forwardRef<

--- a/storybook/src/components/ui/Field.stories.tsx
+++ b/storybook/src/components/ui/Field.stories.tsx
@@ -29,7 +29,7 @@ type FieldPlaygroundProps = {
   defaultValue: string;
   clearable: boolean;
   options: readonly FieldOption[];
-  height: "sm" | "md" | "lg";
+  height: "sm" | "md" | "lg" | "xl";
 };
 
 function FieldPlayground({

--- a/tests/primitives/input.test.tsx
+++ b/tests/primitives/input.test.tsx
@@ -17,6 +17,7 @@ describe("Input", () => {
     ["sm", "var(--control-h-sm)"],
     ["md", "var(--control-h-md)"],
     ["lg", "var(--control-h-lg)"],
+    ["xl", "var(--control-h-xl)"],
   ])("applies %s height", (size, value) => {
     const { getByRole } = render(
       <Input aria-label={size} height={size} />,

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -81,6 +81,7 @@
   --control-h-sm: 32px;
   --control-h-md: 40px;
   --control-h-lg: 48px;
+  --control-h-xl: 56px;
   --control-h: var(--control-h-md);
   --control-radius: var(--radius-xl);
   --control-fs: var(--font-ui);


### PR DESCRIPTION
## Summary
- add an `xl` control height token and expose it through Field/Input primitives and select sizing
- refresh the component gallery to use tokenized input sizing without overriding radii
- update docs and tests to cover the new size option

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68cdd9a7e320832c854d19521182c73e