### PR TITLE
Use hero divider blur token

### DIFF
--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -22,6 +22,7 @@
     calc(-1 * var(--space-1) / 4) hsl(var(--accent) / 0.25);
   --btn-primary-active-shadow: inset 0 0 0 calc(var(--space-1) / 4)
     hsl(var(--accent) / 0.6);
+  --hero-divider-blur: calc(var(--spacing-1) * 1.5);
   --pillar-wave-start: 257 90% 70%;
   --pillar-wave-end: 198 90% 62%;
   --pillar-wave-shadow: 258 90% 38% / 0.35;

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -327,7 +327,7 @@ function Hero<Key extends string = string>({
                 {frame ? (
                   <span
                     aria-hidden
-                    className="hero2-divider-glow absolute inset-x-0 top-0 h-px blur-[6px] opacity-60 bg-[hsl(var(--divider))]"
+                    className="hero2-divider-glow absolute inset-x-0 top-0 h-px opacity-60 bg-[hsl(var(--divider))]"
                   />
                 ) : null}
                 <div className={actionRowClass}>
@@ -545,6 +545,9 @@ export function HeroGlitchStyles() {
       }
 
       /* === Neon divider (unchanged) ===================================== */
+      .hero2-divider-glow {
+        filter: blur(var(--hero-divider-blur, calc(var(--spacing-1) * 1.5)));
+      }
       .neon-primary {
         --neon: var(--primary);
       }

--- a/src/components/ui/layout/NeomorphicHeroFrame.tsx
+++ b/src/components/ui/layout/NeomorphicHeroFrame.tsx
@@ -401,7 +401,7 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
           variantStyles?.slot.gapMd,
           "md:grid-cols-12",
           "before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-[hsl(var(--accent))] before:opacity-60 before:content-['']",
-          "after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-px after:bg-[hsl(var(--accent))] after:opacity-40 after:blur-sm after:content-['']",
+          "after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-px after:bg-[hsl(var(--accent))] after:opacity-40 after:[filter:blur(var(--hero-divider-blur,calc(var(--spacing-1)*1.5)))] after:content-['']",
         )}
         data-align={align}
       >

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -171,7 +171,7 @@ exports[`ReviewsPage > renders default state 1`] = `
           </div>
         </div>
         <div
-          class="group/hero-slots relative z-[1] isolate w-full grid grid-cols-1 mt-[var(--space-6)] md:mt-[var(--space-7)] pt-[var(--space-5)] md:pt-[var(--space-6)] gap-[var(--space-3)] md:gap-[var(--space-4)] md:grid-cols-12 before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-[hsl(var(--accent))] before:opacity-60 before:content-[''] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-px after:bg-[hsl(var(--accent))] after:opacity-40 after:blur-sm after:content-['']"
+          class="group/hero-slots relative z-[1] isolate w-full grid grid-cols-1 mt-[var(--space-6)] md:mt-[var(--space-7)] pt-[var(--space-5)] md:pt-[var(--space-6)] gap-[var(--space-3)] md:gap-[var(--space-4)] md:grid-cols-12 before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-[hsl(var(--accent))] before:opacity-60 before:content-[''] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-px after:bg-[hsl(var(--accent))] after:opacity-40 after:[filter:blur(var(--hero-divider-blur,calc(var(--spacing-1)*1.5)))] after:content-['']"
           data-align="center"
           role="group"
         >


### PR DESCRIPTION
## Summary
- add a hero divider blur token to the theme and use it for the neon divider glow
- update Hero and NeomorphicHeroFrame to pull the glow blur from the shared token
- refresh the ReviewsPage snapshot to reflect the new tokenized blur class

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce872e379c832cb57f9c8691e07c5a