### PR TITLE
Handle invalid cheat sheet sub-tab cache

### DIFF
--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -56,11 +56,20 @@ const decodeTab = (value: unknown): Tab | null => {
   return null;
 };
 
+const decodeSubTab = (value: unknown): SubTab | null => {
+  if (value === "sheet" || value === "comps") {
+    return value;
+  }
+  return null;
+};
+
 export default function TeamCompPage() {
   const [tab, setTab] = usePersistentState<Tab>(TAB_KEY, "cheat", {
     decode: decodeTab,
   });
-  const [subTab, setSubTab] = usePersistentState<SubTab>(SUB_TAB_KEY, "sheet");
+  const [subTab, setSubTab] = usePersistentState<SubTab>(SUB_TAB_KEY, "sheet", {
+    decode: decodeSubTab,
+  });
   const [query, setQuery] = usePersistentState<string>(QUERY_KEY, "");
   const tabBaseId = React.useId();
   const subTabBaseId = React.useId();

--- a/tests/team/TeamCompPage.test.tsx
+++ b/tests/team/TeamCompPage.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import TeamCompPage from "@/components/team/TeamCompPage";
 import * as BuilderModule from "@/components/team/Builder";
 import type { TeamState } from "@/components/team/Builder";
+import { createStorageKey } from "@/lib/db";
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -12,6 +13,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.runAllTimers();
   vi.useRealTimers();
+  window.localStorage.clear();
 });
 
 describe("TeamCompPage builder tab", () => {
@@ -59,5 +61,18 @@ describe("TeamCompPage jungle clears tab", () => {
       )
     ).toBeInTheDocument();
     expect(screen.getByText(/\d+ shown/i)).toBeInTheDocument();
+  });
+});
+
+describe("TeamCompPage cheat sheet sub-tab", () => {
+  it("falls back to sheet when cached value is invalid", () => {
+    const storageKey = createStorageKey("team:cheatsheet:activeSubTab.v1");
+    window.localStorage.setItem(storageKey, JSON.stringify("invalid"));
+
+    render(<TeamCompPage />);
+
+    const sheetPanel = screen.getByRole("tabpanel", { name: "Cheat Sheet" });
+    expect(sheetPanel).not.toHaveAttribute("hidden");
+    window.localStorage.removeItem(storageKey);
   });
 });


### PR DESCRIPTION
## Summary
- add a decoder for cheat sheet sub-tabs so persistent state ignores invalid cache entries
- cover the new decoding behaviour with a unit test that seeds localStorage with a bad value

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cecc78bccc832c8335c7c5d554dd16