### PR TITLE
Add aria-pressed to interactive badge toggle

### DIFF
--- a/src/components/ui/primitives/Badge.tsx
+++ b/src/components/ui/primitives/Badge.tsx
@@ -44,21 +44,26 @@ const toneBorder: Record<Tone, string> = {
   support: "border-tone-sup",
 };
 
-export default function Badge<T extends React.ElementType = "span">({
-  size = "sm",
-  tone = "neutral",
-  interactive = false,
-  selected = false,
-  glitch = false,
-  disabled = false,
-  as,
-  className,
-  children,
-  ...rest
-}: BadgeProps<T>) {
+export default function Badge<T extends React.ElementType = "span">(
+  props: BadgeProps<T>,
+) {
+  const {
+    size = "sm",
+    tone = "neutral",
+    interactive = false,
+    selected,
+    glitch = false,
+    disabled = false,
+    as,
+    className,
+    children,
+    ...rest
+  } = props;
   const Comp = (as ?? (interactive ? "button" : "span")) as React.ElementType;
   const isStringElement = typeof Comp === "string";
   const isButtonElement = isStringElement && Comp === "button";
+  const isToggleBadge = Object.prototype.hasOwnProperty.call(props, "selected");
+  const isSelected = selected ?? false;
   const {
     onKeyDown: userOnKeyDown,
     onClick: userOnClick,
@@ -113,10 +118,10 @@ export default function Badge<T extends React.ElementType = "span">({
       {...disabledProps}
       onClick={userOnClick}
       onKeyDown={mergedOnKeyDown}
-      data-selected={selected ? "true" : undefined}
+      data-selected={isSelected ? "true" : undefined}
       data-disabled={disabled ? "true" : undefined}
       aria-disabled={disabled ? "true" : undefined}
-      aria-pressed={interactive ? selected : undefined}
+      aria-pressed={interactive && isToggleBadge ? isSelected : undefined}
       className={cn(
         "inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em]",
         "border bg-muted/18",
@@ -129,7 +134,7 @@ export default function Badge<T extends React.ElementType = "span">({
             "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--surface-2))] hover:bg-muted/28 active:bg-muted/36 active:translate-y-[var(--space-1)] motion-reduce:active:translate-y-0 data-[disabled=true]:opacity-[var(--disabled)] data-[disabled=true]:cursor-default",
             !isButtonElement && "data-[disabled=true]:pointer-events-none",
           ),
-        selected &&
+        isSelected &&
           "bg-primary-soft/36 border-[var(--ring-contrast)] shadow-inset-contrast shadow-glow-xl text-[var(--text-on-accent)]",
         glitch &&
           "shadow-inset-hairline shadow-glow-md hover:shadow-inset-contrast hover:shadow-glow-lg",


### PR DESCRIPTION
## Summary
- set `aria-pressed` on interactive badges that provide a `selected` state so their toggle status is announced to assistive tech

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cebfa83910832c98e4053a555f0237