### PR TITLE
Align goal controls with tokenized sizing

### DIFF
--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -78,7 +78,8 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
             <Input
               ref={titleRef}
               id="goal-title"
-              className="h-10 text-ui font-medium"
+              height="md"
+              inputClassName="font-medium"
               value={title}
               onChange={(e) => onTitleChange(e.target.value)}
               required
@@ -91,7 +92,8 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
             Metric (optional)
             <Input
               id="goal-metric"
-              className="h-10 text-ui font-medium tabular-nums"
+              height="md"
+              inputClassName="font-medium tabular-nums"
               value={metric}
               onChange={(e) => onMetricChange(e.target.value)}
               aria-describedby={describedBy || undefined}

--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -172,18 +172,23 @@ export default function Reminders() {
           <div className="flex flex-wrap items-center gap-2 sm:gap-3 w-full">
             {/* search */}
             <div className="relative flex-1 min-w-56">
-              <Search size={18} className="absolute left-4 top-1/2 -translate-y-1/2 opacity-70" />
+              <Search
+                size={18}
+                className="pointer-events-none absolute left-[var(--space-4)] top-1/2 -translate-y-1/2 text-muted-foreground opacity-70"
+              />
               <Input
                 aria-label="Search reminders"
                 placeholder="Search title, text, tags…"
                 name="search-reminders"
-                className="pl-6"
+                height="md"
+                indent
                 value={query}
                 onChange={(e) => setQuery(e.currentTarget.value)}
-              />
-              <span className="absolute right-3 top-1/2 -translate-y-1/2 text-label font-medium tracking-[0.02em] text-muted-foreground">
-                {filtered.length}
-              </span>
+              >
+                <span className="pointer-events-none absolute right-[var(--space-3)] top-1/2 -translate-y-1/2 text-label font-medium tracking-[0.02em] text-muted-foreground">
+                  {filtered.length}
+                </span>
+              </Input>
             </div>
 
             {/* groups */}
@@ -196,21 +201,25 @@ export default function Reminders() {
             />
 
             {/* pinned */}
-              <SegmentedButton
-                className="h-10"
-                onClick={() => setOnlyPinned(v => !v)}
-                aria-pressed={onlyPinned}
-                title="Pinned only"
-                isActive={onlyPinned}
-              >
-                {onlyPinned ? <PinOff className="mr-1" /> : <Pin className="mr-1" />}
-                {onlyPinned ? "Pinned only" : "Any pin"}
-              </SegmentedButton>
+            <SegmentedButton
+              className="min-h-[var(--control-h-md)]"
+              onClick={() => setOnlyPinned(v => !v)}
+              aria-pressed={onlyPinned}
+              title="Pinned only"
+              isActive={onlyPinned}
+            >
+              {onlyPinned ? <PinOff className="mr-1" /> : <Pin className="mr-1" />}
+              {onlyPinned ? "Pinned only" : "Any pin"}
+            </SegmentedButton>
 
             {/* actions */}
-              <SegmentedButton className="h-10" onClick={resetSeeds} title="Replace with curated seeds">
-                Reset
-              </SegmentedButton>
+            <SegmentedButton
+              className="min-h-[var(--control-h-md)]"
+              onClick={resetSeeds}
+              title="Replace with curated seeds"
+            >
+              Reset
+            </SegmentedButton>
           </div>
         </SectionCard.Header>
 


### PR DESCRIPTION
## Summary
- update goal form inputs to rely on the Input height prop and tokenized typography utilities instead of hard-coded heights
- replace reminders toolbar spacing overrides with design token heights and padding, using the Input slot for the count badge

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cefefead64832cbf79eb54bb1f8087