### PR TITLE
Align review controls with design tokens

### DIFF
--- a/src/components/reviews/ResultScoreSection.tsx
+++ b/src/components/reviews/ResultScoreSection.tsx
@@ -90,7 +90,7 @@ function ResultScoreSection(
             }
           }}
           className={cn(
-            "relative inline-flex h-10 w-48 select-none items-center overflow-hidden rounded-card r-card-lg",
+            "relative inline-flex h-[var(--control-h-md)] w-[calc(var(--space-8)*3)] select-none items-center overflow-hidden rounded-card r-card-lg",
             "border border-border bg-card",
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           )}
@@ -98,13 +98,13 @@ function ResultScoreSection(
         >
           <span
             aria-hidden
-            className="absolute top-1 bottom-1 left-1 rounded-[var(--control-radius)] transition-transform duration-300 [background:var(--result-indicator-gradient)] shadow-[var(--shadow-neo-soft)]"
+            className="absolute top-[var(--space-1)] bottom-[var(--space-1)] left-[var(--space-1)] rounded-[var(--control-radius)] transition-transform duration-300 [background:var(--result-indicator-gradient)] shadow-[var(--shadow-neo-soft)]"
             style={resultIndicatorStyle}
           />
           <div className="relative z-10 grid w-full grid-cols-2 text-ui font-mono">
             <div
               className={cn(
-                "py-2 text-center",
+                "py-[var(--space-2)] text-center",
                 result === "Win" ? "text-foreground" : "text-muted-foreground",
               )}
             >
@@ -112,7 +112,7 @@ function ResultScoreSection(
             </div>
             <div
               className={cn(
-                "py-2 text-center",
+                "py-[var(--space-2)] text-center",
                 result === "Loss" ? "text-foreground" : "text-muted-foreground",
               )}
             >

--- a/src/components/reviews/ReviewSummaryHeader.tsx
+++ b/src/components/reviews/ReviewSummaryHeader.tsx
@@ -30,7 +30,7 @@ export default function ReviewSummaryHeader({
   const ResultBadge = result && (
     <span
       className={cn(
-        "inline-flex h-10 items-center rounded-card r-card-lg border px-3 text-ui font-medium",
+        "inline-flex h-[var(--control-h-md)] items-center rounded-card r-card-lg border px-[var(--space-3)] text-ui font-medium",
         "border-border bg-card",
         result === "Win"
           ? "shadow-[0_0_0_var(--hairline-w)_hsl(var(--ring)/.35)_inset] bg-gradient-to-r from-success/20 to-accent/16"
@@ -52,12 +52,12 @@ export default function ReviewSummaryHeader({
             {title || "Untitled review"}
           </div>
         </div>
-        <div className="flex items-center justify-end gap-2">
+        <div className="flex items-center justify-end gap-[var(--space-2)]">
           {role ? (
             <span
               className={cn(
-                "inline-flex h-10 items-center gap-2 rounded-card r-card-lg border border-border",
-                "bg-card px-3 text-ui font-medium",
+                "inline-flex h-[var(--control-h-md)] items-center gap-[var(--space-2)] rounded-card r-card-lg border border-border",
+                "bg-card px-[var(--space-3)] text-ui font-medium",
               )}
               title={roleLabel}
             >

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -421,26 +421,26 @@ exports[`ReviewEditor > renders default state 1`] = `
         <button
           aria-checked="true"
           aria-labelledby=":r6:"
-          class="relative inline-flex h-10 w-48 select-none items-center overflow-hidden rounded-card r-card-lg border border-border bg-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          class="relative inline-flex h-[var(--control-h-md)] w-[calc(var(--space-8)*3)] select-none items-center overflow-hidden rounded-card r-card-lg border border-border bg-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           role="switch"
           title="Toggle Win/Loss"
           type="button"
         >
           <span
             aria-hidden="true"
-            class="absolute top-1 bottom-1 left-1 rounded-[var(--control-radius)] transition-transform duration-300 [background:var(--result-indicator-gradient)] shadow-[var(--shadow-neo-soft)]"
+            class="absolute top-[var(--space-1)] bottom-[var(--space-1)] left-[var(--space-1)] rounded-[var(--control-radius)] transition-transform duration-300 [background:var(--result-indicator-gradient)] shadow-[var(--shadow-neo-soft)]"
             style="width: calc(50% - var(--space-1)); transform: translate3d(0,0,0); transition-timing-function: cubic-bezier(.22,1,.36,1); --result-indicator-gradient: linear-gradient(90deg, hsl(var(--success)/0.22), hsl(var(--accent)/0.18));"
           />
           <div
             class="relative z-10 grid w-full grid-cols-2 text-ui font-mono"
           >
             <div
-              class="py-2 text-center text-foreground"
+              class="py-[var(--space-2)] text-center text-foreground"
             >
               Win
             </div>
             <div
-              class="py-2 text-center text-muted-foreground"
+              class="py-[var(--space-2)] text-center text-muted-foreground"
             >
               Loss
             </div>


### PR DESCRIPTION
## Summary
- swap review summary role/result badges to the control-height and spacing tokens
- update the win/loss toggle to use design tokens for sizing and spacing
- refresh the review editor snapshot to capture the token-driven layout

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cefef8cdac832c82bea7d0fa8f81a5