### PR TITLE
Align segmented button spacing tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -596,7 +596,9 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
   }
 
   .btn-like-segmented {
-    @apply inline-flex items-center rounded-[var(--control-radius)] border px-4 py-2 text-ui font-medium tracking-[0.02em] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--theme-ring] focus-visible:ring-offset-0 disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none;
+    --btn-like-segmented-h: var(--control-h-md);
+    --btn-like-segmented-px: var(--space-4);
+    @apply inline-flex items-center rounded-[var(--control-radius)] border text-ui font-medium tracking-[0.02em] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] focus-visible:ring-offset-0 disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none;
     position: relative;
     overflow: hidden;
     border-color: hsl(var(--card-hairline));
@@ -604,6 +606,20 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
       linear-gradient(90deg, hsl(var(--primary-soft)) 0%, transparent 100%),
       hsl(var(--card));
     color: hsl(var(--muted-foreground));
+    min-height: var(--btn-like-segmented-h);
+    padding-inline: var(--btn-like-segmented-px);
+  }
+  .btn-like-segmented--sm {
+    --btn-like-segmented-h: var(--control-h-sm);
+    --btn-like-segmented-px: var(--space-4);
+  }
+  .btn-like-segmented--md {
+    --btn-like-segmented-h: var(--control-h-md);
+    --btn-like-segmented-px: var(--space-4);
+  }
+  .btn-like-segmented--lg {
+    --btn-like-segmented-h: var(--control-h-lg);
+    --btn-like-segmented-px: var(--space-8);
   }
   .btn-like-segmented:hover {
     background:

--- a/src/components/chrome/PageTabs.tsx
+++ b/src/components/chrome/PageTabs.tsx
@@ -93,7 +93,7 @@ export default function PageTabs({
     }: TabRenderContext<string, PageTabBarItem>) => {
       const { className: baseClassName, onClick, ...restProps } = props;
       const mergedClassName = cn(
-        "btn-like-segmented min-h-[var(--control-h-lg)] font-mono text-ui px-[var(--space-4)] py-[var(--space-3)]",
+        "btn-like-segmented btn-like-segmented--lg font-mono text-ui",
         baseClassName,
         active && "btn-glitch is-active",
         disabled && "pointer-events-none opacity-[var(--disabled)]",

--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -197,7 +197,6 @@ export default function Reminders() {
 
             {/* pinned */}
               <SegmentedButton
-                className="h-10"
                 onClick={() => setOnlyPinned(v => !v)}
                 aria-pressed={onlyPinned}
                 title="Pinned only"
@@ -208,7 +207,7 @@ export default function Reminders() {
               </SegmentedButton>
 
             {/* actions */}
-              <SegmentedButton className="h-10" onClick={resetSeeds} title="Replace with curated seeds">
+              <SegmentedButton onClick={resetSeeds} title="Replace with curated seeds">
                 Reset
               </SegmentedButton>
           </div>

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -122,6 +122,12 @@ const sizeMap: Record<Size, { h: string; px: string; text: string }> = {
   },
 };
 
+const glitchSizeClass: Record<Size, string> = {
+  sm: "btn-like-segmented--sm",
+  md: "btn-like-segmented--md",
+  lg: "btn-like-segmented--lg",
+};
+
 export default function TabBar<
   K extends string = string,
   Extra extends Record<string, unknown> | undefined = undefined,
@@ -292,6 +298,7 @@ export default function TabBar<
             const baseClass = isGlitch
               ? cn(
                   "btn-like-segmented font-mono text-ui",
+                  glitchSizeClass[size],
                   size === "lg" ? "text-body" : "text-ui",
                   active && "btn-glitch is-active",
                   isDisabled && "pointer-events-none opacity-[var(--disabled)]",


### PR DESCRIPTION
## Summary
- replace the segmented button base spacing with control-height and spacing tokens and add explicit size modifiers
- update PageTabs and TabBar glitch buttons to use the new size modifiers while keeping reminders actions on tokenized defaults

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cdd77202d8832c8ba255a6c10c5f1a