### PR TITLE
Tokenize pill and toolbar spacing

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -855,10 +855,11 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
 
   /* Base chip & variants */
   .pill {
+    --pill-height: calc(var(--space-6) - var(--space-1));
     @apply inline-flex items-center rounded-full border text-label font-medium tracking-[0.02em];
-    height: 1.75rem;
-    padding: 0 0.75rem;
-    gap: 0.5rem;
+    height: var(--pill-height);
+    padding: 0 var(--space-3);
+    gap: var(--space-2);
     background: hsl(var(--card));
     color: hsl(var(--foreground));
     border-color: hsl(var(--border) / 0.35);
@@ -2087,13 +2088,13 @@ a:active .lucide {
   .toolbar {
     display: grid;
     grid-template-columns: 1fr auto;
-    gap: 0.75rem;
+    gap: var(--space-3);
     align-items: center;
   }
   .toolbar-right {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: var(--space-2);
   }
   @media (max-width: 640px) {
     .toolbar {


### PR DESCRIPTION
## Summary
- replace the pill component sizing with spacing tokens, introducing a helper custom property so the 28px height still maps cleanly to the scale
- swap toolbar layout gaps to use shared spacing tokens to keep planner header, review, and gallery chips consistent

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cf243d411c832ca9fa8106602c89fc