### PR TITLE
Add text-ui default to SectionCard body

### DIFF
--- a/src/components/ui/layout/SectionCard.tsx
+++ b/src/components/ui/layout/SectionCard.tsx
@@ -143,7 +143,7 @@ function Body({ className, ...props }: BodyProps) {
   return (
     <div
       {...props}
-      className={cn("section-b", className)}
+      className={cn("section-b", "text-ui", className)}
       aria-labelledby={labelledBy}
     />
   );


### PR DESCRIPTION
## Summary
- ensure `SectionCard.Body` applies the `text-ui` utility by default so section content uses the UI type scale
- reviewed the prompts gallery `SectionCard` examples to confirm the rendered body text follows the intended sizing

## Testing
- `npm run check`
- `npm test -- --run tests/home/HomePage.test.tsx`
- `npm test -- --run tests/team/JungleClears.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68cfdd9c8668832c84c1b5bfd1a4c92d