### PR TITLE
Use spacing tokens in GalleryItem wrapper

### DIFF
--- a/src/components/prompts/GalleryItem.tsx
+++ b/src/components/prompts/GalleryItem.tsx
@@ -17,7 +17,7 @@ export default function GalleryItem({
   return (
     <div
       className={cn(
-        "flex flex-col items-center space-y-2 px-2 sm:px-3 md:px-0",
+        "flex flex-col items-center space-y-[var(--space-2)] px-[var(--space-2)] sm:px-[var(--space-3)] md:px-0",
         className,
       )}
     >


### PR DESCRIPTION
## Summary
- replace the GalleryItem wrapper spacing utilities with token-based equivalents while keeping the responsive breakpoints intact

## Testing
- npm run check
- curl -I http://localhost:3000/prompts

------
https://chatgpt.com/codex/tasks/task_e_68cddad0bc8c832c8a21b98664f8e8c3