### PR TITLE
Add scope attributes to props table headers

### DIFF
--- a/src/components/prompts/ComponentsView.tsx
+++ b/src/components/prompts/ComponentsView.tsx
@@ -121,16 +121,16 @@ function PropsTable({
         <table className="w-full min-w-[28rem] border-separate border-spacing-0 text-left">
           <thead>
             <tr className="text-label text-muted-foreground">
-              <th className="px-[var(--space-4)] py-[var(--space-3)] font-semibold">
+              <th scope="col" className="px-[var(--space-4)] py-[var(--space-3)] font-semibold">
                 Prop
               </th>
-              <th className="px-[var(--space-4)] py-[var(--space-3)] font-semibold">
+              <th scope="col" className="px-[var(--space-4)] py-[var(--space-3)] font-semibold">
                 Type
               </th>
-              <th className="px-[var(--space-4)] py-[var(--space-3)] font-semibold">
+              <th scope="col" className="px-[var(--space-4)] py-[var(--space-3)] font-semibold">
                 Default
               </th>
-              <th className="px-[var(--space-4)] py-[var(--space-3)] font-semibold">
+              <th scope="col" className="px-[var(--space-4)] py-[var(--space-3)] font-semibold">
                 Description
               </th>
             </tr>


### PR DESCRIPTION
## Summary
- add column scope attributes to the props table headers in the components gallery view
- improve table semantics to satisfy WCAG 1.3.1 requirements

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68ce85ff1f18832c88f1d5e588d710f3