### PR TITLE
Add review component stories for state coverage

### DIFF
--- a/storybook/src/components/reviews/ReviewEditor.stories.tsx
+++ b/storybook/src/components/reviews/ReviewEditor.stories.tsx
@@ -1,0 +1,236 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { ReviewEditor } from "@/components/reviews";
+import type { Review } from "@/lib/types";
+import { Skeleton } from "@/components/ui";
+import { cn } from "@/lib/utils";
+
+const reviewSeed: Review = {
+  id: "review-seed-1",
+  title: "Lux vs Ahri — Mid lane review",
+  opponent: "Ahri",
+  lane: "Mid Lane",
+  side: "Blue",
+  patch: "14.21",
+  duration: "32:18",
+  matchup: "Lux vs Ahri",
+  tags: ["lane-phase", "vision"],
+  pillars: ["Vision", "Tempo"],
+  notes:
+    "Early slow push created crash timing for first roam. Need faster ward swap before 6.",
+  createdAt: Date.now() - 1000 * 60 * 60 * 24,
+  result: "Win",
+  score: 8,
+  role: "MID",
+  focusOn: true,
+  focus: 7,
+  markers: [
+    { id: "m1", time: "03:15", seconds: 195, note: "Wave held for bounce" },
+    { id: "m2", time: "08:41", seconds: 521, note: "Forcing flash mid" },
+  ],
+};
+
+type ReviewEditorComponentProps = React.ComponentProps<typeof ReviewEditor>;
+
+const noopChangeMeta: NonNullable<ReviewEditorComponentProps["onChangeMeta"]> = () =>
+  undefined;
+const noopChangeNotes: NonNullable<ReviewEditorComponentProps["onChangeNotes"]> = () =>
+  undefined;
+const noopChangeTags: NonNullable<ReviewEditorComponentProps["onChangeTags"]> = () =>
+  undefined;
+const noopRename: NonNullable<ReviewEditorComponentProps["onRename"]> = () => undefined;
+const noopDone: NonNullable<ReviewEditorComponentProps["onDone"]> = () => undefined;
+const noopDelete: NonNullable<ReviewEditorComponentProps["onDelete"]> = () => undefined;
+
+const meta: Meta<typeof ReviewEditor> = {
+  title: "Reviews/ReviewEditor",
+  component: ReviewEditor,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "`ReviewEditor` expects a hydrated `Review` record plus callbacks for persisting metadata, notes, and lifecycle events. Use semantic spacing tokens (`var(--space-*)`) around the editor to keep cards aligned with the planner grid.",
+      },
+    },
+    chromatic: { pauseAnimationAtEnd: true },
+  },
+  args: {
+    review: reviewSeed,
+    onChangeMeta: noopChangeMeta,
+    onChangeNotes: noopChangeNotes,
+    onChangeTags: noopChangeTags,
+    onRename: noopRename,
+    onDone: noopDone,
+    onDelete: noopDelete,
+  },
+  argTypes: {
+    review: {
+      control: false,
+      description:
+        "Hydrated review entity including id, tags, pillars, and optional metadata fields used throughout the editor rails.",
+    },
+    onChangeMeta: {
+      control: false,
+      description:
+        "Callback fired whenever nested sections commit metadata updates (lane, opponent, score, pillars, timestamps).",
+    },
+    onChangeNotes: {
+      control: false,
+      description: "Persist edited notes when focus leaves the textarea or save actions trigger.",
+    },
+    onChangeTags: {
+      control: false,
+      description: "Persist chip tag changes from the quick-add footer.",
+    },
+    onRename: {
+      control: false,
+      description: "Optional handler for syncing lane title edits into surrounding shells.",
+    },
+    onDone: {
+      control: false,
+      description: "Optional handler invoked when the editor loses focus so callers can close drawers or navigate away.",
+    },
+    onDelete: {
+      control: false,
+      description: "Optional handler connected to the trash action in the header rail.",
+    },
+    className: {
+      control: false,
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ReviewEditor>;
+
+function StorySurface({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen w-full bg-[var(--background)] py-[var(--space-8)]">
+      <div className="mx-auto flex w-full max-w-[min(75rem,100%)] flex-col gap-[var(--space-6)] px-[var(--space-6)]">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Baseline editor with populated review seed demonstrating compliant spacing, slider rails, and timestamp markers in their default arrangement.",
+      },
+    },
+  },
+  render: (args) => (
+    <StorySurface>
+      <ReviewEditor {...args} className={cn("w-full", args.className)} />
+    </StorySurface>
+  ),
+};
+
+function EditorLoadingSkeleton() {
+  return (
+    <div className="rounded-card border border-border/40 bg-[color-mix(in_oklab,var(--surface) 92%,transparent)] p-[var(--space-5)] shadow-[var(--shadow-outline-subtle)]">
+      <div className="flex flex-col gap-[var(--space-4)]">
+        <Skeleton className="h-[var(--space-5)] w-full max-w-[calc(var(--space-8)*2)]" />
+        <div className="grid gap-[var(--space-3)] sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+          <Skeleton className="h-[var(--space-8)] rounded-[var(--control-radius)]" />
+          <Skeleton className="h-[var(--space-8)] rounded-[var(--control-radius)]" />
+        </div>
+        <Skeleton className="h-[calc(var(--space-8)*3)] rounded-[var(--control-radius)]" />
+        <Skeleton className="h-[calc(var(--space-8)*2+var(--space-4))] rounded-[var(--control-radius)]" />
+      </div>
+    </div>
+  );
+}
+
+export const Loading: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "While review data hydrates, layer skeleton placeholders that mirror the editor grid so motion stays predictable and spacing stays token-aligned.",
+      },
+    },
+  },
+  render: (args) => (
+    <StorySurface>
+      <div className="grid gap-[var(--space-4)]">
+        <EditorLoadingSkeleton />
+        <ReviewEditor
+          {...args}
+          className={cn(
+            "pointer-events-none opacity-40 blur-[1px]",
+            args.className,
+          )}
+        />
+      </div>
+    </StorySurface>
+  ),
+};
+
+function ErrorBanner({ message }: { message: string }) {
+  return (
+    <div
+      role="alert"
+      className="rounded-card border border-danger/40 bg-[color-mix(in_oklab,var(--danger)/15%,transparent)] px-[var(--space-4)] py-[var(--space-3)] text-label text-danger shadow-[var(--shadow-outline-subtle)]"
+    >
+      {message}
+    </div>
+  );
+}
+
+export const Error: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Surface sync failures with a semantic danger banner while keeping the editor visible for context. QA can wire the retry button into `onDone` or close actions as needed.",
+      },
+    },
+  },
+  render: (args) => (
+    <StorySurface>
+      <div className="grid gap-[var(--space-4)]">
+        <ErrorBanner message="Failed to save review changes. Check your connection and retry." />
+        <ReviewEditor {...args} className={cn("ring-1 ring-danger/40", args.className)} />
+      </div>
+    </StorySurface>
+  ),
+};
+
+function ReducedMotionPreview({ children }: { children: React.ReactNode }) {
+  React.useEffect(() => {
+    if (typeof document === "undefined") return;
+    const root = document.documentElement;
+    root.classList.add("no-animations");
+    return () => {
+      root.classList.remove("no-animations");
+    };
+  }, []);
+  return <>{children}</>;
+}
+
+export const ReducedMotion: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Reduced-motion mode disables the editor's neon focus and pulse animations while preserving spacing and state readability.",
+      },
+    },
+  },
+  render: (args) => (
+    <ReducedMotionPreview>
+      <StorySurface>
+        <ReviewEditor
+          {...args}
+          className={cn("data-[reduced-motion=true]:transition-none", args.className)}
+        />
+      </StorySurface>
+    </ReducedMotionPreview>
+  ),
+};

