### PR TITLE
Fix persistent state defaults reacting to initial changes

### DIFF
--- a/tests/lib/db.test.ts
+++ b/tests/lib/db.test.ts
@@ -420,6 +420,36 @@ describe("usePersistentState", () => {
     expect(result.current[0]).toEqual(initialState);
   });
 
+  it("updates state when the default changes without a stored override", async () => {
+    const { usePersistentState, createStorageKey, flushWriteLocal } = await import("@/lib/db");
+
+    const key = "default-updates";
+    const fullKey = createStorageKey(key);
+
+    const { result, rerender } = renderHook(
+      ({ initial }) => usePersistentState(key, initial),
+      {
+        initialProps: { initial: 1 },
+      },
+    );
+
+    expect(result.current[0]).toBe(1);
+
+    act(() => {
+      window.localStorage.clear();
+    });
+
+    rerender({ initial: 2 });
+
+    await waitFor(() => {
+      expect(result.current[0]).toBe(2);
+    });
+
+    flushWriteLocal();
+
+    expect(window.localStorage.getItem(fullKey)).toBe("2");
+  });
+
   it("applies decode and encode callbacks when provided", async () => {
     const {
       usePersistentState,


### PR DESCRIPTION
## Summary
- track the last persisted value inside `usePersistentState` so default changes apply when there is no stored override
- reuse a deep equality helper to skip redundant writes and to avoid resetting state when the initial input is unchanged
- add a regression test covering default changes after storage clears

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68ce8061751c832cb9d09539a72607b1