### PR TITLE
Tie select glitch offsets to theme tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,6 +11,14 @@
     --settings-column-width: calc(var(--space-4) * 14);
     --surface-overlay-soft: 0.12;
     --surface-overlay-strong: 0.2;
+    --select-glitch-caret-shift: calc(var(--spacing-0-25) * 3 / 5);
+    --select-glitch-text-shadow-offset: var(--select-glitch-caret-shift);
+    --select-glitch-caret-shadow-blur: var(--spacing-1);
+    --select-glitch-chroma-shift-strong: calc(var(--spacing-0-25) / 4);
+    --select-glitch-chroma-shift-medium: calc(var(--spacing-0-25) * 3 / 20);
+    --select-glitch-chroma-shift-light: calc(var(--spacing-0-25) / 10);
+    --select-glitch-flicker-blur-base: calc(var(--spacing-2) - var(--spacing-0-25));
+    --select-glitch-flicker-blur-peak: var(--spacing-2);
   }
 
   body {

--- a/src/components/ui/select/Select.module.css
+++ b/src/components/ui/select/Select.module.css
@@ -18,7 +18,7 @@
 
 .glitchTrigger:hover .caret {
   animation: caret-jitter 0.9s steps(2, end) infinite;
-  filter: drop-shadow(0 0 4px hsl(var(--ring) / 0.55));
+  filter: drop-shadow(0 0 var(--select-glitch-caret-shadow-blur) hsl(var(--ring) / 0.55));
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -37,7 +37,7 @@
     transform: translateX(0) rotate(var(--rot, 0deg));
   }
   50% {
-    transform: translateX(0.6px) rotate(var(--rot, 0deg));
+    transform: translateX(var(--select-glitch-caret-shift)) rotate(var(--rot, 0deg));
   }
 }
 
@@ -102,16 +102,28 @@
     transform: translate(0, 0);
   }
   20% {
-    transform: translate(0.25px, -0.25px);
+    transform: translate(
+      var(--select-glitch-chroma-shift-strong),
+      calc(var(--select-glitch-chroma-shift-strong) * -1)
+    );
   }
   40% {
-    transform: translate(-0.25px, 0.25px);
+    transform: translate(
+      calc(var(--select-glitch-chroma-shift-strong) * -1),
+      var(--select-glitch-chroma-shift-strong)
+    );
   }
   60% {
-    transform: translate(0.15px, 0.15px);
+    transform: translate(
+      var(--select-glitch-chroma-shift-medium),
+      var(--select-glitch-chroma-shift-medium)
+    );
   }
   80% {
-    transform: translate(-0.15px, -0.1px);
+    transform: translate(
+      calc(var(--select-glitch-chroma-shift-medium) * -1),
+      calc(var(--select-glitch-chroma-shift-light) * -1)
+    );
   }
 }
 
@@ -123,7 +135,7 @@
     hsl(var(--ring) / 0.18),
     transparent 60%
   );
-  filter: blur(7px) saturate(1.06);
+  filter: blur(var(--select-glitch-flicker-blur-base)) saturate(1.06);
   mix-blend-mode: screen;
   opacity: 0.18;
   animation:
@@ -161,10 +173,10 @@
 @keyframes border-pulse {
   0%,
   100% {
-    filter: blur(7px) saturate(1.02);
+    filter: blur(var(--select-glitch-flicker-blur-base)) saturate(1.02);
   }
   50% {
-    filter: blur(8px) saturate(1.18);
+    filter: blur(var(--select-glitch-flicker-blur-peak)) saturate(1.18);
   }
 }
 
@@ -233,6 +245,6 @@
 
 .glitchText:hover {
   text-shadow:
-    0.6px 0 hsl(var(--accent-2) / 0.45),
-    -0.6px 0 hsl(var(--lav-deep) / 0.45);
+    var(--select-glitch-text-shadow-offset) 0 hsl(var(--accent-2) / 0.45),
+    calc(var(--select-glitch-text-shadow-offset) * -1) 0 hsl(var(--lav-deep) / 0.45);
 }


### PR DESCRIPTION
## Summary
- add semantic glitch offset and blur custom properties to the global theme so the select control can inherit spacing tweaks
- refactor the AnimatedSelect styles to use the new variables for caret jitter, chroma shift, flicker blur, and hover shadows

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce81f8b368832cb57c121e3262b7a0