### PR TITLE
Add persistent decoders for goals, reviews, and prompts

### DIFF
--- a/src/components/goals/useGoals.ts
+++ b/src/components/goals/useGoals.ts
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { uid, usePersistentState } from "@/lib/db";
-import type { Goal, Pillar } from "@/lib/types";
+import { isPillar, type Goal, type Pillar } from "@/lib/types";
 
 export const ACTIVE_CAP = 3;
 
@@ -13,8 +13,50 @@ type AddGoalInput = {
   pillar: Pillar | "";
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function decodeGoal(value: unknown): Goal | null {
+  if (!isRecord(value)) return null;
+  const id = value["id"];
+  const title = value["title"];
+  const done = value["done"];
+  const createdAt = value["createdAt"];
+  if (typeof id !== "string") return null;
+  if (typeof title !== "string") return null;
+  if (typeof done !== "boolean") return null;
+  if (typeof createdAt !== "number" || !Number.isFinite(createdAt)) return null;
+  const goal: Goal = { id, title, done, createdAt };
+  const pillar = value["pillar"];
+  if (isPillar(pillar)) {
+    goal.pillar = pillar;
+  }
+  const metric = value["metric"];
+  if (typeof metric === "string") {
+    goal.metric = metric;
+  }
+  const notes = value["notes"];
+  if (typeof notes === "string") {
+    goal.notes = notes;
+  }
+  return goal;
+}
+
+export function decodeGoals(value: unknown): Goal[] | null {
+  if (!Array.isArray(value)) return null;
+  const result: Goal[] = [];
+  for (const entry of value) {
+    const goal = decodeGoal(entry);
+    if (goal) result.push(goal);
+  }
+  return result;
+}
+
 export function useGoals() {
-  const [goals, setGoals] = usePersistentState<Goal[]>("goals.v2", []);
+  const [goals, setGoals] = usePersistentState<Goal[]>("goals.v2", [], {
+    decode: decodeGoals,
+  });
   const [err, setErr] = React.useState<string | null>(null);
   const [lastDeleted, setLastDeleted] = React.useState<Goal | null>(null);
   const undoTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/src/components/reviews/useReviews.ts
+++ b/src/components/reviews/useReviews.ts
@@ -2,14 +2,154 @@
 
 import * as React from "react";
 import { usePersistentState } from "@/lib/db";
-import type { Review } from "@/lib/types";
+import {
+  isPillar,
+  isRole,
+  isSide,
+  type Pillar,
+  type Review,
+  type ReviewMarker,
+} from "@/lib/types";
 
 const REVIEWS_STORAGE_KEY = "reviews.v1" as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function decodeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const result: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === "string") {
+      result.push(entry);
+    }
+  }
+  return result;
+}
+
+function decodePillarArray(value: unknown): Pillar[] {
+  if (!Array.isArray(value)) return [];
+  const result: Pillar[] = [];
+  for (const entry of value) {
+    if (isPillar(entry)) {
+      result.push(entry);
+    }
+  }
+  return result;
+}
+
+function decodeReviewMarker(value: unknown): ReviewMarker | null {
+  if (!isRecord(value)) return null;
+  const id = value["id"];
+  const time = value["time"];
+  const seconds = value["seconds"];
+  const note = value["note"];
+  if (typeof id !== "string") return null;
+  if (typeof time !== "string") return null;
+  if (typeof seconds !== "number" || !Number.isFinite(seconds)) return null;
+  if (typeof note !== "string") return null;
+  const marker: ReviewMarker = { id, time, seconds, note };
+  if (typeof value["noteOnly"] === "boolean") {
+    marker.noteOnly = value["noteOnly"];
+  }
+  return marker;
+}
+
+function decodeReview(value: unknown): Review | null {
+  if (!isRecord(value)) return null;
+  const id = value["id"];
+  const title = value["title"];
+  const createdAt = value["createdAt"];
+  if (typeof id !== "string") return null;
+  if (typeof title !== "string") return null;
+  if (typeof createdAt !== "number" || !Number.isFinite(createdAt)) return null;
+  const review: Review = {
+    id,
+    title,
+    createdAt,
+    tags: decodeStringArray(value["tags"]),
+    pillars: decodePillarArray(value["pillars"]),
+  };
+  const opponent = value["opponent"];
+  if (typeof opponent === "string") {
+    review.opponent = opponent;
+  }
+  const lane = value["lane"];
+  if (typeof lane === "string") {
+    review.lane = lane;
+  }
+  const side = value["side"];
+  if (isSide(side)) {
+    review.side = side;
+  }
+  const patch = value["patch"];
+  if (typeof patch === "string") {
+    review.patch = patch;
+  }
+  const duration = value["duration"];
+  if (typeof duration === "string") {
+    review.duration = duration;
+  }
+  const matchup = value["matchup"];
+  if (typeof matchup === "string") {
+    review.matchup = matchup;
+  }
+  const notes = value["notes"];
+  if (typeof notes === "string") {
+    review.notes = notes;
+  }
+  const resultValue = value["result"];
+  if (resultValue === "Win" || resultValue === "Loss") {
+    review.result = resultValue;
+  }
+  const score = value["score"];
+  if (typeof score === "number" && Number.isFinite(score)) {
+    review.score = score;
+  }
+  const role = value["role"];
+  if (isRole(role)) {
+    review.role = role;
+  }
+  const focusOn = value["focusOn"];
+  if (typeof focusOn === "boolean") {
+    review.focusOn = focusOn;
+  }
+  const focus = value["focus"];
+  if (typeof focus === "number" && Number.isFinite(focus)) {
+    review.focus = focus;
+  }
+  const markersRaw = value["markers"];
+  if (Array.isArray(markersRaw)) {
+    const markers = markersRaw
+      .map(decodeReviewMarker)
+      .filter((marker): marker is ReviewMarker => marker !== null);
+    if (markers.length > 0 || markersRaw.length === 0) {
+      review.markers = markers;
+    }
+  }
+  const status = value["status"];
+  if (status === "new") {
+    review.status = status;
+  }
+  return review;
+}
+
+export function decodeReviews(value: unknown): Review[] | null {
+  if (!Array.isArray(value)) return null;
+  const result: Review[] = [];
+  for (const entry of value) {
+    const review = decodeReview(entry);
+    if (review) result.push(review);
+  }
+  return result;
+}
 
 export function useReviews() {
   const [reviews, setReviews] = usePersistentState<Review[]>(
     REVIEWS_STORAGE_KEY,
     [],
+    { decode: decodeReviews },
   );
 
   const totalCount = reviews.length;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,3 +53,32 @@ export type Goal = {
   done: boolean;
   createdAt: number;
 };
+
+const PILLAR_VALUES = [
+  "Wave",
+  "Trading",
+  "Vision",
+  "Tempo",
+  "Positioning",
+  "Comms",
+] as const;
+
+const SIDE_VALUES = ["Blue", "Red"] as const;
+
+const ROLE_VALUES = ["TOP", "JUNGLE", "MID", "BOT", "SUPPORT"] as const;
+
+const PILLAR_SET = new Set<string>(PILLAR_VALUES);
+const SIDE_SET = new Set<string>(SIDE_VALUES);
+const ROLE_SET = new Set<string>(ROLE_VALUES);
+
+export function isPillar(value: unknown): value is Pillar {
+  return typeof value === "string" && PILLAR_SET.has(value);
+}
+
+export function isSide(value: unknown): value is Side {
+  return typeof value === "string" && SIDE_SET.has(value);
+}
+
+export function isRole(value: unknown): value is Role {
+  return typeof value === "string" && ROLE_SET.has(value);
+}

--- a/tests/goals/decodeGoals.test.ts
+++ b/tests/goals/decodeGoals.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { decodeGoals } from "@/components/goals";
+
+describe("decodeGoals", () => {
+  it("returns null for non-array inputs", () => {
+    expect(decodeGoals(null)).toBeNull();
+    expect(decodeGoals(undefined)).toBeNull();
+    expect(decodeGoals({})).toBeNull();
+  });
+
+  it("filters invalid goal entries while preserving valid fields", () => {
+    const decoded = decodeGoals([
+      {
+        id: "g1",
+        title: "Keep",
+        pillar: "Wave",
+        metric: "CS",
+        notes: "Track progress",
+        done: false,
+        createdAt: 1,
+      },
+      {
+        id: 2,
+        title: "Skip",
+        done: false,
+        createdAt: 2,
+      },
+      null,
+      {
+        id: "g2",
+        title: "Second",
+        pillar: "NotAPillar",
+        metric: 42,
+        notes: { text: "bad" },
+        done: true,
+        createdAt: 3,
+      },
+    ]);
+
+    expect(decoded).toEqual([
+      {
+        id: "g1",
+        title: "Keep",
+        pillar: "Wave",
+        metric: "CS",
+        notes: "Track progress",
+        done: false,
+        createdAt: 1,
+      },
+      {
+        id: "g2",
+        title: "Second",
+        done: true,
+        createdAt: 3,
+      },
+    ]);
+  });
+});

--- a/tests/prompts/decodePrompts.test.ts
+++ b/tests/prompts/decodePrompts.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { decodePrompts } from "@/components/prompts";
+
+describe("decodePrompts", () => {
+  it("returns null for non-array inputs", () => {
+    expect(decodePrompts(null)).toBeNull();
+    expect(decodePrompts(undefined)).toBeNull();
+    expect(decodePrompts({})).toBeNull();
+  });
+
+  it("filters invalid prompt entries", () => {
+    const decoded = decodePrompts([
+      {
+        id: "p1",
+        title: "Keep",
+        text: "Prompt one",
+        createdAt: 1,
+      },
+      {
+        id: "p2",
+        text: "",
+        createdAt: 2,
+        title: 123,
+      },
+      {
+        id: 3,
+        text: "Bad",
+        createdAt: 3,
+      },
+      {
+        id: "p4",
+        text: 4,
+        createdAt: "bad",
+      },
+    ]);
+
+    expect(decoded).toEqual([
+      {
+        id: "p1",
+        title: "Keep",
+        text: "Prompt one",
+        createdAt: 1,
+      },
+      {
+        id: "p2",
+        text: "",
+        createdAt: 2,
+      },
+    ]);
+  });
+});

--- a/tests/reviews/decodeReviews.test.ts
+++ b/tests/reviews/decodeReviews.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import { decodeReviews } from "@/components/reviews/useReviews";
+
+describe("decodeReviews", () => {
+  it("returns null for non-array inputs", () => {
+    expect(decodeReviews(null)).toBeNull();
+    expect(decodeReviews(undefined)).toBeNull();
+    expect(decodeReviews({})).toBeNull();
+  });
+
+  it("repairs review entries and drops corrupted data", () => {
+    const decoded = decodeReviews([
+      {
+        id: "r1",
+        title: "Primary",
+        opponent: "Zed",
+        lane: "Mid",
+        side: "Blue",
+        patch: "14.1",
+        duration: "35:00",
+        matchup: "Zed vs Talon",
+        tags: ["solo", 1, "review"],
+        pillars: ["Wave", "Tempo", "Fake"],
+        notes: "Focus on wave control",
+        result: "Win",
+        score: 8,
+        role: "MID",
+        focusOn: true,
+        focus: 7,
+        markers: [
+          {
+            id: "m1",
+            time: "00:30",
+            seconds: 30,
+            note: "Trading mistake",
+            noteOnly: true,
+          },
+          {
+            id: "m2",
+            time: 42,
+            seconds: "oops",
+            note: null,
+          },
+        ],
+        status: "new",
+        createdAt: 10,
+      },
+      {
+        id: "r2",
+        title: "Secondary",
+        tags: "nope",
+        pillars: ["Comms", "Nope"],
+        side: "Green",
+        result: "Draw",
+        score: "9",
+        role: "COACH",
+        focusOn: "yes",
+        focus: "ten",
+        markers: "none",
+        notes: 123,
+        createdAt: 20,
+      },
+      {
+        id: "bad",
+        title: "skip",
+        createdAt: "bad",
+        tags: [],
+        pillars: [],
+      },
+    ]);
+
+    expect(decoded).toEqual([
+      {
+        id: "r1",
+        title: "Primary",
+        opponent: "Zed",
+        lane: "Mid",
+        side: "Blue",
+        patch: "14.1",
+        duration: "35:00",
+        matchup: "Zed vs Talon",
+        tags: ["solo", "review"],
+        pillars: ["Wave", "Tempo"],
+        notes: "Focus on wave control",
+        result: "Win",
+        score: 8,
+        role: "MID",
+        focusOn: true,
+        focus: 7,
+        markers: [
+          {
+            id: "m1",
+            time: "00:30",
+            seconds: 30,
+            note: "Trading mistake",
+            noteOnly: true,
+          },
+        ],
+        status: "new",
+        createdAt: 10,
+      },
+      {
+        id: "r2",
+        title: "Secondary",
+        tags: [],
+        pillars: ["Comms"],
+        createdAt: 20,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add decoder helpers for persisted goals, reviews, and prompts and wire them into `usePersistentState`
- expose runtime validators for pillar, side, and role discriminators to support sanitization
- add unit tests that confirm corrupted storage data is filtered before hydrating state

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfe500bd2c832c9b7a3dff01de22c8