### PR TITLE
Fix Hardstuck accent text color

### DIFF
--- a/scripts/themes.ts
+++ b/scripts/themes.ts
@@ -272,7 +272,7 @@ export const themes: ThemeDefinition[] = [
       { name: "accent", value: "120 100% 60%" },
       { name: "accent-2", value: "120 100% 20%" },
       { name: "accent-foreground", value: "0 0% 0%" },
-      { name: "text-on-accent", value: "hsl(var(--background))" },
+      { name: "text-on-accent", value: "hsl(var(--hardstuck-foreground))" },
       { name: "accent-soft", value: "120 100% 12%" },
       { name: "glow", value: "120 100% 68%" },
       { name: "ring-muted", value: "120 30% 20%" },


### PR DESCRIPTION
## Summary
- point the Hardstuck theme's text-on-accent token at the dedicated hardstuck foreground color
- regenerate theme outputs to keep the CSS in sync

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce81743318832c96bde92e8bbb6501