### PR TITLE
feat: add xl input size variant

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -78,6 +78,7 @@
 | control-h-sm | 32px |
 | control-h-md | 40px |
 | control-h-lg | 48px |
+| control-h-xl | 56px |
 | control-h | var(--control-h-md) |
 | control-radius | var(--radius-xl) |
 | control-fs | var(--font-ui) |

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -400,7 +400,8 @@ export default function ComponentGallery() {
           <Input
             aria-label="Demo input"
             placeholder="Type here"
-            className="w-56 rounded-full"
+            height="xl"
+            className="w-56"
           />
         ),
       },
@@ -537,9 +538,9 @@ export default function ComponentGallery() {
             <Input aria-label="Small input demo" height="sm" placeholder="Small" />
             <Input aria-label="Medium input demo" placeholder="Medium" />
             <Input aria-label="Large input demo" height="lg" placeholder="Large" />
-            <Input aria-label="Tall input demo" height={12} placeholder="h-12" />
+            <Input aria-label="Tall input demo" height="xl" placeholder="Tall" />
             <Input aria-label="Input with icon demo" placeholder="With icon" hasEndSlot>
-              <Plus className="absolute right-[var(--space-3)] top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+              <Plus className="absolute right-[var(--space-3)] top-1/2 -translate-y-1/2 size-[var(--space-4)] text-muted-foreground" />
             </Input>
           </div>
         ),

--- a/src/components/ui/primitives/Field.gallery.tsx
+++ b/src/components/ui/primitives/Field.gallery.tsx
@@ -75,7 +75,7 @@ export default defineGallerySection({
       kind: "primitive",
       tags: ["field", "input"],
       props: [
-        { name: "height", type: '"sm" | "md" | "lg" | number', defaultValue: '"md"' },
+        { name: "height", type: '"sm" | "md" | "lg" | "xl" | number', defaultValue: '"md"' },
         { name: "disabled", type: "boolean", defaultValue: "false" },
         { name: "invalid", type: "boolean", defaultValue: "false" },
         { name: "loading", type: "boolean", defaultValue: "false" },

--- a/src/components/ui/primitives/Field.tsx
+++ b/src/components/ui/primitives/Field.tsx
@@ -8,12 +8,13 @@ import { cn } from "@/lib/utils";
 import Spinner from "../feedback/Spinner";
 import IconButton from "./IconButton";
 
-export type FieldHeight = "sm" | "md" | "lg";
+export type FieldHeight = "sm" | "md" | "lg" | "xl";
 
 const HEIGHT_MAP: Record<FieldHeight, string> = {
   sm: "var(--control-h-sm)",
   md: "var(--control-h-md)",
   lg: "var(--control-h-lg)",
+  xl: "var(--control-h-xl)",
 };
 
 const FIELD_ROOT_BASE = cn(

--- a/src/components/ui/primitives/Input.gallery.tsx
+++ b/src/components/ui/primitives/Input.gallery.tsx
@@ -62,7 +62,7 @@ export default defineGallerySection({
       tags: ["input", "text"],
       props: [
         { name: "placeholder", type: "string" },
-        { name: "height", type: '"sm" | "md" | "lg"', defaultValue: '"md"' },
+        { name: "height", type: '"sm" | "md" | "lg" | "xl"', defaultValue: '"md"' },
         { name: "disabled", type: "boolean", defaultValue: "false" },
         { name: "data-loading", type: "boolean", defaultValue: "false" },
       ],

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 import { useFieldIds } from "@/lib/useFieldIds";
 import Field from "./Field";
 
-export type InputSize = "sm" | "md" | "lg";
+export type InputSize = "sm" | "md" | "lg" | "xl";
 
 export type InputProps = Omit<
   React.InputHTMLAttributes<HTMLInputElement>,

--- a/src/components/ui/select/AnimatedSelect.tsx
+++ b/src/components/ui/select/AnimatedSelect.tsx
@@ -49,6 +49,12 @@ const SIZE_STYLES: Record<
     caret: "size-[var(--space-6)]",
     prefix: "size-[var(--space-6)]",
   },
+  xl: {
+    height: "h-[var(--control-h-xl)]",
+    paddingX: "px-[var(--space-4)]",
+    caret: "size-[var(--space-7)]",
+    prefix: "size-[var(--space-7)]",
+  },
 };
 
 const AnimatedSelect = React.forwardRef<

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -81,6 +81,7 @@
   --control-h-sm: 32px;
   --control-h-md: 40px;
   --control-h-lg: 48px;
+  --control-h-xl: 56px;
   --control-h: var(--control-h-md);
   --control-radius: var(--radius-xl);
   --control-fs: var(--font-ui);

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -81,6 +81,7 @@ export default {
   controlHSm: "32px",
   controlHMd: "40px",
   controlHLg: "48px",
+  controlHXl: "56px",
   controlH: "var(--control-h-md)",
   controlRadius: "var(--radius-xl)",
   controlFs: "var(--font-ui)",


### PR DESCRIPTION
## Summary
- add an xl control height token and expose it through the Input/Field primitives
- update galleries to demonstrate the xl size with token-based icon sizing
- extend animated select sizing so the new xl option stays consistent

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cdd9c0f4e8832c979b9daf2bd1fdda