### PR TITLE
Refine review list container styling

### DIFF
--- a/src/components/reviews/ReviewList.tsx
+++ b/src/components/reviews/ReviewList.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import type { Review } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import ReviewListItem from "./ReviewListItem";
-import { Button, Card } from "@/components/ui";
+import { Button } from "@/components/ui";
 import { Tv } from "lucide-react";
 
 export type ReviewListProps = {
@@ -14,6 +14,8 @@ export type ReviewListProps = {
   onSelect?: (id: string) => void;
   onCreate?: () => void;
   className?: string;
+  header?: React.ReactNode;
+  hoverRing?: boolean;
 };
 
 export default function ReviewList({
@@ -22,28 +24,43 @@ export default function ReviewList({
   onSelect,
   onCreate,
   className,
+  header,
+  hoverRing = false,
 }: ReviewListProps) {
   const count = reviews.length;
 
-  // Allow the list to grow with the sidebar instead of capping at 520px
-  const containerClass = cn("w-full mx-auto backdrop-blur-sm", className);
+  const containerClass = cn(
+    "w-full mx-auto rounded-card r-card-lg border border-border/35 bg-card/60 text-card-foreground shadow-outline-subtle",
+    "ds-card-pad backdrop-blur-sm transition-colors transition-shadow duration-200",
+    hoverRing &&
+      "hover:ring-2 hover:ring-[var(--theme-ring)] focus-within:ring-2 focus-within:ring-[var(--theme-ring)]",
+    className,
+  );
+
+  const headerNode = header ? (
+    <header className="mb-[var(--space-2)] text-ui text-muted-foreground">
+      {header}
+    </header>
+  ) : null;
 
   if (count === 0) {
     return (
-      <Card className={containerClass}>
-        <div className="ds-card-pad flex flex-col items-center justify-center gap-[var(--space-3)] text-center text-ui text-muted-foreground">
+      <section data-scope="reviews" className={containerClass}>
+        {headerNode}
+        <div className="flex flex-col items-center justify-center gap-[var(--space-3)] text-center text-ui text-muted-foreground">
           <Tv className="size-[var(--space-5)] opacity-60" />
           <p>No reviews yet</p>
           <Button variant="primary" onClick={onCreate}>
             New Review
           </Button>
         </div>
-      </Card>
+      </section>
     );
   }
 
   return (
-    <Card className={containerClass}>
+    <section data-scope="reviews" className={containerClass}>
+      {headerNode}
       <ul className="flex flex-col gap-[var(--space-3)]">
         {reviews.map((r) => (
           <li key={r.id}>
@@ -55,6 +72,6 @@ export default function ReviewList({
           </li>
         ))}
       </ul>
-    </Card>
+    </section>
   );
 }

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -153,23 +153,18 @@ export default function ReviewsPage({
           aria-label="Review list"
           className="md:col-span-2 lg:col-span-4"
         >
-          <div className="card-neo-soft rounded-card r-card-lg overflow-hidden bg-card/50 shadow-neo-strong">
-            <div className="section-b">
-              <div className="mb-[var(--space-2)] text-ui text-muted-foreground">
-                {filtered.length} shown
-              </div>
-              <ReviewList
-                reviews={filtered}
-                selectedId={selectedId}
-                onSelect={(id) => {
-                  setDetailMode("summary");
-                  onSelect(id);
-                }}
-                onCreate={onCreate}
-                className="h-auto overflow-auto p-[var(--space-2)] md:h-[calc(100vh-var(--header-stack)-var(--space-6))]"
-              />
-            </div>
-          </div>
+          <ReviewList
+            reviews={filtered}
+            selectedId={selectedId}
+            onSelect={(id) => {
+              setDetailMode("summary");
+              onSelect(id);
+            }}
+            onCreate={onCreate}
+            className="h-auto overflow-auto p-[var(--space-2)] md:h-[calc(100vh-var(--header-stack)-var(--space-6))]"
+            header={`${filtered.length} shown`}
+            hoverRing
+          />
         </nav>
         <div aria-live="polite" className="md:col-span-4 lg:col-span-8">
           {!active ? (

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -392,160 +392,152 @@ exports[`ReviewsPage > renders default state 1`] = `
         aria-label="Review list"
         class="md:col-span-2 lg:col-span-4"
       >
-        <div
-          class="card-neo-soft rounded-card r-card-lg overflow-hidden bg-card/50 shadow-neo-strong"
+        <section
+          class="w-full mx-auto rounded-card r-card-lg border border-border/35 bg-card/60 text-card-foreground shadow-outline-subtle ds-card-pad backdrop-blur-sm transition-shadow duration-200 hover:ring-2 hover:ring-[var(--theme-ring)] focus-within:ring-2 focus-within:ring-[var(--theme-ring)] h-auto overflow-auto p-[var(--space-2)] md:h-[calc(100vh-var(--header-stack)-var(--space-6))]"
+          data-scope="reviews"
         >
-          <div
-            class="section-b"
+          <header
+            class="mb-[var(--space-2)] text-ui text-muted-foreground"
           >
-            <div
-              class="mb-[var(--space-2)] text-ui text-muted-foreground"
-            >
-              3
-               shown
-            </div>
-            <div
-              class="rounded-card r-card-lg border border-border/25 bg-card/60 text-card-foreground shadow-outline-subtle w-full mx-auto backdrop-blur-sm h-auto overflow-auto p-[var(--space-2)] md:h-[calc(100vh-var(--header-stack)-var(--space-6))]"
-            >
-              <ul
-                class="flex flex-col gap-[var(--space-3)]"
+            3 shown
+          </header>
+          <ul
+            class="flex flex-col gap-[var(--space-3)]"
+          >
+            <li>
+              <button
+                aria-label="Open review: Alpha"
+                class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
+                data-scope="reviews"
+                type="button"
               >
-                <li>
-                  <button
-                    aria-label="Open review: Alpha"
-                    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
-                    data-scope="reviews"
-                    type="button"
+                <div
+                  class="flex flex-col gap-[var(--space-2)]"
+                >
+                  <div
+                    class="flex items-start justify-between gap-[var(--space-2)]"
                   >
                     <div
-                      class="flex flex-col gap-[var(--space-2)]"
+                      class="truncate font-medium text-body"
                     >
-                      <div
-                        class="flex items-start justify-between gap-[var(--space-2)]"
-                      >
-                        <div
-                          class="truncate font-medium text-body"
-                        >
-                          Alpha
-                        </div>
-                        <div
-                          class="truncate text-ui text-muted-foreground"
-                        >
-                          Lux vs Ahri
-                        </div>
-                      </div>
-                      <div
-                        class="flex items-center justify-between gap-[var(--space-2)]"
-                      >
-                        <div
-                          class="flex items-center gap-[var(--space-2)]"
-                        >
-                          <span
-                            aria-hidden="true"
-                            class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
-                          />
-                          <span
-                            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
-                          >
-                            MID
-                          </span>
-                        </div>
-                      </div>
+                      Alpha
                     </div>
-                  </button>
-                </li>
-                <li>
-                  <button
-                    aria-label="Open review: Gamma"
-                    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
-                    data-scope="reviews"
-                    type="button"
+                    <div
+                      class="truncate text-ui text-muted-foreground"
+                    >
+                      Lux vs Ahri
+                    </div>
+                  </div>
+                  <div
+                    class="flex items-center justify-between gap-[var(--space-2)]"
                   >
                     <div
-                      class="flex flex-col gap-[var(--space-2)]"
+                      class="flex items-center gap-[var(--space-2)]"
                     >
-                      <div
-                        class="flex items-start justify-between gap-[var(--space-2)]"
+                      <span
+                        aria-hidden="true"
+                        class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
+                      />
+                      <span
+                        class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
                       >
-                        <div
-                          class="truncate font-medium text-body"
-                        >
-                          Gamma
-                        </div>
-                        <div
-                          class="truncate text-ui text-muted-foreground"
-                        >
-                          Ashe vs Cait
-                        </div>
-                      </div>
-                      <div
-                        class="flex items-center justify-between gap-[var(--space-2)]"
-                      >
-                        <div
-                          class="flex items-center gap-[var(--space-2)]"
-                        >
-                          <span
-                            aria-hidden="true"
-                            class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
-                          />
-                          <span
-                            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
-                          >
-                            BOT
-                          </span>
-                        </div>
-                      </div>
+                        MID
+                      </span>
                     </div>
-                  </button>
-                </li>
-                <li>
-                  <button
-                    aria-label="Open review: Beta"
-                    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
-                    data-scope="reviews"
-                    type="button"
+                  </div>
+                </div>
+              </button>
+            </li>
+            <li>
+              <button
+                aria-label="Open review: Gamma"
+                class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
+                data-scope="reviews"
+                type="button"
+              >
+                <div
+                  class="flex flex-col gap-[var(--space-2)]"
+                >
+                  <div
+                    class="flex items-start justify-between gap-[var(--space-2)]"
                   >
                     <div
-                      class="flex flex-col gap-[var(--space-2)]"
+                      class="truncate font-medium text-body"
                     >
-                      <div
-                        class="flex items-start justify-between gap-[var(--space-2)]"
-                      >
-                        <div
-                          class="truncate font-medium text-body"
-                        >
-                          Beta
-                        </div>
-                        <div
-                          class="truncate text-ui text-muted-foreground"
-                        >
-                          Garen vs Darius
-                        </div>
-                      </div>
-                      <div
-                        class="flex items-center justify-between gap-[var(--space-2)]"
-                      >
-                        <div
-                          class="flex items-center gap-[var(--space-2)]"
-                        >
-                          <span
-                            aria-hidden="true"
-                            class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
-                          />
-                          <span
-                            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
-                          >
-                            TOP
-                          </span>
-                        </div>
-                      </div>
+                      Gamma
                     </div>
-                  </button>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </div>
+                    <div
+                      class="truncate text-ui text-muted-foreground"
+                    >
+                      Ashe vs Cait
+                    </div>
+                  </div>
+                  <div
+                    class="flex items-center justify-between gap-[var(--space-2)]"
+                  >
+                    <div
+                      class="flex items-center gap-[var(--space-2)]"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
+                      />
+                      <span
+                        class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
+                      >
+                        BOT
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </button>
+            </li>
+            <li>
+              <button
+                aria-label="Open review: Beta"
+                class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
+                data-scope="reviews"
+                type="button"
+              >
+                <div
+                  class="flex flex-col gap-[var(--space-2)]"
+                >
+                  <div
+                    class="flex items-start justify-between gap-[var(--space-2)]"
+                  >
+                    <div
+                      class="truncate font-medium text-body"
+                    >
+                      Beta
+                    </div>
+                    <div
+                      class="truncate text-ui text-muted-foreground"
+                    >
+                      Garen vs Darius
+                    </div>
+                  </div>
+                  <div
+                    class="flex items-center justify-between gap-[var(--space-2)]"
+                  >
+                    <div
+                      class="flex items-center gap-[var(--space-2)]"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
+                      />
+                      <span
+                        class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
+                      >
+                        TOP
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </button>
+            </li>
+          </ul>
+        </section>
       </nav>
       <div
         aria-live="polite"


### PR DESCRIPTION
## Summary
- let `ReviewList` render its own token-based container with optional hover ring support and header slot
- update `ReviewsPage` to rely on the new API for the sidebar count and remove the redundant wrapper

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfcfb3ea80832c8096af562d32ef51