### PR TITLE
Use spacing token for spinner default size

### DIFF
--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -3535,7 +3535,7 @@ React.useEffect(() => {
       name: "Spinner",
       element: <SpinnerShowcase />,
       tags: ["spinner", "loading"],
-      code: `<Spinner size={24} />`,
+      code: `<Spinner size="var(--space-6)" />`,
     },
   ],
   toggles: [

--- a/src/components/ui/feedback/Spinner.tsx
+++ b/src/components/ui/feedback/Spinner.tsx
@@ -9,7 +9,10 @@ type SpinnerProps = {
   size?: CSSProperties["width"];
 };
 
-export default function Spinner({ className, size = 24 }: SpinnerProps) {
+export default function Spinner({
+  className,
+  size = "var(--space-6)",
+}: SpinnerProps) {
   return (
     <div
       role="status"


### PR DESCRIPTION
## Summary
- default the Spinner component to use the `var(--space-6)` token instead of a hard-coded number
- refresh the prompts gallery snippet to reference the new spinner sizing token

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cef4c44d0c832cad54505a1700ae07