### PR TITLE
Align button controls with shared xl sizing

### DIFF
--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -197,7 +197,7 @@ export default function Reminders() {
 
             {/* pinned */}
               <SegmentedButton
-                className="h-10"
+                size="md"
                 onClick={() => setOnlyPinned(v => !v)}
                 aria-pressed={onlyPinned}
                 title="Pinned only"
@@ -208,7 +208,11 @@ export default function Reminders() {
               </SegmentedButton>
 
             {/* actions */}
-              <SegmentedButton className="h-10" onClick={resetSeeds} title="Replace with curated seeds">
+              <SegmentedButton
+                size="md"
+                onClick={resetSeeds}
+                title="Replace with curated seeds"
+              >
                 Reset
               </SegmentedButton>
           </div>

--- a/src/components/goals/reminders/ReminderFilters.tsx
+++ b/src/components/goals/reminders/ReminderFilters.tsx
@@ -34,6 +34,7 @@ export default function ReminderFilters() {
           className="overflow-x-auto"
           right={
             <SegmentedButton
+              size="sm"
               className="inline-flex items-center gap-1"
               onClick={toggleFilters}
               aria-expanded={showFilters}
@@ -57,6 +58,7 @@ export default function ReminderFilters() {
             size="sm"
           />
           <SegmentedButton
+            size="sm"
             onClick={togglePinned}
             aria-pressed={onlyPinned}
             title="Pinned only"

--- a/src/components/prompts/IconButtonShowcase.tsx
+++ b/src/components/prompts/IconButtonShowcase.tsx
@@ -12,12 +12,6 @@ type ShowcaseButtonProps = Pick<
 
 const ICON_BUTTONS = [
   {
-    size: "xs",
-    variant: "ring",
-    "aria-label": "Add item xs",
-    title: "Add item xs",
-  },
-  {
     size: "sm",
     variant: "ring",
     "aria-label": "Add item sm",

--- a/src/components/prompts/OnboardingTabs.tsx
+++ b/src/components/prompts/OnboardingTabs.tsx
@@ -122,7 +122,8 @@ export default function OnboardingTabs() {
           <li className="flex gap-[var(--space-2)]">
             <span className="mt-[var(--space-2)] h-[var(--space-2)] w-[var(--space-2)] rounded-full bg-current" />
             <span>
-              IconButton adds a compact <code>xs</code> size.
+              IconButton now mirrors Button sizing, spanning shared <code>sm</code>
+              through <code>xl</code> control heights.
             </span>
           </li>
           <li className="flex gap-[var(--space-2)]">

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -32,24 +32,37 @@ export const buttonSizes = {
     gap: "gap-[var(--space-4)]",
     icon: "[&_svg]:size-[var(--space-8)]",
   },
+  xl: {
+    height: "h-[var(--control-h-xl)]",
+    padding: "px-[var(--space-8)]",
+    text: "text-title-lg",
+    gap: "gap-[var(--space-4)]",
+    icon: "[&_svg]:size-[var(--space-8)]",
+  },
 } as const;
 
 export type ButtonSize = keyof typeof buttonSizes;
 
 type Tone = "primary" | "accent" | "info" | "danger";
 
-type ControlHeightToken = "controlHSm" | "controlHMd" | "controlHLg";
+type ControlHeightToken =
+  | "controlHSm"
+  | "controlHMd"
+  | "controlHLg"
+  | "controlHXl";
 
 const FALLBACK_CONTROL_HEIGHTS: Record<ButtonSize, number> = {
   sm: 32,
   md: 40,
   lg: 48,
+  xl: 56,
 };
 
 const CONTROL_HEIGHT_TOKENS: Record<ButtonSize, ControlHeightToken> = {
   sm: "controlHSm",
   md: "controlHMd",
   lg: "controlHLg",
+  xl: "controlHXl",
 };
 
 const parsePxTokenValue = (value: unknown): number | null => {
@@ -85,6 +98,10 @@ const spinnerSizes: Record<ButtonSize, string> = {
   lg: halfControlHeight(
     CONTROL_HEIGHT_TOKENS.lg,
     FALLBACK_CONTROL_HEIGHTS.lg,
+  ),
+  xl: halfControlHeight(
+    CONTROL_HEIGHT_TOKENS.xl,
+    FALLBACK_CONTROL_HEIGHTS.xl,
   ),
 };
 

--- a/src/components/ui/primitives/GlitchSegmented.tsx
+++ b/src/components/ui/primitives/GlitchSegmented.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { cn, slugify } from "@/lib/utils";
+import { buttonSizes, type ButtonSize } from "./Button";
 import styles from "./GlitchSegmented.module.css";
 
 export interface GlitchSegmentedGroupProps {
@@ -11,6 +12,7 @@ export interface GlitchSegmentedGroupProps {
   ariaLabelledby?: string;
   children: React.ReactNode;
   className?: string;
+  size?: ButtonSize;
 }
 
 export interface GlitchSegmentedButtonProps
@@ -19,7 +21,52 @@ export interface GlitchSegmentedButtonProps
   icon?: React.ReactNode;
   selected?: boolean;
   onSelect?: () => void;
+  size?: ButtonSize;
 }
+
+type GlitchSegmentedSizeStyles = {
+  height: string;
+  paddingX: string;
+  gap: string;
+  text: string;
+  icon: string;
+  iconWrap: string;
+};
+
+const GLITCH_SEGMENTED_SIZE_STYLES: Record<ButtonSize, GlitchSegmentedSizeStyles> = {
+  sm: {
+    height: buttonSizes.sm.height,
+    paddingX: "px-[var(--space-3)]",
+    gap: "gap-[var(--space-2)]",
+    text: "text-ui",
+    icon: "[&_svg]:size-[var(--space-4)]",
+    iconWrap: "size-[var(--space-4)]",
+  },
+  md: {
+    height: buttonSizes.md.height,
+    paddingX: "px-[var(--space-4)]",
+    gap: "gap-[var(--space-3)]",
+    text: "text-ui",
+    icon: "[&_svg]:size-[var(--space-5)]",
+    iconWrap: "size-[var(--space-5)]",
+  },
+  lg: {
+    height: buttonSizes.lg.height,
+    paddingX: "px-[var(--space-5)]",
+    gap: "gap-[var(--space-3)]",
+    text: "text-title",
+    icon: "[&_svg]:size-[var(--space-6)]",
+    iconWrap: "size-[var(--space-6)]",
+  },
+  xl: {
+    height: buttonSizes.xl.height,
+    paddingX: "px-[var(--space-6)]",
+    gap: "gap-[var(--space-4)]",
+    text: "text-title-lg",
+    icon: "[&_svg]:size-[var(--space-7)]",
+    iconWrap: "size-[var(--space-7)]",
+  },
+};
 
 export const GlitchSegmentedGroup = ({
   value,
@@ -28,6 +75,7 @@ export const GlitchSegmentedGroup = ({
   ariaLabelledby,
   children,
   className,
+  size = "sm",
 }: GlitchSegmentedGroupProps) => {
   const btnRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
   const setBtnRef = (index: number) => (el: HTMLButtonElement | null) => {
@@ -90,6 +138,7 @@ export const GlitchSegmentedGroup = ({
           tabIndex: selected ? 0 : -1,
           selected,
           onSelect: () => onChange(child.props.value),
+          size: buttonChild.props.size ?? size,
           id: child.props.id ?? `${normalizedValue}-tab`,
           "aria-controls":
             child.props["aria-controls"] ?? `${normalizedValue}-panel`,
@@ -103,7 +152,9 @@ export const GlitchSegmentedGroup = ({
 export const GlitchSegmentedButton = React.forwardRef<
   HTMLButtonElement,
   GlitchSegmentedButtonProps
->(({ icon, children, className, selected, onSelect, ...rest }, ref) => {
+>(({ icon, children, className, selected, onSelect, size = "sm", ...rest }, ref) => {
+  const sizeStyles = GLITCH_SEGMENTED_SIZE_STYLES[size] ??
+    GLITCH_SEGMENTED_SIZE_STYLES.sm;
   return (
     <button
       ref={ref}
@@ -114,19 +165,29 @@ export const GlitchSegmentedButton = React.forwardRef<
       onClick={onSelect}
       className={cn(
         styles.glitchScanlines,
-        "flex-1 h-[var(--control-h-sm)] px-[var(--space-3)] inline-flex items-center justify-center gap-[var(--space-2)] text-ui font-medium select-none",
+        "flex-1 inline-flex items-center justify-center font-medium select-none",
         "rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)]",
         "bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active]",
         "motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft",
         "motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none",
         "data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)]",
         "disabled:opacity-[var(--disabled)] disabled:pointer-events-none",
+        sizeStyles.height,
+        sizeStyles.paddingX,
+        sizeStyles.gap,
+        sizeStyles.text,
+        sizeStyles.icon,
         className,
       )}
       {...rest}
     >
       {icon ? (
-        <span className="inline-flex h-[var(--space-4)] w-[var(--space-4)] items-center justify-center">
+        <span
+          className={cn(
+            "inline-flex items-center justify-center",
+            sizeStyles.iconWrap,
+          )}
+        >
           {icon}
         </span>
       ) : null}

--- a/src/components/ui/primitives/IconButton.gallery.tsx
+++ b/src/components/ui/primitives/IconButton.gallery.tsx
@@ -54,7 +54,7 @@ const ICON_BUTTON_STATES = [
   props: React.ComponentProps<typeof IconButton>;
 }>;
 
-const ICON_BUTTON_SIZES = ["xs", "sm", "md", "lg", "xl"] as const;
+const ICON_BUTTON_SIZES = ["sm", "md", "lg", "xl"] as const;
 
 function IconButtonGalleryPreview() {
   return (
@@ -104,7 +104,7 @@ export default defineGallerySection({
         },
         {
           name: "size",
-          type: '"xs" | "sm" | "md" | "lg" | "xl"',
+          type: '"sm" | "md" | "lg" | "xl"',
         },
         {
           name: "loading",
@@ -136,9 +136,6 @@ export default defineGallerySection({
       }),
       code: `<div className="flex flex-col gap-[var(--space-4)]">
   <div className="flex flex-wrap gap-[var(--space-2)]">
-    <IconButton size="xs" variant="ring" aria-label="Add item xs">
-      <Plus />
-    </IconButton>
     <IconButton size="sm" variant="ring" aria-label="Add item sm">
       <Plus />
     </IconButton>

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -6,7 +6,7 @@ import { hasTextContent } from "@/lib/react";
 import { cn } from "@/lib/utils";
 import type { ButtonSize } from "./Button";
 
-export type IconButtonSize = ButtonSize | "xl" | "xs";
+export type IconButtonSize = ButtonSize;
 type Icon = "xs" | "sm" | "md" | "lg" | "xl";
 
 type Tone = "primary" | "accent" | "info" | "danger";
@@ -55,7 +55,6 @@ const iconMap: Record<Icon, string> = {
   xl: "[&_svg]:size-[var(--space-7)]",
 };
 const defaultIcon: Record<IconButtonSize, Icon> = {
-  xs: "xs",
   sm: "xs",
   md: "sm",
   lg: "md",
@@ -63,11 +62,10 @@ const defaultIcon: Record<IconButtonSize, Icon> = {
 };
 const getSizeClass = (s: IconButtonSize) => {
   const sizeMap: Record<IconButtonSize, string> = {
-    xs: "h-[var(--space-5)] w-[var(--space-5)]",
     sm: "h-[var(--control-h-sm)] w-[var(--control-h-sm)]",
     md: "h-[var(--control-h-md)] w-[var(--control-h-md)]",
     lg: "h-[var(--control-h-lg)] w-[var(--control-h-lg)]",
-    xl: "h-[var(--space-8)] w-[var(--space-8)]",
+    xl: "h-[var(--control-h-xl)] w-[var(--control-h-xl)]",
   };
   return sizeMap[s];
 };

--- a/src/components/ui/primitives/SegmentedButton.gallery.tsx
+++ b/src/components/ui/primitives/SegmentedButton.gallery.tsx
@@ -39,6 +39,11 @@ export default defineGallerySection({
         { name: "isActive", type: "boolean", defaultValue: "false" },
         { name: "loading", type: "boolean", defaultValue: "false" },
         { name: "disabled", type: "boolean", defaultValue: "false" },
+        {
+          name: "size",
+          type: '"sm" | "md" | "lg" | "xl"',
+          defaultValue: '"md"',
+        },
       ],
       axes: [
         {

--- a/src/components/ui/primitives/SegmentedButton.tsx
+++ b/src/components/ui/primitives/SegmentedButton.tsx
@@ -2,19 +2,58 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
+import type { ButtonSize } from "./Button";
 
 export type SegmentedButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   as?: React.ElementType;
   isActive?: boolean;
   href?: string;
   loading?: boolean;
+  size?: ButtonSize;
+};
+
+const SEGMENTED_SIZE_CLASSES: Record<ButtonSize, string> = {
+  sm: cn(
+    "h-[var(--control-h-sm)]",
+    "px-[var(--space-3)]",
+    "py-[var(--space-1)]",
+    "text-ui",
+    "gap-[var(--space-2)]",
+  ),
+  md: cn(
+    "h-[var(--control-h-md)]",
+    "px-[var(--space-4)]",
+    "py-[var(--space-2)]",
+    "text-ui",
+    "gap-[var(--space-2)]",
+  ),
+  lg: cn(
+    "h-[var(--control-h-lg)]",
+    "px-[var(--space-5)]",
+    "py-[var(--space-3)]",
+    "text-title",
+    "gap-[var(--space-3)]",
+  ),
+  xl: cn(
+    "h-[var(--control-h-xl)]",
+    "px-[var(--space-6)]",
+    "py-[var(--space-3)]",
+    "text-title-lg",
+    "gap-[var(--space-4)]",
+  ),
 };
 
 const SegmentedButton = React.forwardRef<
   HTMLElement,
   SegmentedButtonProps
->(({ as: Comp = "button", isActive, className, type, loading, disabled, href, ...props }, ref) => {
-  const cls = cn("btn-like-segmented", isActive && "is-active", className);
+>(({ as: Comp = "button", isActive, className, type, loading, disabled, href, size = "md", ...props }, ref) => {
+  const sizeClasses = SEGMENTED_SIZE_CLASSES[size] ?? SEGMENTED_SIZE_CLASSES.md;
+  const cls = cn(
+    "btn-like-segmented",
+    sizeClasses,
+    isActive && "is-active",
+    className,
+  );
   const typeProp =
     Comp === "button" && (props as React.ButtonHTMLAttributes<HTMLButtonElement>).type === undefined
       ? { type: type ?? "button" }

--- a/tests/primitives/icon-button.test.tsx
+++ b/tests/primitives/icon-button.test.tsx
@@ -25,11 +25,10 @@ describe("IconButton", () => {
   });
 
   const sizeCases = [
-    ["xs", "h-[var(--space-5)] w-[var(--space-5)]"],
     ["sm", "h-[var(--control-h-sm)] w-[var(--control-h-sm)]"],
     ["md", "h-[var(--control-h-md)] w-[var(--control-h-md)]"],
     ["lg", "h-[var(--control-h-lg)] w-[var(--control-h-lg)]"],
-    ["xl", "h-[var(--space-8)] w-[var(--space-8)]"],
+    ["xl", "h-[var(--control-h-xl)] w-[var(--control-h-xl)]"],
   ] as const;
 
   sizeCases.forEach(([size, cls]) => {
@@ -72,7 +71,6 @@ describe("IconButton", () => {
   });
 
   const defaultIconCases = [
-    ["xs", "[&_svg]:size-[var(--space-3)]"],
     ["sm", "[&_svg]:size-[var(--space-3)]"],
     ["md", "[&_svg]:size-[var(--space-4)]"],
     ["lg", "[&_svg]:size-[var(--space-5)]"],

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 <button
                   aria-controls="top-panel"
                   aria-selected="false"
-                  class="_glitchScanlines_ff763a flex-1 h-[var(--control-h-sm)] px-[var(--space-3)] inline-flex items-center justify-center gap-[var(--space-2)] text-ui font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none"
+                  class="_glitchScanlines_ff763a flex-1 inline-flex items-center justify-center font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none h-[var(--control-h-sm)] px-[var(--space-3)] gap-[var(--space-2)] text-ui [&_svg]:size-[var(--space-4)]"
                   id="top-tab"
                   role="tab"
                   tabindex="-1"
@@ -61,7 +61,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                   value="TOP"
                 >
                   <span
-                    class="inline-flex h-[var(--space-4)] w-[var(--space-4)] items-center justify-center"
+                    class="inline-flex items-center justify-center size-[var(--space-4)]"
                   >
                     <svg
                       aria-hidden="true"
@@ -90,7 +90,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 <button
                   aria-controls="jungle-panel"
                   aria-selected="false"
-                  class="_glitchScanlines_ff763a flex-1 h-[var(--control-h-sm)] px-[var(--space-3)] inline-flex items-center justify-center gap-[var(--space-2)] text-ui font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none"
+                  class="_glitchScanlines_ff763a flex-1 inline-flex items-center justify-center font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none h-[var(--control-h-sm)] px-[var(--space-3)] gap-[var(--space-2)] text-ui [&_svg]:size-[var(--space-4)]"
                   id="jungle-tab"
                   role="tab"
                   tabindex="-1"
@@ -98,7 +98,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                   value="JUNGLE"
                 >
                   <span
-                    class="inline-flex h-[var(--space-4)] w-[var(--space-4)] items-center justify-center"
+                    class="inline-flex items-center justify-center size-[var(--space-4)]"
                   >
                     <svg
                       aria-hidden="true"
@@ -132,7 +132,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 <button
                   aria-controls="mid-panel"
                   aria-selected="true"
-                  class="_glitchScanlines_ff763a flex-1 h-[var(--control-h-sm)] px-[var(--space-3)] inline-flex items-center justify-center gap-[var(--space-2)] text-ui font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none"
+                  class="_glitchScanlines_ff763a flex-1 inline-flex items-center justify-center font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none h-[var(--control-h-sm)] px-[var(--space-3)] gap-[var(--space-2)] text-ui [&_svg]:size-[var(--space-4)]"
                   data-selected="true"
                   id="mid-tab"
                   role="tab"
@@ -141,7 +141,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                   value="MID"
                 >
                   <span
-                    class="inline-flex h-[var(--space-4)] w-[var(--space-4)] items-center justify-center"
+                    class="inline-flex items-center justify-center size-[var(--space-4)]"
                   >
                     <svg
                       aria-hidden="true"
@@ -182,7 +182,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 <button
                   aria-controls="bot-panel"
                   aria-selected="false"
-                  class="_glitchScanlines_ff763a flex-1 h-[var(--control-h-sm)] px-[var(--space-3)] inline-flex items-center justify-center gap-[var(--space-2)] text-ui font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none"
+                  class="_glitchScanlines_ff763a flex-1 inline-flex items-center justify-center font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none h-[var(--control-h-sm)] px-[var(--space-3)] gap-[var(--space-2)] text-ui [&_svg]:size-[var(--space-4)]"
                   id="bot-tab"
                   role="tab"
                   tabindex="-1"
@@ -190,7 +190,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                   value="BOT"
                 >
                   <span
-                    class="inline-flex h-[var(--space-4)] w-[var(--space-4)] items-center justify-center"
+                    class="inline-flex items-center justify-center size-[var(--space-4)]"
                   >
                     <svg
                       aria-hidden="true"
@@ -245,7 +245,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 <button
                   aria-controls="support-panel"
                   aria-selected="false"
-                  class="_glitchScanlines_ff763a flex-1 h-[var(--control-h-sm)] px-[var(--space-3)] inline-flex items-center justify-center gap-[var(--space-2)] text-ui font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none"
+                  class="_glitchScanlines_ff763a flex-1 inline-flex items-center justify-center font-medium select-none rounded-full transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none h-[var(--control-h-sm)] px-[var(--space-3)] gap-[var(--space-2)] text-ui [&_svg]:size-[var(--space-4)]"
                   id="support-tab"
                   role="tab"
                   tabindex="-1"
@@ -253,7 +253,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                   value="SUPPORT"
                 >
                   <span
-                    class="inline-flex h-[var(--space-4)] w-[var(--space-4)] items-center justify-center"
+                    class="inline-flex items-center justify-center size-[var(--space-4)]"
                   >
                     <svg
                       aria-hidden="true"

--- a/tests/ui/button.test.tsx
+++ b/tests/ui/button.test.tsx
@@ -14,6 +14,7 @@ describe("Button", () => {
     sm: "h-[var(--control-h-sm)]",
     md: "h-[var(--control-h-md)]",
     lg: "h-[var(--control-h-lg)]",
+    xl: "h-[var(--control-h-xl)]",
   };
 
   const variantToneClasses: Record<

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -81,6 +81,7 @@ export default {
   controlHSm: "32px",
   controlHMd: "40px",
   controlHLg: "48px",
+  controlHXl: "56px",
   controlH: "var(--control-h-md)",
   controlRadius: "var(--radius-xl)",
   controlFs: "var(--font-ui)",


### PR DESCRIPTION
## Summary
- add an xl entry to button primitives and control tokens so spinners, fallbacks, and sizes resolve `--control-h-xl`
- align IconButton with the shared ButtonSize union, removing the bespoke xs case and refreshing gallery/prompt docs
- allow segmented controls to accept the shared size prop and update reminder actions to use the standardized sizing

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce75dff51c832c9325e7ecd70a05e8