### PR TITLE
Improve reminder delete button labels

### DIFF
--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -290,6 +290,9 @@ function ReminderCard({
     setTitle(value.title); setBody(value.body ?? ""); setTagsText(value.tags.join(", ")); setEditing(false);
   }
 
+  const reminderName = value.title.trim() || "Untitled reminder";
+  const deleteLabel = `Delete ${reminderName}`;
+
   return (
     <article className="card-neo rounded-card p-4 sm:p-5 relative">
       {value.pinned && (
@@ -370,8 +373,8 @@ function ReminderCard({
           ) : (
             <>
               <IconButton
-                title="Delete"
-                aria-label="Delete"
+                title={deleteLabel}
+                aria-label={deleteLabel}
                 onClick={onDelete}
                 size="sm"
                 iconSize="sm"

--- a/src/components/goals/reminders/ReminderList.tsx
+++ b/src/components/goals/reminders/ReminderList.tsx
@@ -96,6 +96,10 @@ function RemTile({
     const baseLabel = pinned ? "Unpin reminder" : "Pin reminder";
     return value.title ? `${baseLabel} ${value.title}` : baseLabel;
   }, [pinned, value.title]);
+  const deleteLabel = React.useMemo(() => {
+    const name = value.title.trim() || "Untitled reminder";
+    return `Delete ${name}`;
+  }, [value.title]);
 
   return (
     <article className="card-neo rounded-card card-pad relative group">
@@ -142,8 +146,8 @@ function RemTile({
 
         <div className="flex items-center gap-[var(--space-1)]">
           <IconButton
-            title="Delete"
-            aria-label="Delete"
+            title={deleteLabel}
+            aria-label={deleteLabel}
             onClick={onDelete}
             size="sm"
             iconSize="sm"


### PR DESCRIPTION
## Summary
- add context-sensitive delete labels to reminder list tiles with an "Untitled reminder" fallback
- apply the same delete labelling to the reminders card variant for consistency

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ce9f7749a8832c8bb1fb5a0eb8eb4c