### PR TITLE
Improve NavBar responsiveness

### DIFF
--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -23,7 +23,7 @@ export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
   const reduceMotion = useReducedMotion();
 
   return (
-    <nav aria-label="Primary" className="max-w-full overflow-x-auto md:overflow-visible">
+    <nav aria-label="Primary" className="max-w-full overflow-x-auto">
       <ul className="flex min-w-max items-center gap-[var(--space-2)]">
         {items.map(({ href, label }) => {
           const active = isNavActive(path, href);

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -27,7 +27,7 @@ export default function SiteChrome() {
         <Link
           href="/"
           aria-label="Home"
-          className="col-span-full flex items-center gap-[var(--space-3)] md:col-span-4"
+          className="col-span-full flex items-center gap-[var(--space-3)] md:col-span-3 lg:col-span-3"
         >
           <span
             className="h-[var(--space-2)] w-[var(--space-2)] rounded-full animate-pulse bg-[hsl(var(--accent-overlay))] shadow-[var(--shadow-glow-sm)]"
@@ -38,11 +38,11 @@ export default function SiteChrome() {
           </span>
         </Link>
 
-        <div className="col-span-full hidden min-w-0 items-center md:col-span-5 md:flex">
+        <div className="col-span-full hidden min-w-0 items-center md:col-span-6 md:flex lg:col-span-7">
           <NavBar />
         </div>
 
-        <div className="col-span-full flex items-center justify-end gap-[var(--space-3)] md:col-span-3 md:justify-self-end">
+        <div className="col-span-full flex items-center justify-end gap-[var(--space-3)] md:col-span-3 md:justify-self-end lg:col-span-2">
           <ThemeToggle />
           <AnimationToggle />
         </div>


### PR DESCRIPTION
## Summary
- rebalance the SiteChrome grid so the NavBar span can grow while the toggles stay aligned
- keep the NavBar container scrollable at medium widths to prevent pill overlap with longer labels

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce95acf270832c8fce3f90b2dec4b4