### PR TITLE
Refine team glitch glow variables

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,6 +19,12 @@
     --select-glitch-chroma-shift-light: calc(var(--spacing-0-25) / 10);
     --select-glitch-flicker-blur-base: calc(var(--spacing-2) - var(--spacing-0-25));
     --select-glitch-flicker-blur-peak: var(--spacing-2);
+    --team-glitch-ring-color: hsl(var(--ring) / 0.55);
+    --team-glitch-ring-blur: var(--space-2);
+    --team-glitch-ring-shadow: 0 0 var(--team-glitch-ring-blur) var(--team-glitch-ring-color);
+    --team-glitch-accent-color: hsl(var(--accent) / 0.35);
+    --team-glitch-accent-blur: var(--spacing-0-5);
+    --team-glitch-accent-shadow: 0 0 var(--team-glitch-accent-blur) var(--team-glitch-accent-color);
   }
 
   body {

--- a/src/components/team/style.css
+++ b/src/components/team/style.css
@@ -53,8 +53,14 @@
 }
 [data-scope="team"] .glitch-flicker {
   text-shadow:
-    0 0 0.45rem hsl(var(--ring) / 0.55),
-    0 0 0.1rem hsl(var(--accent) / 0.35);
+    var(
+      --team-glitch-ring-shadow,
+      0 0 var(--space-2) hsl(var(--ring) / 0.55)
+    ),
+    var(
+      --team-glitch-accent-shadow,
+      0 0 var(--spacing-0-5) hsl(var(--accent) / 0.35)
+    );
 }
 
 @media (prefers-reduced-motion: no-preference) {


### PR DESCRIPTION
## Summary
- add team glitch glow custom properties to the global theme so intensity tweaks flow through a single source
- update the team glitch text shadow to use the new theme variables rather than hard-coded rem values

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce87363048832cbd77686f7b152dc7