### PR TITLE
Add interaction state demos for theme controls

### DIFF
--- a/src/components/ui/theme/BackgroundPicker.tsx
+++ b/src/components/ui/theme/BackgroundPicker.tsx
@@ -27,12 +27,14 @@ export type BackgroundPickerProps = {
   bg: Background;
   onBgChange: (bg: Background) => void;
   className?: string;
+  disabled?: boolean;
 };
 
 export default function BackgroundPicker({
   bg,
   onBgChange,
   className = "",
+  disabled = false,
 }: BackgroundPickerProps) {
   const items: SelectItem[] = React.useMemo(
     () =>
@@ -55,6 +57,7 @@ export default function BackgroundPicker({
       value={String(bg)}
       onChange={(v) => onBgChange(Number(v) as Background)}
       className={className}
+      disabled={disabled}
     />
   );
 }

--- a/src/components/ui/theme/ThemePicker.tsx
+++ b/src/components/ui/theme/ThemePicker.tsx
@@ -9,18 +9,28 @@ export type ThemePickerProps = {
   variant: Variant;
   onVariantChange: (v: Variant) => void;
   className?: string;
+  disabled?: boolean;
 };
 
-export default function ThemePicker({ variant, onVariantChange, className = "" }: ThemePickerProps) {
-  const items: SelectItem[] = React.useMemo(() => VARIANTS.map(v => ({ value: v.id, label: v.label })), []);
+export default function ThemePicker({
+  variant,
+  onVariantChange,
+  className = "",
+  disabled = false,
+}: ThemePickerProps) {
+  const items: SelectItem[] = React.useMemo(
+    () => VARIANTS.map((v) => ({ value: v.id, label: v.label })),
+    [],
+  );
   return (
     <SettingsSelect
       ariaLabel="Theme"
       prefixLabel="Theme"
       items={items}
       value={variant}
-      onChange={v => onVariantChange(v as Variant)}
+      onChange={(v) => onVariantChange(v as Variant)}
       className={className}
+      disabled={disabled}
     />
   );
 }


### PR DESCRIPTION
## Summary
- add state wrappers in the prompts gallery to showcase hover, focus, active, disabled, and loading for ThemePicker, BackgroundPicker, SettingsSelect, and ThemeToggle
- enable ThemePicker and BackgroundPicker to forward disabled state to SettingsSelect so gallery demos can disable the trigger

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cebc6ba71c832c9e6205548fac153e