### PR TITLE
Use neumorphic inset shadow for TabBar fallback variant

### DIFF
--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -206,7 +206,7 @@ export default function TabBar<
     : isGlitch
       ? "[--focus:hsl(var(--ring))]"
       : cn(
-          "border-border/30 bg-card/60 shadow-neo-inset",
+          "border-border/30 bg-card/60 shadow-[var(--shadow-neo-inset)]",
           "[--hover:hsl(var(--primary)/0.18)]",
           "[--active:hsl(var(--primary)/0.28)]",
           "[--focus:hsl(var(--ring))]",


### PR DESCRIPTION
## Summary
- swap the default TabBar container shadow to use the neumorphic inset token
- ensure the neumorphic token continues to drive depth cues across themes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce8746321c832c821da52987774387