### PR TITLE
refactor: align skeleton spacing tokens

### DIFF
--- a/src/components/prompts/SkeletonShowcase.tsx
+++ b/src/components/prompts/SkeletonShowcase.tsx
@@ -2,21 +2,21 @@ import { Skeleton } from "@/components/ui";
 
 export default function SkeletonShowcase() {
   return (
-    <div className="space-y-4">
-      <div className="space-y-2">
+    <div className="space-y-[var(--space-4)]">
+      <div className="space-y-[var(--space-2)]">
         <Skeleton
           ariaHidden={false}
           role="status"
           aria-label="Loading primary title"
-          className="h-6 w-2/5 sm:w-1/3"
+          className="h-[var(--space-6)] w-2/5 sm:w-1/3"
           radius="card"
         />
         <Skeleton className="w-full" />
         <Skeleton className="w-5/6" />
       </div>
-      <div className="flex items-center gap-3">
-        <Skeleton className="h-12 w-12 flex-none" radius="full" />
-        <div className="flex-1 space-y-2">
+      <div className="flex items-center gap-[var(--space-3)]">
+        <Skeleton className="h-[var(--space-8)] w-12 flex-none" radius="full" />
+        <div className="flex-1 space-y-[var(--space-2)]">
           <Skeleton className="w-3/4" />
           <Skeleton className="w-2/3" />
         </div>


### PR DESCRIPTION
## Summary
- replace SkeletonShowcase spacing utilities with CSS variable tokens
- update skeleton heights to use space tokens to keep the vertical rhythm consistent

## Testing
- npm run check


------
https://chatgpt.com/codex/tasks/task_e_68cef40ed2d0832c8a27f5c9925892a1