### PR TITLE
Use spacing tokens for spinner sizing

### DIFF
--- a/src/components/prompts/SpinnerShowcase.tsx
+++ b/src/components/prompts/SpinnerShowcase.tsx
@@ -3,9 +3,9 @@ import { Spinner } from "@/components/ui";
 export default function SpinnerShowcase() {
   return (
     <div className="flex items-center gap-4">
-      <Spinner size={16} />
-      <Spinner size={24} />
-      <Spinner size={32} />
+      <Spinner size="var(--space-4)" />
+      <Spinner size="var(--space-5)" />
+      <Spinner size="var(--space-6)" />
     </div>
   );
 }

--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -1307,7 +1307,7 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
       name: "Spinner",
       element: <SpinnerShowcase />,
       tags: ["spinner", "loading"],
-      code: `<Spinner size={24} />`,
+      code: `<Spinner size="var(--space-6)" />`,
     },
   ],
   toggles: [

--- a/src/components/ui/feedback/Spinner.tsx
+++ b/src/components/ui/feedback/Spinner.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 
 export default function Spinner({
   className,
-  size = 24,
+  size = "var(--space-6)",
 }: {
   className?: string;
   size?: string | number;

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -37,10 +37,10 @@ export type ButtonSize = keyof typeof buttonSizes;
 
 type Tone = "primary" | "accent" | "info" | "danger";
 
-const spinnerSizes: Record<ButtonSize, number> = {
-  sm: 16,
-  md: 20,
-  lg: 24,
+const spinnerSizes: Record<ButtonSize, string> = {
+  sm: "var(--space-4)",
+  md: "calc(var(--space-5) - var(--space-1))",
+  lg: "var(--space-5)",
 };
 
 const MotionSlot = motion.create(Slot);

--- a/src/components/ui/primitives/Field.tsx
+++ b/src/components/ui/primitives/Field.tsx
@@ -111,7 +111,7 @@ export const FieldRoot = React.forwardRef<HTMLDivElement, FieldRootProps>(
               data-slot="spinner"
               className="pointer-events-none absolute right-[var(--space-4)] top-1/2 -translate-y-1/2 text-muted-foreground"
             >
-              {spinner ?? <Spinner size={16} />}
+              {spinner ?? <Spinner size="var(--space-4)" />}
             </span>
           ) : null}
         </div>

--- a/src/components/ui/toggles/Toggle.tsx
+++ b/src/components/ui/toggles/Toggle.tsx
@@ -94,7 +94,7 @@ export default function Toggle({
     >
       {loading ? (
         <span className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center">
-          <Spinner size={16} className="border-border border-t-transparent opacity-80" />
+          <Spinner size="var(--space-4)" className="border-border border-t-transparent opacity-80" />
         </span>
       ) : null}
       {/* Sliding indicator */}


### PR DESCRIPTION
## Summary
- default the Spinner component to the `var(--space-6)` token and switch call sites to pass spacing tokens
- update Button, Field, Toggle, and gallery examples to avoid numeric Spinner sizes

## Testing
- npm run check
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cddaf0b5ac832caafdb3b0f39d805d