### PR TITLE
Refactor team spacing utilities to use tokens

### DIFF
--- a/src/components/team/Builder.tsx
+++ b/src/components/team/Builder.tsx
@@ -173,10 +173,10 @@ export default React.forwardRef<BuilderHandle, BuilderProps>(
   }));
 
   return (
-    <div data-scope="team" className="w-full mt-6">
+    <div data-scope="team" className="w-full mt-[var(--space-6)]">
       <SectionCard className="card-neo-soft glitch-card">
         <SectionCard.Body>
-          <div className="grid grid-cols-1 md:grid-cols-12 gap-6">
+          <div className="grid grid-cols-1 md:grid-cols-12 gap-[var(--space-6)]">
             {/* Allies */}
             <div className="md:col-span-5">
               <SideEditor
@@ -237,14 +237,14 @@ function SideEditor(props: {
   const { side, title, icon, value, onLane, onNotes, onClear, onCopy, count } = props;
 
   return (
-    <div className="rounded-card p-4 glitch-card card-neo relative">
+    <div className="rounded-card p-[var(--space-4)] glitch-card card-neo relative">
       {/* neon rail */}
       <span aria-hidden className="glitch-rail" />
 
-      <header className="mb-3 flex items-center gap-2">
+      <header className="mb-3 flex items-center gap-[var(--space-2)]">
         {/* glitchy side title */}
         <span
-          className="glitch-title glitch-flicker title-glow inline-flex items-center gap-2"
+          className="glitch-title glitch-flicker title-glow inline-flex items-center gap-[var(--space-2)]"
           data-text={title}
         >
           {icon}
@@ -256,13 +256,13 @@ function SideEditor(props: {
         </span>
       </header>
 
-      <div className="grid gap-3">
+      <div className="grid gap-[var(--space-3)]">
         {LANES.map(({ key, label }) => {
           const inputId = `${side}-${key}`;
           return (
             <div
               key={key}
-              className="grid grid-cols-[calc(var(--spacing-8)+var(--spacing-5))_1fr] items-center gap-3"
+              className="grid grid-cols-[calc(var(--spacing-8)+var(--spacing-5))_1fr] items-center gap-[var(--space-3)]"
             >
               <label
                 className="glitch-title glitch-flicker text-label font-medium tracking-[0.02em] text-muted-foreground"
@@ -281,9 +281,9 @@ function SideEditor(props: {
           );
         })}
 
-        <div className="grid gap-3">
+        <div className="grid gap-[var(--space-3)]">
           <label
-            className="text-label font-medium tracking-[0.02em] text-muted-foreground inline-flex items-center gap-2"
+            className="text-label font-medium tracking-[0.02em] text-muted-foreground inline-flex items-center gap-[var(--space-2)]"
             htmlFor={`${side}-notes`}
           >
             <NotebookPen className="opacity-80" /> Notes
@@ -300,7 +300,7 @@ function SideEditor(props: {
         </div>
 
         {/* side actions: icon-only, same behavior */}
-        <div className="mt-1 flex items-center gap-2 justify-end">
+        <div className="mt-[var(--space-1)] flex items-center gap-[var(--space-2)] justify-end">
           <IconButton
             title={`Clear ${title}`}
             aria-label={`Clear ${title}`}

--- a/src/components/team/ChampListEditor.tsx
+++ b/src/components/team/ChampListEditor.tsx
@@ -22,8 +22,9 @@ export type ChampListEditorProps = {
   inputClassName?: string;
 };
 
-const VIEW_CONTAINER = "champ-badges mt-1";
-const EDIT_CONTAINER = "champ-badges mt-1 flex flex-wrap gap-2";
+const VIEW_CONTAINER = "champ-badges mt-[var(--space-1)]";
+const EDIT_CONTAINER =
+  "champ-badges mt-[var(--space-1)] flex flex-wrap gap-[var(--space-2)]";
 const PILL_BASE =
   "champ-badge glitch-pill border-border bg-card text-foreground text-label font-medium tracking-[0.02em]";
 const INPUT_BASE =

--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -462,7 +462,7 @@ export default function CheatSheet({
     <section
       data-scope="team"
       className={[
-        "grid gap-4 sm:gap-6 md:grid-cols-2 xl:grid-cols-3",
+        "grid gap-[var(--space-4)] sm:gap-[var(--space-6)] md:grid-cols-2 xl:grid-cols-3",
         className,
       ].join(" ")}
     >
@@ -475,13 +475,13 @@ export default function CheatSheet({
             className={[
               "group glitch-card card-neo relative h-full",
               dense
-                ? "p-4"
-                : "p-5",
+                ? "p-[var(--space-4)]"
+                : "p-[var(--space-5)]",
             ].join(" ")}
           >
             {/* Top-right edit/save control */}
             {editing && (
-              <div className="absolute right-2 top-2 z-10 flex items-center gap-1 opacity-100 pointer-events-auto">
+              <div className="absolute right-2 top-2 z-10 flex items-center gap-[var(--space-1)] opacity-100 pointer-events-auto">
                 {!isEditing ? (
                   <IconButton
                     title="Edit"
@@ -522,7 +522,7 @@ export default function CheatSheet({
             </header>
 
             {/* Body */}
-            <div className="grid grid-cols-1 gap-4">
+            <div className="grid grid-cols-1 gap-[var(--space-4)]">
               <div>
                 <Label>Wins when</Label>
                 <BulletListEdit
@@ -560,7 +560,7 @@ export default function CheatSheet({
               {/* Examples with fixed role column */}
               <div>
                 <Label>Examples</Label>
-                <div className="mt-2 space-y-2">
+                <div className="mt-[var(--space-2)] space-y-[var(--space-2)]">
                   {ROLES.map(
                     (role) => {
                       const champs = a.examples?.[role] ?? [];
@@ -574,10 +574,10 @@ export default function CheatSheet({
                       return (
                         <div
                           key={role}
-                          className="grid grid-cols-[calc(var(--spacing-8)+var(--spacing-5))_1fr] items-start gap-x-3"
+                          className="grid grid-cols-[calc(var(--spacing-8)+var(--spacing-5))_1fr] items-start gap-x-[var(--space-3)]"
                         >
                           <div
-                            className="glitch-title glitch-flicker text-label font-medium tracking-[0.02em] text-muted-foreground pt-1"
+                            className="glitch-title glitch-flicker text-label font-medium tracking-[0.02em] text-muted-foreground pt-[var(--space-1)]"
                             data-text={role}
                           >
                             {role}

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -250,7 +250,7 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
           {editing && (
             <form
               onSubmit={addNew}
-              className="rounded-card flex items-center gap-6 glitch"
+              className="rounded-card flex items-center gap-[var(--space-6)] glitch"
             >
               <Input
                 dir="ltr"
@@ -276,22 +276,22 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
 
           {/* Empty states */}
           {items.length === 0 ? (
-            <div className="rounded-card r-card-lg p-6 text-ui font-medium text-muted-foreground border border-border">
+            <div className="rounded-card r-card-lg p-[var(--space-6)] text-ui font-medium text-muted-foreground border border-border">
               No comps yet. Type a title above and press Enter.
             </div>
           ) : filtered.length === 0 ? (
-            <div className="rounded-card r-card-lg p-6 text-ui font-medium text-muted-foreground border border-border">
+            <div className="rounded-card r-card-lg p-[var(--space-6)] text-ui font-medium text-muted-foreground border border-border">
               Nothing matches your search.
             </div>
           ) : null}
 
           {/* Cards grid */}
-          <div className="grid grid-cols-12 gap-4">
+          <div className="grid grid-cols-12 gap-[var(--space-4)]">
             {filtered.map((c) => {
               const editingCard = editingId === c.id;
               const showActions = isCoarsePointer || editing || editingCard;
               const actionClasses = [
-                "absolute right-2 top-2 z-10 flex items-center gap-1 transition-opacity",
+                "absolute right-2 top-2 z-10 flex items-center gap-[var(--space-1)] transition-opacity",
                 showActions
                   ? "opacity-100 pointer-events-auto"
                   : "opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto",
@@ -300,7 +300,7 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
               return (
                 <article
                   key={c.id}
-                  className="col-span-12 md:col-span-6 xl:col-span-4 group card-neo glitch-card relative p-7"
+                  className="col-span-12 md:col-span-6 xl:col-span-4 group card-neo glitch-card relative p-[var(--space-7)]"
                 >
                   {/* Action controls: copy, edit, delete, save */}
                   <div className={actionClasses}>
@@ -378,7 +378,7 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
                   </header>
 
                   {/* roles */}
-                  <div className="grid gap-3">
+                  <div className="grid gap-[var(--space-3)]">
                     {ROLES.map((r) => {
                       const list = c.roles[r] ?? [];
                       const setList = (next: string[]) =>
@@ -387,10 +387,10 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
                       return (
                         <div
                           key={r}
-                          className="grid grid-cols-[calc(var(--spacing-8)+var(--spacing-5))_1fr] items-start gap-3"
+                          className="grid grid-cols-[calc(var(--spacing-8)+var(--spacing-5))_1fr] items-start gap-[var(--space-3)]"
                         >
                           <div
-                            className="glitch-title glitch-flicker text-label font-medium tracking-[0.02em] text-muted-foreground pt-1"
+                            className="glitch-title glitch-flicker text-label font-medium tracking-[0.02em] text-muted-foreground pt-[var(--space-1)]"
                             data-text={r}
                           >
                             {r}
@@ -402,15 +402,15 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
                             onChange={setList}
                             editing={editing && editingCard}
                             emptyLabel="-"
-                            viewClassName="champ-badges mt-1 flex flex-wrap gap-2"
+                            viewClassName="champ-badges mt-[var(--space-1)] flex flex-wrap gap-[var(--space-2)]"
                           />
                         </div>
                       );
                     })}
 
                     {/* notes */}
-                    <div className="grid gap-3">
-                      <label className="text-label font-medium tracking-[0.02em] text-muted-foreground inline-flex items-center gap-2">
+                    <div className="grid gap-[var(--space-3)]">
+                      <label className="text-label font-medium tracking-[0.02em] text-muted-foreground inline-flex items-center gap-[var(--space-2)]">
                         <NotebookPen className="opacity-80" /> Notes
                       </label>
                       {!editingCard ? (

--- a/src/components/team/style.css
+++ b/src/components/team/style.css
@@ -2,7 +2,8 @@
 
 /* Champ badges */
 .champ-badges {
-  @apply flex flex-wrap gap-2;
+  @apply flex flex-wrap;
+  gap: var(--space-2);
 }
 .champ-badge {
   @apply inline-flex items-center h-6 px-2 rounded-full border text-label leading-none whitespace-nowrap;

--- a/tests/team/TeamCompPage.test.tsx
+++ b/tests/team/TeamCompPage.test.tsx
@@ -22,7 +22,7 @@ describe("TeamCompPage builder tab", () => {
     const heroHeading = screen.getByRole("heading", { name: "Builder" });
     expect(heroHeading).toBeInTheDocument();
     const cardParent = screen.getByText("Allies").closest("section")?.parentElement;
-    expect(cardParent).toHaveClass("mt-6");
+    expect(cardParent).toHaveClass("mt-[var(--space-6)]");
   });
 
   it("handles missing lane entries gracefully", () => {


### PR DESCRIPTION
## Summary
- replace hard-coded spacing utilities in the team builder, cheat sheet, and my comps components with `var(--space-*)` tokens
- update champ badge styles to express layout gap via the spacing token scale
- adjust the TeamCompPage spacing test to assert the new token-backed class

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cead1ff1e8832cb00c4a15e238a77f