### PR TITLE
Refine planner handler naming

### DIFF
--- a/src/components/planner/DayCard.tsx
+++ b/src/components/planner/DayCard.tsx
@@ -81,7 +81,7 @@ export default function DayCard({ iso, isToday }: Props) {
           toggleProject={toggleProject}
           renameProject={renameProject}
           deleteProject={deleteProject}
-          onAdd={addProject}
+          addProject={addProject}
         />
       </div>
       {selectedProjectId && (

--- a/src/components/planner/ProjectList.tsx
+++ b/src/components/planner/ProjectList.tsx
@@ -18,7 +18,7 @@ type Props = {
   toggleProject: (id: string) => void;
   renameProject: (id: string, name: string) => void;
   deleteProject: (id: string) => void;
-  onAdd: (name: string) => string | void;
+  addProject: (name: string) => string | void;
 };
 
 export default function ProjectList({
@@ -29,7 +29,7 @@ export default function ProjectList({
   toggleProject,
   renameProject,
   deleteProject,
-  onAdd,
+  addProject,
 }: Props) {
   const [editingProjectId, setEditingProjectId] = React.useState<string | null>(
     null,
@@ -60,7 +60,7 @@ export default function ProjectList({
   function addProjectCommit() {
     const v = draftProject.trim();
     if (!v) return;
-    const id = onAdd(v);
+    const id = addProject(v);
     setDraftProject("");
     if (id) setSelectedProjectId(id);
   }

--- a/src/components/planner/TaskList.tsx
+++ b/src/components/planner/TaskList.tsx
@@ -90,18 +90,18 @@ export default function TaskList({
             <TaskRow
               key={t.id}
               task={t}
-              onToggle={() => {
+              toggleTask={() => {
                 toggleTask(t.id);
                 setSelectedTaskId(t.id);
               }}
-              onDelete={() => {
+              deleteTask={() => {
                 deleteTask(t.id);
                 setSelectedTaskId("");
               }}
-              onEdit={(title) => renameTask(t.id, title)}
-              onSelect={() => setSelectedTaskId(t.id)}
-              onAddImage={(url) => addTaskImage(t.id, url)}
-              onRemoveImage={(url, index) => removeTaskImage(t.id, url, index)}
+              renameTask={(title) => renameTask(t.id, title)}
+              selectTask={() => setSelectedTaskId(t.id)}
+              addImage={(url) => addTaskImage(t.id, url)}
+              removeImage={(url, index) => removeTaskImage(t.id, url, index)}
             />
           ))}
         </ul>

--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -20,22 +20,22 @@ const layoutClasses =
 
 type Props = {
   task: DayTask;
-  onToggle: () => void;
-  onDelete: () => void;
-  onEdit: (title: string) => void;
-  onSelect: () => void;
-  onAddImage: (url: string) => void;
-  onRemoveImage: (url: string, index: number) => void;
+  toggleTask: () => void;
+  deleteTask: () => void;
+  renameTask: (title: string) => void;
+  selectTask: () => void;
+  addImage: (url: string) => void;
+  removeImage: (url: string, index: number) => void;
 };
 
 export default function TaskRow({
   task,
-  onToggle,
-  onDelete,
-  onEdit,
-  onSelect,
-  onAddImage,
-  onRemoveImage,
+  toggleTask,
+  deleteTask,
+  renameTask,
+  selectTask,
+  addImage,
+  removeImage,
 }: Props) {
   const [editing, setEditing] = React.useState(false);
   const [title, setTitle] = React.useState(task.title);
@@ -90,8 +90,8 @@ export default function TaskRow({
   );
 
   const handleRowClick = React.useCallback(() => {
-    onSelect();
-  }, [onSelect]);
+    selectTask();
+  }, [selectTask]);
 
   const handleRowKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLButtonElement>) => {
@@ -99,14 +99,14 @@ export default function TaskRow({
 
       if (event.key === "Enter") {
         event.preventDefault();
-        onSelect();
+        selectTask();
       }
 
       if (event.key === " " || event.key === "Spacebar") {
         event.preventDefault();
       }
     },
-    [onSelect],
+    [selectTask],
   );
 
   const handleRowKeyUp = React.useCallback(
@@ -115,10 +115,10 @@ export default function TaskRow({
 
       if (event.key === " " || event.key === "Spacebar") {
         event.preventDefault();
-        onSelect();
+        selectTask();
       }
     },
-    [onSelect],
+    [selectTask],
   );
 
   function start() {
@@ -131,21 +131,21 @@ export default function TaskRow({
       setTitle(task.title);
       return;
     }
-    if (v !== task.title) onEdit(v);
+    if (v !== task.title) renameTask(v);
   }
   function cancel() {
     setEditing(false);
     setTitle(task.title);
   }
 
-  function addImage() {
+  function commitImage() {
     const error = validateImageUrl(trimmedImageUrl);
     if (error) {
       setImageError(error);
       return;
     }
 
-    onAddImage(trimmedImageUrl);
+    addImage(trimmedImageUrl);
     setImageUrl("");
     setImageError(null);
   }
@@ -188,7 +188,7 @@ export default function TaskRow({
             <CheckCircle
               checked={task.done}
               onChange={() => {
-                if (!editing) onToggle();
+                if (!editing) toggleTask();
               }}
               aria-label={`Toggle ${task.title} done`}
               size="sm"
@@ -202,7 +202,7 @@ export default function TaskRow({
                 className="task-tile__text block w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-card r-card-lg"
                 onClick={(e) => {
                   e.stopPropagation();
-                  onToggle();
+                  toggleTask();
                 }}
                 onDoubleClick={(e) => {
                   e.stopPropagation();
@@ -264,7 +264,7 @@ export default function TaskRow({
               title="Delete"
               onClick={(e) => {
                 e.stopPropagation();
-                onDelete();
+                deleteTask();
               }}
               onPointerDown={(e) => e.stopPropagation()}
               size="sm"
@@ -298,7 +298,7 @@ export default function TaskRow({
               <IconButton
                 aria-label="Remove image"
                 title="Remove image"
-                onClick={() => onRemoveImage(url, index)}
+                onClick={() => removeImage(url, index)}
                 size="sm"
                 iconSize="xs"
                 variant="ghost"
@@ -312,7 +312,7 @@ export default function TaskRow({
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          addImage();
+          commitImage();
         }}
         className="mt-[var(--space-2)] flex items-center gap-[var(--space-2)]"
       >

--- a/src/components/prompts/ComponentGallery.tsx
+++ b/src/components/prompts/ComponentGallery.tsx
@@ -746,12 +746,12 @@ export default function ComponentGallery() {
                 createdAt: Date.now(),
                 images: ["https://placekitten.com/100/100"],
               }}
-              onToggle={() => {}}
-              onDelete={() => {}}
-              onEdit={() => {}}
-              onSelect={() => {}}
-              onAddImage={() => {}}
-              onRemoveImage={() => {}}
+              toggleTask={() => {}}
+              deleteTask={() => {}}
+              renameTask={() => {}}
+              selectTask={() => {}}
+              addImage={() => {}}
+              removeImage={() => {}}
             />
           </ul>
         ),
@@ -798,7 +798,7 @@ export default function ComponentGallery() {
             toggleProject={() => {}}
             renameProject={() => {}}
             deleteProject={() => {}}
-            onAdd={() => ""}
+            addProject={() => ""}
           />
         ),
         className: "sm:col-span-2 md:col-span-12",

--- a/tests/planner/TaskRow.test.tsx
+++ b/tests/planner/TaskRow.test.tsx
@@ -25,12 +25,12 @@ describe("TaskRow", () => {
           createdAt: Date.now(),
           images: [],
         }}
-        onToggle={noop}
-        onDelete={noop}
-        onEdit={noop}
-        onSelect={noop}
-        onAddImage={noop}
-        onRemoveImage={noop}
+        toggleTask={noop}
+        deleteTask={noop}
+        renameTask={noop}
+        selectTask={noop}
+        addImage={noop}
+        removeImage={noop}
       />,
     );
     const textButton = screen.getByRole("button", { name: "Test task" });
@@ -42,9 +42,9 @@ describe("TaskRow", () => {
   });
 
   it("does not propagate row selection from inner controls", () => {
-    const onSelect = vi.fn();
-    const onToggle = vi.fn();
-    const onDelete = vi.fn();
+    const selectTask = vi.fn();
+    const toggleTask = vi.fn();
+    const deleteTask = vi.fn();
     render(
       <TaskRow
         task={{
@@ -54,23 +54,23 @@ describe("TaskRow", () => {
           createdAt: Date.now(),
           images: [],
         }}
-        onToggle={onToggle}
-        onDelete={onDelete}
-        onEdit={noop}
-        onSelect={onSelect}
-        onAddImage={noop}
-        onRemoveImage={noop}
+        toggleTask={toggleTask}
+        deleteTask={deleteTask}
+        renameTask={noop}
+        selectTask={selectTask}
+        addImage={noop}
+        removeImage={noop}
       />,
     );
     fireEvent.click(screen.getAllByLabelText("Toggle Test task done")[0]);
     fireEvent.click(screen.getAllByLabelText("Edit task")[0]);
     fireEvent.click(screen.getAllByLabelText("Delete task")[0]);
-    expect(onSelect).not.toHaveBeenCalled();
+    expect(selectTask).not.toHaveBeenCalled();
   });
 
   it("renders images and supports add/remove", () => {
-    const onAddImage = vi.fn();
-    const onRemoveImage = vi.fn();
+    const addImage = vi.fn();
+    const removeImage = vi.fn();
     render(
       <TaskRow
         task={{
@@ -80,22 +80,22 @@ describe("TaskRow", () => {
           createdAt: Date.now(),
           images: ["https://example.com/a.jpg"],
         }}
-        onToggle={noop}
-        onDelete={noop}
-        onEdit={noop}
-        onSelect={noop}
-        onAddImage={onAddImage}
-        onRemoveImage={onRemoveImage}
+        toggleTask={noop}
+        deleteTask={noop}
+        renameTask={noop}
+        selectTask={noop}
+        addImage={addImage}
+        removeImage={removeImage}
       />,
     );
     const img = screen.getByRole("img", { name: /image for with image/i });
     expect(img).toBeInTheDocument();
     fireEvent.click(screen.getAllByLabelText("Remove image")[0]);
-    expect(onRemoveImage).toHaveBeenCalledWith("https://example.com/a.jpg", 0);
+    expect(removeImage).toHaveBeenCalledWith("https://example.com/a.jpg", 0);
   });
 
   it("passes the correct index when removing duplicate images", () => {
-    const onRemoveImage = vi.fn();
+    const removeImage = vi.fn();
     render(
       <TaskRow
         task={{
@@ -108,19 +108,19 @@ describe("TaskRow", () => {
             "https://example.com/a.jpg",
           ],
         }}
-        onToggle={noop}
-        onDelete={noop}
-        onEdit={noop}
-        onSelect={noop}
-        onAddImage={noop}
-        onRemoveImage={onRemoveImage}
+        toggleTask={noop}
+        deleteTask={noop}
+        renameTask={noop}
+        selectTask={noop}
+        addImage={noop}
+        removeImage={removeImage}
       />,
     );
 
     const removeButtons = screen.getAllByLabelText("Remove image");
     fireEvent.click(removeButtons[1]);
-    expect(onRemoveImage).toHaveBeenCalledTimes(1);
-    expect(onRemoveImage).toHaveBeenCalledWith("https://example.com/a.jpg", 1);
+    expect(removeImage).toHaveBeenCalledTimes(1);
+    expect(removeImage).toHaveBeenCalledWith("https://example.com/a.jpg", 1);
   });
 
   it("allows adding an image via the attach button", () => {
@@ -137,12 +137,12 @@ describe("TaskRow", () => {
           createdAt: Date.now(),
           images: [],
         }}
-        onToggle={noop}
-        onDelete={noop}
-        onEdit={noop}
-        onSelect={noop}
-        onAddImage={handleAddImage}
-        onRemoveImage={noop}
+        toggleTask={noop}
+        deleteTask={noop}
+        renameTask={noop}
+        selectTask={noop}
+        addImage={handleAddImage}
+        removeImage={noop}
       />,
     );
     const input = screen.getByLabelText("Add image URL");
@@ -171,12 +171,12 @@ describe("TaskRow", () => {
           createdAt: Date.now(),
           images: [],
         }}
-        onToggle={noop}
-        onDelete={noop}
-        onEdit={noop}
-        onSelect={noop}
-        onAddImage={handleAddImage}
-        onRemoveImage={noop}
+        toggleTask={noop}
+        deleteTask={noop}
+        renameTask={noop}
+        selectTask={noop}
+        addImage={handleAddImage}
+        removeImage={noop}
       />,
     );
 
@@ -203,12 +203,12 @@ describe("TaskRow", () => {
           createdAt: Date.now(),
           images: [],
         }}
-        onToggle={noop}
-        onDelete={noop}
-        onEdit={noop}
-        onSelect={noop}
-        onAddImage={noop}
-        onRemoveImage={noop}
+        toggleTask={noop}
+        deleteTask={noop}
+        renameTask={noop}
+        selectTask={noop}
+        addImage={noop}
+        removeImage={noop}
       />,
     );
 


### PR DESCRIPTION
## Summary
- rename the ProjectList add handler to `addProject` and update DayCard and the gallery demo
- standardize TaskRow props around verb-based handler names and adjust TaskList and tests accordingly

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfe206ca60832cb79b11751cd86d1d