### PR TITLE
Refine review list item accent interactions

### DIFF
--- a/src/components/reviews/ReviewListItem.tsx
+++ b/src/components/reviews/ReviewListItem.tsx
@@ -6,12 +6,16 @@ import { cn } from "@/lib/utils";
 import type { Review } from "@/lib/types";
 import Badge from "@/components/ui/primitives/Badge";
 
+const accentInteractionTokens =
+  "[--hover:theme('colors.interaction.accent.hover')] [--active:theme('colors.interaction.accent.active')]";
+
 const shellBase = cn(
   "relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20",
-  "hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)]",
-  "focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)]",
-  "active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)]",
-  "data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent",
+  accentInteractionTokens,
+  "hover:bg-[--hover] hover:ring-2 hover:ring-[var(--focus)]",
+  "focus-visible:bg-[--hover] focus-visible:ring-2 focus-visible:ring-[var(--focus)]",
+  "active:bg-[--active] active:ring-2 active:ring-[var(--focus)]",
+  "data-[selected=true]:bg-interaction-accent-surfaceHover data-[selected=true]:border-[var(--ring-contrast)] data-[selected=true]:shadow-[var(--shadow-badge),_var(--shadow-glow-md)] data-[selected=true]:ring-2 data-[selected=true]:ring-[var(--focus)]",
 );
 
 const statusDotBase =

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`ReviewListItem > renders default state 1`] = `
 <div>
   <button
     aria-label="Open review: Sample Review"
-    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
+    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 [--hover:theme('colors.interaction.accent.hover')] [--active:theme('colors.interaction.accent.active')] hover:bg-[--hover] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[--hover] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[--active] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-interaction-accent-surfaceHover data-[selected=true]:border-[var(--ring-contrast)] data-[selected=true]:shadow-[var(--shadow-badge),_var(--shadow-glow-md)] data-[selected=true]:ring-2 data-[selected=true]:ring-[var(--focus)]"
     data-scope="reviews"
     type="button"
   >
@@ -58,7 +58,7 @@ exports[`ReviewListItem > renders disabled state 1`] = `
 <div>
   <button
     aria-label="Open review: Sample Review"
-    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
+    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 [--hover:theme('colors.interaction.accent.hover')] [--active:theme('colors.interaction.accent.active')] hover:bg-[--hover] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[--hover] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[--active] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-interaction-accent-surfaceHover data-[selected=true]:border-[var(--ring-contrast)] data-[selected=true]:shadow-[var(--shadow-badge),_var(--shadow-glow-md)] data-[selected=true]:ring-2 data-[selected=true]:ring-[var(--focus)]"
     data-scope="reviews"
     disabled=""
     type="button"
@@ -112,7 +112,7 @@ exports[`ReviewListItem > renders disabled state 1`] = `
 exports[`ReviewListItem > renders loading state 1`] = `
 <div>
   <div
-    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent motion-safe:animate-pulse motion-reduce:animate-none"
+    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 [--hover:theme('colors.interaction.accent.hover')] [--active:theme('colors.interaction.accent.active')] hover:bg-[--hover] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[--hover] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[--active] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-interaction-accent-surfaceHover data-[selected=true]:border-[var(--ring-contrast)] data-[selected=true]:shadow-[var(--shadow-badge),_var(--shadow-glow-md)] data-[selected=true]:ring-2 data-[selected=true]:ring-[var(--focus)] motion-safe:animate-pulse motion-reduce:animate-none"
     data-scope="reviews"
   >
     <div
@@ -130,7 +130,7 @@ exports[`ReviewListItem > renders selected state 1`] = `
   <button
     aria-current="true"
     aria-label="Open review: Sample Review"
-    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
+    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 [--hover:theme('colors.interaction.accent.hover')] [--active:theme('colors.interaction.accent.active')] hover:bg-[--hover] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[--hover] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[--active] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-interaction-accent-surfaceHover data-[selected=true]:border-[var(--ring-contrast)] data-[selected=true]:shadow-[var(--shadow-badge),_var(--shadow-glow-md)] data-[selected=true]:ring-2 data-[selected=true]:ring-[var(--focus)]"
     data-scope="reviews"
     data-selected="true"
     type="button"
@@ -185,7 +185,7 @@ exports[`ReviewListItem > renders untitled state 1`] = `
 <div>
   <button
     aria-label="Open review: Untitled Review"
-    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
+    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 [--hover:theme('colors.interaction.accent.hover')] [--active:theme('colors.interaction.accent.active')] hover:bg-[--hover] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[--hover] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[--active] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-interaction-accent-surfaceHover data-[selected=true]:border-[var(--ring-contrast)] data-[selected=true]:shadow-[var(--shadow-badge),_var(--shadow-glow-md)] data-[selected=true]:ring-2 data-[selected=true]:ring-[var(--focus)]"
     data-scope="reviews"
     type="button"
   >

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -413,7 +413,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                 <li>
                   <button
                     aria-label="Open review: Alpha"
-                    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
+                    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 [--hover:theme('colors.interaction.accent.hover')] [--active:theme('colors.interaction.accent.active')] hover:bg-[--hover] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[--hover] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[--active] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-interaction-accent-surfaceHover data-[selected=true]:border-[var(--ring-contrast)] data-[selected=true]:shadow-[var(--shadow-badge),_var(--shadow-glow-md)] data-[selected=true]:ring-2 data-[selected=true]:ring-[var(--focus)]"
                     data-scope="reviews"
                     type="button"
                   >
@@ -457,7 +457,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                 <li>
                   <button
                     aria-label="Open review: Gamma"
-                    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
+                    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 [--hover:theme('colors.interaction.accent.hover')] [--active:theme('colors.interaction.accent.active')] hover:bg-[--hover] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[--hover] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[--active] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-interaction-accent-surfaceHover data-[selected=true]:border-[var(--ring-contrast)] data-[selected=true]:shadow-[var(--shadow-badge),_var(--shadow-glow-md)] data-[selected=true]:ring-2 data-[selected=true]:ring-[var(--focus)]"
                     data-scope="reviews"
                     type="button"
                   >
@@ -501,7 +501,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                 <li>
                   <button
                     aria-label="Open review: Beta"
-                    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-accent/10 hover:ring-2 hover:ring-[var(--theme-ring)] focus-visible:bg-accent/15 focus-visible:ring-2 focus-visible:ring-[var(--theme-ring)] active:bg-accent/20 active:ring-2 active:ring-[var(--theme-ring)] data-[selected=true]:bg-accent/20 data-[selected=true]:ring-2 data-[selected=true]:ring-accent"
+                    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 [--hover:theme('colors.interaction.accent.hover')] [--active:theme('colors.interaction.accent.active')] hover:bg-[--hover] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[--hover] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[--active] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-interaction-accent-surfaceHover data-[selected=true]:border-[var(--ring-contrast)] data-[selected=true]:shadow-[var(--shadow-badge),_var(--shadow-glow-md)] data-[selected=true]:ring-2 data-[selected=true]:ring-[var(--focus)]"
                     data-scope="reviews"
                     type="button"
                   >


### PR DESCRIPTION
## Summary
- switch ReviewListItem to the accent interaction tokens for hover/focus/active surfaces and the shared focus ring
- reuse the badge + glow shadow tokens for the selected review state to keep neumorphic elevation consistent
- update review snapshots to capture the refreshed styling

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfcf0f328c832caf3b7799e052fb78