### PR TITLE
Use spacing token max width for ColorsView search

### DIFF
--- a/src/components/prompts/ColorsView.tsx
+++ b/src/components/prompts/ColorsView.tsx
@@ -145,7 +145,7 @@ export default function ColorsView({ groups }: ColorsViewProps) {
               and z-index tokens. Copy any token for quick use in new surfaces.
             </p>
           </div>
-          <div className="w-full max-w-md">
+          <div className="w-full max-w-[calc(var(--space-8)*7)]">
             <SearchBar
               value={query}
               onValueChange={setQuery}


### PR DESCRIPTION
## Summary
- replace the ColorsView search container's Tailwind preset max width with a spacing-token-based calc value to preserve the intended layout constraint

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfe58c3320832c82f48537c24725eb