### PR TITLE
Adjust weekly calendar grid span at md

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -349,7 +349,7 @@ function HeroPlannerCards() {
           </div>
         </NeoCard>
       </div>
-      <div className="col-span-12 md:col-span-12 lg:col-span-4">
+      <div className="col-span-12 md:col-span-6 lg:col-span-4">
         <NeoCard className="flex h-full flex-col gap-[var(--space-4)] p-[var(--space-4)] md:p-[var(--space-5)]">
           <header className="space-y-[var(--space-1)]">
             <p className="text-label text-muted-foreground">Weekly calendar</p>


### PR DESCRIPTION
## Summary
- set the weekly calendar dashboard card to span six columns at the medium breakpoint so it aligns with the adjacent goals card

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfe419c9d8832ca2ca8320d6eafe9b