### PR TITLE
Add aria-pressed to interactive badge toggle

### DIFF
--- a/src/components/ui/primitives/Badge.tsx
+++ b/src/components/ui/primitives/Badge.tsx
@@ -116,6 +116,7 @@ export default function Badge<T extends React.ElementType = "span">({
       data-selected={selected ? "true" : undefined}
       data-disabled={disabled ? "true" : undefined}
       aria-disabled={disabled ? "true" : undefined}
+      aria-pressed={interactive ? selected : undefined}
       className={cn(
         "inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em]",
         "border bg-muted/18",


### PR DESCRIPTION
## Summary
- set `aria-pressed` on interactive badges so their selected state is announced to assistive tech

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cebdd66a70832ca1eafc2c9f931c92