### PR TITLE
Refine review editor token usage

### DIFF
--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -13,6 +13,7 @@ import type { Review, Role } from "@/lib/types";
 import Input from "@/components/ui/primitives/Input";
 import Textarea from "@/components/ui/primitives/Textarea";
 import IconButton from "@/components/ui/primitives/IconButton";
+import Badge from "@/components/ui/primitives/Badge";
 import { Tag, Trash2, Check, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePersistentState } from "@/lib/db";
@@ -154,13 +155,6 @@ export default function ReviewEditor({
     commitMeta({ role: v });
   }
 
-  function onIconKey(e: React.KeyboardEvent, handler: () => void) {
-    if (e.key === " " || e.key === "Enter") {
-      e.preventDefault();
-      handler();
-    }
-  }
-
   return (
     <SectionCard
       ref={rootRef}
@@ -236,28 +230,22 @@ export default function ReviewEditor({
         {/* Focus */}
         <div>
           <div className="flex items-center gap-[var(--space-3)]">
-            <button
-              type="button"
+            <IconButton
               aria-label={focusOn ? "Brain light on" : "Brain light off"}
+              title={focusOn ? "Brain light on" : "Brain light off"}
               aria-pressed={focusOn}
-              className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              size="xl"
+              variant="ghost"
+              tone="primary"
               onClick={() => {
                 const v = !focusOn;
                 setFocusOn(v);
                 commitMeta({ focusOn: v });
                 if (v) focusRangeRef.current?.focus();
               }}
-              onKeyDown={(e) =>
-                onIconKey(e, () => {
-                  const v = !focusOn;
-                  setFocusOn(v);
-                  commitMeta({ focusOn: v });
-                  if (v) focusRangeRef.current?.focus();
-                })
-              }
             >
               <NeonIcon kind="brain" on={focusOn} size="xl" />
-            </button>
+            </IconButton>
           </div>
 
           {focusOn && (
@@ -289,7 +277,9 @@ export default function ReviewEditor({
                 />
               </ReviewSurface>
               <div className="mt-[var(--space-1)] flex items-center gap-[var(--space-2)] text-ui text-muted-foreground">
-                <span className="pill h-[var(--space-5)] px-[var(--space-2)] text-ui">{focus}/10</span>
+                <Badge as="span" size="sm" className="font-mono tabular-nums text-ui">
+                  {focus}/10
+                </Badge>
                 <span>{focusMsg}</span>
               </div>
             </>
@@ -353,10 +343,10 @@ export default function ReviewEditor({
           ) : (
             <div className="mt-[var(--space-2)] flex flex-wrap items-center gap-[var(--space-2)]">
               {tags.map((t) => (
-                <button
+                <Badge
                   key={t}
-                  type="button"
-                  className="chip h-[var(--control-h-lg)] px-[var(--space-4)] text-ui group inline-flex items-center gap-[var(--space-1)]"
+                  interactive
+                  className="group text-ui"
                   title="Remove tag"
                   onClick={() => removeTag(t)}
                 >
@@ -364,7 +354,7 @@ export default function ReviewEditor({
                   <span className="opacity-0 transition-opacity group-hover:opacity-100">
                     ✕
                   </span>
-                </button>
+                </Badge>
               ))}
             </div>
           )}

--- a/src/components/reviews/ReviewList.tsx
+++ b/src/components/reviews/ReviewList.tsx
@@ -31,7 +31,7 @@ export default function ReviewList({
   if (count === 0) {
     return (
       <Card className={containerClass}>
-        <div className="flex flex-col items-center justify-center gap-[var(--space-3)] p-[var(--space-6)] text-ui text-muted-foreground">
+        <div className="ds-card-pad flex flex-col items-center justify-center gap-[var(--space-3)] text-center text-ui text-muted-foreground">
           <Tv className="size-[var(--space-5)] opacity-60" />
           <p>No reviews yet</p>
           <Button variant="primary" onClick={onCreate}>

--- a/src/components/reviews/TimestampMarkers.tsx
+++ b/src/components/reviews/TimestampMarkers.tsx
@@ -3,6 +3,7 @@ import SectionLabel from "@/components/reviews/SectionLabel";
 import NeonIcon from "@/components/reviews/NeonIcon";
 import Input from "@/components/ui/primitives/Input";
 import IconButton from "@/components/ui/primitives/IconButton";
+import Badge from "@/components/ui/primitives/Badge";
 import { Plus, FileText, Trash2 } from "lucide-react";
 import { uid, usePersistentState } from "@/lib/db";
 import { formatMmSs, parseMmSs } from "@/lib/date";
@@ -11,6 +12,7 @@ import {
   LAST_MARKER_MODE_KEY,
   LAST_MARKER_TIME_KEY,
 } from "@/components/reviews/reviewData";
+import ReviewSurface from "./ReviewSurface";
 
 export type TimestampMarkersHandle = {
   save: () => void;
@@ -71,13 +73,6 @@ function TimestampMarkers(
     [markers],
   );
 
-  function onIconKey(e: React.KeyboardEvent, handler: () => void) {
-    if (e.key === " " || e.key === "Enter") {
-      e.preventDefault();
-      handler();
-    }
-  }
-
   const addMarker = React.useCallback(() => {
     const s = useTimestamp ? parsedTime : 0;
     const safeS = s === null ? 0 : s;
@@ -122,47 +117,36 @@ function TimestampMarkers(
     <div>
       <SectionLabel>Timestamps</SectionLabel>
       <div className="mt-[var(--space-1)] flex items-center gap-[var(--space-2)]">
-        <button
-          type="button"
+        <IconButton
           aria-label="Use timestamp"
+          title="Timestamp mode"
           aria-pressed={useTimestamp}
-          className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          size="xl"
+          variant="ghost"
+          tone="primary"
           onClick={() => {
             setUseTimestamp(true);
             setLastMarkerMode(true);
             setTTime(lastMarkerTime);
           }}
-          onKeyDown={(e) =>
-            onIconKey(e, () => {
-              setUseTimestamp(true);
-              setLastMarkerMode(true);
-              setTTime(lastMarkerTime);
-            })
-          }
-          title="Timestamp mode"
         >
           <NeonIcon kind="clock" on={useTimestamp} size="xl" />
-        </button>
+        </IconButton>
 
-        <button
-          type="button"
+        <IconButton
           aria-label="Use note only"
+          title="Note-only mode"
           aria-pressed={!useTimestamp}
-          className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          size="xl"
+          variant="ghost"
+          tone="accent"
           onClick={() => {
             setUseTimestamp(false);
             setLastMarkerMode(false);
           }}
-          onKeyDown={(e) =>
-            onIconKey(e, () => {
-              setUseTimestamp(false);
-              setLastMarkerMode(false);
-            })
-          }
-          title="Note-only mode"
         >
           <NeonIcon kind="file" on={!useTimestamp} size="xl" />
-        </button>
+        </IconButton>
       </div>
 
       <div className="mt-[var(--space-3)] grid gap-[var(--space-2)]">
@@ -194,9 +178,13 @@ function TimestampMarkers(
               }}
             />
           ) : (
-            <span className="pill flex h-[calc(var(--space-6) - var(--space-1))] w-[var(--space-8)] items-center justify-center px-0">
+            <Badge
+              as="span"
+              size="sm"
+              className="min-w-[var(--space-8)] justify-center text-ui"
+            >
               <FileText aria-hidden className="icon-xs opacity-80" />
-            </span>
+            </Badge>
           )}
 
           <Input
@@ -223,7 +211,6 @@ function TimestampMarkers(
             variant="primary"
             disabled={!canAddMarker}
             onClick={addMarker}
-            onKeyDown={(e) => onIconKey(e, addMarker)}
           >
             <Plus />
           </IconButton>
@@ -239,16 +226,28 @@ function TimestampMarkers(
         ) : (
           <ul className="mt-[var(--space-3)] space-y-[var(--space-2)]">
             {sortedMarkers.map((m) => (
-              <li
+              <ReviewSurface
+                as="li"
                 key={m.id}
-                className="grid grid-cols-[auto_1fr_auto] items-center gap-[var(--space-2)] rounded-card r-card-lg border border-border bg-card px-[var(--space-3)] py-[var(--space-2)]"
+                padding="sm"
+                className="grid grid-cols-[auto_1fr_auto] items-center gap-[var(--space-2)]"
               >
                 {m.noteOnly ? (
-                  <span className="pill flex h-[calc(var(--space-6) - var(--space-1))] w-[var(--space-8)] items-center justify-center px-0">
+                  <Badge
+                    as="span"
+                    size="sm"
+                    className="min-w-[var(--space-8)] justify-center text-ui"
+                  >
                     <FileText aria-hidden className="icon-xs opacity-80" />
-                  </span>
+                  </Badge>
                 ) : (
-                  <span className="pill h-[calc(var(--space-6) - var(--space-1))] w-[var(--space-8)] px-[var(--space-3)] text-ui font-mono tabular-nums text-center">{m.time}</span>
+                  <Badge
+                    as="span"
+                    size="sm"
+                    className="min-w-[var(--space-8)] justify-center font-mono tabular-nums text-ui"
+                  >
+                    {m.time}
+                  </Badge>
                 )}
 
                 <span className="truncate text-ui">{m.note}</span>
@@ -262,7 +261,7 @@ function TimestampMarkers(
                 >
                   <Trash2 />
                 </IconButton>
-              </li>
+              </ReviewSurface>
             ))}
           </ul>
         )}

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -548,7 +548,9 @@ exports[`ReviewEditor > renders default state 1`] = `
           <button
             aria-label="Brain light off"
             aria-pressed="false"
-            class="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            class="inline-flex items-center justify-center select-none rounded-[var(--radius-full)] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] border bg-card/35 hover:bg-[--hover] [--hover:theme('colors.interaction.foreground.tintHover')] [--active:theme('colors.interaction.foreground.tintActive')] border-line/35 text-foreground h-[var(--control-h-xl)] w-[var(--control-h-xl)] [&_svg]:size-[calc(var(--control-h-xl)/2)]"
+            tabindex="0"
+            title="Brain light off"
             type="button"
           >
             <span
@@ -1597,7 +1599,8 @@ exports[`ReviewEditor > renders default state 1`] = `
           <button
             aria-label="Use timestamp"
             aria-pressed="true"
-            class="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            class="inline-flex items-center justify-center select-none rounded-[var(--radius-full)] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] border bg-card/35 hover:bg-[--hover] [--hover:theme('colors.interaction.foreground.tintHover')] [--active:theme('colors.interaction.foreground.tintActive')] border-line/35 text-foreground h-[var(--control-h-xl)] w-[var(--control-h-xl)] [&_svg]:size-[calc(var(--control-h-xl)/2)]"
+            tabindex="0"
             title="Timestamp mode"
             type="button"
           >
@@ -1767,7 +1770,8 @@ exports[`ReviewEditor > renders default state 1`] = `
           <button
             aria-label="Use note only"
             aria-pressed="false"
-            class="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            class="inline-flex items-center justify-center select-none rounded-[var(--radius-full)] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] border bg-card/35 hover:bg-[--hover] [--hover:theme('colors.interaction.accent.tintHover')] [--active:theme('colors.interaction.accent.tintActive')] border-accent/35 text-[var(--text-on-accent)] h-[var(--control-h-xl)] w-[var(--control-h-xl)] [&_svg]:size-[calc(var(--control-h-xl)/2)]"
+            tabindex="0"
             title="Note-only mode"
             type="button"
           >


### PR DESCRIPTION
## Summary
- swap the review editor focus toggle and tag pills to IconButton and Badge primitives so spacing comes from design tokens
- refactor timestamp markers to reuse IconButton, Badge, and ReviewSurface for mode toggles, badges, and list rows with semantic padding
- align the review list empty state padding with the shared ds-card-pad utility

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfcb25842c832c8b99616d257b8fa5