### PR TITLE
Update textarea gallery states

### DIFF
--- a/src/components/ui/primitives/Textarea.gallery.tsx
+++ b/src/components/ui/primitives/Textarea.gallery.tsx
@@ -5,29 +5,71 @@ import { createGalleryPreview, defineGallerySection } from "@/components/gallery
 import Textarea from "./Textarea";
 
 const TEXTAREA_STATES = [
-  { label: "Default", props: { placeholder: "Share your thoughts" } },
+  {
+    label: "Default",
+    className: undefined,
+    textareaClassName: undefined,
+    props: { placeholder: "Share your thoughts" },
+  },
+  {
+    label: "Hover",
+    className: "bg-[--hover]",
+    textareaClassName: undefined,
+    props: { placeholder: "Hover" },
+  },
+  {
+    label: "Focus-visible",
+    className: "ring-2 ring-[hsl(var(--ring))]",
+    textareaClassName: undefined,
+    props: { placeholder: "Focus-visible" },
+  },
+  {
+    label: "Active",
+    className: "bg-[--active]",
+    textareaClassName: undefined,
+    props: { placeholder: "Active" },
+  },
   {
     label: "Invalid",
+    className: "ring-2 ring-[hsl(var(--danger))]",
+    textareaClassName: undefined,
     props: { placeholder: "Needs attention", "aria-invalid": true },
   },
   {
-    label: "Read only",
-    props: { placeholder: "Read only", readOnly: true },
+    label: "Read-only",
+    className: "bg-[hsl(var(--card)/0.72)]",
+    textareaClassName: "text-muted-foreground",
+    props: { placeholder: "Read-only", readOnly: true },
   },
   {
     label: "Disabled",
+    className: undefined,
+    textareaClassName: undefined,
     props: { placeholder: "Disabled", disabled: true },
+  },
+  {
+    label: "Loading",
+    className: undefined,
+    textareaClassName: undefined,
+    props: { placeholder: "Loading", "data-loading": true },
   },
 ] satisfies ReadonlyArray<{
   label: string;
+  className?: string;
+  textareaClassName?: string;
   props: React.ComponentProps<typeof Textarea>;
 }>;
 
 function TextareaGalleryPreview() {
   return (
     <div className="flex flex-col gap-[var(--space-2)]">
-      {TEXTAREA_STATES.map(({ label, props }) => (
-        <Textarea key={label} {...props} />
+      {TEXTAREA_STATES.map(({ label, className, textareaClassName, props }) => (
+        <Textarea
+          key={label}
+          className={className}
+          textareaClassName={textareaClassName}
+          {...props}
+        />
       ))}
       <Textarea
         placeholder="Resizable textarea"
@@ -55,6 +97,7 @@ export default defineGallerySection({
           name: "aria-invalid",
           type: 'boolean | "grammar" | "spelling" | undefined',
         },
+        { name: "data-loading", type: "boolean", defaultValue: "false" },
         { name: "resize", type: "string" },
       ],
       axes: [
@@ -70,9 +113,22 @@ export default defineGallerySection({
         render: () => <TextareaGalleryPreview />,
       }),
       code: `<Textarea placeholder="Share your thoughts" />
-<Textarea placeholder="Needs attention" aria-invalid />
-<Textarea placeholder="Read only" readOnly />
+<Textarea placeholder="Hover" className="bg-[--hover]" />
+<Textarea placeholder="Focus-visible" className="ring-2 ring-[hsl(var(--ring))]" />
+<Textarea placeholder="Active" className="bg-[--active]" />
+<Textarea
+  placeholder="Needs attention"
+  className="ring-2 ring-[hsl(var(--danger))]"
+  aria-invalid
+/> 
+<Textarea
+  placeholder="Read-only"
+  className="bg-[hsl(var(--card)/0.72)]"
+  textareaClassName="text-muted-foreground"
+  readOnly
+/> 
 <Textarea placeholder="Disabled" disabled />
+<Textarea placeholder="Loading" data-loading />
 <Textarea placeholder="Resizable textarea" resize="resize-y" aria-label="Resizable textarea" />`,
     },
   ],

--- a/src/components/ui/primitives/Textarea.tsx
+++ b/src/components/ui/primitives/Textarea.tsx
@@ -18,6 +18,8 @@ export type TextareaProps =
     textareaClassName?: string;
     /** Tailwind `resize-*` utility to control resizing behavior */
     resize?: string;
+    /** Optional loading state forwarded via `data-loading` */
+    "data-loading"?: string | boolean | number;
   };
 
 export default React.forwardRef<HTMLTextAreaElement, TextareaProps>(
@@ -42,12 +44,19 @@ export default React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         slugifyFallback: true,
       },
     );
+    const loadingAttr = props["data-loading"];
+    const loading =
+      loadingAttr === "" ||
+      loadingAttr === true ||
+      loadingAttr === "true" ||
+      loadingAttr === 1;
 
     return (
       <Field.Root
         invalid={isInvalid}
         disabled={props.disabled}
         readOnly={props.readOnly}
+        loading={loading}
         className={cn("items-start", className)}
       >
         <Field.Textarea


### PR DESCRIPTION
## Summary
- showcase the textarea primitive in default, hover, focus-visible, active, invalid, read-only, disabled, and loading states with token-based styling in the gallery
- forward the `data-loading` flag through the textarea primitive so the Field loader renders correctly during loading previews

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce94ba3c44832c92e8a79e1b3635b9