--- a/storybook/src/components/reviews/ReviewList.stories.tsx
+++ b/storybook/src/components/reviews/ReviewList.stories.tsx
@@ -1,0 +1,229 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { ReviewList } from "@/components/reviews";
+import type { Review } from "@/lib/types";
+import { Button, Card, Skeleton } from "@/components/ui";
+import { cn } from "@/lib/utils";
+
+const reviewListSeed: Review[] = [
+  {
+    id: "review-201",
+    title: "Lux vs Ahri — Mid control",
+    matchup: "Lux vs Ahri",
+    tags: ["priority", "vision"],
+    pillars: ["Vision", "Tempo"],
+    createdAt: Date.now() - 1000 * 60 * 60 * 6,
+    role: "MID",
+    result: "Win",
+    score: 8,
+  },
+  {
+    id: "review-202",
+    title: "Sivir vs Xayah — Tempo review",
+    matchup: "Sivir vs Xayah",
+    tags: ["lane-phase"],
+    pillars: ["Wave"],
+    createdAt: Date.now() - 1000 * 60 * 60 * 30,
+    role: "BOT",
+    result: "Loss",
+    score: 5,
+  },
+  {
+    id: "review-203",
+    title: "Leona roam timings",
+    matchup: "Leona vs Nautilus",
+    tags: ["roam", "vision"],
+    pillars: ["Comms", "Vision"],
+    createdAt: Date.now() - 1000 * 60 * 90,
+    role: "SUPPORT",
+    result: "Win",
+    score: 7,
+    status: "new",
+  },
+];
+
+type ReviewListComponentProps = React.ComponentProps<typeof ReviewList>;
+
+const noopSelect: NonNullable<ReviewListComponentProps["onSelect"]> = () => undefined;
+const noopCreate: NonNullable<ReviewListComponentProps["onCreate"]> = () => undefined;
+
+const meta: Meta<typeof ReviewList> = {
+  title: "Reviews/ReviewList",
+  component: ReviewList,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "`ReviewList` renders a vertical stack of `ReviewListItem` shells. Provide the current review collection, the selected id, and callbacks for row selection and creation so QA can confirm sidebar flows.",
+      },
+    },
+    chromatic: { pauseAnimationAtEnd: true },
+  },
+  args: {
+    reviews: reviewListSeed,
+    selectedId: reviewListSeed[0]?.id ?? null,
+    onSelect: noopSelect,
+    onCreate: noopCreate,
+  },
+  argTypes: {
+    reviews: {
+      control: false,
+      description: "Ordered array of review entities to display in the sidebar list.",
+    },
+    selectedId: {
+      control: false,
+      description: "Currently focused review id so the list can highlight the active row.",
+    },
+    onSelect: {
+      control: false,
+      description: "Handler invoked when a row is clicked or activated via keyboard.",
+    },
+    onCreate: {
+      control: false,
+      description: "Callback wired to the empty state action for drafting a new review.",
+    },
+    className: { control: false },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ReviewList>;
+
+function StorySurface({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen w-full bg-[var(--background)] py-[var(--space-8)]">
+      <div className="mx-auto flex w-full max-w-[min(36rem,100%)] flex-col gap-[var(--space-5)] px-[var(--space-6)]">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Default list with the most recent review selected. The status pulse uses semantic motion tokens while spacing respects the review rail grid.",
+      },
+    },
+  },
+  render: (args) => (
+    <StorySurface>
+      <ReviewList {...args} className={cn("w-full", args.className)} />
+    </StorySurface>
+  ),
+};
+
+function ReviewListSkeleton() {
+  return (
+    <Card className="space-y-[var(--space-3)] p-[var(--space-4)] shadow-[var(--shadow-outline-subtle)]">
+      {[0, 1, 2].map((row) => (
+        <div key={row} className="space-y-[var(--space-2)]">
+          <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*4)]" />
+          <Skeleton className="h-[var(--space-3)] w-full max-w-[calc(var(--space-8)*3)]" />
+        </div>
+      ))}
+    </Card>
+  );
+}
+
+export const Loading: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "While the review feed loads, swap in skeleton rows sized with spacing tokens and keep the existing list blurred underneath to avoid layout shift.",
+      },
+    },
+  },
+  render: (args) => (
+    <StorySurface>
+      <div className="relative">
+        <ReviewList
+          {...args}
+          className={cn("pointer-events-none opacity-30 blur-[1px]", args.className)}
+        />
+        <div
+          aria-hidden
+          className="absolute inset-[var(--space-3)] flex flex-col gap-[var(--space-3)]"
+        >
+          <ReviewListSkeleton />
+        </div>
+      </div>
+    </StorySurface>
+  ),
+};
+
+function ErrorBanner({ message }: { message: string }) {
+  return (
+    <div
+      role="alert"
+      className="rounded-card border border-danger/40 bg-[color-mix(in_oklab,var(--danger)/15%,transparent)] px-[var(--space-4)] py-[var(--space-3)] text-label text-danger shadow-[var(--shadow-outline-subtle)]"
+    >
+      {message}
+    </div>
+  );
+}
+
+export const Error: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Pair the list with an inline alert when fetches fail. The banner keeps motion minimal while `ReviewList` remains disabled until retries succeed.",
+      },
+    },
+  },
+  render: (args) => (
+    <StorySurface>
+      <div className="grid gap-[var(--space-4)]">
+        <ErrorBanner message="We couldn't load your recent reviews. Try again in a few seconds." />
+        <div className="rounded-card border border-border/40 bg-card/60 p-[var(--space-3)]">
+          <div className="flex items-center justify-between gap-[var(--space-3)]">
+            <span className="text-ui text-muted-foreground">Last sync attempt: 30s ago</span>
+            <Button size="sm" tone="accent" onClick={() => args.onSelect?.("retry")}>Retry</Button>
+          </div>
+        </div>
+        <ReviewList
+          {...args}
+          reviews={[]}
+          selectedId={null}
+          className={cn("pointer-events-none ring-1 ring-danger/40", args.className)}
+        />
+      </div>
+    </StorySurface>
+  ),
+};
+
+function ReducedMotionPreview({ children }: { children: React.ReactNode }) {
+  React.useEffect(() => {
+    if (typeof document === "undefined") return;
+    const root = document.documentElement;
+    root.classList.add("no-animations");
+    return () => {
+      root.classList.remove("no-animations");
+    };
+  }, []);
+  return <>{children}</>;
+}
+
+export const ReducedMotion: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Reduced-motion mode removes the status dot blink while keeping spacing, shadows, and selection rings intact for accessibility sign-off.",
+      },
+    },
+  },
+  render: (args) => (
+    <ReducedMotionPreview>
+      <StorySurface>
+        <ReviewList {...args} />
+      </StorySurface>
+    </ReducedMotionPreview>
+  ),
+};

