### PR TITLE
Expand Badge size tokens to match primitives

### DIFF
--- a/src/components/components/ComponentsPageClient.tsx
+++ b/src/components/components/ComponentsPageClient.tsx
@@ -601,7 +601,7 @@ export default function ComponentsPageClient({
               <Badge
                 id={countDescriptionId}
                 tone="support"
-                size="sm"
+                size="md"
                 className="text-muted-foreground"
               >
                 {countLabel}

--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -440,9 +440,9 @@ function ReminderCard({
             )}
             <div className="flex flex-wrap items-center gap-[var(--space-2)] pt-[var(--space-1)]">
               {value.tags.map((t) => <span key={t} className="pill">{t}</span>)}
-              <Badge size="xs" tone="neutral" className="opacity-75">{value.group}</Badge>
+              <Badge size="sm" tone="neutral" className="opacity-75">{value.group}</Badge>
               <Badge
-                size="xs"
+                size="sm"
                 tone={
                   value.source === "MLA" ? "primary"
                   : value.source === "BLA" ? "accent"

--- a/src/components/goals/reminders/ReminderList.tsx
+++ b/src/components/goals/reminders/ReminderList.tsx
@@ -288,7 +288,7 @@ function RemTile({
                 as="button"
                 interactive
                 tone="primary"
-                size="xs"
+                size="sm"
                 onClick={togglePinned}
                 title={togglePinnedLabel}
                 aria-label={togglePinnedLabel}

--- a/src/components/prompts/ColorsView.tsx
+++ b/src/components/prompts/ColorsView.tsx
@@ -156,7 +156,7 @@ export default function ColorsView({ groups }: ColorsViewProps) {
             />
           </div>
         </div>
-        <Badge size="xs" tone="support">
+        <Badge size="sm" tone="support">
           {countLabel}
         </Badge>
       </header>
@@ -178,7 +178,7 @@ export default function ColorsView({ groups }: ColorsViewProps) {
               <UiSectionCard.Header
                 title={group.label}
                 actions={
-                  <Badge size="xs" tone="support">
+                  <Badge size="sm" tone="support">
                     {tokenCount} {tokenSuffix}
                   </Badge>
                 }

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -1315,9 +1315,11 @@ export default function ComponentGallery() {
       {
         label: "Badge Sizes",
         element: (
-          <div className="w-56 flex justify-center gap-[var(--space-2)]">
-            <Badge size="xs">XS</Badge>
+          <div className="w-56 flex flex-wrap justify-center gap-[var(--space-2)]">
             <Badge size="sm">SM</Badge>
+            <Badge size="md">MD</Badge>
+            <Badge size="lg">LG</Badge>
+            <Badge size="xl">XL</Badge>
           </div>
         ),
       },

--- a/src/components/prompts/ComponentsView.tsx
+++ b/src/components/prompts/ComponentsView.tsx
@@ -201,7 +201,7 @@ function VariantsMatrix({ axes }: { axes: readonly GalleryAxis[] }) {
             <ul className="mt-[var(--space-3)] flex flex-wrap gap-[var(--space-2)]">
               {axis.values.map((value) => (
                 <li key={value.value} className="flex flex-col gap-[var(--space-1)]">
-                  <Badge tone="support" size="sm" className="text-muted-foreground">
+                  <Badge tone="support" size="md" className="text-muted-foreground">
                     {value.value}
                   </Badge>
                   {value.description ? (
@@ -317,7 +317,7 @@ function StatesSection({
                 <ul className="flex flex-wrap gap-[var(--space-2)]">
                   {axis.values.map((value) => (
                     <li key={value.value}>
-                      <Badge tone="support" size="sm" className="text-muted-foreground">
+                      <Badge tone="support" size="md" className="text-muted-foreground">
                         {value.value}
                       </Badge>
                     </li>

--- a/src/components/prompts/PromptList.tsx
+++ b/src/components/prompts/PromptList.tsx
@@ -36,7 +36,7 @@ export default function PromptList({ prompts, query }: PromptListProps) {
           {q ? (
             <>
               No prompts match
-              <Badge size="xs" tone="neutral">{q}</Badge>
+              <Badge size="sm" tone="neutral">{q}</Badge>
             </>
           ) : (
             "No prompts saved yet"

--- a/src/components/reviews/ReviewCard.tsx
+++ b/src/components/reviews/ReviewCard.tsx
@@ -81,12 +81,12 @@ export default function ReviewCard({
           {Array.isArray(review.tags) && review.tags.length > 0 && (
             <div className="mt-[var(--space-2)] flex flex-wrap gap-[var(--space-2)]">
               {review.tags.slice(0, 6).map((t) => (
-                <Badge key={t} size="xs" tone="accent">
+                <Badge key={t} size="sm" tone="accent">
                   {t}
                 </Badge>
               ))}
               {review.tags.length > 6 && (
-                <Badge size="xs" tone="accent">
+                <Badge size="sm" tone="accent">
                   +{review.tags.length - 6}
                 </Badge>
               )}

--- a/src/components/reviews/ReviewEditor.tsx
+++ b/src/components/reviews/ReviewEditor.tsx
@@ -277,7 +277,7 @@ export default function ReviewEditor({
                 />
               </ReviewSurface>
               <div className="mt-[var(--space-1)] flex items-center gap-[var(--space-2)] text-ui text-muted-foreground">
-                <Badge as="span" size="sm" className="font-mono tabular-nums text-ui">
+                <Badge as="span" size="md" className="font-mono tabular-nums text-ui">
                   {focus}/10
                 </Badge>
                 <span>{focusMsg}</span>

--- a/src/components/reviews/ReviewListItem.tsx
+++ b/src/components/reviews/ReviewListItem.tsx
@@ -113,7 +113,7 @@ export default function ReviewListItem({
             />
             {role ? (
               <Badge
-                size="xs"
+                size="sm"
                 tone="neutral"
                 className="px-[var(--space-1)]"
               >

--- a/src/components/reviews/TimestampMarkers.tsx
+++ b/src/components/reviews/TimestampMarkers.tsx
@@ -180,7 +180,7 @@ function TimestampMarkers(
           ) : (
             <Badge
               as="span"
-              size="sm"
+              size="md"
               className="min-w-[var(--space-8)] justify-center text-ui"
             >
               <FileText aria-hidden className="icon-xs opacity-80" />
@@ -235,7 +235,7 @@ function TimestampMarkers(
                 {m.noteOnly ? (
                   <Badge
                     as="span"
-                    size="sm"
+                    size="md"
                     className="min-w-[var(--space-8)] justify-center text-ui"
                   >
                     <FileText aria-hidden className="icon-xs opacity-80" />
@@ -243,7 +243,7 @@ function TimestampMarkers(
                 ) : (
                   <Badge
                     as="span"
-                    size="sm"
+                    size="md"
                     className="min-w-[var(--space-8)] justify-center font-mono tabular-nums text-ui"
                   >
                     {m.time}

--- a/src/components/team/ChampListEditor.tsx
+++ b/src/components/team/ChampListEditor.tsx
@@ -88,7 +88,7 @@ export default function ChampListEditor({
         <div className={cn(VIEW_CONTAINER, viewClassName)}>
           <Badge
             glitch
-            size="xs"
+            size="sm"
             disabled
             className={cn(PILL_CLASSNAME, pillClassName)}
           >
@@ -105,7 +105,7 @@ export default function ChampListEditor({
           <Badge
             key={index}
             glitch
-            size="xs"
+            size="sm"
             className={cn(PILL_CLASSNAME, pillClassName)}
           >
             <i className="dot" />
@@ -122,7 +122,7 @@ export default function ChampListEditor({
         <Badge
           key={index}
           glitch
-          size="xs"
+          size="sm"
           className={cn(PILL_CLASSNAME, editPillClassName ?? pillClassName)}
         >
           <i className="dot" />

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -358,7 +358,7 @@ export default function TeamCompPage() {
                 {laneSummaries.map((lane) => (
                   <Badge
                     key={lane.key}
-                    size="xs"
+                    size="sm"
                     tone={lane.key as LaneTone}
                     className="min-w-[calc(var(--space-8)+var(--space-3))]"
                   >
@@ -368,14 +368,14 @@ export default function TeamCompPage() {
               </div>
             </div>
             <div className="flex flex-wrap items-center gap-[var(--space-2)]">
-              <Badge size="xs" tone={gapTone}>
+              <Badge size="sm" tone={gapTone}>
                 {openLabel}
               </Badge>
-              <Badge size="xs" tone={clashTone}>
+              <Badge size="sm" tone={clashTone}>
                 {clashLabel}
               </Badge>
               {active?.hint ? (
-                <Badge size="xs" tone="accent">
+                <Badge size="sm" tone="accent">
                   {active.hint}
                 </Badge>
               ) : null}
@@ -448,7 +448,7 @@ export default function TeamCompPage() {
             </Button>
             <div className="flex items-center gap-[var(--space-1)] text-label text-muted-foreground">
               <span>Sends to</span>
-              <Badge size="xs" tone="accent">
+              <Badge size="sm" tone="accent">
                 {targetBucket}
               </Badge>
             </div>

--- a/src/components/ui/primitives/Badge.gallery.tsx
+++ b/src/components/ui/primitives/Badge.gallery.tsx
@@ -12,9 +12,28 @@ const ROLE_BADGES = [
   { tone: "support", label: "Support" },
 ] as const;
 
+const SIZE_OPTIONS = [
+  { token: "sm", label: "Small" },
+  { token: "md", label: "Medium" },
+  { token: "lg", label: "Large" },
+  { token: "xl", label: "Extra large" },
+] as const;
+
 function BadgeGalleryPreview() {
   return (
     <div className="flex flex-col gap-[var(--space-3)]">
+      <div className="flex flex-col gap-[var(--space-1)]">
+        <div className="flex flex-wrap gap-[var(--space-2)]">
+          {SIZE_OPTIONS.map(({ token, label }) => (
+            <Badge key={token} size={token}>
+              {label}
+            </Badge>
+          ))}
+        </div>
+        <p className="text-caption text-muted-foreground">
+          <code>xs</code> is available as an alias of <code>sm</code> for legacy badges.
+        </p>
+      </div>
       <div className="flex flex-wrap gap-[var(--space-2)]">
         <Badge tone="neutral">Neutral</Badge>
         <Badge tone="accent">Accent</Badge>
@@ -55,8 +74,9 @@ export default defineGallerySection({
         },
         {
           name: "size",
-          type: '"xs" | "sm"',
-          defaultValue: '"sm"',
+          type: '"sm" | "md" | "lg" | "xl"',
+          defaultValue: '"md"',
+          description: 'Use "xs" as an alias for "sm" when migrating legacy code.',
         },
         { name: "interactive", type: "boolean", defaultValue: "false" },
         { name: "selected", type: "boolean", defaultValue: "false" },
@@ -79,6 +99,12 @@ export default defineGallerySection({
           ],
         },
         {
+          id: "size",
+          label: "Size",
+          type: "variant",
+          values: SIZE_OPTIONS.map(({ label }) => ({ value: label })),
+        },
+        {
           id: "state",
           label: "State",
           type: "state",
@@ -95,6 +121,15 @@ export default defineGallerySection({
         render: () => <BadgeGalleryPreview />,
       }),
       code: `<div className="flex flex-col gap-[var(--space-3)]">
+  <div className="flex flex-wrap gap-[var(--space-2)]">
+    <Badge size="sm">Small</Badge>
+    <Badge size="md">Medium</Badge>
+    <Badge size="lg">Large</Badge>
+    <Badge size="xl">Extra large</Badge>
+  </div>
+  <p className="text-caption text-muted-foreground">
+    <code>xs</code> is available as an alias of <code>sm</code> for legacy badges.
+  </p>
   <div className="flex flex-wrap gap-[var(--space-2)]">
     <Badge tone="neutral">Neutral</Badge>
     <Badge tone="accent">Accent</Badge>

--- a/src/components/ui/primitives/Badge.tsx
+++ b/src/components/ui/primitives/Badge.tsx
@@ -3,7 +3,8 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-type Size = "xs" | "sm";
+type BaseSize = "sm" | "md" | "lg" | "xl";
+type Size = "xs" | BaseSize;
 type Tone =
   | "neutral"
   | "primary"
@@ -28,9 +29,16 @@ export type BadgeProps<T extends React.ElementType = "span"> =
   BadgeOwnProps<T> &
     Omit<React.ComponentPropsWithoutRef<T>, keyof BadgeOwnProps<T>>;
 
+const baseSizeMap: Record<BaseSize, string> = {
+  sm: "px-[var(--space-2)] py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)]",
+  md: "px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)]",
+  lg: "px-[var(--space-4)] py-[var(--space-2)] text-ui leading-none [&_svg]:size-[var(--icon-size-md)]",
+  xl: "px-[var(--space-5)] py-[var(--space-3)] text-title leading-none [&_svg]:size-[var(--icon-size-xl)]",
+};
+
 const sizeMap: Record<Size, string> = {
-  xs: "px-[var(--space-2)] py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)]",
-  sm: "px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)]",
+  xs: baseSizeMap.sm,
+  ...baseSizeMap,
 };
 
 const toneBorder: Record<Tone, string> = {
@@ -48,7 +56,7 @@ export default function Badge<T extends React.ElementType = "span">(
   props: BadgeProps<T>,
 ) {
   const {
-    size = "sm",
+    size = "md",
     tone = "neutral",
     interactive = false,
     selected,

--- a/tests/ui/badge.test.tsx
+++ b/tests/ui/badge.test.tsx
@@ -13,6 +13,9 @@ describe('Badge', () => {
     const badge = getByText('Neutral');
     expect(badge).toHaveClass('border-card-hairline');
     expect(badge).toHaveClass('bg-muted/18');
+    expect(badge).toHaveClass('px-[var(--space-3)]');
+    expect(badge).toHaveClass('py-[var(--space-2)]');
+    expect(badge).toHaveClass('text-label');
   });
 
   it('applies accent tone styles', () => {
@@ -21,12 +24,34 @@ describe('Badge', () => {
     expect(badge).toHaveClass('border-[var(--accent-overlay)]');
   });
 
-  it('supports the xs size', () => {
-    const { getByText } = render(<Badge size="xs">Small</Badge>);
-    const badge = getByText('Small');
-    expect(badge).toHaveClass('px-[var(--space-2)]');
-    expect(badge).toHaveClass('py-[var(--space-1)]');
-    expect(badge).toHaveClass('text-label');
+  it('supports the size tokens', () => {
+    const { getByText } = render(
+      <>
+        <Badge size="sm">Small</Badge>
+        <Badge size="md">Medium</Badge>
+        <Badge size="lg">Large</Badge>
+        <Badge size="xl">Extra large</Badge>
+        <Badge size="xs">Alias</Badge>
+      </>,
+    );
+
+    expect(getByText('Small')).toHaveClass('px-[var(--space-2)]');
+    expect(getByText('Small')).toHaveClass('py-[var(--space-1)]');
+    expect(getByText('Small')).toHaveClass('text-label');
+
+    expect(getByText('Medium')).toHaveClass('px-[var(--space-3)]');
+    expect(getByText('Medium')).toHaveClass('py-[var(--space-2)]');
+    expect(getByText('Medium')).toHaveClass('text-label');
+
+    expect(getByText('Large')).toHaveClass('px-[var(--space-4)]');
+    expect(getByText('Large')).toHaveClass('text-ui');
+
+    expect(getByText('Extra large')).toHaveClass('px-[var(--space-5)]');
+    expect(getByText('Extra large')).toHaveClass('py-[var(--space-3)]');
+    expect(getByText('Extra large')).toHaveClass('text-title');
+
+    expect(getByText('Alias')).toHaveClass('px-[var(--space-2)]');
+    expect(getByText('Alias')).toHaveClass('py-[var(--space-1)]');
   });
 });
 


### PR DESCRIPTION
## Summary
- extend the badge size map to include the standard sm/md/lg/xl tokens while keeping an xs alias
- migrate planner, review, prompt, and team badge usages to the new size names
- refresh the badge gallery and tests to document the expanded size matrix

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfdad0c568832cb47e312ffc0b131e