### PR TITLE
Refine icon sizing tokens across planner surfaces

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,6 +27,11 @@
     --team-glitch-accent-color: hsl(var(--accent) / 0.35);
     --team-glitch-accent-blur: var(--spacing-0-5);
     --team-glitch-accent-shadow: 0 0 var(--team-glitch-accent-blur) var(--team-glitch-accent-color);
+    --icon-size-xs: calc(var(--space-4) - var(--spacing-0-5));
+    --icon-size-sm: var(--space-4);
+    --icon-size-md: calc(var(--space-5) - var(--space-1) - var(--spacing-0-5));
+    --icon-size-lg: var(--space-5);
+    --icon-size-xl: var(--space-6);
   }
 
   body {
@@ -845,6 +850,12 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
     background: hsl(var(--card));
     color: hsl(var(--foreground));
     border-color: hsl(var(--border) / 0.35);
+    --pill-icon-size: var(--icon-size-xs);
+  }
+  .pill > svg,
+  .pill svg {
+    width: var(--pill-icon-size);
+    height: var(--pill-icon-size);
   }
   .pill--low {
     background: hsl(var(--accent) / 0.15);
@@ -1916,6 +1927,31 @@ a:active .lucide {
 }
 
 @layer utilities {
+  .icon-xs {
+    width: var(--icon-size-xs);
+    height: var(--icon-size-xs);
+  }
+
+  .icon-sm {
+    width: var(--icon-size-sm);
+    height: var(--icon-size-sm);
+  }
+
+  .icon-md {
+    width: var(--icon-size-md);
+    height: var(--icon-size-md);
+  }
+
+  .icon-lg {
+    width: var(--icon-size-lg);
+    height: var(--icon-size-lg);
+  }
+
+  .icon-xl {
+    width: var(--icon-size-xl);
+    height: var(--icon-size-xl);
+  }
+
   .stack-xs {
     display: flex;
     flex-direction: column;

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -348,7 +348,7 @@ function GoalsPageContent() {
           <span className="text-label font-medium tracking-[0.02em] opacity-75">
             {reminderCount}
           </span>
-          <Search className="opacity-80" size={16} />
+          <Search className="icon-sm opacity-80" />
         </div>
       ),
     };

--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -173,8 +173,8 @@ export default function Reminders() {
             {/* search */}
             <div className="relative flex-1 min-w-56">
               <Search
-                size={18}
-                className="pointer-events-none absolute left-[var(--space-4)] top-1/2 -translate-y-1/2 text-muted-foreground opacity-70"
+                aria-hidden
+                className="icon-md pointer-events-none absolute left-[var(--space-4)] top-1/2 -translate-y-1/2 text-muted-foreground opacity-70"
               />
               <Input
                 aria-label="Search reminders"

--- a/src/components/goals/reminders/ReminderFilters.tsx
+++ b/src/components/goals/reminders/ReminderFilters.tsx
@@ -40,7 +40,7 @@ export default function ReminderFilters() {
               title="Filters"
               isActive={showFilters}
             >
-              <SlidersHorizontal size={16} aria-hidden />
+              <SlidersHorizontal className="icon-sm" aria-hidden />
               Filters
             </SegmentedButton>
           }

--- a/src/components/goals/reminders/ReminderQuickAddForm.tsx
+++ b/src/components/goals/reminders/ReminderQuickAddForm.tsx
@@ -43,7 +43,7 @@ export default function ReminderQuickAddForm() {
           size="md"
           variant="solid"
         >
-          <Plus size={16} aria-hidden />
+          <Plus aria-hidden />
         </IconButton>
         <div className={`${neonClass} hidden sm:block`}>
           <p className="neon-note neon-glow text-label font-medium tracking-[0.02em] italic">

--- a/src/components/reviews/NeonIcon.tsx
+++ b/src/components/reviews/NeonIcon.tsx
@@ -13,10 +13,30 @@ type Props = {
   staticGlow?: boolean;
 };
 
+type SizeToken = "xs" | "sm" | "md" | "lg" | "xl";
+
+const sizeTokens: Record<SizeToken, string> = {
+  xs: "var(--icon-size-xs)",
+  sm: "var(--icon-size-sm)",
+  md: "var(--icon-size-md)",
+  lg: "var(--icon-size-lg)",
+  xl: "var(--icon-size-xl)",
+};
+
+function resolveSize(size: Props["size"]): Props["size"] {
+  if (typeof size === "string") {
+    const token = sizeTokens[size as SizeToken];
+    if (token) {
+      return token;
+    }
+  }
+  return size;
+}
+
 export default function NeonIcon({
   kind,
   on,
-  size = "1em",
+  size: sizeProp = "1em",
   className,
   title,
   staticGlow = false,
@@ -30,7 +50,7 @@ export default function NeonIcon({
       key={staticGlow ? `${kind}-${on}` : undefined}
       icon={Icon}
       on={on}
-      size={size}
+      size={resolveSize(sizeProp)}
       colorVar={colorVar}
       className={className}
       title={title}

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -256,7 +256,7 @@ export default function ReviewEditor({
                 })
               }
             >
-              <NeonIcon kind="brain" on={focusOn} size={32} />
+              <NeonIcon kind="brain" on={focusOn} size="xl" />
             </button>
           </div>
 

--- a/src/components/reviews/ReviewSummaryScore.tsx
+++ b/src/components/reviews/ReviewSummaryScore.tsx
@@ -41,7 +41,7 @@ export default function ReviewSummaryScore({
       {focusOn && typeof focus === "number" && focusMsg && (
         <div className="mt-[var(--space-4)] space-y-[var(--space-2)]">
           <div className="mb-[var(--space-2)] flex items-center gap-[var(--space-2)]" aria-label="Focus">
-            <NeonIcon kind="brain" on={true} size={32} staticGlow />
+            <NeonIcon kind="brain" on={true} size="xl" staticGlow />
             <div className="h-[var(--hairline-w)] flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
           </div>
           <ScoreMeter

--- a/src/components/reviews/ReviewSummaryTimestamps.tsx
+++ b/src/components/reviews/ReviewSummaryTimestamps.tsx
@@ -18,8 +18,8 @@ export default function ReviewSummaryTimestamps({
   return (
     <div>
       <div className="mb-[var(--space-2)] flex items-center gap-[var(--space-2)]" aria-label="Timestamps">
-        <NeonIcon kind="clock" on={!!hasTimed} size={32} staticGlow />
-        <NeonIcon kind="file" on={!!hasNoteOnly} size={32} staticGlow />
+        <NeonIcon kind="clock" on={!!hasTimed} size="xl" staticGlow />
+        <NeonIcon kind="file" on={!!hasNoteOnly} size="xl" staticGlow />
         <div className="h-[var(--hairline-w)] flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
       </div>
       {!markers.length ? (
@@ -41,7 +41,7 @@ export default function ReviewSummaryTimestamps({
                     title="Note"
                     aria-label="Note"
                   >
-                    <FileText size={14} className="opacity-80" />
+                    <FileText aria-hidden className="icon-xs opacity-80" />
                   </span>
                 ) : (
                   <span className="pill h-7 px-[var(--space-3)] text-ui font-mono tabular-nums leading-none">

--- a/src/components/reviews/TimestampMarkers.tsx
+++ b/src/components/reviews/TimestampMarkers.tsx
@@ -141,7 +141,7 @@ function TimestampMarkers(
           }
           title="Timestamp mode"
         >
-          <NeonIcon kind="clock" on={useTimestamp} size={32} />
+          <NeonIcon kind="clock" on={useTimestamp} size="xl" />
         </button>
 
         <button
@@ -161,7 +161,7 @@ function TimestampMarkers(
           }
           title="Note-only mode"
         >
-          <NeonIcon kind="file" on={!useTimestamp} size={32} />
+          <NeonIcon kind="file" on={!useTimestamp} size="xl" />
         </button>
       </div>
 
@@ -195,7 +195,7 @@ function TimestampMarkers(
             />
           ) : (
             <span className="pill h-7 w-16 px-0 flex items-center justify-center">
-              <FileText size={14} className="opacity-80" />
+              <FileText aria-hidden className="icon-xs opacity-80" />
             </span>
           )}
 
@@ -245,7 +245,7 @@ function TimestampMarkers(
               >
                 {m.noteOnly ? (
                   <span className="pill h-7 w-16 px-0 flex items-center justify-center">
-                    <FileText size={14} className="opacity-80" />
+                    <FileText aria-hidden className="icon-xs opacity-80" />
                   </span>
                 ) : (
                   <span className="pill h-7 w-16 px-3 text-ui font-mono tabular-nums text-center">{m.time}</span>

--- a/src/components/ui/primitives/Badge.tsx
+++ b/src/components/ui/primitives/Badge.tsx
@@ -29,8 +29,8 @@ export type BadgeProps<T extends React.ElementType = "span"> =
     Omit<React.ComponentPropsWithoutRef<T>, keyof BadgeOwnProps<T>>;
 
 const sizeMap: Record<Size, string> = {
-  xs: "px-[var(--space-2)] py-[var(--space-1)] text-label leading-none",
-  sm: "px-[var(--space-3)] py-[var(--space-2)] text-label leading-none",
+  xs: "px-[var(--space-2)] py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)]",
+  sm: "px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)]",
 };
 
 const toneBorder: Record<Tone, string> = {

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -555,7 +555,7 @@ exports[`ReviewEditor > renders default state 1`] = `
               aria-hidden="true"
               class="ni-root relative inline-grid place-items-center overflow-visible rounded-full border border-border bg-card/35"
               data-phase="off"
-              style="--ni-size: 32px; --ni-k: 18px; --ni-color: hsl(var(--primary));"
+              style="--ni-size: var(--icon-size-xl); --ni-k: calc(var(--icon-size-xl) * 0.56); --ni-color: hsl(var(--primary));"
             >
               <svg
                 aria-hidden="true"
@@ -1605,7 +1605,7 @@ exports[`ReviewEditor > renders default state 1`] = `
               aria-hidden="true"
               class="ni-root relative inline-grid place-items-center overflow-visible rounded-full border border-border bg-card/35"
               data-phase="steady-on"
-              style="--ni-size: 32px; --ni-k: 18px; --ni-color: hsl(var(--accent));"
+              style="--ni-size: var(--icon-size-xl); --ni-k: calc(var(--icon-size-xl) * 0.56); --ni-color: hsl(var(--accent));"
             >
               <svg
                 aria-hidden="true"
@@ -1775,7 +1775,7 @@ exports[`ReviewEditor > renders default state 1`] = `
               aria-hidden="true"
               class="ni-root relative inline-grid place-items-center overflow-visible rounded-full border border-border bg-card/35"
               data-phase="off"
-              style="--ni-size: 32px; --ni-k: 18px; --ni-color: hsl(var(--ring));"
+              style="--ni-size: var(--icon-size-xl); --ni-k: calc(var(--icon-size-xl) * 0.56); --ni-color: hsl(var(--ring));"
             >
               <svg
                 aria-hidden="true"

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`ReviewListItem > renders default state 1`] = `
             class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none border-card-hairline px-[var(--space-1)]"
+            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
           >
             MID
           </span>
@@ -91,7 +91,7 @@ exports[`ReviewListItem > renders disabled state 1`] = `
             class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none border-card-hairline px-[var(--space-1)]"
+            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
           >
             MID
           </span>
@@ -163,7 +163,7 @@ exports[`ReviewListItem > renders selected state 1`] = `
             class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none border-card-hairline px-[var(--space-1)]"
+            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
           >
             MID
           </span>
@@ -218,7 +218,7 @@ exports[`ReviewListItem > renders untitled state 1`] = `
             class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none border-card-hairline px-[var(--space-1)]"
+            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
           >
             MID
           </span>

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -445,7 +445,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                             class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
                           />
                           <span
-                            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none border-card-hairline px-[var(--space-1)]"
+                            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
                           >
                             MID
                           </span>
@@ -489,7 +489,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                             class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
                           />
                           <span
-                            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none border-card-hairline px-[var(--space-1)]"
+                            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
                           >
                             BOT
                           </span>
@@ -533,7 +533,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                             class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
                           />
                           <span
-                            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none border-card-hairline px-[var(--space-1)]"
+                            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
                           >
                             TOP
                           </span>


### PR DESCRIPTION
## Summary
- add reusable icon size CSS tokens and utilities while aligning badge and pill primitives with the new sizing system
- replace hard-coded icon sizes in goals and reminders UI with token-based classes so they inherit shared dimensions
- update review neon icon consumers and snapshots to rely on the shared token map for consistent sizing

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68cf079394d8832cba14116fdc93d954