### PR TITLE
Stop persisting placeholder entries in BulletListEdit

### DIFF
--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -285,20 +285,24 @@ function BulletListEdit({
   editing: boolean;
   ariaLabel: string;
 }) {
-  const [list, setList] = React.useState<string[]>(
-    items.length ? sanitizeList(items) : [""],
-  );
+  const [list, setList] = React.useState<string[]>(() => {
+    const sanitized = sanitizeList(items);
+    const cleaned = sanitized.map((item) => item.trim()).filter(Boolean);
+    return cleaned.length ? sanitized : [""];
+  });
   const liRefs = React.useRef<Array<HTMLLIElement | null>>([]);
 
   React.useEffect(() => {
-    setList(items.length ? sanitizeList(items) : [""]);
+    const sanitized = sanitizeList(items);
+    const cleaned = sanitized.map((item) => item.trim()).filter(Boolean);
+    setList(cleaned.length ? sanitized : [""]);
   }, [items]);
 
   function update(next: string[]) {
     const sanitized = sanitizeList(next);
-    setList(sanitized);
     const cleaned = sanitized.map((item) => item.trim()).filter(Boolean);
-    onChange(cleaned.length ? cleaned : [""]);
+    setList(cleaned.length ? sanitized : [""]);
+    onChange(cleaned.length ? cleaned : []);
   }
 
   function handleItemInput(i: number, e: React.FormEvent<HTMLLIElement>) {


### PR DESCRIPTION
## Summary
- update the BulletListEdit state management so the UI keeps a temporary blank row but the change handler now emits an empty array when the list is cleared
- reset the local list state to a blank placeholder whenever the sanitized items are empty so view and edit modes keep working with empty arrays

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cec096ae6c832cae4164b87f620115