### PR TITLE
Tone down welcome hero halos

### DIFF
--- a/src/components/home/WelcomeHeroFigure.tsx
+++ b/src/components/home/WelcomeHeroFigure.tsx
@@ -4,18 +4,47 @@ import { cn } from "@/lib/utils";
 
 type CSSVarStyle = React.CSSProperties & Record<`--${string}`, string>;
 
-const figureVariables: CSSVarStyle = {
+type WelcomeHeroFigureTone = "default" | "subtle";
+
+const figureBaseVariables: CSSVarStyle = {
   "--welcome-figure-rim": "calc(var(--space-2) / 1.4)",
-  "--welcome-figure-glow": "calc(var(--space-5) + var(--space-1))",
   "--welcome-figure-rim-gradient":
     "conic-gradient(from 125deg at 50% 50%, hsl(var(--accent) / 0.92), hsl(var(--accent-2) / 0.88), hsl(var(--ring) / 0.85), hsl(var(--accent) / 0.92))",
   "--welcome-figure-surface": "hsl(var(--card) / 0.95)",
   "--welcome-figure-inner": "hsl(var(--surface) / 0.88)",
   "--welcome-figure-outline": "0 0 0 var(--hairline-w) hsl(var(--card-hairline) / 0.65)",
-  "--welcome-figure-primary-halo":
-    "radial-gradient(circle at 52% 36%, hsl(var(--accent-2) / 0.5), transparent 72%)",
-  "--welcome-figure-secondary-halo":
-    "radial-gradient(circle at 34% 70%, hsl(var(--accent) / 0.32), transparent 78%)",
+};
+
+const haloToneVariables: Record<WelcomeHeroFigureTone, CSSVarStyle> = {
+  default: {
+    "--welcome-figure-glow": "calc(var(--space-4) + var(--space-1))",
+    "--welcome-figure-primary-halo":
+      "radial-gradient(circle at 52% 36%, hsl(var(--accent-2) / 0.34), transparent 68%)",
+    "--welcome-figure-secondary-halo":
+      "radial-gradient(circle at 34% 70%, hsl(var(--accent) / 0.28), transparent 74%)",
+    "--welcome-figure-primary-opacity": "0.35",
+    "--welcome-figure-secondary-opacity": "0.3",
+    "--welcome-figure-primary-blur": "calc(var(--welcome-figure-glow) * 0.85)",
+    "--welcome-figure-secondary-blur": "calc(var(--welcome-figure-glow) * 0.6)",
+    "--welcome-figure-glitch-opacity": "0.36",
+  },
+  subtle: {
+    "--welcome-figure-glow": "calc(var(--space-3) + var(--space-1))",
+    "--welcome-figure-primary-halo":
+      "radial-gradient(circle at 52% 36%, hsl(var(--accent-2) / 0.28), transparent 64%)",
+    "--welcome-figure-secondary-halo":
+      "radial-gradient(circle at 34% 70%, hsl(var(--accent) / 0.22), transparent 70%)",
+    "--welcome-figure-primary-opacity": "0.3",
+    "--welcome-figure-secondary-opacity": "0.26",
+    "--welcome-figure-primary-blur": "calc(var(--welcome-figure-glow) * 0.7)",
+    "--welcome-figure-secondary-blur": "calc(var(--welcome-figure-glow) * 0.5)",
+    "--welcome-figure-glitch-opacity": "0.18",
+  },
+};
+
+const defaultFigureVariables: CSSVarStyle = {
+  ...figureBaseVariables,
+  ...haloToneVariables.default,
 };
 
 const rimStyle: React.CSSProperties = {
@@ -46,12 +75,19 @@ const defaultSizes =
 export interface WelcomeHeroFigureProps {
   className?: string;
   imageSizes?: string;
+  haloTone?: WelcomeHeroFigureTone;
+  showGlitchRail?: boolean;
 }
 
 export default function WelcomeHeroFigure({
   className,
   imageSizes = defaultSizes,
+  haloTone = "default",
+  showGlitchRail,
 }: WelcomeHeroFigureProps) {
+  const toneVariables = haloToneVariables[haloTone];
+  const shouldShowGlitchRail = showGlitchRail ?? haloTone === "default";
+
   return (
     <figure
       className={cn(
@@ -59,22 +95,24 @@ export default function WelcomeHeroFigure({
         "rounded-full",
         className,
       )}
-      style={figureVariables}
+      style={{ ...defaultFigureVariables, ...toneVariables }}
     >
       <span
         aria-hidden
-        className="pointer-events-none absolute -inset-[calc(var(--welcome-figure-rim)*2.3)] rounded-full opacity-80 blur-[var(--welcome-figure-glow)]"
+        className="pointer-events-none absolute -inset-[calc(var(--welcome-figure-rim)*2.3)] rounded-full opacity-[var(--welcome-figure-primary-opacity)] blur-[var(--welcome-figure-primary-blur)]"
         style={haloPrimaryStyle}
       />
       <span
         aria-hidden
-        className="pointer-events-none absolute -inset-[calc(var(--welcome-figure-rim)*1.6)] rounded-full opacity-70 blur-[calc(var(--welcome-figure-glow)*0.75)]"
+        className="pointer-events-none absolute -inset-[calc(var(--welcome-figure-rim)*1.6)] rounded-full opacity-[var(--welcome-figure-secondary-opacity)] blur-[var(--welcome-figure-secondary-blur)]"
         style={haloSecondaryStyle}
       />
-      <span
-        aria-hidden
-        className="glitch-rail pointer-events-none absolute -inset-[calc(var(--welcome-figure-rim)*1.05)] rounded-full mix-blend-screen opacity-75"
-      />
+      {shouldShowGlitchRail ? (
+        <span
+          aria-hidden
+          className="glitch-rail pointer-events-none absolute -inset-[calc(var(--welcome-figure-rim)*1.05)] rounded-full mix-blend-screen opacity-[var(--welcome-figure-glitch-opacity)]"
+        />
+      ) : null}
       <div
         className="relative flex h-full w-full items-center justify-center rounded-full shadow-neoSoft ring-1 ring-border/50"
         style={rimStyle}

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -43,6 +43,7 @@ import {
 import Badge from "@/components/ui/primitives/Badge";
 import SegmentedButton from "@/components/ui/primitives/SegmentedButton";
 import { GoalsTabs, GoalsProgress, type FilterKey } from "@/components/goals";
+import WelcomeHeroFigure from "@/components/home/WelcomeHeroFigure";
 import PromptsHeader from "./PromptsHeader";
 import PromptsComposePanel from "./PromptsComposePanel";
 import PromptsDemos from "./PromptsDemos";
@@ -656,6 +657,28 @@ export default function ComponentGallery() {
         element: (
           <div className="w-full">
             <PromptsDemos />
+          </div>
+        ),
+        className: "sm:col-span-2 md:col-span-12 w-full",
+      },
+      {
+        label: "WelcomeHeroFigure",
+        element: (
+          <div className="w-full space-y-[var(--space-3)]">
+            <div className="grid grid-cols-1 gap-[var(--space-3)] sm:grid-cols-2">
+              <div className="flex flex-col items-center gap-[var(--space-2)]">
+                <span className="text-label font-medium text-muted-foreground">Default halo</span>
+                <div className="w-full max-w-[calc(var(--space-8)*4)]">
+                  <WelcomeHeroFigure />
+                </div>
+              </div>
+              <div className="flex flex-col items-center gap-[var(--space-2)]">
+                <span className="text-label font-medium text-muted-foreground">Toned-down halo</span>
+                <div className="w-full max-w-[calc(var(--space-8)*4)]">
+                  <WelcomeHeroFigure haloTone="subtle" showGlitchRail={false} />
+                </div>
+              </div>
+            </div>
           </div>
         ),
         className: "sm:col-span-2 md:col-span-12 w-full",


### PR DESCRIPTION
## Summary
- introduce halo tone presets for the WelcomeHeroFigure with subtler glow, opacity, and glitch rail controls
- document both default and toned-down hero halos inside the prompts component gallery showcase

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cf1f265a38832cbd4675ae2701c5b0