### PR TITLE
Improve TaskRow rename input accessibility

### DIFF
--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -45,6 +45,10 @@ export default function TaskRow({
   const [imageError, setImageError] = React.useState<string | null>(null);
   const trimmedImageUrl = imageUrl.trim();
   const canAttachImage = trimmedImageUrl.length > 0;
+  const trimmedTaskTitle = task.title.trim();
+  const renameTaskLabel = trimmedTaskTitle
+    ? `Rename task ${trimmedTaskTitle}`
+    : "Rename task";
 
   const validateImageUrl = React.useCallback((value: string) => {
     if (!value) {
@@ -228,7 +232,7 @@ export default function TaskRow({
                   if (e.key === "Enter") commit();
                   if (e.key === "Escape") cancel();
                 }}
-                aria-label="Rename task"
+                aria-label={renameTaskLabel}
               />
             )}
           </div>

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -84,6 +84,7 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
         className={cn(inputClassName)}
         indent={indent}
         hasEndSlot={showEndSlot || loading}
+        aria-label={ariaLabel}
         {...props}
       />
       {children}

--- a/tests/planner/TaskRow.test.tsx
+++ b/tests/planner/TaskRow.test.tsx
@@ -35,7 +35,7 @@ describe("TaskRow", () => {
     );
     const textButton = screen.getByRole("button", { name: "Test task" });
     fireEvent.doubleClick(textButton);
-    const input = screen.getAllByRole("textbox")[0];
+    const input = screen.getByLabelText("Rename task Test task");
     await waitFor(() => {
       expect(input).toHaveFocus();
     });
@@ -191,5 +191,30 @@ describe("TaskRow", () => {
     await screen.findByText("Image URL must start with https.");
     expect(handleAddImage).not.toHaveBeenCalled();
     expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("falls back to a generic rename label when the task title is empty", () => {
+    render(
+      <TaskRow
+        task={{
+          id: "1",
+          title: "   ",
+          done: false,
+          createdAt: Date.now(),
+          images: [],
+        }}
+        onToggle={noop}
+        onDelete={noop}
+        onEdit={noop}
+        onSelect={noop}
+        onAddImage={noop}
+        onRemoveImage={noop}
+      />,
+    );
+
+    const editButton = screen.getAllByLabelText("Edit task")[0];
+    fireEvent.click(editButton);
+
+    expect(screen.getByLabelText("Rename task")).toBeInTheDocument();
   });
 });

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -328,6 +328,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                     style="--field-h: var(--control-h-md);"
                   >
                     <input
+                      aria-label="Lane (used as Title)"
                       class="peer block h-[var(--field-h,var(--control-h-md))] w-full rounded-[inherit] border-none bg-transparent px-[var(--space-3)] text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent focus:outline-none focus-visible:outline-none disabled:cursor-not-allowed read-only:cursor-default transition-[color,opacity] group-data-[disabled=true]/field:text-muted-foreground/70 group-data-[disabled=true]/field:placeholder:text-muted-foreground/50 group-data-[loading=true]/field:opacity-[var(--loading)]"
                       id=":r4:"
                       name="lane"
@@ -1972,6 +1973,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 <input
                   aria-describedby="tTime-error"
                   aria-invalid="true"
+                  aria-label="Timestamp time in mm:ss"
                   class="peer block h-[var(--field-h,var(--control-h-md))] w-full rounded-[inherit] border-none bg-transparent px-[var(--space-3)] text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent focus:outline-none focus-visible:outline-none disabled:cursor-not-allowed read-only:cursor-default transition-[color,opacity] group-data-[disabled=true]/field:text-muted-foreground/70 group-data-[disabled=true]/field:placeholder:text-muted-foreground/50 group-data-[loading=true]/field:opacity-[var(--loading)]"
                   id=":r8:"
                   inputmode="numeric"
@@ -1991,6 +1993,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 style="--field-h: var(--control-h-md);"
               >
                 <input
+                  aria-label="Timestamp note"
                   class="peer block h-[var(--field-h,var(--control-h-md))] w-full rounded-[inherit] border-none bg-transparent px-[var(--space-3)] text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent focus:outline-none focus-visible:outline-none disabled:cursor-not-allowed read-only:cursor-default transition-[color,opacity] group-data-[disabled=true]/field:text-muted-foreground/70 group-data-[disabled=true]/field:placeholder:text-muted-foreground/50 group-data-[loading=true]/field:opacity-[var(--loading)]"
                   id=":r9:"
                   name="timestamp-note"

--- a/tests/ui/__snapshots__/input.test.tsx.snap
+++ b/tests/ui/__snapshots__/input.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`Input > renders default state 1`] = `
     style="--field-h: var(--control-h-md);"
   >
     <input
+      aria-label="test"
       class="peer block h-[var(--field-h,var(--control-h-md))] w-full rounded-[inherit] border-none bg-transparent px-[var(--space-3)] text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent focus:outline-none focus-visible:outline-none disabled:cursor-not-allowed read-only:cursor-default transition-[color,opacity] group-data-[disabled=true]/field:text-muted-foreground/70 group-data-[disabled=true]/field:placeholder:text-muted-foreground/50 group-data-[loading=true]/field:opacity-[var(--loading)]"
       id=":r0:"
       name=":r0:"
@@ -29,6 +30,7 @@ exports[`Input > renders disabled state 1`] = `
     style="--field-h: var(--control-h-md);"
   >
     <input
+      aria-label="test"
       class="peer block h-[var(--field-h,var(--control-h-md))] w-full rounded-[inherit] border-none bg-transparent px-[var(--space-3)] text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent focus:outline-none focus-visible:outline-none disabled:cursor-not-allowed read-only:cursor-default transition-[color,opacity] group-data-[disabled=true]/field:text-muted-foreground/70 group-data-[disabled=true]/field:placeholder:text-muted-foreground/50 group-data-[loading=true]/field:opacity-[var(--loading)]"
       disabled=""
       id=":r4:"
@@ -50,6 +52,7 @@ exports[`Input > renders error state 1`] = `
   >
     <input
       aria-invalid="true"
+      aria-label="test"
       class="peer block h-[var(--field-h,var(--control-h-md))] w-full rounded-[inherit] border-none bg-transparent px-[var(--space-3)] text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent focus:outline-none focus-visible:outline-none disabled:cursor-not-allowed read-only:cursor-default transition-[color,opacity] group-data-[disabled=true]/field:text-muted-foreground/70 group-data-[disabled=true]/field:placeholder:text-muted-foreground/50 group-data-[loading=true]/field:opacity-[var(--loading)]"
       id=":r2:"
       name=":r2:"
@@ -68,6 +71,7 @@ exports[`Input > renders focus state 1`] = `
     style="--field-h: var(--control-h-md);"
   >
     <input
+      aria-label="test"
       class="peer block h-[var(--field-h,var(--control-h-md))] w-full rounded-[inherit] border-none bg-transparent px-[var(--space-3)] text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent focus:outline-none focus-visible:outline-none disabled:cursor-not-allowed read-only:cursor-default transition-[color,opacity] group-data-[disabled=true]/field:text-muted-foreground/70 group-data-[disabled=true]/field:placeholder:text-muted-foreground/50 group-data-[loading=true]/field:opacity-[var(--loading)]"
       id=":r1:"
       name=":r1:"


### PR DESCRIPTION
## Summary
- derive a rename input label from the task title with a safe fallback for empty names
- forward custom aria-labels through the Input primitive so assistive text reaches the native input
- refresh planner task row tests and related snapshots to assert the new labeling behavior

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cea6ed3100832c84a84b65f7d13b8b