### PR TITLE
Align prompt cards with medium radius

### DIFF
--- a/src/components/prompts/ComponentsView.tsx
+++ b/src/components/prompts/ComponentsView.tsx
@@ -116,7 +116,7 @@ function PropsTable({
     >
       <SectionHeading id={headingId}>Props</SectionHeading>
       <div
-        className="overflow-x-auto rounded-card border border-[hsl(var(--card-hairline)/0.6)] bg-[hsl(var(--surface-1)/0.6)] shadow-[var(--shadow-inset-hairline)]"
+        className="overflow-x-auto rounded-card r-card-md border border-[hsl(var(--card-hairline)/0.6)] bg-[hsl(var(--surface-1)/0.6)] shadow-[var(--shadow-inset-hairline)]"
       >
         <table className="w-full min-w-[28rem] border-separate border-spacing-0 text-left">
           <thead>
@@ -186,7 +186,7 @@ function VariantsMatrix({ axes }: { axes: readonly GalleryAxis[] }) {
         {axes.map((axis) => (
           <article
             key={axis.id}
-            className="rounded-card border border-[hsl(var(--card-hairline)/0.6)] bg-[hsl(var(--surface-1)/0.6)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)]"
+            className="rounded-card r-card-md border border-[hsl(var(--card-hairline)/0.6)] bg-[hsl(var(--surface-1)/0.6)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)]"
           >
             <div className="space-y-[var(--space-1)]">
               <h4 className="text-ui font-semibold tracking-[-0.01em] text-foreground">
@@ -307,7 +307,7 @@ function StatesSection({
     >
       <SectionHeading id={headingId}>States</SectionHeading>
       {stateAxes.length > 0 ? (
-        <div className="rounded-card border border-[hsl(var(--card-hairline)/0.6)] bg-[hsl(var(--surface-1)/0.6)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)]">
+        <div className="rounded-card r-card-md border border-[hsl(var(--card-hairline)/0.6)] bg-[hsl(var(--surface-1)/0.6)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)]">
           <div className="grid gap-[var(--space-3)] md:grid-cols-2">
             {stateAxes.map((axis) => (
               <div key={axis.id} className="space-y-[var(--space-2)]">
@@ -383,7 +383,7 @@ function StatePreviewCard({
 
   return (
     <article
-      className="flex flex-col gap-[var(--space-3)] rounded-card border border-[hsl(var(--card-hairline)/0.6)] bg-[linear-gradient(140deg,hsl(var(--card)/0.94),hsl(var(--surface-2)/0.72))] p-[var(--space-4)] shadow-neo"
+      className="flex flex-col gap-[var(--space-3)] rounded-card r-card-md border border-[hsl(var(--card-hairline)/0.6)] bg-[linear-gradient(140deg,hsl(var(--card)/0.94),hsl(var(--surface-2)/0.72))] p-[var(--space-4)] shadow-neo"
       aria-labelledby={headingId}
       aria-describedby={descriptionId}
     >


### PR DESCRIPTION
## Summary
- add the r-card-md token to prompt gallery props tables, variant cards, and state axis wrappers
- update state preview cards to pair rounded-card with r-card-md so neo shadows honor the medium radius

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cebc39448c832c9679949a1600425e