### PR TITLE
Use spacing tokens across goals UI

### DIFF
--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -72,8 +72,8 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
             </Button>
           }
         />
-        <SectionCard.Body className="grid gap-6">
-          <Label htmlFor="goal-title" className="mb-0 grid gap-2">
+        <SectionCard.Body className="grid gap-[var(--space-6)]">
+          <Label htmlFor="goal-title" className="mb-0 grid gap-[var(--space-2)]">
             Title
             <Input
               ref={titleRef}
@@ -88,7 +88,7 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
             />
           </Label>
 
-          <Label htmlFor="goal-metric" className="mb-0 grid gap-2">
+          <Label htmlFor="goal-metric" className="mb-0 grid gap-[var(--space-2)]">
             Metric (optional)
             <Input
               id="goal-metric"
@@ -100,7 +100,7 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
             />
           </Label>
 
-          <Label htmlFor="goal-notes" className="mb-0 grid gap-2">
+          <Label htmlFor="goal-notes" className="mb-0 grid gap-[var(--space-2)]">
             Notes (optional)
             <Textarea
               id="goal-notes"

--- a/src/components/goals/GoalList.tsx
+++ b/src/components/goals/GoalList.tsx
@@ -85,7 +85,7 @@ export default function GoalList({
             <li key={g.id} className="flex">
               <article
                 className={[
-                  "relative flex min-h-8 w-full flex-1 flex-col overflow-hidden rounded-card r-card-lg p-6",
+                  "relative flex min-h-8 w-full flex-1 flex-col overflow-hidden rounded-card r-card-lg p-[var(--space-6)]",
                   "bg-card/30 backdrop-blur-md",
                   "shadow-ring [--ring:var(--accent)]",
                   "transition-all duration-[var(--dur-quick)] hover:-translate-y-1 hover:shadow-ring",
@@ -95,8 +95,8 @@ export default function GoalList({
                   aria-hidden
                   className="pointer-events-none absolute inset-0 rounded-card r-card-lg p-px [background:linear-gradient(135deg,hsl(var(--primary)),hsl(var(--accent)),transparent)] [mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] [mask-composite:exclude]"
                 />
-                <header className="relative z-[1] flex items-start justify-between gap-2">
-                  <div className="flex-1 pr-6">
+                <header className="relative z-[1] flex items-start justify-between gap-[var(--space-2)]">
+                  <div className="flex-1 pr-[var(--space-6)]">
                     <h3
                       id={headingId}
                       className={[
@@ -120,7 +120,7 @@ export default function GoalList({
                       />
                     ) : null}
                   </div>
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-[var(--space-2)]">
                     {isEditing ? (
                       <>
                         <IconButton
@@ -179,9 +179,9 @@ export default function GoalList({
                     )}
                   </div>
                 </header>
-                <div className="relative z-[1] mt-4 space-y-2 text-ui font-medium text-muted-foreground">
+                <div className="relative z-[1] mt-[var(--space-4)] space-y-[var(--space-2)] text-ui font-medium text-muted-foreground">
                   {isEditing ? (
-                    <div className="space-y-2">
+                    <div className="space-y-[var(--space-2)]">
                       <Input
                         aria-label="Metric"
                         value={draft.metric}
@@ -215,8 +215,8 @@ export default function GoalList({
                     </>
                   )}
                 </div>
-                <footer className="relative z-[1] mt-auto pt-3 flex items-center justify-between text-label font-medium tracking-[0.02em] text-muted-foreground">
-                  <span className="inline-flex items-center gap-2">
+                <footer className="relative z-[1] mt-auto pt-[var(--space-3)] flex items-center justify-between text-label font-medium tracking-[0.02em] text-muted-foreground">
+                  <span className="inline-flex items-center gap-[var(--space-2)]">
                     <span
                       aria-hidden
                       className={[

--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -48,10 +48,10 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
         title="Goal Queue"
         titleClassName="text-title font-semibold tracking-[-0.01em]"
       />
-      <SectionCard.Body className="grid gap-6">
+      <SectionCard.Body className="grid gap-[var(--space-6)]">
           <ul className="divide-y divide-border/10">
             {items.length === 0 ? (
-              <li className="py-3 text-ui font-medium text-muted-foreground">No queued goals</li>
+              <li className="py-[var(--space-3)] text-ui font-medium text-muted-foreground">No queued goals</li>
             ) : (
               items.map((it) => {
                 const created = new Date(it.createdAt);
@@ -60,7 +60,7 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
                 const deleteLabel = `Delete queued goal ${goalLabel}`;
 
                 return (
-                  <li key={it.id} className="group flex items-center gap-2 py-3">
+                  <li key={it.id} className="group flex items-center gap-[var(--space-2)] py-[var(--space-3)]">
                     <span className="h-2 w-2 rounded-full bg-foreground/40" aria-hidden />
                     <p className="flex-1 truncate text-ui font-medium">{it.text}</p>
                     <time
@@ -69,7 +69,7 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
                     >
                       {shortDate.format(created)}
                     </time>
-                    <div className="flex items-center gap-1 ml-2">
+                    <div className="flex items-center gap-[var(--space-1)] ml-[var(--space-2)]">
                       <IconButton
                         title={deleteLabel}
                         aria-label={deleteLabel}
@@ -88,7 +88,7 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
             )}
           </ul>
 
-          <form onSubmit={submit} className="flex items-center gap-2 pt-3">
+          <form onSubmit={submit} className="flex items-center gap-[var(--space-2)] pt-[var(--space-3)]">
             <span className="h-2 w-2 rounded-full bg-foreground/40" aria-hidden />
             <label className="sr-only" htmlFor={inputId}>
               Add to queue and press Enter

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -74,9 +74,9 @@ const DOMAIN_ITEMS: Array<{
   label: string;
   icon: React.ReactNode;
 }> = [
-  { key: "Life", label: "Life", icon: <Sparkles className="mr-1" /> },
-  { key: "League", label: "League", icon: <Gamepad2 className="mr-1" /> },
-  { key: "Learn", label: "Learn", icon: <GraduationCap className="mr-1" /> },
+  { key: "Life", label: "Life", icon: <Sparkles className="mr-[var(--space-1)]" /> },
+  { key: "League", label: "League", icon: <Gamepad2 className="mr-[var(--space-1)]" /> },
+  { key: "Learn", label: "Learn", icon: <GraduationCap className="mr-[var(--space-1)]" /> },
 ];
 
 const HERO_HEADINGS: Record<Tab, string> = {
@@ -344,7 +344,7 @@ function GoalsPageContent() {
       placeholder: "Search title, text, tags…",
       debounceMs: 80,
       right: (
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-[var(--space-2)]">
           <span className="text-label font-medium tracking-[0.02em] opacity-75">
             {reminderCount}
           </span>
@@ -360,7 +360,7 @@ function GoalsPageContent() {
       <Button
         variant="primary"
         size="md"
-        className="px-4 whitespace-nowrap"
+        className="px-[var(--space-4)] whitespace-nowrap"
         onClick={handleAddReminder}
       >
         <Plus />
@@ -374,9 +374,9 @@ function GoalsPageContent() {
       as="main"
       id="goals-main"
       aria-labelledby="goals-header"
-      className="py-6"
+      className="py-[var(--space-6)]"
     >
-      <div className="grid gap-6">
+      <div className="grid gap-[var(--space-6)]">
         {/* ======= HEADER ======= */}
         <PageHeader
           header={{
@@ -387,7 +387,7 @@ function GoalsPageContent() {
             icon: <Flag className="opacity-80" />,
             sticky: false,
             barClassName:
-              "flex-col items-start justify-start gap-2 sm:flex-row sm:items-center sm:justify-between",
+              "flex-col items-start justify-start gap-[var(--space-2)] sm:flex-row sm:items-center sm:justify-between sm:gap-[var(--space-4)]",
             tabs: {
               items: TABS,
               value: tab,
@@ -422,8 +422,8 @@ function GoalsPageContent() {
           ref={goalsRef}
         >
           {tab === "goals" && (
-            <div className="grid gap-4">
-              <div className="space-y-2">
+            <div className="grid gap-[var(--space-4)]">
+              <div className="space-y-[var(--space-2)]">
                 {totalCount === 0 ? (
                   <GoalsProgress
                     total={totalCount}
@@ -437,7 +437,7 @@ function GoalsPageContent() {
                       topClassName="top-0"
                       className="flex items-center justify-between"
                     >
-                      <div className="flex items-center gap-2 sm:gap-4">
+                      <div className="flex items-center gap-[var(--space-2)] sm:gap-[var(--space-4)]">
                         <h2 className="text-title font-semibold tracking-[-0.01em]">Your Goals</h2>
                         <GoalsProgress total={totalCount} pct={pctDone} />
                       </div>
@@ -492,7 +492,7 @@ function GoalsPageContent() {
           hidden={tab !== "reminders"}
           tabIndex={tab === "reminders" ? 0 : -1}
           ref={remindersRef}
-          className="grid gap-4"
+          className="grid gap-[var(--space-4)]"
         >
           {tab === "reminders" && <RemindersTab />}
         </div>
@@ -504,7 +504,7 @@ function GoalsPageContent() {
           hidden={tab !== "timer"}
           tabIndex={tab === "timer" ? 0 : -1}
           ref={timerRef}
-          className="grid gap-4"
+          className="grid gap-[var(--space-4)]"
         >
           {tab === "timer" && <TimerTab />}
         </div>

--- a/src/components/goals/GoalsProgress.tsx
+++ b/src/components/goals/GoalsProgress.tsx
@@ -19,8 +19,8 @@ export default function GoalsProgress({
 }: GoalsProgressProps) {
   if (total === 0) {
     return (
-      <div className="rounded-card r-card-md border border-border bg-surface-2 p-6 text-center">
-        <p className="mb-4 text-muted-foreground text-ui font-medium">No goals yet.</p>
+      <div className="rounded-card r-card-md border border-border bg-surface-2 p-[var(--space-6)] text-center">
+        <p className="mb-[var(--space-4)] text-muted-foreground text-ui font-medium">No goals yet.</p>
         {onAddFirst && (
           <Button onClick={onAddFirst} size="sm" className="mx-auto">
             Add a first goal

--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -165,11 +165,11 @@ export default function Reminders() {
   }
 
   return (
-    <div className="grid gap-3">
+    <div className="grid gap-[var(--space-3)]">
       <SectionCard className="card-neo-soft">
         <SectionCard.Header sticky topClassName="top-0">
           {/* header row (no Quick Add here anymore) */}
-          <div className="flex flex-wrap items-center gap-2 sm:gap-3 w-full">
+          <div className="flex flex-wrap items-center gap-[var(--space-2)] sm:gap-[var(--space-3)] w-full">
             {/* search */}
             <div className="relative flex-1 min-w-56">
               <Search
@@ -208,7 +208,7 @@ export default function Reminders() {
               title="Pinned only"
               isActive={onlyPinned}
             >
-              {onlyPinned ? <PinOff className="mr-1" /> : <Pin className="mr-1" />}
+              {onlyPinned ? <PinOff className="mr-[var(--space-1)]" /> : <Pin className="mr-[var(--space-1)]" />}
               {onlyPinned ? "Pinned only" : "Any pin"}
             </SegmentedButton>
 
@@ -224,9 +224,9 @@ export default function Reminders() {
         </SectionCard.Header>
 
         {/* Panel body now holds Quick Add + neon quote + cards grid */}
-        <SectionCard.Body className="grid gap-3">
+        <SectionCard.Body className="grid gap-[var(--space-3)]">
           {/* Quick Add row (in the SAME panel as cards) */}
-          <div className="sm:p-4 flex items-center gap-4">
+          <div className="sm:p-[var(--space-4)] flex items-center gap-[var(--space-4)]">
             <Input
               aria-label="Quick add"
               placeholder={`Quick add to ${group === "all" ? "Pre-Game" : group.charAt(0).toUpperCase() + group.slice(1)}…`}
@@ -245,7 +245,7 @@ export default function Reminders() {
           </div>
 
           {/* Cards grid */}
-          <div className="grid card-neo-soft gap-3 sm:gap-4 md:grid-cols-12">
+          <div className="grid card-neo-soft gap-[var(--space-3)] sm:gap-[var(--space-4)] md:grid-cols-12">
             {filtered.map((r) => (
               <div key={r.id} className="md:col-span-6">
                 <ReminderCard
@@ -307,12 +307,12 @@ function ReminderCard({
   const cancelLabel = `Cancel ${currentTitle}`;
 
   return (
-    <article className="card-neo rounded-card p-4 sm:p-5 relative">
+    <article className="card-neo rounded-card p-[var(--space-4)] sm:p-[var(--space-5)] relative">
       {value.pinned && (
-        <span aria-hidden className="absolute inset-y-3 left-0 w-0.5 rounded-full bg-primary/55" />
+        <span aria-hidden className="absolute inset-y-[var(--space-3)] left-0 w-0.5 rounded-full bg-primary/55" />
       )}
 
-      <div className="flex items-center justify-between gap-2 mb-2">
+      <div className="flex items-center justify-between gap-[var(--space-2)] mb-[var(--space-2)]">
         {editing ? (
           <Input
             ref={titleRef}
@@ -326,7 +326,7 @@ function ReminderCard({
             className="font-semibold"
           />
         ) : (
-          <div className="flex items-center gap-2 min-w-0">
+          <div className="flex items-center gap-[var(--space-2)] min-w-0">
             <h3 className="font-semibold title-glow truncate" title={value.title}>
               {value.title}
             </h3>
@@ -343,7 +343,7 @@ function ReminderCard({
           </div>
         )}
 
-        <div className="card-neo flex items-center gap-1">
+        <div className="card-neo flex items-center gap-[var(--space-1)]">
           <IconButton
             title={value.pinned ? "Unpin" : "Pin"}
             aria-label={value.pinned ? "Unpin" : "Pin"}
@@ -399,7 +399,7 @@ function ReminderCard({
         </div>
       </div>
 
-      <div className="space-y-3">
+      <div className="space-y-[var(--space-3)]">
         {editing ? (
           <>
             <Textarea
@@ -438,7 +438,7 @@ function ReminderCard({
             ) : (
               <p className="text-ui font-medium text-muted-foreground/80">No text. Click to edit.</p>
             )}
-            <div className="flex flex-wrap items-center gap-2 pt-1">
+            <div className="flex flex-wrap items-center gap-[var(--space-2)] pt-[var(--space-1)]">
               {value.tags.map((t) => <span key={t} className="pill">{t}</span>)}
               <Badge size="xs" tone="neutral" className="opacity-75">{value.group}</Badge>
               <Badge

--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -11,7 +11,7 @@ export default function RemindersTab() {
   return (
     <SectionCard className="goal-card">
       <SectionCard.Body>
-        <div className="grid gap-3">
+        <div className="grid gap-[var(--space-3)]">
           <ReminderQuickAddForm />
           <ReminderFilters />
           <ReminderList />

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -35,25 +35,25 @@ const PROFILES: Profile[] = [
   {
     key: "study",
     label: "Studying",
-    icon: <BookOpen className="mr-1" />,
+    icon: <BookOpen className="mr-[var(--space-1)]" />,
     defaultMin: 45,
   },
   {
     key: "clean",
     label: "Cleaning",
-    icon: <Brush className="mr-1" />,
+    icon: <Brush className="mr-[var(--space-1)]" />,
     defaultMin: 30,
   },
   {
     key: "code",
     label: "Coding",
-    icon: <Code2 className="mr-1" />,
+    icon: <Code2 className="mr-[var(--space-1)]" />,
     defaultMin: 60,
   },
   {
     key: "custom",
     label: "Custom",
-    icon: <User className="mr-1" />,
+    icon: <User className="mr-[var(--space-1)]" />,
     defaultMin: 25,
   },
 ];
@@ -332,7 +332,7 @@ export default function TimerTab() {
 
   // Right slot content for Custom: quick duration chips + custom time field
   const rightSlot = isCustom ? (
-    <div className="flex items-center flex-wrap gap-2">
+    <div className="flex items-center flex-wrap gap-[var(--space-2)]">
       <DurationSelector
         value={minutes}
         onChange={(m) => {
@@ -358,7 +358,7 @@ export default function TimerTab() {
         onKeyDown={(e) => e.key === "Enter" && commitEdit()}
         placeholder="mm:ss"
         disabled={running}
-        className="w-[5ch] rounded-full border border-border/20 bg-background/20 px-2 text-center text-ui font-medium backdrop-blur focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="w-[5ch] rounded-full border border-border/20 bg-background/20 px-[var(--space-2)] text-center text-ui font-medium backdrop-blur focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         type="text"
       />
     </div>
@@ -491,7 +491,7 @@ export default function TimerTab() {
             </div>
 
             {/* progress bar */}
-            <div className="mt-6 w-full">
+            <div className="mt-[var(--space-6)] w-full">
               <div className="relative h-2 w-full rounded-full bg-background/20 shadow-neo-inset">
                 <div className="absolute inset-0 bg-[repeating-linear-gradient(to_right,transparent,transparent_9%,hsl(var(--foreground)/0.15)_9%,hsl(var(--foreground)/0.15)_10%)]" />
                 <div
@@ -499,13 +499,13 @@ export default function TimerTab() {
                   style={{ width: `${pct}%` }}
                 />
               </div>
-              <div className="mt-1 text-right text-label font-medium tracking-[0.02em] text-muted-foreground tabular-nums">
+              <div className="mt-[var(--space-1)] text-right text-label font-medium tracking-[0.02em] text-muted-foreground tabular-nums">
                 {pct}%
               </div>
             </div>
 
             {/* controls */}
-            <div className="mt-6 flex w-full flex-wrap justify-center gap-2 overflow-x-auto">
+            <div className="mt-[var(--space-6)] flex w-full flex-wrap justify-center gap-[var(--space-2)] overflow-x-auto">
               {!running ? (
                 <SegmentedButton
                   className="gap-[var(--space-2)]"
@@ -538,11 +538,11 @@ export default function TimerTab() {
 
             {/* Complete state */}
             {finished && (
-              <div className="mt-6 grid place-items-center">
-                <div className="rounded-full bg-[linear-gradient(90deg,hsl(var(--accent)/0.35),hsl(var(--accent-2)/0.35)))] px-3 py-1 text-ui font-medium text-foreground shadow-[var(--shadow-glow-md)] ring-1 ring-inset ring-border/50 motion-safe:animate-pulse motion-reduce:animate-none">
+              <div className="mt-[var(--space-6)] grid place-items-center">
+                <div className="rounded-full bg-[linear-gradient(90deg,hsl(var(--accent)/0.35),hsl(var(--accent-2)/0.35)))] px-[var(--space-3)] py-[var(--space-1)] text-ui font-medium text-foreground shadow-[var(--shadow-glow-md)] ring-1 ring-inset ring-border/50 motion-safe:animate-pulse motion-reduce:animate-none">
                   Complete
                 </div>
-                <div className="mt-2 text-label font-medium tracking-[0.02em] text-muted-foreground">
+                <div className="mt-[var(--space-2)] text-label font-medium tracking-[0.02em] text-muted-foreground">
                   Good. Now do the review, not Twitter.
                 </div>
               </div>

--- a/src/components/goals/reminders/ReminderFilters.tsx
+++ b/src/components/goals/reminders/ReminderFilters.tsx
@@ -34,7 +34,7 @@ export default function ReminderFilters() {
           className="overflow-x-auto"
           right={
             <SegmentedButton
-              className="inline-flex items-center gap-1"
+              className="inline-flex items-center gap-[var(--space-1)]"
               onClick={toggleFilters}
               aria-expanded={showFilters}
               title="Filters"
@@ -48,7 +48,7 @@ export default function ReminderFilters() {
       )}
 
       {showFilters && (
-        <div className="flex flex-wrap items-center gap-4 pl-1">
+        <div className="flex flex-wrap items-center gap-[var(--space-4)] pl-[var(--space-1)]">
           <TabBar
             items={sourceTabs}
             value={source}
@@ -62,7 +62,7 @@ export default function ReminderFilters() {
             title="Pinned only"
             isActive={onlyPinned}
           >
-            {onlyPinned ? <PinOff className="mr-1" /> : <Pin className="mr-1" />}
+            {onlyPinned ? <PinOff className="mr-[var(--space-1)]" /> : <Pin className="mr-[var(--space-1)]" />}
             {onlyPinned ? "Pinned only" : "Any pin"}
           </SegmentedButton>
         </div>

--- a/src/components/goals/reminders/ReminderList.tsx
+++ b/src/components/goals/reminders/ReminderList.tsx
@@ -121,7 +121,7 @@ function RemTile({
           ) : (
             <div className="flex items-center gap-[var(--space-2)] min-w-0">
               <h4
-                className="font-semibold uppercase tracking-wide pr-2 title-glow glitch leading-6 truncate"
+                className="font-semibold uppercase tracking-wide pr-[var(--space-2)] title-glow glitch leading-6 truncate"
                 title={value.title}
               >
                 {value.title}

--- a/src/components/goals/reminders/ReminderQuickAddForm.tsx
+++ b/src/components/goals/reminders/ReminderQuickAddForm.tsx
@@ -25,7 +25,7 @@ export default function ReminderQuickAddForm() {
     <>
       <form
         onSubmit={handleSubmit}
-        className="rounded-card flex items-center gap-2 sm:gap-6 glitch"
+        className="rounded-card flex items-center gap-[var(--space-2)] sm:gap-[var(--space-6)] glitch"
       >
         <Input
           aria-label="Quick add reminder"


### PR DESCRIPTION
## Summary
- replace fixed Tailwind spacing utilities in goals progress, lists, and forms with spacing tokens
- align reminders, timer, and queue components with `var(--space-*)` helpers for consistent paddings and gaps
- normalize goals page hero actions and tabs to rely on design token spacing

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cf1f3cca24832ca18468d97e83d1c5