### PR TITLE
Align home hero spacing tokens

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -476,7 +476,7 @@ function HomePageContent() {
                               variant="primary"
                               size="sm"
                               tactile
-                              className="whitespace-nowrap px-4"
+                              className="whitespace-nowrap"
                             >
                               <Link href="/planner">Plan Week</Link>
                             </Button>
@@ -561,7 +561,7 @@ export default function Page() {
   return (
     <Suspense
       fallback={
-        <div className="flex justify-center p-6">
+        <div className="flex justify-center p-[var(--space-6)]">
           <Spinner />
         </div>
       }


### PR DESCRIPTION
## Summary
- remove the hard-coded horizontal padding on the home hero CTA button so the primary sm size controls spacing
- swap the Suspense fallback padding to the var-based spacing token for consistency with the design system

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfdb1a5c1c832c8d219ddcb274ed42