### PR TITLE
Fix TodayHeroProjects list semantics

### DIFF
--- a/src/components/planner/TodayHeroProjects.tsx
+++ b/src/components/planner/TodayHeroProjects.tsx
@@ -55,6 +55,12 @@ export default function TodayHeroProjects({
   onProjectRenameCancel,
   onToggleShowAllProjects,
 }: TodayHeroProjectsProps) {
+  const activeProjectOptionId = visibleProjects.some(
+    (project) => project.id === selectedProjectId,
+  )
+    ? `${projectsListId}-option-${selectedProjectId}`
+    : undefined;
+
   return (
     <div className="mt-[var(--space-4)] space-y-[var(--space-4)]">
       <form onSubmit={onProjectFormSubmit}>
@@ -73,12 +79,14 @@ export default function TodayHeroProjects({
           <ul
             id={projectsListId}
             className="space-y-[var(--space-2)]"
-            role="list"
+            role="listbox"
             aria-label="Projects"
+            aria-activedescendant={activeProjectOptionId}
           >
             {visibleProjects.map((project) => {
               const isEditing = editingProjectId === project.id;
               const isSelected = selectedProjectId === project.id;
+              const optionId = `${projectsListId}-option-${project.id}`;
               return (
                 <li key={project.id} role="presentation">
                   <div
@@ -89,6 +97,7 @@ export default function TodayHeroProjects({
                     )}
                     tabIndex={0}
                     role="option"
+                    id={optionId}
                     aria-selected={isSelected}
                     aria-disabled={isEditing}
                     onClick={() => {


### PR DESCRIPTION
## Summary
- convert the TodayHeroProjects list into a listbox with ids for options so selection semantics remain valid
- report the active project via aria-activedescendant to keep aria-selected in sync during keyboard selection

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfe57a8b18832c87f45b7c45edaaae