### PR TITLE
Fix Hardstuck accent text contrast

### DIFF
--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -22,17 +22,6 @@
     calc(-1 * var(--space-1) / 4) hsl(var(--accent) / 0.25);
   --btn-primary-active-shadow: inset 0 0 0 calc(var(--space-1) / 4)
     hsl(var(--accent) / 0.6);
-  --card-overlay-scanlines: repeating-linear-gradient(
-    to bottom,
-    hsl(var(--foreground) / 0.035) 0,
-    hsl(var(--foreground) / 0.035) var(--spacing-0-25),
-    transparent var(--spacing-0-5),
-    transparent calc(var(--spacing-0-5) + var(--spacing-0-25))
-  );
-  --spacing-0-125: calc(var(--spacing-1) / 8);
-  --spacing-0-25: calc(var(--spacing-1) / 4);
-  --spacing-0-5: calc(var(--spacing-1) / 2);
-  --spacing-0-75: calc(var(--spacing-1) * 0.75);
   --pillar-wave-start: 257 90% 70%;
   --pillar-wave-end: 198 90% 62%;
   --pillar-wave-shadow: 258 90% 38% / 0.35;
@@ -273,7 +262,7 @@ html.theme-hardstuck {
   --accent: 120 100% 60%;
   --accent-2: 120 100% 20%;
   --accent-foreground: 0 0% 0%;
-  --text-on-accent: hsl(var(--hardstuck-foreground));
+  --text-on-accent: hsl(var(--background));
   --accent-soft: 120 100% 12%;
   --glow: 120 100% 68%;
   --ring-muted: 120 30% 20%;
@@ -938,8 +927,8 @@ html.bg-intense body::after {
 .pretty-border::before {
   content: "";
   position: absolute;
-  inset: calc(var(--hairline-w) * -1);
-  padding: var(--hairline-w);
+  inset: -1px;
+  padding: 1px;
   border-radius: inherit;
   pointer-events: none;
   background: conic-gradient(


### PR DESCRIPTION
## Summary
- regenerate `src/app/themes.css` so the Hardstuck theme’s `--text-on-accent` token now resolves to `hsl(var(--background))` for dark-on-bright pairings
- ensure the generated CSS stays in sync with the source theme definition

## Testing
- npm run contrast-report
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce839ff20c832ca26d5c97c26e7599