### PR TITLE
Use spacing tokens for MyComps action controls

### DIFF
--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -296,7 +296,7 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
               const editingCard = editingId === c.id;
               const showActions = isCoarsePointer || editing || editingCard;
               const actionClasses = [
-                "absolute right-2 top-2 z-10 flex items-center gap-[var(--space-1)] transition-opacity",
+                "absolute right-[var(--space-2)] top-[var(--space-2)] z-10 flex items-center gap-[var(--space-1)] transition-opacity",
                 showActions
                   ? "opacity-100 pointer-events-auto"
                   : "opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto",


### PR DESCRIPTION
## Summary
- replace the MyComps action button positioning utilities with spacing tokens to keep controls snug to the card corner across devices

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfe586cdd8832c974a209959954001