### PR TITLE
Add shared persistence logger and expose clipboard fallback errors

### DIFF
--- a/docs/storage-helpers.md
+++ b/docs/storage-helpers.md
@@ -5,5 +5,10 @@ The planner provides tiny helpers for working with `localStorage` in [`src/lib/l
 - `parseJSON(raw)` safely parses a JSON string and returns `null` on failure.
 - `readLocal(key)` reads a value from `localStorage` and parses it with `parseJSON`.
 - `writeLocal(key, value)` serializes a value to JSON and stores it.
+- All helpers report quota and serialization problems through the shared
+  [`persistenceLogger`](../src/lib/logging.ts), which warns during development
+  and tests while staying silent in production builds. Use the same logger in
+  any future persistence helpers so intentional fallbacks remain easy to audit
+  without spamming end-user consoles.
 
 These helpers are reused by both `db.ts` and `theme.ts`, including the static bootstrap logic shipped in [`public/scripts/theme-bootstrap.js`](../public/scripts/theme-bootstrap.js).

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,18 +1,24 @@
 // src/lib/clipboard.ts
 // Shared clipboard helper with textarea fallback.
 
+import { createLogger } from "./logging";
+
+const clipboardLog = createLogger("clipboard");
+
 export async function copyText(text: string): Promise<void> {
   if (typeof navigator === "undefined" || typeof document === "undefined") {
     return;
   }
 
   const clipboard = navigator.clipboard;
+  let lastError: unknown = null;
 
   if (clipboard?.writeText) {
     try {
       await clipboard.writeText(text);
       return;
-    } catch {
+    } catch (error) {
+      lastError = error;
       // Continue to other fallbacks.
     }
   }
@@ -22,12 +28,17 @@ export async function copyText(text: string): Promise<void> {
       const item = new ClipboardItem({ "text/plain": new Blob([text], { type: "text/plain" }) });
       await clipboard.write([item]);
       return;
-    } catch {
+    } catch (error) {
+      lastError = error;
       // Continue to the textarea fallback.
     }
   }
 
   if (!document.body) {
+    clipboardLog.warn(
+      "Unable to copy text because document.body is not available.",
+      lastError,
+    );
     return;
   }
 
@@ -37,13 +48,26 @@ export async function copyText(text: string): Promise<void> {
   document.body.appendChild(ta);
   ta.select();
 
+  let copied = false;
   try {
     if (typeof document.execCommand === "function") {
-      document.execCommand("copy");
+      copied = document.execCommand("copy");
+      if (copied) {
+        return;
+      }
     }
+  } catch (error) {
+    lastError = error;
   } finally {
     document.getSelection()?.removeAllRanges();
     ta.remove();
+  }
+
+  if (!copied) {
+    clipboardLog.warn(
+      "Failed to copy text with the available clipboard strategies.",
+      lastError,
+    );
   }
 }
 

--- a/src/lib/local-bootstrap.ts
+++ b/src/lib/local-bootstrap.ts
@@ -1,3 +1,5 @@
+import { persistenceLogger } from "./logging";
+
 export function parseJSON<T>(raw: string | null): T | null {
   if (!raw) return null;
   try {
@@ -12,7 +14,11 @@ export function readLocal<T>(key: string): T | null {
     const raw =
       typeof window === "undefined" ? null : window.localStorage.getItem(key);
     return parseJSON<T>(raw);
-  } catch {
+  } catch (error) {
+    persistenceLogger.warn(
+      `local-bootstrap readLocal("${key}") failed; returning null.`,
+      error,
+    );
     return null;
   }
 }
@@ -25,8 +31,11 @@ export function writeLocal(key: string, value: unknown) {
     } else {
       window.localStorage.setItem(key, JSON.stringify(value));
     }
-  } catch {
-    // ignore
+  } catch (error) {
+    persistenceLogger.warn(
+      `local-bootstrap writeLocal("${key}") failed; ignoring value.`,
+      error,
+    );
   }
 }
 

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -1,0 +1,36 @@
+// src/lib/logging.ts
+// Lightweight scoped logger used across client utilities.
+
+export type Logger = {
+  warn: (message: string, ...details: unknown[]) => void;
+};
+
+const isProduction = process.env.NODE_ENV === "production";
+
+function formatPrefix(scope: string): string {
+  const trimmed = scope.trim();
+  return trimmed ? `[planner:${trimmed}]` : "[planner]";
+}
+
+export function createLogger(scope: string): Logger {
+  const prefix = formatPrefix(scope);
+  if (isProduction) {
+    const warn: Logger["warn"] = () => {
+      /* no-op in production */
+    };
+    return {
+      warn,
+    };
+  }
+  return {
+    warn(message: string, ...details: unknown[]) {
+      if (details.length > 0) {
+        console.warn(`${prefix} ${message}`, ...details);
+      } else {
+        console.warn(`${prefix} ${message}`);
+      }
+    },
+  };
+}
+
+export const persistenceLogger = createLogger("persistence");

--- a/tests/lib/db.test.ts
+++ b/tests/lib/db.test.ts
@@ -200,7 +200,7 @@ describe("scheduleWrite", () => {
     expect(stringifySpy).toHaveBeenCalledTimes(1);
     expect(structuredCloneSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(
-      `Skipping persistence for "${key}" because value could not be cloned.`,
+      `[planner:persistence] Skipping persistence for "${key}" because value could not be cloned.`,
       value,
     );
 
@@ -226,7 +226,7 @@ describe("scheduleWrite", () => {
       scheduleWrite(key, value);
 
       expect(warnSpy).toHaveBeenCalledWith(
-        `Skipping persistence for "${key}" because value.self contains a circular reference.`,
+        `[planner:persistence] Skipping persistence for "${key}" because value.self contains a circular reference.`,
         value,
       );
 


### PR DESCRIPTION
## Summary
- add a scoped logger that no-ops in production and use it to surface clipboard fallback failures
- route local-bootstrap and db helpers through the shared persistence logger so quota/serialization skips are intentional
- document the logging policy for persistence helpers to guide future storage work

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfe23ee834832c9a8478da1e48a664