### PR TITLE
Add default asset URLs for noise and glitch overlays

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,6 +11,8 @@
     --settings-column-width: calc(var(--space-4) * 14);
     --surface-overlay-soft: 0.12;
     --surface-overlay-strong: 0.2;
+    --asset-noise-url: url("/noise.svg");
+    --asset-glitch-gif-url: url("/glitch-gif.gif");
   }
 
   body {
@@ -84,7 +86,7 @@
     inset: 0;
     pointer-events: none;
     z-index: 3;
-    background-image: var(--asset-glitch-gif-url, none);
+    background-image: var(--asset-glitch-gif-url, url("/glitch-gif.gif"));
     background-size: cover;
     background-position: center;
     mix-blend-mode: overlay;
@@ -238,7 +240,7 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
     2px 100%;
 }
 .bg-noise {
-  background-image: var(--asset-noise-url, none);
+  background-image: var(--asset-noise-url, url("/noise.svg"));
   opacity: 0.1;
 }
 


### PR DESCRIPTION
## Summary
- define default noise and glitch asset URLs on :root for consumers of globals.css
- fall back to the public noise and glitch assets when custom properties are unset so overlays render outside the Next layout

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce8333147c832ca6d6ba47e9672cc2