### PR TITLE
Use spacing tokens in prompt showcases

### DIFF
--- a/src/components/prompts/ColorGallery.tsx
+++ b/src/components/prompts/ColorGallery.tsx
@@ -33,7 +33,7 @@ export default function ColorGallery() {
   }, [palette]);
 
   return (
-    <div className="flex flex-col gap-8">
+    <div className="flex flex-col gap-[var(--space-8)]">
       <TabBar
         items={paletteTabs}
         value={palette}
@@ -51,12 +51,12 @@ export default function ColorGallery() {
           ref={(el) => {
             panelRefs.current[p.key] = el;
           }}
-          className="grid gap-8 sm:grid-cols-2 md:grid-cols-3"
+          className="grid gap-[var(--space-8)] sm:grid-cols-2 md:grid-cols-3"
         >
           {p.key === "aurora" && (
-            <div className="flex flex-col items-center gap-2 sm:col-span-2 md:col-span-3">
+            <div className="flex flex-col items-center gap-[var(--space-2)] sm:col-span-2 md:col-span-3">
               <span className="text-ui font-medium">Aurora Palette</span>
-              <div className="flex gap-2">
+              <div className="flex gap-[var(--space-2)]">
                 <div
                   className="rounded-[var(--radius-md)] bg-aurora-g"
                   style={auroraSwatchStyle}
@@ -82,7 +82,7 @@ export default function ColorGallery() {
             </div>
           )}
           {COLOR_PALETTES[p.key].map((c) => (
-            <div key={c} className="flex flex-col items-center gap-2">
+            <div key={c} className="flex flex-col items-center gap-[var(--space-2)]">
               <span className="text-label uppercase tracking-wide text-accent-3">
                 {c}
               </span>

--- a/src/components/prompts/SelectShowcase.tsx
+++ b/src/components/prompts/SelectShowcase.tsx
@@ -9,7 +9,7 @@ const items = [
 export default function SelectShowcase() {
   const [value, setValue] = React.useState<string>();
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-[var(--space-4)]">
       <AnimatedSelect
         items={items}
         value={value}

--- a/src/components/prompts/SpinnerShowcase.tsx
+++ b/src/components/prompts/SpinnerShowcase.tsx
@@ -2,7 +2,7 @@ import { Spinner } from "@/components/ui";
 
 export default function SpinnerShowcase() {
   return (
-    <div className="flex items-center gap-4">
+    <div className="flex items-center gap-[var(--space-4)]">
       <Spinner size={16} />
       <Spinner size={24} />
       <Spinner size={32} />

--- a/src/components/prompts/ToggleShowcase.tsx
+++ b/src/components/prompts/ToggleShowcase.tsx
@@ -4,7 +4,7 @@ import { Toggle } from "@/components/ui";
 export default function ToggleShowcase() {
   const [value, setValue] = React.useState<"Left" | "Right">("Left");
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-[var(--space-4)]">
       <Toggle value={value} onChange={setValue} />
       <Toggle disabled />
       <Toggle loading />


### PR DESCRIPTION
## Summary
- replace prompt showcase gap utilities with CSS spacing tokens
- align color gallery spacing utilities with spacing tokens

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cef40b45f4832c92dc04986e3ed4ec