### PR TITLE
Use shadow tokens for secondary button

### DIFF
--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -7,7 +7,6 @@ import { motion, useReducedMotion } from "framer-motion";
 import type { HTMLMotionProps } from "framer-motion";
 import { cn, withBasePath } from "@/lib/utils";
 import Spinner from "../feedback/Spinner";
-import { neuRaised, neuInset } from "./Neu";
 
 export const buttonSizes = {
   sm: {
@@ -183,12 +182,12 @@ export const variants: Record<
     ),
     whileHover: tactile
       ? { scale: 1.01 }
-      : { scale: 1.02, boxShadow: neuRaised(15) },
+      : { scale: 1.02, boxShadow: "var(--shadow-neo-soft)" as CSSProperties["boxShadow"] },
     whileTap: tactile
       ? { scale: 0.98 }
       : {
           scale: 0.97,
-          boxShadow: neuInset(9) as CSSProperties["boxShadow"],
+          boxShadow: "var(--shadow-neo-inset)" as CSSProperties["boxShadow"],
         },
   }),
   ghost: () => ({
@@ -294,25 +293,29 @@ export const Button = React.forwardRef<
   } else if (variant === "secondary") {
     const accentVar = tone === "primary" ? "--ring" : colorVar[tone];
     const baseSecondaryShadows = {
-      "--btn-secondary-shadow-rest": neuRaised(),
-      "--btn-secondary-shadow-hover": neuRaised(15),
-      "--btn-secondary-shadow-active": neuInset(9),
+      "--btn-secondary-shadow-rest": "var(--shadow-neo)",
+      "--btn-secondary-shadow-hover": "var(--shadow-neo-soft)",
+      "--btn-secondary-shadow-active": "var(--shadow-neo-inset)",
     } as CSSProperties;
 
     const tactileSecondary = tactile
       ? {
           "--btn-secondary-shadow-rest": composeShadow([
+            "var(--shadow-neo-inset)",
             `inset 0 var(--spacing-0-5) var(--space-2) hsl(var(${accentVar}) / 0.18)`,
             `inset 0 calc(-1 * var(--spacing-0-5)) var(--space-2) hsl(var(--shadow-color) / 0.22)`,
             `0 0 0 var(--spacing-0-25) hsl(var(${accentVar}) / 0.22)`,
           ]),
           "--btn-secondary-shadow-hover": composeShadow([
+            "var(--shadow-neo-inset)",
+            "var(--shadow-neo-soft)",
             `inset 0 var(--spacing-0-5) var(--space-2) hsl(var(${accentVar}) / 0.2)`,
             `inset 0 calc(-1 * var(--spacing-0-5)) var(--space-2) hsl(var(--shadow-color) / 0.26)`,
             `0 0 0 var(--spacing-0-5) hsl(var(${accentVar}) / 0.28)`,
             `0 var(--space-3) var(--space-6) hsl(var(${accentVar}) / 0.22)`,
           ]),
           "--btn-secondary-shadow-active": composeShadow([
+            "var(--shadow-neo-inset)",
             `inset 0 var(--spacing-0-5) var(--space-2) hsl(var(${accentVar}) / 0.28)`,
             `inset 0 calc(-1 * var(--spacing-0-5)) var(--space-2) hsl(var(--shadow-color) / 0.3)`,
             `0 0 0 var(--spacing-0-5) hsl(var(${accentVar}) / 0.32)`,

--- a/tests/primitives/__snapshots__/button.test.tsx.snap
+++ b/tests/primitives/__snapshots__/button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button > matches snapshot for secondary danger tone 1`] = `
 <button
   class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[disabled=true]:opacity-[var(--disabled)] data-[disabled=true]:pointer-events-none h-[var(--control-h-md)] px-[var(--space-4)] text-ui gap-[var(--space-2)] [&_svg]:size-[var(--space-5)] shadow-[var(--btn-secondary-shadow-rest)] hover:shadow-[var(--btn-secondary-shadow-hover)] active:shadow-[var(--btn-secondary-shadow-active)] [--hover:theme('colors.interaction.danger.hover')] [--active:theme('colors.interaction.danger.active')] text-danger-foreground bg-danger/25"
-  style="--btn-secondary-shadow-rest: 12px 12px 24px hsl(var(--panel)/0.72), -12px -12px 24px hsl(var(--foreground)/0.06); --btn-secondary-shadow-hover: 15px 15px 30px hsl(var(--panel)/0.72), -15px -15px 30px hsl(var(--foreground)/0.06); --btn-secondary-shadow-active: inset 6px 6px 14px hsl(var(--panel)/0.85), inset -6px -6px 14px hsl(var(--foreground)/0.08);"
+  style="--btn-secondary-shadow-rest: var(--shadow-neo); --btn-secondary-shadow-hover: var(--shadow-neo-soft); --btn-secondary-shadow-active: var(--shadow-neo-inset);"
   tabindex="0"
   type="button"
 >


### PR DESCRIPTION
## Summary
- retune the secondary button variant to rely on neumorphic shadow tokens for rest, hover, and active states
- keep tactile overrides by layering token-based shadows instead of raw values and update motion overrides
- refresh the button snapshot to capture the new token-backed styling

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cdd9b44188832cb672dc168c1ff97d