### PR TITLE
Align glitch segmented radius with control tokens

### DIFF
--- a/src/components/ui/primitives/GlitchSegmented.tsx
+++ b/src/components/ui/primitives/GlitchSegmented.tsx
@@ -71,7 +71,7 @@ export const GlitchSegmentedGroup = ({
       aria-label={ariaLabelledby ? undefined : ariaLabel}
       aria-labelledby={ariaLabelledby}
       className={cn(
-        "inline-flex rounded-[var(--radius-full)] bg-[var(--btn-bg)] p-[var(--space-1)] gap-[var(--space-1)]",
+        "inline-flex rounded-[var(--control-radius)] bg-[var(--btn-bg)] p-[var(--space-1)] gap-[var(--space-1)]",
         "[--hover:hsl(var(--foreground)/0.08)] [--focus:hsl(var(--ring))] [--active:hsl(var(--foreground)/0.12)] [--disabled:0.5]",
         className,
       )}
@@ -115,7 +115,7 @@ export const GlitchSegmentedButton = React.forwardRef<
       className={cn(
         styles.glitchScanlines,
         "flex-1 h-[var(--control-h-sm)] px-[var(--space-3)] inline-flex items-center justify-center gap-[var(--space-2)] text-ui font-medium select-none",
-        "rounded-[var(--radius-full)] transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)]",
+        "rounded-[var(--control-radius)] transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)]",
         "bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active]",
         "motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft",
         "motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none",

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -47,13 +47,13 @@ exports[`ReviewEditor > renders default state 1`] = `
               />
               <div
                 aria-labelledby=":r0:"
-                class="inline-flex rounded-[var(--radius-full)] gap-[var(--space-1)] [--hover:hsl(var(--foreground)/0.08)] [--focus:hsl(var(--ring))] [--active:hsl(var(--foreground)/0.12)] [--disabled:0.5] relative w-full bg-transparent p-0"
+                class="inline-flex rounded-[var(--control-radius)] gap-[var(--space-1)] [--hover:hsl(var(--foreground)/0.08)] [--focus:hsl(var(--ring))] [--active:hsl(var(--foreground)/0.12)] [--disabled:0.5] relative w-full bg-transparent p-0"
                 role="tablist"
               >
                 <button
                   aria-controls="top-panel"
                   aria-selected="false"
-                  class="_glitchScanlines_ff763a flex-1 h-[var(--control-h-sm)] px-[var(--space-3)] inline-flex items-center justify-center gap-[var(--space-2)] text-ui font-medium select-none rounded-[var(--radius-full)] transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none"
+                  class="_glitchScanlines_ff763a flex-1 h-[var(--control-h-sm)] px-[var(--space-3)] inline-flex items-center justify-center gap-[var(--space-2)] text-ui font-medium select-none rounded-[var(--control-radius)] transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none"
                   id="top-tab"
                   role="tab"
                   tabindex="-1"
@@ -90,7 +90,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 <button
                   aria-controls="jungle-panel"
                   aria-selected="false"
-                  class="_glitchScanlines_ff763a flex-1 h-[var(--control-h-sm)] px-[var(--space-3)] inline-flex items-center justify-center gap-[var(--space-2)] text-ui font-medium select-none rounded-[var(--radius-full)] transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none"
+                  class="_glitchScanlines_ff763a flex-1 h-[var(--control-h-sm)] px-[var(--space-3)] inline-flex items-center justify-center gap-[var(--space-2)] text-ui font-medium select-none rounded-[var(--control-radius)] transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none"
                   id="jungle-tab"
                   role="tab"
                   tabindex="-1"
@@ -132,7 +132,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 <button
                   aria-controls="mid-panel"
                   aria-selected="true"
-                  class="_glitchScanlines_ff763a flex-1 h-[var(--control-h-sm)] px-[var(--space-3)] inline-flex items-center justify-center gap-[var(--space-2)] text-ui font-medium select-none rounded-[var(--radius-full)] transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none"
+                  class="_glitchScanlines_ff763a flex-1 h-[var(--control-h-sm)] px-[var(--space-3)] inline-flex items-center justify-center gap-[var(--space-2)] text-ui font-medium select-none rounded-[var(--control-radius)] transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none"
                   data-selected="true"
                   id="mid-tab"
                   role="tab"
@@ -182,7 +182,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 <button
                   aria-controls="bot-panel"
                   aria-selected="false"
-                  class="_glitchScanlines_ff763a flex-1 h-[var(--control-h-sm)] px-[var(--space-3)] inline-flex items-center justify-center gap-[var(--space-2)] text-ui font-medium select-none rounded-[var(--radius-full)] transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none"
+                  class="_glitchScanlines_ff763a flex-1 h-[var(--control-h-sm)] px-[var(--space-3)] inline-flex items-center justify-center gap-[var(--space-2)] text-ui font-medium select-none rounded-[var(--control-radius)] transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none"
                   id="bot-tab"
                   role="tab"
                   tabindex="-1"
@@ -245,7 +245,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 <button
                   aria-controls="support-panel"
                   aria-selected="false"
-                  class="_glitchScanlines_ff763a flex-1 h-[var(--control-h-sm)] px-[var(--space-3)] inline-flex items-center justify-center gap-[var(--space-2)] text-ui font-medium select-none rounded-[var(--radius-full)] transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none"
+                  class="_glitchScanlines_ff763a flex-1 h-[var(--control-h-sm)] px-[var(--space-3)] inline-flex items-center justify-center gap-[var(--space-2)] text-ui font-medium select-none rounded-[var(--control-radius)] transition focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] bg-[var(--btn-bg)] text-[var(--btn-fg)] hover:bg-[--hover] active:bg-[--active] motion-safe:hover:-translate-y-px motion-safe:hover:shadow-neon-soft motion-safe:active:shadow-neon-soft motion-safe:active:scale-95 motion-reduce:transform-none data-[selected=true]:shadow-neon-strong data-[selected=true]:ring-1 data-[selected=true]:ring-[var(--neon-soft)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none"
                   id="support-tab"
                   role="tab"
                   tabindex="-1"


### PR DESCRIPTION
## Summary
- align the glitch segmented group and button primitives to use the shared control radius token
- refresh the ReviewEditor snapshot to capture the updated segmented silhouette

## Testing
- npm run build-gallery-usage
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfc8aadaf4832c9e0aa2e982dab042