### PR TITLE
Refine review editor spacing tokens

### DIFF
--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -13,6 +13,7 @@ import type { Review, Role } from "@/lib/types";
 import Input from "@/components/ui/primitives/Input";
 import Textarea from "@/components/ui/primitives/Textarea";
 import IconButton from "@/components/ui/primitives/IconButton";
+import Badge from "@/components/ui/primitives/Badge";
 import { Tag, Trash2, Check, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePersistentState } from "@/lib/db";
@@ -154,13 +155,6 @@ export default function ReviewEditor({
     commitMeta({ role: v });
   }
 
-  function onIconKey(e: React.KeyboardEvent, handler: () => void) {
-    if (e.key === " " || e.key === "Enter") {
-      e.preventDefault();
-      handler();
-    }
-  }
-
   return (
     <SectionCard
       ref={rootRef}
@@ -236,28 +230,21 @@ export default function ReviewEditor({
         {/* Focus */}
         <div>
           <div className="flex items-center gap-[var(--space-3)]">
-            <button
-              type="button"
+            <IconButton
               aria-label={focusOn ? "Brain light on" : "Brain light off"}
+              title={focusOn ? "Brain light on" : "Brain light off"}
               aria-pressed={focusOn}
-              className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              size="xl"
+              variant="ghost"
               onClick={() => {
                 const v = !focusOn;
                 setFocusOn(v);
                 commitMeta({ focusOn: v });
                 if (v) focusRangeRef.current?.focus();
               }}
-              onKeyDown={(e) =>
-                onIconKey(e, () => {
-                  const v = !focusOn;
-                  setFocusOn(v);
-                  commitMeta({ focusOn: v });
-                  if (v) focusRangeRef.current?.focus();
-                })
-              }
             >
               <NeonIcon kind="brain" on={focusOn} size="xl" />
-            </button>
+            </IconButton>
           </div>
 
           {focusOn && (
@@ -289,7 +276,9 @@ export default function ReviewEditor({
                 />
               </ReviewSurface>
               <div className="mt-[var(--space-1)] flex items-center gap-[var(--space-2)] text-ui text-muted-foreground">
-                <span className="pill h-[var(--space-5)] px-[var(--space-2)] text-ui">{focus}/10</span>
+                <Badge size="xs" tone="accent" className="font-mono tabular-nums">
+                  {focus}/10
+                </Badge>
                 <span>{focusMsg}</span>
               </div>
             </>
@@ -313,7 +302,7 @@ export default function ReviewEditor({
           <SectionLabel id={tagsLabelId}>Tags</SectionLabel>
           <div className="mt-[var(--space-1)] flex items-center gap-[var(--space-2)]">
             <div className="relative flex-1">
-              <Tag className="pointer-events-none absolute left-[var(--space-4)] top-1/2 size-[var(--space-4)] -translate-y-1/2 text-muted-foreground" />
+              <Tag className="pointer-events-none absolute left-[var(--space-4)] top-1/2 size-[var(--icon-size-sm)] -translate-y-1/2 text-muted-foreground" />
               <Input
                 name="tag-input"
                 value={draftTag}
@@ -353,18 +342,24 @@ export default function ReviewEditor({
           ) : (
             <div className="mt-[var(--space-2)] flex flex-wrap items-center gap-[var(--space-2)]">
               {tags.map((t) => (
-                <button
+                <Badge
                   key={t}
-                  type="button"
-                  className="chip h-[var(--control-h-lg)] px-[var(--space-4)] text-ui group inline-flex items-center gap-[var(--space-1)]"
+                  size="sm"
+                  tone="accent"
+                  interactive
+                  className="group"
+                  aria-label={`Remove tag ${t}`}
                   title="Remove tag"
                   onClick={() => removeTag(t)}
                 >
                   <span>#{t}</span>
-                  <span className="opacity-0 transition-opacity group-hover:opacity-100">
+                  <span
+                    aria-hidden
+                    className="opacity-0 transition-opacity duration-200 ease-out group-hover:opacity-100 group-focus-visible:opacity-100"
+                  >
                     ✕
                   </span>
-                </button>
+                </Badge>
               ))}
             </div>
           )}

--- a/src/components/reviews/ReviewList.tsx
+++ b/src/components/reviews/ReviewList.tsx
@@ -31,8 +31,8 @@ export default function ReviewList({
   if (count === 0) {
     return (
       <Card className={containerClass}>
-        <div className="flex flex-col items-center justify-center gap-[var(--space-3)] p-[var(--space-6)] text-ui text-muted-foreground">
-          <Tv className="size-[var(--space-5)] opacity-60" />
+        <div className="ds-card-pad flex flex-col items-center justify-center gap-[var(--space-3)] text-ui text-muted-foreground">
+          <Tv className="size-[var(--icon-size-lg)] opacity-60" />
           <p>No reviews yet</p>
           <Button variant="primary" onClick={onCreate}>
             New Review

--- a/src/components/reviews/TimestampMarkers.tsx
+++ b/src/components/reviews/TimestampMarkers.tsx
@@ -3,6 +3,7 @@ import SectionLabel from "@/components/reviews/SectionLabel";
 import NeonIcon from "@/components/reviews/NeonIcon";
 import Input from "@/components/ui/primitives/Input";
 import IconButton from "@/components/ui/primitives/IconButton";
+import Badge from "@/components/ui/primitives/Badge";
 import { Plus, FileText, Trash2 } from "lucide-react";
 import { uid, usePersistentState } from "@/lib/db";
 import { formatMmSs, parseMmSs } from "@/lib/date";
@@ -122,11 +123,12 @@ function TimestampMarkers(
     <div>
       <SectionLabel>Timestamps</SectionLabel>
       <div className="mt-[var(--space-1)] flex items-center gap-[var(--space-2)]">
-        <button
-          type="button"
+        <IconButton
           aria-label="Use timestamp"
+          title="Timestamp mode"
           aria-pressed={useTimestamp}
-          className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          size="xl"
+          variant="ghost"
           onClick={() => {
             setUseTimestamp(true);
             setLastMarkerMode(true);
@@ -139,16 +141,16 @@ function TimestampMarkers(
               setTTime(lastMarkerTime);
             })
           }
-          title="Timestamp mode"
         >
           <NeonIcon kind="clock" on={useTimestamp} size="xl" />
-        </button>
+        </IconButton>
 
-        <button
-          type="button"
+        <IconButton
           aria-label="Use note only"
+          title="Note-only mode"
           aria-pressed={!useTimestamp}
-          className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          size="xl"
+          variant="ghost"
           onClick={() => {
             setUseTimestamp(false);
             setLastMarkerMode(false);
@@ -159,10 +161,9 @@ function TimestampMarkers(
               setLastMarkerMode(false);
             })
           }
-          title="Note-only mode"
         >
           <NeonIcon kind="file" on={!useTimestamp} size="xl" />
-        </button>
+        </IconButton>
       </div>
 
       <div className="mt-[var(--space-3)] grid gap-[var(--space-2)]">
@@ -194,9 +195,14 @@ function TimestampMarkers(
               }}
             />
           ) : (
-            <span className="pill flex h-[calc(var(--space-6) - var(--space-1))] w-[var(--space-8)] items-center justify-center px-0">
+            <Badge
+              size="sm"
+              className="flex items-center justify-center"
+              style={{ minWidth: "var(--space-8)" }}
+              aria-hidden
+            >
               <FileText aria-hidden className="icon-xs opacity-80" />
-            </span>
+            </Badge>
           )}
 
           <Input
@@ -244,11 +250,22 @@ function TimestampMarkers(
                 className="grid grid-cols-[auto_1fr_auto] items-center gap-[var(--space-2)] rounded-card r-card-lg border border-border bg-card px-[var(--space-3)] py-[var(--space-2)]"
               >
                 {m.noteOnly ? (
-                  <span className="pill flex h-[calc(var(--space-6) - var(--space-1))] w-[var(--space-8)] items-center justify-center px-0">
+                  <Badge
+                    size="sm"
+                    className="flex items-center justify-center"
+                    style={{ minWidth: "var(--space-8)" }}
+                    aria-hidden
+                  >
                     <FileText aria-hidden className="icon-xs opacity-80" />
-                  </span>
+                  </Badge>
                 ) : (
-                  <span className="pill h-[calc(var(--space-6) - var(--space-1))] w-[var(--space-8)] px-[var(--space-3)] text-ui font-mono tabular-nums text-center">{m.time}</span>
+                  <Badge
+                    size="sm"
+                    className="justify-center font-mono tabular-nums"
+                    style={{ minWidth: "var(--space-8)" }}
+                  >
+                    {m.time}
+                  </Badge>
                 )}
 
                 <span className="truncate text-ui">{m.note}</span>

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -548,7 +548,9 @@ exports[`ReviewEditor > renders default state 1`] = `
           <button
             aria-label="Brain light off"
             aria-pressed="false"
-            class="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            class="inline-flex items-center justify-center select-none rounded-[var(--radius-full)] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] border bg-card/35 hover:bg-[--hover] [--hover:theme('colors.interaction.foreground.tintHover')] [--active:theme('colors.interaction.foreground.tintActive')] border-line/35 text-foreground h-[var(--control-h-xl)] w-[var(--control-h-xl)] [&_svg]:size-[calc(var(--control-h-xl)/2)]"
+            tabindex="0"
+            title="Brain light off"
             type="button"
           >
             <span
@@ -1597,7 +1599,8 @@ exports[`ReviewEditor > renders default state 1`] = `
           <button
             aria-label="Use timestamp"
             aria-pressed="true"
-            class="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            class="inline-flex items-center justify-center select-none rounded-[var(--radius-full)] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] border bg-card/35 hover:bg-[--hover] [--hover:theme('colors.interaction.foreground.tintHover')] [--active:theme('colors.interaction.foreground.tintActive')] border-line/35 text-foreground h-[var(--control-h-xl)] w-[var(--control-h-xl)] [&_svg]:size-[calc(var(--control-h-xl)/2)]"
+            tabindex="0"
             title="Timestamp mode"
             type="button"
           >
@@ -1767,7 +1770,8 @@ exports[`ReviewEditor > renders default state 1`] = `
           <button
             aria-label="Use note only"
             aria-pressed="false"
-            class="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            class="inline-flex items-center justify-center select-none rounded-[var(--radius-full)] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] border bg-card/35 hover:bg-[--hover] [--hover:theme('colors.interaction.foreground.tintHover')] [--active:theme('colors.interaction.foreground.tintActive')] border-line/35 text-foreground h-[var(--control-h-xl)] w-[var(--control-h-xl)] [&_svg]:size-[calc(var(--control-h-xl)/2)]"
+            tabindex="0"
             title="Note-only mode"
             type="button"
           >
@@ -2068,7 +2072,7 @@ exports[`ReviewEditor > renders default state 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="lucide lucide-tag pointer-events-none absolute left-[var(--space-4)] top-1/2 size-[var(--space-4)] -translate-y-1/2 text-muted-foreground"
+              class="lucide lucide-tag pointer-events-none absolute left-[var(--space-4)] top-1/2 size-[var(--icon-size-sm)] -translate-y-1/2 text-muted-foreground"
               fill="none"
               height="24"
               stroke="currentColor"


### PR DESCRIPTION
## Summary
- update the review editor focus toggle and tags to use IconButton/Badge primitives with tokenized spacing
- align timestamp marker mode toggles and chips with shared primitives and spacing variables
- refresh the review list empty state padding to reuse ds-card-pad tokens and update the snapshot

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfca324318832c9560c08cb961eddd