### PR TITLE
Ensure isometric room hero maintains lifted state

### DIFF
--- a/src/components/home/IsometricRoom.tsx
+++ b/src/components/home/IsometricRoom.tsx
@@ -29,7 +29,7 @@ export default function IsometricRoom({ variant }: IsometricRoomProps) {
     <Card
       role="img"
       aria-label={`Isometric room with ${label}`}
-      className={`relative h-[var(--room-size)] overflow-hidden bg-background border shadow-neo transition-[transform,box-shadow] duration-[var(--dur-quick)] ease-[var(--ease-out)] motion-reduce:transition-none hover:-translate-y-[var(--space-1)] hover:shadow-neo-soft focus-visible:shadow-neo-soft active:translate-y-0 active:shadow-neo-inset focus-visible:ring-2 focus-visible:ring-[var(--focus)] focus-visible:ring-offset-0 motion-reduce:hover:translate-y-0 [--room-size:calc(var(--space-8)*3)] [--room-depth:calc(var(--room-size)/2)] ${VARIANT_STYLES[variant]}`}
+      className={`relative h-[var(--room-size)] overflow-hidden bg-background border shadow-neo transition-[transform,box-shadow] duration-[var(--dur-quick)] ease-[var(--ease-out)] motion-reduce:transition-none hover:-translate-y-[var(--space-1)] hover:shadow-neo-soft focus-visible:shadow-neo-soft active:translate-y-0 active:shadow-neo-soft focus-visible:ring-2 focus-visible:ring-[var(--focus)] focus-visible:ring-offset-0 motion-reduce:hover:translate-y-0 [--room-size:calc(var(--space-8)*3)] [--room-depth:calc(var(--room-size)/2)] ${VARIANT_STYLES[variant]}`}
     >
       <div className="absolute inset-0 [transform-style:preserve-3d]">
         <div className="absolute inset-x-0 bottom-0 h-[var(--room-depth)] bg-[hsl(var(--room-floor))] origin-bottom [transform:rotateX(90deg)]" />


### PR DESCRIPTION
## Summary
- switch the isometric room hero tile's active elevation from the inset token to the shared soft shadow so it stays raised while pressed

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfe84608c8832c9262e62f9b5111ad