### PR TITLE
Align result score toggle highlight radius

### DIFF
--- a/src/components/reviews/ResultScoreSection.tsx
+++ b/src/components/reviews/ResultScoreSection.tsx
@@ -98,7 +98,7 @@ function ResultScoreSection(
         >
           <span
             aria-hidden
-            className="absolute top-1 bottom-1 left-1 rounded-[var(--control-radius)] transition-transform duration-300 [background:var(--result-indicator-gradient)] shadow-[var(--shadow-neo-soft)]"
+            className="absolute top-1 bottom-1 left-1 rounded-[inherit] transition-transform duration-300 [background:var(--result-indicator-gradient)] shadow-[var(--shadow-neo-soft)]"
             style={resultIndicatorStyle}
           />
           <div className="relative z-10 grid w-full grid-cols-2 text-ui font-mono">

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -428,7 +428,7 @@ exports[`ReviewEditor > renders default state 1`] = `
         >
           <span
             aria-hidden="true"
-            class="absolute top-1 bottom-1 left-1 rounded-[var(--control-radius)] transition-transform duration-300 [background:var(--result-indicator-gradient)] shadow-[var(--shadow-neo-soft)]"
+            class="absolute top-1 bottom-1 left-1 rounded-[inherit] transition-transform duration-300 [background:var(--result-indicator-gradient)] shadow-[var(--shadow-neo-soft)]"
             style="width: calc(50% - var(--space-1)); transform: translate3d(0,0,0); transition-timing-function: cubic-bezier(.22,1,.36,1); --result-indicator-gradient: linear-gradient(90deg, hsl(var(--success)/0.22), hsl(var(--accent)/0.18));"
           />
           <div


### PR DESCRIPTION
## Summary
- have the ResultScoreSection toggle highlight inherit the parent card radius so the corners stay flush with r-card-lg frames
- refresh the ReviewEditor snapshot to capture the updated radius class

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cefefa9418832cabcbed3e57e265a6