### PR TITLE
Add accessible label to goal queue input

### DIFF
--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -17,6 +17,7 @@ interface GoalQueueProps {
 
 export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
   const [val, setVal] = React.useState("");
+  const inputId = React.useId();
 
   function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -71,7 +72,11 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
 
           <form onSubmit={submit} className="flex items-center gap-2 pt-3">
             <span className="h-2 w-2 rounded-full bg-foreground/40" aria-hidden />
+            <label className="sr-only" htmlFor={inputId}>
+              Add to queue and press Enter
+            </label>
             <Input
+              id={inputId}
               className="flex-1 text-ui font-medium"
               height="sm"
               value={val}

--- a/tests/goals/goal-queue.test.tsx
+++ b/tests/goals/goal-queue.test.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, afterEach, expect, vi } from "vitest";
+import GoalQueue from "@/components/goals/GoalQueue";
+
+describe("GoalQueue", () => {
+  afterEach(cleanup);
+
+  it("associates the add input with its label", () => {
+    const onAdd = vi.fn();
+    const onRemove = vi.fn();
+    render(<GoalQueue items={[]} onAdd={onAdd} onRemove={onRemove} />);
+
+    const input = screen.getByLabelText("Add to queue and press Enter");
+    const form = input.closest("form");
+    if (!form) {
+      throw new Error("Expected add input to be wrapped in a form");
+    }
+
+    fireEvent.change(input, { target: { value: "Review accessibility" } });
+    fireEvent.submit(form);
+
+    expect(onAdd).toHaveBeenCalledWith("Review accessibility");
+  });
+});


### PR DESCRIPTION
## Summary
- add a screen-reader label to the goal queue input and tie it to a stable id
- keep the existing helper text while wiring the Input to the generated id
- cover the queue form with a test that submits via the labeled control

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce8a816010832ca91343f83dd61708