### PR TITLE
Use CSS variable for noise background image

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,7 +73,7 @@
     inset: 0;
     pointer-events: none;
     z-index: 4;
-    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='140' height='140'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.06'/></svg>");
+    background-image: var(--asset-noise-url, url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='140' height='140'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.06'/></svg>"));
     background-size: 140px 140px;
   }
 


### PR DESCRIPTION
## Summary
- update the fx-noise overlay to read its noise asset from the shared CSS variable with a data URI fallback

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce83098408832cbf841ab66b811e65