### PR TITLE
Add frameless HeroPortraitFrame variant

### DIFF
--- a/src/components/home/HeroPortraitFrame.tsx
+++ b/src/components/home/HeroPortraitFrame.tsx
@@ -8,6 +8,7 @@ export interface HeroPortraitFrameProps {
   imageSizes?: string;
   priority?: boolean;
   className?: string;
+  frame?: boolean;
 }
 
 type CSSVarStyle = React.CSSProperties & Record<`--${string}`, string>;
@@ -39,6 +40,14 @@ const innerStyle: React.CSSProperties = {
   boxShadow: "var(--portrait-outline)",
 };
 
+const framelessContainerStyle: CSSVarStyle = {
+  ...frameVariables,
+  width: innerStyle.width,
+  height: innerStyle.height,
+  background: innerStyle.background,
+  boxShadow: innerStyle.boxShadow,
+};
+
 const glowStyle: React.CSSProperties = {
   background: "var(--portrait-glow-gradient)",
 };
@@ -52,15 +61,37 @@ export default function HeroPortraitFrame({
   imageSizes = defaultSizes,
   priority = false,
   className,
+  frame = true,
 }: HeroPortraitFrameProps) {
+  const baseClassName = "relative isolate flex shrink-0 items-center justify-center";
+  const portraitImage = (
+    <Image
+      src={imageSrc}
+      alt={imageAlt}
+      sizes={imageSizes}
+      priority={priority}
+      fill
+      className="object-contain object-center"
+    />
+  );
+
+  if (!frame) {
+    return (
+      <div
+        className={cn(
+          baseClassName,
+          "overflow-hidden rounded-full shadow-neo",
+          className,
+        )}
+        style={framelessContainerStyle}
+      >
+        {portraitImage}
+      </div>
+    );
+  }
+
   return (
-    <div
-      className={cn(
-        "relative isolate flex shrink-0 items-center justify-center",
-        className,
-      )}
-      style={frameVariables}
-    >
+    <div className={cn(baseClassName, className)} style={frameVariables}>
       <span
         aria-hidden
         className="pointer-events-none absolute -inset-[calc(var(--portrait-rim)*1.6)] rounded-full blur-[var(--portrait-glow)] opacity-80"
@@ -78,14 +109,7 @@ export default function HeroPortraitFrame({
           className="relative flex items-center justify-center overflow-hidden rounded-full"
           style={innerStyle}
         >
-          <Image
-            src={imageSrc}
-            alt={imageAlt}
-            sizes={imageSizes}
-            priority={priority}
-            fill
-            className="object-contain object-center"
-          />
+          {portraitImage}
         </div>
       </div>
     </div>

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -10,4 +10,5 @@ export { default as QuickActionGrid } from "./QuickActionGrid";
 export { default as BottomNav } from "../chrome/BottomNav";
 export { default as IsometricRoom } from "./IsometricRoom";
 export { default as HeroPortraitFrame } from "./HeroPortraitFrame";
+export type { HeroPortraitFrameProps } from "./HeroPortraitFrame";
 export { default as WelcomeHeroFigure } from "./WelcomeHeroFigure";

--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -1478,18 +1478,30 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
       description:
         "Circular neumorphic portrait frame with lavender glow and glitch accent rim built from semantic tokens.",
       element: (
-        <div className="flex justify-center">
+        <div className="flex flex-wrap items-center justify-center gap-[var(--space-3)]">
           <HeroPortraitFrame
+            imageSrc="/hero_image.png"
+            imageAlt="Illustration of the Planner hero floating above a holographic dashboard"
+          />
+          <HeroPortraitFrame
+            frame={false}
             imageSrc="/hero_image.png"
             imageAlt="Illustration of the Planner hero floating above a holographic dashboard"
           />
         </div>
       ),
       tags: ["hero", "portrait", "glitch"],
-      code: `<HeroPortraitFrame
-  imageSrc="/hero_image.png"
-  imageAlt="Illustration of the Planner hero floating above a holographic dashboard"
-/>`,
+      code: `<div className="flex flex-wrap items-center justify-center gap-[var(--space-3)]">
+  <HeroPortraitFrame
+    imageSrc="/hero_image.png"
+    imageAlt="Illustration of the Planner hero floating above a holographic dashboard"
+  />
+  <HeroPortraitFrame
+    frame={false}
+    imageSrc="/hero_image.png"
+    imageAlt="Illustration of the Planner hero floating above a holographic dashboard"
+  />
+</div>`,
     },
     {
       id: "welcome-hero-figure",


### PR DESCRIPTION
## Summary
- add a `frame` prop to `HeroPortraitFrame` with a frameless rendering path that keeps sizing tokens and reusable image markup
- re-export the updated prop type and showcase both framed and frameless variants in the prompts gallery entry

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce9595a1bc832c80c9c76a50fadbaf