### PR TITLE
Adjust TabBar hairline layering

### DIFF
--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -210,10 +210,9 @@ export default function TabBar<
           "[--hover:hsl(var(--primary)/0.18)]",
           "[--active:hsl(var(--primary)/0.28)]",
           "[--focus:hsl(var(--ring))]",
-          "[--tab-stroke:hsl(var(--border)/0.55)]",
-          "[--tab-shadow:inset_0_0_0_1px_var(--tab-stroke),_inset_0_1px_0_hsl(var(--border)/0.18)]",
-          "[--tab-shadow-hover:inset_0_0_0_1px_hsl(var(--border)/0.62),_inset_0_1px_0_hsl(var(--border)/0.24)]",
-          "[--tab-shadow-active:inset_0_0_0_1px_hsl(var(--border)/0.68),_inset_0_1px_0_hsl(var(--border)/0.3)]",
+          "[--tab-shadow:inset_0_1px_0_hsl(var(--border)/0.18)]",
+          "[--tab-shadow-hover:inset_0_1px_0_hsl(var(--border)/0.24)]",
+          "[--tab-shadow-active:inset_0_1px_0_hsl(var(--border)/0.3)]",
         );
 
   const containerClasses = cn(


### PR DESCRIPTION
## Summary
- stop layering a duplicate hairline on default TabBar tabs
- let the tablist border provide the single outline and keep state shadows for hover/active

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfcdcf148c832cac7870044752f454