### PR TITLE
Update prompts demo input height token

### DIFF
--- a/src/components/prompts/PromptsDemos.tsx
+++ b/src/components/prompts/PromptsDemos.tsx
@@ -56,7 +56,7 @@ export default function PromptsDemos() {
           <Input height="sm" placeholder="Small" />
           <Input placeholder="Medium" />
           <Input height="lg" placeholder="Large" />
-          <Input height={12} placeholder="h-12" />
+          <Input height="xl" placeholder="Extra large" />
           <Input className="rounded-full" placeholder="Rounded" />
           <Input placeholder="Disabled" disabled />
           <Input placeholder="Error" aria-invalid="true" />


### PR DESCRIPTION
## Summary
- replace the unsupported numeric height example in the prompts demo with the `xl` token
- refresh the demo placeholder label so it describes the new extra large size

## Testing
- npm run build-gallery-usage
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cef58d4be4832c8bc5f8cba1b33779