### PR TITLE
Add aria labels to CheckCircle gallery samples

### DIFF
--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -3565,13 +3565,33 @@ React.useEffect(() => {
       name: "CheckCircle",
       element: (
         <div className="flex gap-4">
-          <CheckCircle checked={false} onChange={() => {}} size="md" />
-          <CheckCircle checked onChange={() => {}} size="md" />
+          <CheckCircle
+            aria-label="Enable notifications"
+            checked={false}
+            onChange={() => {}}
+            size="md"
+          />
+          <CheckCircle
+            aria-label="Enable notifications"
+            checked
+            onChange={() => {}}
+            size="md"
+          />
         </div>
       ),
       tags: ["checkbox", "toggle"],
-      code: `<CheckCircle checked={false} onChange={() => {}} size="md" />
-<CheckCircle checked onChange={() => {}} size="md" />`,
+      code: `<CheckCircle
+  aria-label="Enable notifications"
+  checked={false}
+  onChange={() => {}}
+  size="md"
+/>
+<CheckCircle
+  aria-label="Enable notifications"
+  checked
+  onChange={() => {}}
+  size="md"
+/>`,
     },
   ],
   homepage: [


### PR DESCRIPTION
## Summary
- add an aria-label to each CheckCircle example in the prompts gallery
- update the code snippet so it matches the rendered examples

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cefcdd2c60832ca49f423548d6e065