### PR TITLE
Adjust label gallery spacing token usage

### DIFF
--- a/src/components/ui/Label.gallery.tsx
+++ b/src/components/ui/Label.gallery.tsx
@@ -7,7 +7,7 @@ import Label from "./Label";
 
 function LabelGalleryPreview() {
   return (
-    <div className="flex w-64 flex-col gap-[var(--space-3)]">
+    <div className="flex w-[calc(var(--space-8)*4)] flex-col gap-[var(--space-3)]">
       <div>
         <Label htmlFor="label-default">Email</Label>
         <Input id="label-default" placeholder="player@example.gg" />
@@ -48,7 +48,7 @@ export default defineGallerySection({
         id: "ui:label:pairing",
         render: () => <LabelGalleryPreview />,
       }),
-      code: `<div className="w-64 space-y-[var(--space-3)]">
+      code: `<div className="w-[calc(var(--space-8)*4)] space-y-[var(--space-3)]">
   <div>
     <Label htmlFor="label-default">Email</Label>
     <Input id="label-default" placeholder="player@example.gg" />


### PR DESCRIPTION
## Summary
- align the Label gallery preview wrapper width with spacing tokens
- mirror the width change in the embedded code sample

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cebaf432b4832c8fdd05d3baf9bcac