### PR TITLE
Update Reviews hero layout for responsive alignment

### DIFF
--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -95,18 +95,20 @@ export default function ReviewsPage({
           sticky: false,
           topClassName: "top-[var(--header-stack)]",
           heading: "Browse Reviews",
-          subtitle: <span className="pill">Total {base.length}</span>,
+          subtitle: (
+            <p className="text-ui text-muted-foreground">Total {base.length}</p>
+          ),
           search: {
             round: true,
             value: q,
             onValueChange: setQ,
             placeholder: "Search title, tags, opponent, patch…",
             "aria-label": "Search reviews",
-            className: "flex-1",
+            className: "w-full md:w-7/12",
           },
           actions: (
-            <div className="flex flex-col gap-[var(--space-2)] sm:flex-row sm:items-center sm:gap-[var(--space-3)]">
-              <label className="flex w-full flex-col gap-[var(--space-1)] sm:w-auto sm:flex-row sm:items-center sm:gap-[var(--space-2)]">
+            <div className="grid w-full grid-cols-1 gap-[var(--space-2)] md:grid-cols-12 md:items-center md:gap-[var(--space-3)]">
+              <label className="flex w-full flex-col gap-[var(--space-1)] md:col-span-7 md:flex-row md:items-center md:gap-[var(--space-2)]">
                 <span className="text-ui font-medium text-muted-foreground">
                   Sort
                 </span>
@@ -120,7 +122,7 @@ export default function ReviewsPage({
                     { value: "oldest", label: "Oldest" },
                     { value: "title", label: "Title" },
                   ]}
-                  className="w-full sm:w-auto"
+                  className="w-full"
                   size="lg"
                 />
               </label>
@@ -128,7 +130,7 @@ export default function ReviewsPage({
                 type="button"
                 variant="primary"
                 size="lg"
-                className="w-full whitespace-nowrap px-[var(--space-4)] sm:w-auto"
+                className="w-full whitespace-nowrap px-[var(--space-4)] md:col-span-5 md:justify-self-end"
                 onClick={() => {
                   setQ("");
                   setSort("newest");

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -155,12 +155,12 @@ exports[`ReviewsPage > renders default state 1`] = `
                         <span
                           class="text-ui md:text-body text-muted-foreground break-words font-normal"
                         >
-                          <span
-                            class="pill"
+                          <p
+                            class="text-ui text-muted-foreground"
                           >
                             Total 
                             3
-                          </span>
+                          </p>
                         </span>
                       </div>
                     </div>
@@ -185,7 +185,7 @@ exports[`ReviewsPage > renders default state 1`] = `
               class="relative z-[1] flex w-full min-w-0 flex-col"
             >
               <form
-                class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-[var(--space-2)] data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"
+                class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-[var(--space-2)] data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none max-w-[calc(var(--space-8)*10)] rounded-full w-full md:w-7/12"
                 role="search"
               >
                 <div
@@ -274,10 +274,10 @@ exports[`ReviewsPage > renders default state 1`] = `
               class="relative z-[1] flex w-full min-w-0 flex-col"
             >
               <div
-                class="flex flex-col gap-[var(--space-2)] sm:flex-row sm:items-center sm:gap-[var(--space-3)]"
+                class="grid w-full grid-cols-1 gap-[var(--space-2)] md:grid-cols-12 md:items-center md:gap-[var(--space-3)]"
               >
                 <label
-                  class="flex w-full flex-col gap-[var(--space-1)] sm:w-auto sm:flex-row sm:items-center sm:gap-[var(--space-2)]"
+                  class="flex w-full flex-col gap-[var(--space-1)] md:col-span-7 md:flex-row md:items-center md:gap-[var(--space-2)]"
                 >
                   <span
                     class="text-ui font-medium text-muted-foreground"
@@ -285,7 +285,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                     Sort
                   </span>
                   <div
-                    class="glitch-wrap w-full sm:w-auto"
+                    class="glitch-wrap w-full"
                   >
                     <div
                       class="group inline-flex rounded-[var(--control-radius)] border border-[--theme-ring] focus-within:ring-2 focus-within:ring-[var(--theme-ring)] focus-within:ring-offset-0"
@@ -343,7 +343,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                   </div>
                 </label>
                 <button
-                  class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[disabled=true]:opacity-[var(--disabled)] data-[disabled=true]:pointer-events-none h-[var(--control-h-lg)] text-title gap-[var(--space-4)] [&_svg]:size-[var(--space-8)] w-full whitespace-nowrap px-[var(--space-4)] sm:w-auto shadow-[var(--btn-primary-shadow-rest)] hover:shadow-[var(--btn-primary-shadow-hover)] active:shadow-[var(--btn-primary-shadow-active)] active:translate-y-px bg-primary-soft border-[hsl(var(--primary)/0.35)] text-[hsl(var(--primary-foreground))] [--hover:theme('colors.interaction.primary.hover')] [--active:theme('colors.interaction.primary.active')]"
+                  class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[disabled=true]:opacity-[var(--disabled)] data-[disabled=true]:pointer-events-none h-[var(--control-h-lg)] text-title gap-[var(--space-4)] [&_svg]:size-[var(--space-8)] w-full whitespace-nowrap px-[var(--space-4)] md:col-span-5 md:justify-self-end shadow-[var(--btn-primary-shadow-rest)] hover:shadow-[var(--btn-primary-shadow-hover)] active:shadow-[var(--btn-primary-shadow-active)] active:translate-y-px bg-primary-soft border-[hsl(var(--primary)/0.35)] text-[hsl(var(--primary-foreground))] [--hover:theme('colors.interaction.primary.hover')] [--active:theme('colors.interaction.primary.active')]"
                   style="--glow-active: hsl(var(--primary) / 0.35); --btn-primary-hover-shadow: 0 2px 6px -1px hsl(var(--primary) / 0.25); --btn-primary-active-shadow: inset 0 0 0 1px hsl(var(--primary) / 0.6); --btn-primary-shadow-rest: 0 0 calc(var(--space-4) / 2) var(--glow-active); --btn-primary-shadow-hover: 0 0 var(--space-4) var(--glow-active); --btn-primary-shadow-active: var(--btn-primary-active-shadow);"
                   tabindex="0"
                   type="button"


### PR DESCRIPTION
## Summary
- restyle the Reviews hero subtitle to use muted body text instead of the pill badge
- size the Reviews hero search input for medium breakpoints and lay out the sort/filter actions in a 12-column grid with the CTA aligned to the end
- refresh the ReviewsPage snapshot to cover the new markup

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfcd185d88832cba628a5c0ac518f4