### PR TITLE
Align review spacing with spacing tokens

### DIFF
--- a/src/components/reviews/ReviewCard.tsx
+++ b/src/components/reviews/ReviewCard.tsx
@@ -33,7 +33,7 @@ export default function ReviewCard({
       aria-disabled={isDisabled ? true : undefined}
       aria-busy={isLoading ? true : undefined}
       className={cn(
-        "group rounded-card r-card-lg border border-border bg-card/85 p-3",
+        "group rounded-card r-card-lg border border-border bg-card/85 p-[var(--space-3)]",
         "transition-colors transition-shadow duration-200 focus-visible:outline-none",
         "shadow-neoSoft",
         "hover:border-ring/60 hover:bg-card hover:shadow-ring",
@@ -44,9 +44,9 @@ export default function ReviewCard({
         "data-[state=loading]:pointer-events-none data-[state=loading]:opacity-80 data-[state=loading]:shadow-outline-faint data-[state=loading]:cursor-progress",
       )}
     >
-      <div className="flex items-start gap-2">
+      <div className="flex items-start gap-[var(--space-2)]">
         <div className="min-w-0 flex-1">
-          <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center justify-between gap-[var(--space-2)]">
             <h3
               className={cn(
                 "truncate font-semibold transition-colors",
@@ -69,7 +69,7 @@ export default function ReviewCard({
             </IconButton>
           </div>
 
-          <div className="mt-1 text-ui text-muted-foreground grid grid-cols-2 gap-2">
+          <div className="mt-[var(--space-1)] text-ui text-muted-foreground grid grid-cols-2 gap-[var(--space-2)]">
             <span>Opponent: {review.opponent || "—"}</span>
             <span>Lane: {review.lane || "—"}</span>
             <span>Side: {review.side || "—"}</span>
@@ -79,7 +79,7 @@ export default function ReviewCard({
           </div>
 
           {Array.isArray(review.tags) && review.tags.length > 0 && (
-            <div className="mt-2 flex flex-wrap gap-2">
+            <div className="mt-[var(--space-2)] flex flex-wrap gap-[var(--space-2)]">
               {review.tags.slice(0, 6).map((t) => (
                 <Badge key={t} size="xs" tone="accent">
                   {t}

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -168,9 +168,9 @@ export default function ReviewEditor({
       className={cn("transition-none shadow-none", className)}
     >
       <div className="section-h sticky">
-        <div className="grid w-full grid-cols-[1fr_auto] items-center gap-4">
+        <div className="grid w-full grid-cols-[1fr_auto] items-center gap-[var(--space-4)]">
           <div className="min-w-0">
-            <div className="mb-2">
+            <div className="mb-[var(--space-2)]">
               <SectionLabel id={laneLabelId}>Lane</SectionLabel>
               <RoleSelector
                 value={role}
@@ -189,7 +189,7 @@ export default function ReviewEditor({
             />
           </div>
 
-          <div className="ml-2 flex shrink-0 items-center justify-end gap-2 self-start">
+          <div className="ml-[var(--space-2)] flex shrink-0 items-center justify-end gap-[var(--space-2)] self-start">
             {onDelete ? (
               <IconButton
                 aria-label="Delete review"
@@ -222,7 +222,7 @@ export default function ReviewEditor({
         </div>
       </div>
 
-      <div className="section-b ds-card-pad space-y-6">
+      <div className="section-b ds-card-pad space-y-[var(--space-6)]">
         <ResultScoreSection
           ref={resultScoreRef}
           result={review.result ?? "Win"}
@@ -235,7 +235,7 @@ export default function ReviewEditor({
 
         {/* Focus */}
         <div>
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-[var(--space-3)]">
             <button
               type="button"
               aria-label={focusOn ? "Brain light on" : "Brain light off"}
@@ -263,7 +263,7 @@ export default function ReviewEditor({
           {focusOn && (
             <>
               <ReviewSurface
-                className="mt-3 relative h-12"
+                className="mt-[var(--space-3)] relative h-[var(--space-7)]"
                 padding="inline"
                 focusWithin
               >
@@ -288,8 +288,8 @@ export default function ReviewEditor({
                   variant="input"
                 />
               </ReviewSurface>
-              <div className="mt-1 flex items-center gap-2 text-ui text-muted-foreground">
-                <span className="pill h-6 px-2 text-ui">{focus}/10</span>
+              <div className="mt-[var(--space-1)] flex items-center gap-[var(--space-2)] text-ui text-muted-foreground">
+                <span className="pill h-[var(--space-5)] px-[var(--space-2)] text-ui">{focus}/10</span>
                 <span>{focusMsg}</span>
               </div>
             </>
@@ -311,15 +311,15 @@ export default function ReviewEditor({
         {/* Tags */}
         <div>
           <SectionLabel id={tagsLabelId}>Tags</SectionLabel>
-          <div className="mt-1 flex items-center gap-2">
+          <div className="mt-[var(--space-1)] flex items-center gap-[var(--space-2)]">
             <div className="relative flex-1">
-              <Tag className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+              <Tag className="pointer-events-none absolute left-[var(--space-4)] top-1/2 size-[var(--space-4)] -translate-y-1/2 text-muted-foreground" />
               <Input
                 name="tag-input"
                 value={draftTag}
                 onChange={(e) => setDraftTag(e.target.value)}
                 placeholder="Add tag and press Enter"
-                className="pl-6"
+                className="pl-[var(--space-6)]"
                 aria-labelledby={tagsLabelId}
                 onKeyDown={(e) => {
                   if (e.key === "Enter") {
@@ -347,16 +347,16 @@ export default function ReviewEditor({
           </div>
 
           {tags.length === 0 ? (
-            <div className="mt-2 text-ui text-muted-foreground/80">
+            <div className="mt-[var(--space-2)] text-ui text-muted-foreground/80">
               No tags yet.
             </div>
           ) : (
-            <div className="mt-2 flex flex-wrap items-center gap-2">
+            <div className="mt-[var(--space-2)] flex flex-wrap items-center gap-[var(--space-2)]">
               {tags.map((t) => (
                 <button
                   key={t}
                   type="button"
-                  className="chip h-[var(--control-h-lg)] px-4 text-ui group inline-flex items-center gap-1"
+                  className="chip h-[var(--control-h-lg)] px-[var(--space-4)] text-ui group inline-flex items-center gap-[var(--space-1)]"
                   title="Remove tag"
                   onClick={() => removeTag(t)}
                 >

--- a/src/components/reviews/ReviewList.tsx
+++ b/src/components/reviews/ReviewList.tsx
@@ -31,8 +31,8 @@ export default function ReviewList({
   if (count === 0) {
     return (
       <Card className={containerClass}>
-        <div className="flex flex-col items-center justify-center gap-3 p-6 text-ui text-muted-foreground">
-          <Tv className="h-6 w-6 opacity-60" />
+        <div className="flex flex-col items-center justify-center gap-[var(--space-3)] p-[var(--space-6)] text-ui text-muted-foreground">
+          <Tv className="size-[var(--space-5)] opacity-60" />
           <p>No reviews yet</p>
           <Button variant="primary" onClick={onCreate}>
             New Review
@@ -44,7 +44,7 @@ export default function ReviewList({
 
   return (
     <Card className={containerClass}>
-      <ul className="flex flex-col gap-3">
+      <ul className="flex flex-col gap-[var(--space-3)]">
         {reviews.map((r) => (
           <li key={r.id}>
             <ReviewListItem

--- a/src/components/reviews/TimestampMarkers.tsx
+++ b/src/components/reviews/TimestampMarkers.tsx
@@ -121,7 +121,7 @@ function TimestampMarkers(
   return (
     <div>
       <SectionLabel>Timestamps</SectionLabel>
-      <div className="mt-1 flex items-center gap-2">
+      <div className="mt-[var(--space-1)] flex items-center gap-[var(--space-2)]">
         <button
           type="button"
           aria-label="Use timestamp"
@@ -165,8 +165,8 @@ function TimestampMarkers(
         </button>
       </div>
 
-      <div className="mt-3 grid gap-2">
-        <div className="grid grid-cols-[auto_1fr_auto] items-center gap-2">
+      <div className="mt-[var(--space-3)] grid gap-[var(--space-2)]">
+        <div className="grid grid-cols-[auto_1fr_auto] items-center gap-[var(--space-2)]">
           {useTimestamp ? (
             <Input
               ref={timeRef}
@@ -194,7 +194,7 @@ function TimestampMarkers(
               }}
             />
           ) : (
-            <span className="pill h-7 w-16 px-0 flex items-center justify-center">
+            <span className="pill flex h-[calc(var(--space-6) - var(--space-1))] w-[var(--space-8)] items-center justify-center px-0">
               <FileText aria-hidden className="icon-xs opacity-80" />
             </span>
           )}
@@ -229,26 +229,26 @@ function TimestampMarkers(
           </IconButton>
         </div>
         {timeError && (
-          <p id="tTime-error" className="mt-1 text-ui text-danger">
+          <p id="tTime-error" className="mt-[var(--space-1)] text-ui text-danger">
             Enter time as mm:ss
           </p>
         )}
 
         {sortedMarkers.length === 0 ? (
-          <div className="mt-2 text-ui text-muted-foreground">No timestamps yet.</div>
+          <div className="mt-[var(--space-2)] text-ui text-muted-foreground">No timestamps yet.</div>
         ) : (
-          <ul className="mt-3 space-y-2">
+          <ul className="mt-[var(--space-3)] space-y-[var(--space-2)]">
             {sortedMarkers.map((m) => (
               <li
                 key={m.id}
-                className="grid grid-cols-[auto_1fr_auto] items-center gap-2 rounded-card r-card-lg border border-border bg-card px-3 py-2"
+                className="grid grid-cols-[auto_1fr_auto] items-center gap-[var(--space-2)] rounded-card r-card-lg border border-border bg-card px-[var(--space-3)] py-[var(--space-2)]"
               >
                 {m.noteOnly ? (
-                  <span className="pill h-7 w-16 px-0 flex items-center justify-center">
+                  <span className="pill flex h-[calc(var(--space-6) - var(--space-1))] w-[var(--space-8)] items-center justify-center px-0">
                     <FileText aria-hidden className="icon-xs opacity-80" />
                   </span>
                 ) : (
-                  <span className="pill h-7 w-16 px-3 text-ui font-mono tabular-nums text-center">{m.time}</span>
+                  <span className="pill h-[calc(var(--space-6) - var(--space-1))] w-[var(--space-8)] px-[var(--space-3)] text-ui font-mono tabular-nums text-center">{m.time}</span>
                 )}
 
                 <span className="truncate text-ui">{m.note}</span>

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -9,13 +9,13 @@ exports[`ReviewEditor > renders default state 1`] = `
       class="section-h sticky"
     >
       <div
-        class="grid w-full grid-cols-[1fr_auto] items-center gap-4"
+        class="grid w-full grid-cols-[1fr_auto] items-center gap-[var(--space-4)]"
       >
         <div
           class="min-w-0"
         >
           <div
-            class="mb-2"
+            class="mb-[var(--space-2)]"
           >
             <div
               class="mb-2 flex items-center gap-2"
@@ -397,12 +397,12 @@ exports[`ReviewEditor > renders default state 1`] = `
           </div>
         </div>
         <div
-          class="ml-2 flex shrink-0 items-center justify-end gap-2 self-start"
+          class="ml-[var(--space-2)] flex shrink-0 items-center justify-end gap-[var(--space-2)] self-start"
         />
       </div>
     </div>
     <div
-      class="section-b ds-card-pad space-y-6"
+      class="section-b ds-card-pad space-y-[var(--space-6)]"
     >
       <div>
         <div
@@ -543,7 +543,7 @@ exports[`ReviewEditor > renders default state 1`] = `
       </div>
       <div>
         <div
-          class="flex items-center gap-3"
+          class="flex items-center gap-[var(--space-3)]"
         >
           <button
             aria-label="Brain light off"
@@ -1592,7 +1592,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           />
         </div>
         <div
-          class="mt-1 flex items-center gap-2"
+          class="mt-[var(--space-1)] flex items-center gap-[var(--space-2)]"
         >
           <button
             aria-label="Use timestamp"
@@ -1957,10 +1957,10 @@ exports[`ReviewEditor > renders default state 1`] = `
           </button>
         </div>
         <div
-          class="mt-3 grid gap-2"
+          class="mt-[var(--space-3)] grid gap-[var(--space-2)]"
         >
           <div
-            class="grid grid-cols-[auto_1fr_auto] items-center gap-2"
+            class="grid grid-cols-[auto_1fr_auto] items-center gap-[var(--space-2)]"
           >
             <div
               class="flex w-full flex-col gap-[var(--space-1)]"
@@ -2034,13 +2034,13 @@ exports[`ReviewEditor > renders default state 1`] = `
             </button>
           </div>
           <p
-            class="mt-1 text-ui text-danger"
+            class="mt-[var(--space-1)] text-ui text-danger"
             id="tTime-error"
           >
             Enter time as mm:ss
           </p>
           <div
-            class="mt-2 text-ui text-muted-foreground"
+            class="mt-[var(--space-2)] text-ui text-muted-foreground"
           >
             No timestamps yet.
           </div>
@@ -2061,14 +2061,14 @@ exports[`ReviewEditor > renders default state 1`] = `
           />
         </div>
         <div
-          class="mt-1 flex items-center gap-2"
+          class="mt-[var(--space-1)] flex items-center gap-[var(--space-2)]"
         >
           <div
             class="relative flex-1"
           >
             <svg
               aria-hidden="true"
-              class="lucide lucide-tag pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+              class="lucide lucide-tag pointer-events-none absolute left-[var(--space-4)] top-1/2 size-[var(--space-4)] -translate-y-1/2 text-muted-foreground"
               fill="none"
               height="24"
               stroke="currentColor"
@@ -2093,7 +2093,7 @@ exports[`ReviewEditor > renders default state 1`] = `
               class="flex w-full flex-col gap-[var(--space-1)]"
             >
               <div
-                class="group/field relative inline-flex min-h-[var(--field-h,var(--control-h-md))] w-full items-center rounded-[var(--control-radius)] border border-[hsl(var(--card-hairline)/0.65)] bg-[hsl(var(--bg))] text-foreground shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.08),inset_0_calc(var(--hairline-w)*-1)_0_hsl(var(--border)/0.32)] transition-[background,box-shadow,filter] duration-[var(--dur-quick)] ease-out focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] focus-within:ring-offset-0 focus-within:ring-offset-[hsl(var(--bg))] hover:shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.12),inset_0_calc(var(--hairline-w)*-1)_0_hsl(var(--border)/0.45)] active:brightness-[0.96] data-[disabled=true]:pointer-events-none data-[disabled=true]:border-[hsl(var(--card-hairline)/0.4)] data-[disabled=true]:bg-[hsl(var(--card))] data-[disabled=true]:shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.04)] data-[disabled=true]:text-muted-foreground/70 data-[loading=true]:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[invalid=true]:border-[hsl(var(--danger)/0.6)] data-[invalid=true]:focus-within:ring-[hsl(var(--danger))] overflow-hidden pl-6"
+                class="group/field relative inline-flex min-h-[var(--field-h,var(--control-h-md))] w-full items-center rounded-[var(--control-radius)] border border-[hsl(var(--card-hairline)/0.65)] bg-[hsl(var(--bg))] text-foreground shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.08),inset_0_calc(var(--hairline-w)*-1)_0_hsl(var(--border)/0.32)] transition-[background,box-shadow,filter] duration-[var(--dur-quick)] ease-out focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] focus-within:ring-offset-0 focus-within:ring-offset-[hsl(var(--bg))] hover:shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.12),inset_0_calc(var(--hairline-w)*-1)_0_hsl(var(--border)/0.45)] active:brightness-[0.96] data-[disabled=true]:pointer-events-none data-[disabled=true]:border-[hsl(var(--card-hairline)/0.4)] data-[disabled=true]:bg-[hsl(var(--card))] data-[disabled=true]:shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.04)] data-[disabled=true]:text-muted-foreground/70 data-[loading=true]:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[invalid=true]:border-[hsl(var(--danger)/0.6)] data-[invalid=true]:focus-within:ring-[hsl(var(--danger))] overflow-hidden pl-[var(--space-6)]"
                 style="--field-h: var(--control-h-md);"
               >
                 <input
@@ -2138,7 +2138,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           </button>
         </div>
         <div
-          class="mt-2 text-ui text-muted-foreground/80"
+          class="mt-[var(--space-2)] text-ui text-muted-foreground/80"
         >
           No tags yet.
         </div>

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -408,7 +408,7 @@ exports[`ReviewsPage > renders default state 1`] = `
               class="rounded-card r-card-lg border border-border/25 bg-card/60 text-card-foreground shadow-outline-subtle w-full mx-auto backdrop-blur-sm h-auto overflow-auto p-[var(--space-2)] md:h-[calc(100vh-var(--header-stack)-var(--space-6))]"
             >
               <ul
-                class="flex flex-col gap-3"
+                class="flex flex-col gap-[var(--space-3)]"
               >
                 <li>
                   <button


### PR DESCRIPTION
## Summary
- replace review card, list, and editor layout spacing utilities with the shared `var(--space-*)` token classes
- update review editor focus, tag rail, and timestamp marker layouts to use semantic spacing and icon sizes
- refresh review snapshots to capture the new spacing tokens and alignment

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cf23bcbe9c832cb2cb85ea42909934