--- a/storybook/src/components/reviews/TimestampMarkers.stories.tsx
+++ b/storybook/src/components/reviews/TimestampMarkers.stories.tsx
@@ -1,0 +1,210 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { TimestampMarkers } from "@/components/reviews";
+import type { ReviewMarker } from "@/lib/types";
+import { Skeleton } from "@/components/ui";
+import { createStorageKey } from "@/lib/db";
+import {
+  LAST_MARKER_MODE_KEY,
+  LAST_MARKER_TIME_KEY,
+} from "@/components/reviews/reviewData";
+
+const markerSeed: ReviewMarker[] = [
+  {
+    id: "ts-1",
+    time: "02:45",
+    seconds: 165,
+    note: "Crash wave then ward raptor ramp",
+  },
+  {
+    id: "ts-2",
+    time: "09:18",
+    seconds: 558,
+    note: "Skipped recall to shadow jungler",
+  },
+  {
+    id: "ts-3",
+    time: "15:02",
+    seconds: 902,
+    note: "Lost track of bot wave state",
+    noteOnly: true,
+  },
+];
+
+type TimestampMarkersComponentProps = React.ComponentProps<typeof TimestampMarkers>;
+
+const noopCommitMeta: TimestampMarkersComponentProps["commitMeta"] = () => undefined;
+
+const meta: Meta<typeof TimestampMarkers> = {
+  title: "Reviews/TimestampMarkers",
+  component: TimestampMarkers,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "`TimestampMarkers` tracks mm:ss pairs or note-only highlights. Pass an array of persisted `ReviewMarker` entries plus a `commitMeta` callback to store edits.",
+      },
+    },
+    chromatic: { pauseAnimationAtEnd: true },
+  },
+  args: {
+    markers: markerSeed,
+    commitMeta: noopCommitMeta,
+  },
+  argTypes: {
+    markers: {
+      control: false,
+      description:
+        "Existing marker entries, already normalized to `time`, `seconds`, and `noteOnly` flags.",
+    },
+    commitMeta: {
+      control: false,
+      description:
+        "Required callback that receives `{ markers: ReviewMarker[] }` whenever the list is edited.",
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TimestampMarkers>;
+
+function StorySurface({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen w-full bg-[var(--background)] py-[var(--space-8)]">
+      <div className="mx-auto flex w-full max-w-[min(40rem,100%)] flex-col gap-[var(--space-5)] px-[var(--space-6)]">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Markers sorted chronologically with timestamp and note-only entries share the same spacing tokens for predictable scanning.",
+      },
+    },
+  },
+  render: (args) => (
+    <StorySurface>
+      <TimestampMarkers {...args} />
+    </StorySurface>
+  ),
+};
+
+function MarkersLoadingSkeleton() {
+  return (
+    <div className="rounded-card border border-border/40 bg-[color-mix(in_oklab,var(--surface) 92%,transparent)] p-[var(--space-4)] shadow-[var(--shadow-outline-subtle)]">
+      <div className="flex flex-col gap-[var(--space-3)]">
+        <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*2)]" />
+        <div className="flex items-center gap-[var(--space-2)]">
+          <Skeleton className="h-[var(--space-8)] w-[var(--space-8)] rounded-full" />
+          <Skeleton className="h-[var(--space-8)] w-[var(--space-8)] rounded-full" />
+        </div>
+        <div className="grid gap-[var(--space-3)]">
+          <Skeleton className="h-[var(--space-8)] rounded-[var(--control-radius)]" />
+          <Skeleton className="h-[var(--space-8)] rounded-[var(--control-radius)]" />
+        </div>
+        <div className="grid gap-[var(--space-2)]">
+          <Skeleton className="h-[var(--space-6)] rounded-[var(--control-radius)]" />
+          <Skeleton className="h-[var(--space-6)] rounded-[var(--control-radius)]" />
+          <Skeleton className="h-[var(--space-6)] rounded-[var(--control-radius)]" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const Loading: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When review metadata is still loading, skeleton blocks mirror the toggle rail, inputs, and existing markers so the list doesn't jump once content arrives.",
+      },
+    },
+  },
+  render: () => (
+    <StorySurface>
+      <MarkersLoadingSkeleton />
+    </StorySurface>
+  ),
+};
+
+function ErrorPreview(props: React.ComponentProps<typeof TimestampMarkers>) {
+  const cleanupRef = React.useRef<(() => void) | null>(null);
+
+  if (cleanupRef.current === null && typeof window !== "undefined") {
+    const modeKey = createStorageKey(LAST_MARKER_MODE_KEY);
+    const timeKey = createStorageKey(LAST_MARKER_TIME_KEY);
+    const prevMode = window.localStorage.getItem(modeKey);
+    const prevTime = window.localStorage.getItem(timeKey);
+    window.localStorage.setItem(modeKey, JSON.stringify(true));
+    window.localStorage.setItem(timeKey, JSON.stringify("99:99"));
+    cleanupRef.current = () => {
+      if (prevMode === null) {
+        window.localStorage.removeItem(modeKey);
+      } else {
+        window.localStorage.setItem(modeKey, prevMode);
+      }
+      if (prevTime === null) {
+        window.localStorage.removeItem(timeKey);
+      } else {
+        window.localStorage.setItem(timeKey, prevTime);
+      }
+    };
+  }
+
+  React.useEffect(() => () => cleanupRef.current?.(), []);
+  return <TimestampMarkers {...props} />;
+}
+
+export const Error: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Invalid timestamp formats surface inline guidance in the semantic danger color. Seed local storage with the malformed value so QA can verify validation.",
+      },
+    },
+  },
+  render: (args) => (
+    <StorySurface>
+      <ErrorPreview {...args} />
+    </StorySurface>
+  ),
+};
+
+function ReducedMotionPreview({ children }: { children: React.ReactNode }) {
+  React.useEffect(() => {
+    if (typeof document === "undefined") return;
+    const root = document.documentElement;
+    root.classList.add("no-animations");
+    return () => {
+      root.classList.remove("no-animations");
+    };
+  }, []);
+  return <>{children}</>;
+}
+
+export const ReducedMotion: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Reduced-motion mode disables the toggle glow and marker pulses while retaining spacing so the interface stays steady for sensitive users.",
+      },
+    },
+  },
+  render: (args) => (
+    <ReducedMotionPreview>
+      <StorySurface>
+        <TimestampMarkers {...args} />
+      </StorySurface>
+    </ReducedMotionPreview>
+  ),
+};


### PR DESCRIPTION
## Summary
- add Storybook stories for ReviewEditor, ReviewList, and TimestampMarkers with default, loading, error, and reduced-motion scenarios
- highlight required callbacks and design-token spacing for QA while simulating loading and error treatments with Skeleton overlays and alerts
- seed local storage and chromatic parameters so visual-regression snapshots exercise reduced-motion and validation guidance reliably

## Testing
- VITEST_MAX_THREADS=1 VITEST_POOL=1 npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cf247fd0d0832cbe26ad9eb50fb83c