### PR TITLE
Add hero glitch calm modes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -312,6 +312,18 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
     animation: hero-rail-flicker 3.2s steps(24, end) infinite alternate;
     opacity: 0.3;
   }
+  .header-rail--subtle {
+    opacity: 0.65;
+  }
+  .header-rail--subtle::before {
+    opacity: 0.35;
+    filter: saturate(0.85);
+    animation: hero-hue-sweep 12s linear infinite;
+  }
+  .header-rail--subtle::after {
+    opacity: 0.16;
+    animation: hero-rail-flicker 6s steps(24, end) infinite alternate;
+  }
 }
 
 @layer components {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -462,9 +462,10 @@ function HomePageContent() {
                       heading: "Your day at a glance",
                       sticky: false,
                       barVariant: "raised",
+                      glitch: "subtle",
                       topClassName: "top-0",
                       actions: (
-                        <div className="grid w-full grid-cols-12 gap-[var(--space-3)] sm:items-center">
+                        <div className="grid w-full grid-cols-12 gap-[var(--space-4)] sm:items-center">
                           <div className="col-span-12 flex w-full flex-wrap items-center justify-end gap-[var(--space-2)] sm:flex-nowrap md:col-span-8 lg:col-span-7">
                             <ThemeToggle className="shrink-0" />
                             <Button

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -1108,29 +1108,67 @@ export default function ComponentGallery() {
         label: "Hero",
         element: (
           <div className="w-56 space-y-[var(--space-4)]">
-            <Hero
-              heading="Hero"
-              eyebrow="Eyebrow"
-              subtitle="Subtitle"
-              sticky={false}
-              topClassName="top-0"
-              subTabs={{
-                items: [
-                  { key: "one", label: "One" },
-                  { key: "two", label: "Two" },
-                ],
-                value: headerTab,
-                onChange: setHeaderTab,
-                ariaLabel: "Gallery hero tabs",
-                linkPanels: false,
-              }}
-              search={{ value: "", onValueChange: () => {}, round: true }}
-              actions={<Button size="sm">Action</Button>}
-            >
-              <div className="text-ui font-medium text-muted-foreground">
-                Body
-              </div>
-            </Hero>
+            <div className="space-y-[var(--space-2)]">
+              <p className="text-label font-medium text-muted-foreground">
+                Glitch (default)
+              </p>
+              <Hero
+                heading="Hero"
+                eyebrow="Eyebrow"
+                subtitle="Subtitle"
+                sticky={false}
+                topClassName="top-0"
+                subTabs={{
+                  items: [
+                    { key: "one", label: "One" },
+                    { key: "two", label: "Two" },
+                  ],
+                  value: headerTab,
+                  onChange: setHeaderTab,
+                  ariaLabel: "Gallery hero tabs",
+                  linkPanels: false,
+                }}
+                search={{ value: "", onValueChange: () => {}, round: true }}
+                actions={<Button size="sm">Action</Button>}
+              >
+                <div className="text-ui font-medium text-muted-foreground">
+                  Body
+                </div>
+              </Hero>
+            </div>
+            <div className="space-y-[var(--space-2)]">
+              <p className="text-label font-medium text-muted-foreground">
+                Glitch (subtle)
+              </p>
+              <Hero
+                heading="Hero"
+                eyebrow="Eyebrow"
+                subtitle="Subtitle"
+                sticky={false}
+                topClassName="top-0"
+                glitch="subtle"
+                subTabs={{
+                  items: [
+                    { key: "one", label: "One" },
+                    { key: "two", label: "Two" },
+                  ],
+                  value: headerTab,
+                  onChange: setHeaderTab,
+                  ariaLabel: "Gallery hero tabs (subtle)",
+                  linkPanels: false,
+                }}
+                search={{ value: "", onValueChange: () => {}, round: true }}
+                actions={
+                  <Button size="sm" variant="secondary">
+                    Calm action
+                  </Button>
+                }
+              >
+                <div className="text-ui font-medium text-muted-foreground">
+                  Body
+                </div>
+              </Hero>
+            </div>
             <NeomorphicHeroFrame
               variant="dense"
               align="end"

--- a/src/components/ui/layout/Hero.tsx
+++ b/src/components/ui/layout/Hero.tsx
@@ -52,6 +52,9 @@ export interface HeroProps<Key extends string = string>
   /** Whether to include glitchy frame and background layers. */
   frame?: boolean;
 
+  /** Level of glitch treatment for frame overlays. */
+  glitch?: "default" | "subtle" | "off";
+
   /** Divider tint for neon line. */
   dividerTint?: "primary" | "life";
 
@@ -96,6 +99,7 @@ function Hero<Key extends string = string>({
   actions,
   tone = "heroic",
   frame = true,
+  glitch = "default",
   sticky = true,
   topClassName = "top-[var(--space-8)]",
   barClassName,
@@ -112,6 +116,10 @@ function Hero<Key extends string = string>({
   ...rest
 }: HeroProps<Key>) {
   const headingStr = typeof heading === "string" ? heading : undefined;
+  const glitchMode = glitch ?? "default";
+  const isGlitchSubtle = glitchMode === "subtle";
+  const isGlitchOff = glitchMode === "off";
+  const isGlitchCalm = isGlitchSubtle || isGlitchOff;
   const dividerStyle = {
     "--divider": dividerTint === "life" ? "var(--accent)" : "var(--ring)",
   } as React.CSSProperties;
@@ -119,6 +127,8 @@ function Hero<Key extends string = string>({
   const heroVariant: TabBarProps["variant"] | undefined = frame
     ? "neo"
     : undefined;
+
+  const shouldRenderGlitchStyles = frame && !isGlitchCalm;
 
   const Component: HeroElement = as ?? "section";
 
@@ -279,17 +289,21 @@ function Hero<Key extends string = string>({
 
   return (
     <Component className={className} {...(rest as React.HTMLAttributes<HTMLElement>)}>
-      {frame ? <HeroGlitchStyles /> : null}
+      {shouldRenderGlitchStyles ? <HeroGlitchStyles /> : null}
       {frame || isRaisedBar ? <NeomorphicFrameStyles /> : null}
 
       <div className={shellClass}>
 
         <div className={cx(barSpacingClass, barClassName)}>
           <div className={labelClusterClass}>
-            {rail ? (
+            {rail && !isGlitchOff ? (
               <span
                 aria-hidden
-                className="header-rail pointer-events-none absolute left-0 top-[var(--space-1)] bottom-[var(--space-1)] w-[var(--space-2)] rounded-l-2xl"
+                className={cx(
+                  "header-rail",
+                  "pointer-events-none absolute left-0 top-[var(--space-1)] bottom-[var(--space-1)] w-[var(--space-2)] rounded-l-2xl",
+                  isGlitchSubtle && "header-rail--subtle",
+                )}
               />
             ) : null}
             {isRaisedBar ? (
@@ -320,14 +334,21 @@ function Hero<Key extends string = string>({
                   className={cx(
                     "block h-px",
                     frame
-                      ? "hero2-divider-line bg-[hsl(var(--divider))/0.35]"
+                      ? isGlitchOff
+                        ? "hero2-divider-line bg-[hsl(var(--divider))/0.18]"
+                        : isGlitchSubtle
+                          ? "hero2-divider-line bg-[hsl(var(--divider))/0.24]"
+                          : "hero2-divider-line bg-[hsl(var(--divider))/0.35]"
                       : "bg-[hsl(var(--divider))/0.28]",
                   )}
                 />
-                {frame ? (
+                {frame && !isGlitchOff ? (
                   <span
                     aria-hidden
-                    className="hero2-divider-glow absolute inset-x-0 top-0 h-px opacity-60 bg-[hsl(var(--divider))]"
+                    className={cx(
+                      "hero2-divider-glow absolute inset-x-0 top-0 h-px bg-[hsl(var(--divider))]",
+                      isGlitchSubtle ? "opacity-35" : "opacity-60",
+                    )}
                   />
                 ) : null}
                 <div className={actionRowClass}>


### PR DESCRIPTION
## Summary
- add a `glitch` mode option to the Hero layout so calmer variants can drop intense overlays
- tone down header rail styling for subtle mode, use the calmer hero on the home page, and adjust action spacing
- showcase both default and subtle hero treatments in the component gallery documentation

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cf1a62ff74832ca23d7dea272140a3