### PR TITLE
Refactor GoalsCard to use goals hook

### DIFF
--- a/src/components/home/GoalsCard.tsx
+++ b/src/components/home/GoalsCard.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import DashboardCard from "./DashboardCard";
 import DashboardList from "./DashboardList";
-import { usePersistentState } from "@/lib/db";
+import { useGoals } from "@/components/goals";
 import type { Goal } from "@/lib/types";
 import { Progress } from "@/components/ui";
 
@@ -83,7 +83,7 @@ function getGoalStatus(goal: Goal): string {
 }
 
 export default function GoalsCard() {
-  const [goals] = usePersistentState<Goal[]>("goals.v2", []);
+  const { goals } = useGoals();
   const activeGoals = React.useMemo(
     () => goals.filter((g) => !g.done).slice(0, 3),
     [goals],


### PR DESCRIPTION
## Summary
- update the home dashboard goals card to read goals via the shared useGoals hook
- remove the duplicate persistence key usage so the card follows centralized goals logic

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cf215b52ec832c81d1e4bd2d3f89c9