### PR TITLE
Use spacing token for timer ring glow

### DIFF
--- a/src/icons/TimerRingIcon.tsx
+++ b/src/icons/TimerRingIcon.tsx
@@ -53,7 +53,7 @@ export default function TimerRingIcon({
         strokeDasharray={circumference}
         strokeDashoffset={offset}
         className={cn(
-          "drop-shadow-[0_0_6px_hsl(var(--neon-soft))] transition-[stroke-dashoffset] duration-[var(--dur-quick)] ease-linear motion-reduce:transition-none",
+          "drop-shadow-[0_0_calc(var(--space-3)/2)_hsl(var(--neon-soft))] transition-[stroke-dashoffset] duration-[var(--dur-quick)] ease-linear motion-reduce:transition-none",
           pulse && "motion-safe:animate-pulse motion-reduce:animate-none",
         )}
         fill="none"


### PR DESCRIPTION
## Summary
- align the timer ring icon's drop shadow blur with the spacing token scale so it follows design guidance

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfca9a8b68832c9fa656f9d25ea295