### PR TITLE
Use spacing tokens for neon pillar chip blur

### DIFF
--- a/src/components/reviews/PillarsSelector.tsx
+++ b/src/components/reviews/PillarsSelector.tsx
@@ -4,6 +4,9 @@ import PillarBadge from "@/components/ui/league/pillars/PillarBadge";
 import { ALL_PILLARS } from "@/components/reviews/reviewData";
 import type { Pillar, Review } from "@/lib/types";
 
+const auraBlurRadius = "calc(var(--space-3) - var(--spacing-0-5))";
+const neonBlurRadius = "var(--spacing-0-5)";
+
 export type PillarsSelectorHandle = {
   save: () => void;
 };
@@ -52,7 +55,7 @@ function NeonPillarChip({
           (lit ? " opacity-60" : " opacity-0")
         }
         style={{
-          filter: "blur(10px)",
+          filter: `blur(${auraBlurRadius})`,
           background:
             "radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%)",
           transition: "opacity 220ms var(--ease-out)",
@@ -69,7 +72,7 @@ function NeonPillarChip({
         style={{
           background:
             "radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%)",
-          filter: "blur(2px)",
+          filter: `blur(${neonBlurRadius})`,
           transition: "opacity 220ms var(--ease-out)",
         }}
         aria-hidden

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -794,12 +794,12 @@ exports[`ReviewEditor > renders default state 1`] = `
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="filter: blur(10px); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity 220ms var(--ease-out);"
+                style="filter: blur(calc(var(--space-3) - var(--spacing-0-5))); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity 220ms var(--ease-out);"
               />
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(2px); transition: opacity 220ms var(--ease-out);"
+                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(var(--spacing-0-5)); transition: opacity 220ms var(--ease-out);"
               />
               <span
                 class="lg-pillar-badge rounded-full h-[var(--control-h-sm)] px-[var(--space-4)] text-ui gap-[var(--space-2)]"
@@ -921,12 +921,12 @@ exports[`ReviewEditor > renders default state 1`] = `
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="filter: blur(10px); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity 220ms var(--ease-out);"
+                style="filter: blur(calc(var(--space-3) - var(--spacing-0-5))); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity 220ms var(--ease-out);"
               />
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(2px); transition: opacity 220ms var(--ease-out);"
+                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(var(--spacing-0-5)); transition: opacity 220ms var(--ease-out);"
               />
               <span
                 class="lg-pillar-badge rounded-full h-[var(--control-h-sm)] px-[var(--space-4)] text-ui gap-[var(--space-2)]"
@@ -1058,12 +1058,12 @@ exports[`ReviewEditor > renders default state 1`] = `
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="filter: blur(10px); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity 220ms var(--ease-out);"
+                style="filter: blur(calc(var(--space-3) - var(--spacing-0-5))); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity 220ms var(--ease-out);"
               />
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(2px); transition: opacity 220ms var(--ease-out);"
+                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(var(--spacing-0-5)); transition: opacity 220ms var(--ease-out);"
               />
               <span
                 class="lg-pillar-badge rounded-full h-[var(--control-h-sm)] px-[var(--space-4)] text-ui gap-[var(--space-2)]"
@@ -1184,12 +1184,12 @@ exports[`ReviewEditor > renders default state 1`] = `
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="filter: blur(10px); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity 220ms var(--ease-out);"
+                style="filter: blur(calc(var(--space-3) - var(--spacing-0-5))); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity 220ms var(--ease-out);"
               />
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(2px); transition: opacity 220ms var(--ease-out);"
+                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(var(--spacing-0-5)); transition: opacity 220ms var(--ease-out);"
               />
               <span
                 class="lg-pillar-badge rounded-full h-[var(--control-h-sm)] px-[var(--space-4)] text-ui gap-[var(--space-2)]"
@@ -1319,12 +1319,12 @@ exports[`ReviewEditor > renders default state 1`] = `
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="filter: blur(10px); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity 220ms var(--ease-out);"
+                style="filter: blur(calc(var(--space-3) - var(--spacing-0-5))); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity 220ms var(--ease-out);"
               />
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(2px); transition: opacity 220ms var(--ease-out);"
+                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(var(--spacing-0-5)); transition: opacity 220ms var(--ease-out);"
               />
               <span
                 class="lg-pillar-badge rounded-full h-[var(--control-h-sm)] px-[var(--space-4)] text-ui gap-[var(--space-2)]"
@@ -1466,12 +1466,12 @@ exports[`ReviewEditor > renders default state 1`] = `
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="filter: blur(10px); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity 220ms var(--ease-out);"
+                style="filter: blur(calc(var(--space-3) - var(--spacing-0-5))); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity 220ms var(--ease-out);"
               />
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(2px); transition: opacity 220ms var(--ease-out);"
+                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(var(--spacing-0-5)); transition: opacity 220ms var(--ease-out);"
               />
               <span
                 class="lg-pillar-badge rounded-full h-[var(--control-h-sm)] px-[var(--space-4)] text-ui gap-[var(--space-2)]"


### PR DESCRIPTION
## Summary
- derive the NeonPillarChip blur radii from spacing tokens while keeping the gradients intact
- refresh the reviewer snapshot to capture the token-based blur styles

## Testing
- npm test -- --run tests/reviews/ReviewEditor.test.tsx
- npm test -- --run --update tests/reviews/ReviewEditor.test.tsx
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfd8ee34c4832c9abf1741812c1503