### PR TITLE
feat: add brand wordmark component

### DIFF
--- a/src/components/chrome/BrandWordmark.tsx
+++ b/src/components/chrome/BrandWordmark.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type BrandWordmarkProps = React.ComponentPropsWithoutRef<"span">;
+
+const glowStyle = {
+  textShadow: "0 0 var(--space-2) hsl(var(--accent) / 0.35)",
+} as const;
+
+export default function BrandWordmark({
+  className,
+  children = "noxi",
+  style,
+  ...props
+}: BrandWordmarkProps) {
+  return (
+    <span
+      {...props}
+      className={cn(
+        "relative inline-flex items-center font-semibold leading-none text-ui md:text-title",
+        "tracking-[0.08em] text-foreground",
+        "supports-[background-clip:text]:bg-[linear-gradient(120deg,hsl(var(--accent)),hsl(var(--accent-2)))] supports-[background-clip:text]:bg-clip-text supports-[background-clip:text]:text-transparent",
+        "after:pointer-events-none after:absolute after:-inset-[var(--space-1)] after:-z-10 after:rounded-full after:bg-[radial-gradient(120%_120%_at_50%_50%,hsl(var(--accent)/0.22),transparent_70%)] after:opacity-75 after:content-[''] motion-reduce:after:hidden",
+        className,
+      )}
+      style={{
+        ...glowStyle,
+        ...style,
+      }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import NavBar from "@/components/chrome/NavBar";
 import BottomNav from "@/components/chrome/BottomNav";
+import BrandWordmark from "@/components/chrome/BrandWordmark";
 import ThemeToggle from "@/components/ui/theme/ThemeToggle";
 import AnimationToggle from "@/components/ui/AnimationToggle";
 import { PageShell } from "@/components/ui";
@@ -33,9 +34,7 @@ export default function SiteChrome() {
             className="h-[var(--space-2)] w-[var(--space-2)] rounded-full animate-pulse bg-[hsl(var(--accent-overlay))] shadow-[var(--shadow-glow-sm)]"
             aria-hidden
           />
-          <span className="font-mono tracking-wide text-muted-foreground">
-            noxi
-          </span>
+          <BrandWordmark />
         </Link>
 
         <div className="col-span-full hidden min-w-0 items-center md:col-span-6 md:flex lg:col-span-7">

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -54,6 +54,7 @@ import {
   ScoreMeter,
 } from "@/components/reviews";
 import Banner from "@/components/chrome/Banner";
+import BrandWordmark from "@/components/chrome/BrandWordmark";
 import NavBar from "@/components/chrome/NavBar";
 import {
   DayCardHeader,
@@ -952,6 +953,14 @@ export default function ComponentGallery() {
               title="Banner"
               actions={<Button size="sm">Action</Button>}
             />
+          </div>
+        ),
+      },
+      {
+        label: "BrandWordmark",
+        element: (
+          <div className="w-56 flex justify-center">
+            <BrandWordmark />
           </div>
         ),
       },


### PR DESCRIPTION
## Summary
- add a reusable BrandWordmark component with gradient typography styling
- replace the SiteChrome inline text with the new wordmark component
- surface the wordmark in the prompts ComponentGallery for reference

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cf1a79b5f8832c8aa09ee4e22934b0