### PR TITLE
Rename SegmentedButton `isActive` prop to `selected`

### DIFF
--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -206,7 +206,7 @@ export default function Reminders() {
               onClick={() => setOnlyPinned(v => !v)}
               aria-pressed={onlyPinned}
               title="Pinned only"
-              isActive={onlyPinned}
+              selected={onlyPinned}
             >
               {onlyPinned ? <PinOff className="mr-[var(--space-1)]" /> : <Pin className="mr-[var(--space-1)]" />}
               {onlyPinned ? "Pinned only" : "Any pin"}

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -510,7 +510,7 @@ export default function TimerTab() {
                   className="gap-[var(--space-2)]"
                   onClick={pause}
                   title="Pause"
-                  isActive
+                  selected
                 >
                   <Pause />
                   Pause

--- a/src/components/goals/reminders/ReminderFilters.tsx
+++ b/src/components/goals/reminders/ReminderFilters.tsx
@@ -38,7 +38,7 @@ export default function ReminderFilters() {
               onClick={toggleFilters}
               aria-expanded={showFilters}
               title="Filters"
-              isActive={showFilters}
+              selected={showFilters}
             >
               <SlidersHorizontal className="icon-sm" aria-hidden />
               Filters
@@ -60,7 +60,7 @@ export default function ReminderFilters() {
             onClick={togglePinned}
             aria-pressed={onlyPinned}
             title="Pinned only"
-            isActive={onlyPinned}
+            selected={onlyPinned}
           >
             {onlyPinned ? <PinOff className="mr-[var(--space-1)]" /> : <Pin className="mr-[var(--space-1)]" />}
             {onlyPinned ? "Pinned only" : "Any pin"}

--- a/src/components/goals/reminders/ReminderList.tsx
+++ b/src/components/goals/reminders/ReminderList.tsx
@@ -210,7 +210,7 @@ function RemTile({
                 <SegmentedButton
                   key={groupKey}
                   onClick={() => onChange({ group: groupKey })}
-                  isActive={value.group === groupKey}
+                  selected={value.group === groupKey}
                   className="m-[var(--space-1)]"
                 >
                   {groupKey === "pregame" ? "Pre-Game" : capitalize(groupKey)}
@@ -224,7 +224,7 @@ function RemTile({
                   <SegmentedButton
                     key={sourceKey}
                     onClick={() => onChange({ source: sourceKey })}
-                    isActive={value.source === sourceKey}
+                    selected={value.source === sourceKey}
                     className="m-[var(--space-1)]"
                   >
                     {sourceKey}
@@ -238,7 +238,7 @@ function RemTile({
                 <SegmentedButton
                   key={domainKey}
                   onClick={() => onChange({ domain: domainKey })}
-                  isActive={(value.domain ?? "League") === domainKey}
+                  selected={(value.domain ?? "League") === domainKey}
                   className="m-[var(--space-1)]"
                 >
                   {domainKey}

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -180,7 +180,7 @@ export default function ComponentGallery() {
         element: (
           <div className="w-56 flex gap-[var(--space-2)]">
             <SegmentedButton>Default</SegmentedButton>
-            <SegmentedButton isActive>Active</SegmentedButton>
+            <SegmentedButton selected>Active</SegmentedButton>
             <SegmentedButton disabled>Disabled</SegmentedButton>
           </div>
         ),

--- a/src/components/ui/primitives/SegmentedButton.gallery.tsx
+++ b/src/components/ui/primitives/SegmentedButton.gallery.tsx
@@ -22,7 +22,7 @@ const SEGMENTED_BUTTON_STATES: ReadonlyArray<{
       className: SEGMENTED_BUTTON_HOVER_STATE_CLASSNAME,
     },
   },
-  { label: "Active", props: { children: "Active", isActive: true } },
+  { label: "Active", props: { children: "Active", selected: true } },
   {
     label: "Focus-visible",
     props: {
@@ -56,7 +56,7 @@ export default defineGallerySection({
       props: [
         { name: "as", type: "React.ElementType" },
         { name: "href", type: "string" },
-        { name: "isActive", type: "boolean", defaultValue: "false" },
+        { name: "selected", type: "boolean", defaultValue: "false" },
         { name: "loading", type: "boolean", defaultValue: "false" },
         { name: "disabled", type: "boolean", defaultValue: "false" },
       ],
@@ -75,7 +75,7 @@ export default defineGallerySection({
       code: `<div className="flex flex-wrap gap-[var(--space-2)]">
   <SegmentedButton>Default</SegmentedButton>
   <SegmentedButton className="${SEGMENTED_BUTTON_HOVER_STATE_CLASSNAME}">Hover</SegmentedButton>
-  <SegmentedButton isActive>Active</SegmentedButton>
+  <SegmentedButton selected>Active</SegmentedButton>
   <SegmentedButton className="${SEGMENTED_BUTTON_FOCUS_VISIBLE_STATE_CLASSNAME}">Focus-visible</SegmentedButton>
   <SegmentedButton disabled>Disabled</SegmentedButton>
   <SegmentedButton loading>Loading</SegmentedButton>

--- a/src/components/ui/primitives/SegmentedButton.tsx
+++ b/src/components/ui/primitives/SegmentedButton.tsx
@@ -5,6 +5,8 @@ import { cn } from "@/lib/utils";
 
 export type SegmentedButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   as?: React.ElementType;
+  selected?: boolean;
+  /** @deprecated Use `selected` instead. */
   isActive?: boolean;
   href?: string;
   loading?: boolean;
@@ -13,8 +15,9 @@ export type SegmentedButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>
 const SegmentedButton = React.forwardRef<
   HTMLElement,
   SegmentedButtonProps
->(({ as: Comp = "button", isActive, className, type, loading, disabled, href, ...props }, ref) => {
-  const cls = cn("btn-like-segmented", isActive && "is-active", className);
+>(({ as: Comp = "button", selected, isActive, className, type, loading, disabled, href, ...props }, ref) => {
+  const resolvedSelected = selected ?? isActive ?? false;
+  const cls = cn("btn-like-segmented", resolvedSelected && "is-active", className);
   const typeProp =
     Comp === "button" && (props as React.ButtonHTMLAttributes<HTMLButtonElement>).type === undefined
       ? { type: type ?? "button" }
@@ -28,8 +31,8 @@ const SegmentedButton = React.forwardRef<
       className={cls}
       data-loading={loading}
       disabled={isButton ? isDisabled : undefined}
-      aria-pressed={isButton ? isActive : undefined}
-      aria-current={isLink ? (isActive ? "page" : undefined) : undefined}
+      aria-pressed={isButton ? resolvedSelected : undefined}
+      aria-current={isLink ? (resolvedSelected ? "page" : undefined) : undefined}
       href={isLink ? href : undefined}
       {...typeProp}
       {...props}


### PR DESCRIPTION
## Summary
- add a `selected` prop to `SegmentedButton` with a backwards-compatible `isActive` alias and update aria handling
- migrate reminders, timer controls, and prompts gallery to the new prop name
- update the SegmentedButton gallery docs to document and demo `selected`

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfd8a70310832c9fe62d2f12cb3041