### PR TITLE
Add CSS asset fallbacks for noise overlays

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,8 @@
     --shell-max: var(--shell-width);
     --accent-2-foreground: var(--background);
     --danger-foreground: var(--primary-foreground);
+    --asset-noise-url: url("/noise.svg");
+    --asset-glitch-gif-url: url("/glitch-gif.gif");
     --shadow-dropdown: 0 12px 40px hsl(var(--shadow-color) / 0.55);
     --settings-column-width: calc(var(--space-4) * 14);
     --surface-overlay-soft: 0.12;
@@ -98,7 +100,7 @@
     inset: 0;
     pointer-events: none;
     z-index: 3;
-    background-image: var(--asset-glitch-gif-url, none);
+    background-image: var(--asset-glitch-gif-url, url("/glitch-gif.gif"));
     background-size: cover;
     background-position: center;
     mix-blend-mode: overlay;
@@ -252,7 +254,7 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
     2px 100%;
 }
 .bg-noise {
-  background-image: var(--asset-noise-url, none);
+  background-image: var(--asset-noise-url, url("/noise.svg"));
   opacity: 0.1;
 }
 


### PR DESCRIPTION
## Summary
- define default asset URLs for noise and glitch overlays so Storybook and other consumers render textures without Next.js layout overrides
- update `.bg-noise` and `html.fx-gifbars::before` to fall back to public asset URLs when custom variables are absent

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cea6fee954832cb284d832ac149311