### PR TITLE
Update HeroPortraitFrame gallery entry for frame toggle preview

### DIFF
--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -1476,17 +1476,17 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
       id: "hero-portrait-frame",
       name: "HeroPortraitFrame",
       description:
-        "Circular neumorphic portrait frame with lavender glow and glitch accent rim built from semantic tokens.",
+        "Circular neumorphic portrait frame with lavender glow, glitch accent rim, and configurable `frame` toggle built from semantic tokens.",
       element: (
         <div className="flex flex-wrap items-center justify-center gap-[var(--space-3)]">
           <HeroPortraitFrame
             imageSrc="/hero_image.png"
-            imageAlt="Illustration of the Planner hero floating above a holographic dashboard"
+            imageAlt="Illustration of the Planner hero floating above a holographic dashboard with full frame treatment"
           />
           <HeroPortraitFrame
             frame={false}
             imageSrc="/hero_image.png"
-            imageAlt="Illustration of the Planner hero floating above a holographic dashboard"
+            imageAlt="Illustration of the Planner hero floating above a holographic dashboard without frame treatment"
           />
         </div>
       ),
@@ -1494,12 +1494,12 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
       code: `<div className="flex flex-wrap items-center justify-center gap-[var(--space-3)]">
   <HeroPortraitFrame
     imageSrc="/hero_image.png"
-    imageAlt="Illustration of the Planner hero floating above a holographic dashboard"
+    imageAlt="Illustration of the Planner hero floating above a holographic dashboard with full frame treatment"
   />
   <HeroPortraitFrame
     frame={false}
     imageSrc="/hero_image.png"
-    imageAlt="Illustration of the Planner hero floating above a holographic dashboard"
+    imageAlt="Illustration of the Planner hero floating above a holographic dashboard without frame treatment"
   />
 </div>`,
     },


### PR DESCRIPTION
## Summary
- mention the new frame toggle in the HeroPortraitFrame gallery description
- show both framed and frameless variants side by side with descriptive alt text

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce994f2dd0832caea3ba10f6ffa7e1