### PR TITLE
Add midnight focus rollover and tests

### DIFF
--- a/src/components/planner/useFocusDate.ts
+++ b/src/components/planner/useFocusDate.ts
@@ -2,15 +2,14 @@
 
 import * as React from "react";
 import { addDays, toISODate, weekRangeFromISO } from "@/lib/date";
-import { todayISO, useFocus, type ISODate } from "./plannerStore";
+import { useFocus, type ISODate } from "./plannerStore";
 
 /**
  * Exposes the currently focused ISO date and helper to update it.
  * @returns Current focus ISO date, setter, and today's ISO string.
  */
 export function useFocusDate() {
-  const { focus, setFocus } = useFocus();
-  const today = todayISO();
+  const { focus, setFocus, today } = useFocus();
   return { iso: focus, setIso: setFocus, today } as const;
 }
 
@@ -20,7 +19,7 @@ export function useFocusDate() {
  * @returns Week start/end dates, list of day ISO strings, and today checker.
  */
 export function useWeek(iso: ISODate) {
-  const today = todayISO();
+  const { today } = useFocus();
   return React.useMemo(() => {
     const { start, end } = weekRangeFromISO(iso);
     const days: ISODate[] = [];


### PR DESCRIPTION
## Summary
- keep track of the current local day in `PlannerProvider` and reschedule focus at midnight
- expose the current day through the focus context so date hooks react to rollover
- cover the rollover behaviour and timer cleanup in `useFocusDate` tests

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce8a117bb0832caef7d54eaa4dd2cf