### PR TITLE
Use shadow tokens in timer tab

### DIFF
--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -111,7 +111,7 @@ function isFiniteNumber(value: unknown): value is number {
 /* helpers */
 
 const ADJUST_BTN_CLASS =
-  "absolute top-[var(--space-2)] sm:-top-[var(--space-4)] rounded-full bg-background/40 backdrop-blur shadow-glow-md transition-transform duration-[var(--dur-quick)] hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-ring";
+  "absolute top-[var(--space-2)] sm:-top-[var(--space-4)] rounded-full bg-background/40 backdrop-blur shadow-[var(--shadow-glow-md)] transition-transform duration-[var(--dur-quick)] hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-ring";
 
 export default function TimerTab() {
   const [timer, setTimer] = usePersistentState<TimerState>(
@@ -495,7 +495,7 @@ export default function TimerTab() {
               <div className="relative h-2 w-full rounded-full bg-background/20 shadow-neo-inset">
                 <div className="absolute inset-0 bg-[repeating-linear-gradient(to_right,transparent,transparent_9%,hsl(var(--foreground)/0.15)_9%,hsl(var(--foreground)/0.15)_10%)]" />
                 <div
-                  className="h-full rounded-full bg-[linear-gradient(90deg,hsl(var(--accent)),hsl(var(--accent-2)))] shadow-glow-md transition-[width] duration-[var(--dur-quick)] ease-linear"
+                  className="h-full rounded-full bg-[linear-gradient(90deg,hsl(var(--accent)),hsl(var(--accent-2)))] shadow-[var(--shadow-glow-md)] transition-[width] duration-[var(--dur-quick)] ease-linear"
                   style={{ width: `${pct}%` }}
                 />
               </div>
@@ -539,7 +539,7 @@ export default function TimerTab() {
             {/* Complete state */}
             {finished && (
               <div className="mt-6 grid place-items-center">
-                <div className="rounded-full bg-[linear-gradient(90deg,hsl(var(--accent)/0.35),hsl(var(--accent-2)/0.35)))] px-3 py-1 text-ui font-medium text-foreground shadow-glow-md ring-1 ring-inset ring-border/50 motion-safe:animate-pulse motion-reduce:animate-none">
+                <div className="rounded-full bg-[linear-gradient(90deg,hsl(var(--accent)/0.35),hsl(var(--accent-2)/0.35)))] px-3 py-1 text-ui font-medium text-foreground shadow-[var(--shadow-glow-md)] ring-1 ring-inset ring-border/50 motion-safe:animate-pulse motion-reduce:animate-none">
                   Complete
                 </div>
                 <div className="mt-2 text-label font-medium tracking-[0.02em] text-muted-foreground">


### PR DESCRIPTION
## Summary
- replace the timer tab halo, progress fill, and completion badge shadows with explicit design tokens
- keep the timer container on the neomorphic soft shadow token

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce874133d8832cbdfd05aec9de9a6a