### PR TITLE
Use spacing token for prompts props table min width

### DIFF
--- a/src/components/prompts/ComponentsView.tsx
+++ b/src/components/prompts/ComponentsView.tsx
@@ -118,7 +118,7 @@ function PropsTable({
       <div
         className="overflow-x-auto rounded-card border border-[hsl(var(--card-hairline)/0.6)] bg-[hsl(var(--surface-1)/0.6)] shadow-[var(--shadow-inset-hairline)]"
       >
-        <table className="w-full min-w-[28rem] border-separate border-spacing-0 text-left">
+        <table className="w-full min-w-[calc(var(--space-8)*7)] border-separate border-spacing-0 text-left">
           <thead>
             <tr className="text-label text-muted-foreground">
               <th scope="col" className="px-[var(--space-4)] py-[var(--space-3)] font-semibold">


### PR DESCRIPTION
## Summary
- align the prompts props table minimum width with the spacing scale token by switching to calc(var(--space-8)*7)

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68cebcc35928832caabf5797bbe40b93