### PR TITLE
Respect reduced motion in timer ring icon

### DIFF
--- a/src/icons/TimerRingIcon.tsx
+++ b/src/icons/TimerRingIcon.tsx
@@ -46,7 +46,7 @@ export default function TimerRingIcon({ pct, size = 200 }: TimerRingIconProps) {
         strokeDashoffset={offset}
         className={cn(
           "drop-shadow-[0_0_6px_hsl(var(--neon-soft))] transition-[stroke-dashoffset] duration-[var(--dur-quick)] ease-linear motion-reduce:transition-none",
-          pulse && "animate-pulse",
+          pulse && "motion-safe:animate-pulse motion-reduce:animate-none",
         )}
         fill="none"
       />


### PR DESCRIPTION
## Summary
- gate the timer ring pulse animation behind motion-safe and motion-reduce utilities to honor user preferences

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cf1a8956e4832c973ec7a47cacf799