### PR TITLE
Improve HeroPlannerCards toggle accessibility

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -247,21 +247,22 @@ function HeroPlannerCards() {
                 const projectName = task.projectId
                   ? projectNames.get(task.projectId) ?? null
                   : null;
+                const toggleLabel = task.done
+                  ? `Mark ${task.title} as not done`
+                  : `Mark ${task.title} as done`;
                 return (
                   <li key={task.id} className="flex items-start gap-[var(--space-3)]">
                     <CheckCircle
                       checked={task.done}
                       onChange={() => handleToggleTask(task.id)}
-                      aria-label={
-                        task.done
-                          ? `Mark ${task.title} as not done`
-                          : `Mark ${task.title} as done`
-                      }
+                      aria-label={toggleLabel}
                       size="sm"
                     />
                     <button
                       type="button"
                       onClick={() => handleToggleTask(task.id)}
+                      aria-pressed={task.done}
+                      aria-label={toggleLabel}
                       className={cn(
                         "flex flex-col items-start gap-[var(--space-1)] rounded-card r-card-sm px-[var(--space-1)] py-[var(--space-1)] text-left transition",
                         "hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",


### PR DESCRIPTION
## Summary
- share a toggle label string between the checkbox and task title button in HeroPlannerCards
- mark the text toggle button as pressed when the task is done and provide an action-oriented aria-label

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce94de5a64832ca72a3417229b77d3