### PR TITLE
Align pill compact spacing tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1180,7 +1180,7 @@ textarea:-webkit-autofill {
 
 /* Compact pill */
 .pill-compact {
-  @apply inline-flex items-center rounded-full border border-card-hairline px-2 py-1 text-label font-medium tracking-[0.02em] leading-tight;
+  @apply inline-flex items-center rounded-full border border-card-hairline px-[var(--space-2)] py-[var(--space-1)] text-label font-medium tracking-[0.02em] leading-tight;
   background-color: hsl(var(--muted) / 0.18);
 }
 .pill-compact:hover {


### PR DESCRIPTION
## Summary
- replace the .pill-compact horizontal and vertical padding utilities with spacing tokens
- confirm remaining .pill-compact variants avoid raw spacing utilities

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfda58ad1c832cb7b4494c0f2c99c8