### PR TITLE
Align IconButton size tokens

### DIFF
--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -63,11 +63,11 @@ const defaultIcon: Record<IconButtonSize, Icon> = {
 };
 const getSizeClass = (s: IconButtonSize) => {
   const sizeMap: Record<IconButtonSize, string> = {
-    xs: "h-[var(--space-8)] w-[var(--space-8)]",
+    xs: "h-[var(--space-5)] w-[var(--space-5)]",
     sm: "h-[var(--control-h-sm)] w-[var(--control-h-sm)]",
     md: "h-[var(--control-h-md)] w-[var(--control-h-md)]",
     lg: "h-[var(--control-h-lg)] w-[var(--control-h-lg)]",
-    xl: "h-[var(--space-7)] w-[var(--space-7)]",
+    xl: "h-[var(--space-8)] w-[var(--space-8)]",
   };
   return sizeMap[s];
 };

--- a/tests/primitives/icon-button.test.tsx
+++ b/tests/primitives/icon-button.test.tsx
@@ -25,11 +25,11 @@ describe("IconButton", () => {
   });
 
   const sizeCases = [
-    ["xs", "h-[var(--space-8)] w-[var(--space-8)]"],
+    ["xs", "h-[var(--space-5)] w-[var(--space-5)]"],
     ["sm", "h-[var(--control-h-sm)] w-[var(--control-h-sm)]"],
     ["md", "h-[var(--control-h-md)] w-[var(--control-h-md)]"],
     ["lg", "h-[var(--control-h-lg)] w-[var(--control-h-lg)]"],
-    ["xl", "h-[var(--space-7)] w-[var(--space-7)]"],
+    ["xl", "h-[var(--space-8)] w-[var(--space-8)]"],
   ] as const;
 
   sizeCases.forEach(([size, cls]) => {


### PR DESCRIPTION
## Summary
- align the IconButton size map so the xs and xl tokens bracket the control scale
- update the icon button unit test expectations to match the refreshed sizing

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cdd9b67718832ca2c8ee15bc712ff6