### PR TITLE
Refine timer ring sizing with spacing tokens

### DIFF
--- a/src/components/goals/GoalsProgress.tsx
+++ b/src/components/goals/GoalsProgress.tsx
@@ -31,12 +31,23 @@ export default function GoalsProgress({
   }
 
   const v = Math.max(0, Math.min(100, Math.round(pct)));
-  const sizeStyle = maxWidth ?? 64;
+  const customSize =
+    maxWidth == null
+      ? undefined
+      : typeof maxWidth === "number"
+        ? `${maxWidth}px`
+        : maxWidth;
   const ringSize = typeof maxWidth === "number" ? maxWidth : undefined;
   return (
     <div
-      className="relative inline-flex items-center justify-center"
-      style={{ width: sizeStyle, height: sizeStyle }}
+      className="relative inline-flex size-[var(--goals-progress-size,var(--space-8))] items-center justify-center"
+      style={
+        customSize
+          ? ({
+              "--goals-progress-size": customSize,
+            } as React.CSSProperties)
+          : undefined
+      }
       aria-label="Progress"
     >
       <ProgressRingIcon pct={v} size={ringSize} />

--- a/src/components/goals/TimerRing.tsx
+++ b/src/components/goals/TimerRing.tsx
@@ -2,15 +2,29 @@
 
 import * as React from "react";
 import TimerRingIcon from "@/icons/TimerRingIcon";
+import { spacingTokens } from "@/lib/tokens";
+import { cn } from "@/lib/utils";
 
 interface TimerRingProps {
   pct: number; // 0..100
+  className?: string;
   size?: number;
 }
 
-export default function TimerRing({ pct, size = 200 }: TimerRingProps) {
+const DEFAULT_VIEWBOX = (spacingTokens[7] * 7) / 2;
+
+export default function TimerRing({
+  pct,
+  className,
+  size = DEFAULT_VIEWBOX,
+}: TimerRingProps) {
   return (
-    <div className="relative" style={{ width: size, height: size }}>
+    <div
+      className={cn(
+        "relative aspect-square",
+        className ?? "size-[calc(var(--space-8)*3.5)]",
+      )}
+    >
       <TimerRingIcon pct={pct} size={size} />
     </div>
   );

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -402,15 +402,6 @@ export default function TimerTab() {
   }, [running, isCustom, pause, start, reset, setTimer]);
 
   const pct = Math.round(progress * 100);
-  const [ringSize, setRingSize] = React.useState(224);
-  React.useEffect(() => {
-    function update() {
-      setRingSize(Math.min(224, window.innerWidth - 64));
-    }
-    update();
-    window.addEventListener("resize", update);
-    return () => window.removeEventListener("resize", update);
-  }, []);
 
   return (
     <>
@@ -466,10 +457,9 @@ export default function TimerTab() {
 
             {/* ring + digits */}
             <div
-              className="group relative mx-auto flex items-center justify-center"
-              style={{ width: ringSize, height: ringSize }}
+              className="group relative mx-auto flex aspect-square w-full max-w-[min(calc(var(--space-8)*3.5),calc(100vw-var(--space-8)))] items-center justify-center"
             >
-              <TimerRing pct={pct} size={ringSize} />
+              <TimerRing pct={pct} className="size-full" />
               <div className="pointer-events-none absolute inset-0 grid place-items-center">
                 <div className="text-title font-semibold tabular-nums text-foreground drop-shadow-[0_0_var(--space-2)_hsl(var(--neon-soft))] transition-transform duration-[var(--dur-quick)] group-hover:translate-y-0.5 sm:text-title-lg">
                   {formatMmSs(remaining, {

--- a/src/icons/ProgressRingIcon.tsx
+++ b/src/icons/ProgressRingIcon.tsx
@@ -1,15 +1,20 @@
 import * as React from "react";
+import { spacingTokens } from "@/lib/tokens";
 
 interface ProgressRingIconProps {
   pct: number; // 0..100
   size?: number;
 }
 
+const PROGRESS_DIAMETER = spacingTokens[7];
+const TRACK_INSET = spacingTokens[2] / 2;
+const STROKE_WIDTH = spacingTokens[0];
+
 export default function ProgressRingIcon({
   pct,
-  size = 64,
+  size = PROGRESS_DIAMETER,
 }: ProgressRingIconProps) {
-  const radius = size / 2 - 6;
+  const radius = size / 2 - TRACK_INSET;
   const circumference = 2 * Math.PI * radius;
   const offset = circumference - (pct / 100) * circumference;
   return (
@@ -22,7 +27,7 @@ export default function ProgressRingIcon({
         cy={size / 2}
         r={radius}
         stroke="currentColor"
-        strokeWidth={4}
+        strokeWidth={STROKE_WIDTH}
         className="text-foreground/20"
         fill="none"
       />
@@ -31,7 +36,7 @@ export default function ProgressRingIcon({
         cy={size / 2}
         r={radius}
         stroke="currentColor"
-        strokeWidth={4}
+        strokeWidth={STROKE_WIDTH}
         strokeLinecap="round"
         strokeDasharray={circumference}
         strokeDashoffset={offset}

--- a/src/icons/TimerRingIcon.tsx
+++ b/src/icons/TimerRingIcon.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { spacingTokens } from "@/lib/tokens";
 import { cn } from "@/lib/utils";
 
 interface TimerRingIconProps {
@@ -6,10 +7,17 @@ interface TimerRingIconProps {
   size?: number;
 }
 
-export default function TimerRingIcon({ pct, size = 200 }: TimerRingIconProps) {
+const RING_DIAMETER = (spacingTokens[7] * 7) / 2;
+const TRACK_INSET = spacingTokens[2] / 2;
+const STROKE_WIDTH = spacingTokens[0];
+
+export default function TimerRingIcon({
+  pct,
+  size = RING_DIAMETER,
+}: TimerRingIconProps) {
   const uniqueId = React.useId();
   const gradientId = `timer-ring-grad-${uniqueId}`;
-  const radius = size / 2 - 6;
+  const radius = size / 2 - TRACK_INSET;
   const circumference = 2 * Math.PI * radius;
   const offset = circumference - (pct / 100) * circumference;
   const pulse = pct >= 90;
@@ -32,7 +40,7 @@ export default function TimerRingIcon({ pct, size = 200 }: TimerRingIconProps) {
         cy={size / 2}
         r={radius}
         stroke="hsl(var(--card-hairline))"
-        strokeWidth={4}
+        strokeWidth={STROKE_WIDTH}
         fill="none"
       />
       <circle
@@ -40,7 +48,7 @@ export default function TimerRingIcon({ pct, size = 200 }: TimerRingIconProps) {
         cy={size / 2}
         r={radius}
         stroke={`url(#${gradientId})`}
-        strokeWidth={4}
+        strokeWidth={STROKE_WIDTH}
         strokeLinecap="round"
         strokeDasharray={circumference}
         strokeDashoffset={offset}


### PR DESCRIPTION
## Summary
- align the timer tab ring container with spacing-token sizing and drop inline dimension logic
- update TimerRing and GoalsProgress to size via spacing-backed classes and CSS variables
- derive timer/progress ring icon geometry from spacing tokens instead of magic numbers

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cf1fabaaa4832c90d90587392eb4c1