### PR TITLE
Adjust state preview cards to radius lg

### DIFF
--- a/src/components/prompts/ComponentsView.tsx
+++ b/src/components/prompts/ComponentsView.tsx
@@ -383,7 +383,7 @@ function StatePreviewCard({
 
   return (
     <article
-      className="flex flex-col gap-[var(--space-3)] rounded-card r-card-md border border-[hsl(var(--card-hairline)/0.6)] bg-[linear-gradient(140deg,hsl(var(--card)/0.94),hsl(var(--surface-2)/0.72))] p-[var(--space-4)] shadow-neo"
+      className="flex flex-col gap-[var(--space-3)] rounded-card r-card-lg border border-[hsl(var(--card-hairline)/0.6)] bg-[linear-gradient(140deg,hsl(var(--card)/0.94),hsl(var(--surface-2)/0.72))] p-[var(--space-4)] shadow-neo"
       aria-labelledby={headingId}
       aria-describedby={descriptionId}
     >


### PR DESCRIPTION
## Summary
- update state preview cards to use the r-card-lg radius so neo shadows match the radius-3 spec

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cee06c31e4832c86fb06c21c0a8a74