### PR TITLE
Trim team comp role entries

### DIFF
--- a/src/components/team/ChampListEditor.tsx
+++ b/src/components/team/ChampListEditor.tsx
@@ -41,16 +41,24 @@ export default function ChampListEditor({
   editPillClassName,
   inputClassName,
 }: ChampListEditorProps) {
-  const sanitized = React.useMemo(() => sanitizeList(list ?? []), [list]);
-  const workingList = sanitized.length ? sanitized : [""];
+  const normalized = React.useMemo(
+    () => sanitizeList(list ?? []).map((item) => item.trim()),
+    [list],
+  );
+  const workingList = normalized.length ? normalized : [""];
+
+  function normalizeList(next: string[]) {
+    return sanitizeList(next).map((item) => item.trim());
+  }
 
   function commit(next: string[]) {
-    const sanitizedNext = sanitizeList(next);
-    onChange(sanitizedNext.length ? sanitizedNext : []);
+    const normalizedNext = normalizeList(next);
+    onChange(normalizedNext.length ? normalizedNext : []);
   }
 
   function commitWithoutBlanks(next: string[]) {
-    const cleaned = sanitizeList(next).filter((item) => item.trim().length);
+    const normalizedNext = normalizeList(next);
+    const cleaned = normalizedNext.filter((item) => item.length > 0);
     onChange(cleaned.length ? cleaned : []);
   }
 
@@ -63,18 +71,17 @@ export default function ChampListEditor({
   function insertAfter(index: number) {
     const next = [...workingList];
     next.splice(index + 1, 0, "");
-    const sanitizedNext = sanitizeList(next);
-    commit(sanitizedNext.length ? sanitizedNext : [""]);
+    commit(next);
   }
 
   function removeAt(index: number) {
     const next = [...workingList];
     next.splice(index, 1);
-    commit(sanitizeList(next));
+    commit(next);
   }
 
   if (!editing) {
-    if (sanitized.length === 0) {
+    if (normalized.length === 0) {
       if (emptyLabel === undefined) return null;
       return (
         <div className={cn(VIEW_CONTAINER, viewClassName)}>
@@ -91,7 +98,7 @@ export default function ChampListEditor({
 
     return (
       <div className={cn(VIEW_CONTAINER, viewClassName)}>
-        {sanitized.map((champ, index) => (
+        {normalized.map((champ, index) => (
           <span key={index} className={cn(PILL_BASE, pillClassName)}>
             <i className="dot" />
             {champ}

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -95,7 +95,7 @@ function stringify(c: TeamComp) {
 }
 
 /** Normalize arbitrary localStorage entries into the TeamComp shape. */
-function normalize(list: unknown[]): TeamComp[] {
+export function normalizeTeamComps(list: unknown[]): TeamComp[] {
   if (!Array.isArray(list)) return [];
   return list.map((raw): TeamComp => {
     if (!isRecord(raw)) {
@@ -117,7 +117,9 @@ function normalize(list: unknown[]): TeamComp[] {
       const next: Partial<Record<Role, string[]>> = {};
       for (const r of ROLES) {
         const v = raw.roles[r as keyof typeof raw.roles];
-        next[r] = isStringArray(v) ? v.filter(Boolean) : [];
+        next[r] = isStringArray(v)
+          ? v.map((name) => name.trim()).filter((name) => name.length > 0)
+          : [];
       }
       roles = next;
     } else {
@@ -142,7 +144,10 @@ export type MyCompsProps = { query?: string; editing?: boolean };
 export default function MyComps({ query = "", editing = false }: MyCompsProps) {
   // Load and normalize so old/bad records don't break the UI.
   const [raw, setRaw] = usePersistentState<TeamComp[]>(DB_KEY, SEEDS);
-  const items = React.useMemo(() => normalize(raw as unknown[]), [raw]);
+  const items = React.useMemo(
+    () => normalizeTeamComps(raw as unknown[]),
+    [raw],
+  );
   const filtered = React.useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return items;

--- a/tests/team/ChampListEditor.test.tsx
+++ b/tests/team/ChampListEditor.test.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ChampListEditor from "@/components/team/ChampListEditor";
+
+describe("ChampListEditor", () => {
+  it("trims champion names before committing changes", () => {
+    const handleChange = vi.fn();
+
+    render(
+      <ChampListEditor list={[""]} onChange={handleChange} editing />,
+    );
+
+    const input = screen.getByLabelText("Champion name");
+    fireEvent.change(input, { target: { value: "  Ashe  " } });
+
+    expect(handleChange).toHaveBeenLastCalledWith(["Ashe"]);
+  });
+
+  it("normalizes initial list values for editing", () => {
+    const handleChange = vi.fn();
+
+    render(
+      <ChampListEditor
+        list={["  Sejuani  "]}
+        onChange={handleChange}
+        editing
+      />,
+    );
+
+    const input = screen.getByLabelText("Champion name");
+    expect(input).toHaveValue("Sejuani");
+  });
+});

--- a/tests/team/MyComps.normalize.test.ts
+++ b/tests/team/MyComps.normalize.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { normalizeTeamComps, type TeamComp } from "@/components/team/MyComps";
+
+const baseComp: TeamComp = {
+  id: "comp-1",
+  title: "Sample",
+  roles: { Top: [], Jungle: [], Mid: [], Bot: [], Support: [] },
+  notes: "",
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+describe("normalizeTeamComps", () => {
+  it("trims champion names and removes empty entries", () => {
+    const input: unknown[] = [
+      {
+        ...baseComp,
+        roles: {
+          Top: ["  Aatrox  ", ""],
+          Jungle: ["  Sejuani  ", "   "],
+        },
+      },
+    ];
+
+    const [comp] = normalizeTeamComps(input);
+    expect(comp.roles.Top).toEqual(["Aatrox"]);
+    expect(comp.roles.Jungle).toEqual(["Sejuani"]);
+    expect(comp.roles.Mid).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- trim whitespace when normalizing stored team comps
- ensure ChampListEditor emits trimmed champion names while editing
- add regression tests covering the normalization and editor behavior

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ceba22df64832c9a9de6b52208b7da