### PR TITLE
Normalize IconButton sizing tokens

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -75,6 +75,7 @@
 | dur-quick | 140ms |
 | dur-chill | 220ms |
 | dur-slow | 420ms |
+| control-h-xs | 24px |
 | control-h-sm | 32px |
 | control-h-md | 40px |
 | control-h-lg | 48px |

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -4,9 +4,8 @@ import * as React from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { hasTextContent } from "@/lib/react";
 import { cn } from "@/lib/utils";
-import type { ButtonSize } from "./Button";
 
-export type IconButtonSize = ButtonSize | "xl";
+export type IconButtonSize = "sm" | "md" | "lg" | "xl";
 type Icon = "xs" | "sm" | "md" | "lg" | "xl";
 
 type Tone = "primary" | "accent" | "info" | "danger";
@@ -48,7 +47,7 @@ export type IconButtonProps =
     };
 
 const iconMap: Record<Icon, string> = {
-  xs: "[&_svg]:size-[var(--space-3)]",
+  xs: "[&_svg]:size-[calc(var(--control-h-xs)/2)]",
   sm: "[&_svg]:size-[calc(var(--control-h-sm)/2)]",
   md: "[&_svg]:size-[calc(var(--control-h-md)/2)]",
   lg: "[&_svg]:size-[calc(var(--control-h-lg)/2)]",

--- a/tests/primitives/icon-button.test.tsx
+++ b/tests/primitives/icon-button.test.tsx
@@ -41,7 +41,7 @@ describe("IconButton", () => {
   });
 
   const iconCases = [
-    ["xs", "[&_svg]:size-[var(--space-3)]"],
+    ["xs", "[&_svg]:size-[calc(var(--control-h-xs)/2)]"],
     ["sm", "[&_svg]:size-[calc(var(--control-h-sm)/2)]"],
     ["md", "[&_svg]:size-[calc(var(--control-h-md)/2)]"],
     ["lg", "[&_svg]:size-[calc(var(--control-h-lg)/2)]"],

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -78,6 +78,7 @@
   --dur-quick: 140ms;
   --dur-chill: 220ms;
   --dur-slow: 420ms;
+  --control-h-xs: 24px;
   --control-h-sm: 32px;
   --control-h-md: 40px;
   --control-h-lg: 48px;

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -78,6 +78,7 @@ export default {
   durQuick: "140ms",
   durChill: "220ms",
   durSlow: "420ms",
+  controlHXs: "24px",
   controlHSm: "32px",
   controlHMd: "40px",
   controlHLg: "48px",


### PR DESCRIPTION
## Summary
- align IconButton size options with the shared control tokens and remove the dependency on Button size types
- introduce a control-h-xs token and reuse it for extra-small icon sizing
- update IconButton documentation and tests to cover the new tokenized sizing

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce80980830832c8c7313281a436ab2