### PR TITLE
Fix task image removal to target specific duplicates

### DIFF
--- a/src/components/planner/DayCard.tsx
+++ b/src/components/planner/DayCard.tsx
@@ -33,7 +33,7 @@ export default function DayCard({ iso, isToday }: Props) {
     toggleTask,
     deleteTask,
     addTaskImage,
-    removeTaskImage,
+    removeTaskImage: removeTaskImageForDay,
     doneCount,
     totalCount,
   } = useDay(iso);
@@ -101,7 +101,9 @@ export default function DayCard({ iso, isToday }: Props) {
               toggleTask={toggleTask}
               deleteTask={deleteTask}
               addTaskImage={addTaskImage}
-              removeTaskImage={removeTaskImage}
+              removeTaskImage={(id, url, index) =>
+                removeTaskImageForDay(id, url, index)
+              }
               setSelectedTaskId={setSelectedTaskId}
             />
           </div>

--- a/src/components/planner/TaskList.tsx
+++ b/src/components/planner/TaskList.tsx
@@ -16,7 +16,7 @@ type Props = {
   toggleTask: (id: string) => void;
   deleteTask: (id: string) => void;
   addTaskImage: (id: string, url: string) => void;
-  removeTaskImage: (id: string, url: string) => void;
+  removeTaskImage: (id: string, url: string, index: number) => void;
   setSelectedTaskId: (id: string) => void;
 };
 
@@ -101,7 +101,7 @@ export default function TaskList({
               onEdit={(title) => renameTask(t.id, title)}
               onSelect={() => setSelectedTaskId(t.id)}
               onAddImage={(url) => addTaskImage(t.id, url)}
-              onRemoveImage={(url) => removeTaskImage(t.id, url)}
+              onRemoveImage={(url, index) => removeTaskImage(t.id, url, index)}
             />
           ))}
         </ul>

--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -25,7 +25,7 @@ type Props = {
   onEdit: (title: string) => void;
   onSelect: () => void;
   onAddImage: (url: string) => void;
-  onRemoveImage: (url: string) => void;
+  onRemoveImage: (url: string, index: number) => void;
 };
 
 export default function TaskRow({
@@ -294,7 +294,7 @@ export default function TaskRow({
               <IconButton
                 aria-label="Remove image"
                 title="Remove image"
-                onClick={() => onRemoveImage(url)}
+                onClick={() => onRemoveImage(url, index)}
                 size="sm"
                 iconSize="xs"
                 variant="ring"

--- a/src/components/planner/dayCrud.ts
+++ b/src/components/planner/dayCrud.ts
@@ -125,12 +125,26 @@ export function addTaskImage(day: DayRecord, id: string, url: string) {
   });
 }
 
-export function removeTaskImage(day: DayRecord, id: string, url: string) {
+export function removeTaskImage(
+  day: DayRecord,
+  id: string,
+  url: string,
+  imageIndex?: number,
+) {
   return finalizeDay(day, {
-    tasks: day.tasks.map((t) =>
-      t.id === id
-        ? { ...t, images: t.images.filter((img) => img !== url) }
-        : t,
-    ),
+    tasks: day.tasks.map((t) => {
+      if (t.id !== id) return t;
+
+      const indexToRemove =
+        imageIndex !== undefined && t.images[imageIndex] === url
+          ? imageIndex
+          : t.images.indexOf(url);
+
+      if (indexToRemove < 0) return t;
+
+      const images = t.images.slice();
+      images.splice(indexToRemove, 1);
+      return { ...t, images };
+    }),
   });
 }

--- a/src/components/planner/plannerCrud.ts
+++ b/src/components/planner/plannerCrud.ts
@@ -57,8 +57,8 @@ export function makeCrud(iso: ISODate, upsertDay: UpsertDay) {
   const addTaskImage = (id: string, url: string) =>
     upsertDay(iso, (d) => dayAddTaskImage(d, id, url));
 
-  const removeTaskImage = (id: string, url: string) =>
-    upsertDay(iso, (d) => dayRemoveTaskImage(d, id, url));
+  const removeTaskImage = (id: string, url: string, index?: number) =>
+    upsertDay(iso, (d) => dayRemoveTaskImage(d, id, url, index));
 
   const setNotesForDay = (notes: string) =>
     upsertDay(iso, (d) => setNotes(d, notes));

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -791,7 +791,11 @@ export default function ComponentGallery() {
             toggleTask={() => {}}
             deleteTask={() => {}}
             addTaskImage={() => {}}
-            removeTaskImage={() => {}}
+            removeTaskImage={(id, url, index) => {
+              void id;
+              void url;
+              void index;
+            }}
             setSelectedTaskId={() => {}}
           />
         ),

--- a/tests/planner/TaskRow.test.tsx
+++ b/tests/planner/TaskRow.test.tsx
@@ -10,7 +10,7 @@ import {
 import { describe, it, expect, vi, afterEach } from "vitest";
 import TaskRow from "@/components/planner/TaskRow";
 
-const noop = (): void => {};
+const noop = (..._args: unknown[]): void => {};
 
 describe("TaskRow", () => {
   afterEach(cleanup);
@@ -91,7 +91,36 @@ describe("TaskRow", () => {
     const img = screen.getByRole("img", { name: /image for with image/i });
     expect(img).toBeInTheDocument();
     fireEvent.click(screen.getAllByLabelText("Remove image")[0]);
-    expect(onRemoveImage).toHaveBeenCalledWith("https://example.com/a.jpg");
+    expect(onRemoveImage).toHaveBeenCalledWith("https://example.com/a.jpg", 0);
+  });
+
+  it("passes the correct index when removing duplicate images", () => {
+    const onRemoveImage = vi.fn();
+    render(
+      <TaskRow
+        task={{
+          id: "1",
+          title: "With duplicates",
+          done: false,
+          createdAt: Date.now(),
+          images: [
+            "https://example.com/a.jpg",
+            "https://example.com/a.jpg",
+          ],
+        }}
+        onToggle={noop}
+        onDelete={noop}
+        onEdit={noop}
+        onSelect={noop}
+        onAddImage={noop}
+        onRemoveImage={onRemoveImage}
+      />,
+    );
+
+    const removeButtons = screen.getAllByLabelText("Remove image");
+    fireEvent.click(removeButtons[1]);
+    expect(onRemoveImage).toHaveBeenCalledTimes(1);
+    expect(onRemoveImage).toHaveBeenCalledWith("https://example.com/a.jpg", 1);
   });
 
   it("allows adding an image via the attach button", () => {


### PR DESCRIPTION
## Summary
- update planner CRUD `removeTaskImage` to remove a single image slot, respecting an optional index
- plumb image indices through TaskList and TaskRow so the UI calls removal with the correct duplicate image index
- extend TaskRow tests to verify duplicate image removal behavior and align noop helpers

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce94eab78c832cb5ea1653eedfefbc