### PR TITLE
refactor: use spacing tokens in prompts gallery

### DIFF
--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -216,7 +216,7 @@ function ChampListEditorDemo() {
   const [list, setList] = React.useState<string[]>(["Ashe", "Lulu"]);
 
   return (
-    <div className="space-y-3" data-scope="team">
+    <div className="space-y-[var(--space-3)]" data-scope="team">
       <div className="flex items-center justify-between">
         <span className="text-label font-semibold tracking-[0.02em] text-muted-foreground">
           Champions
@@ -230,7 +230,7 @@ function ChampListEditorDemo() {
         onChange={setList}
         editing={editing}
         emptyLabel="-"
-        viewClassName="champ-badges mt-1 flex flex-wrap gap-2"
+        viewClassName="champ-badges mt-[var(--space-1)] flex flex-wrap gap-[var(--space-2)]"
       />
     </div>
   );
@@ -1081,7 +1081,7 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
     },
     actions: {
       node: (
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-[var(--space-2)]">
           <ThemeToggle ariaLabel="Toggle theme" className="shrink-0" />
           <Button size="sm" variant="primary" loading>
             Deploy
@@ -1096,7 +1096,7 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
   }}
 >
   <HeroGrid>
-    <HeroCol span={7} className="space-y-3">
+    <HeroCol span={7} className="space-y-[var(--space-3)]">
       <p className="text-ui text-muted-foreground">
         Default variant uses r-card-lg radius with px-6/md:px-7/lg:px-8 tokens and aligns content to the 12-column grid.
       </p>
@@ -1378,7 +1378,7 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
   onChange={setList}
   editing={editing}
   emptyLabel="-"
-  viewClassName="champ-badges mt-1 flex flex-wrap gap-2"
+  viewClassName="champ-badges mt-[var(--space-1)] flex flex-wrap gap-[var(--space-2)]"
 />`,
     },
     {


### PR DESCRIPTION
## Summary
- replace remaining numeric spacing utilities in the champ list editor demo with spacing tokens
- update the neomorphic hero preview to use spacing tokens for gaps and vertical rhythm
- sync the champ list editor code sample with the updated class names

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cddab996b0832c9e6408ebb386d2d5