### PR TITLE
Adjust active project card shadow

### DIFF
--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -77,10 +77,8 @@
 }
 .proj-card--active {
   border-color: hsl(var(--ring));
-  box-shadow:
-    inset 0 0 0 calc(var(--hairline-w) * 2) hsl(var(--ring) / 0.3),
-    0 calc(var(--space-3) - var(--space-1) / 2) var(--space-5)
-      hsl(var(--shadow-color) / 0.26);
+  box-shadow: 0 calc(var(--space-3) - var(--space-1) / 2) var(--space-5)
+    hsl(var(--shadow-color) / 0.26);
   position: relative;
 }
 .proj-card--active::after {


### PR DESCRIPTION
## Summary
- remove the inset inner shadow from the active planner project card while keeping the accent border and exterior drop shadow intact
- leave the decorative sheen pseudo-element untouched so the highlight animation still renders

## Testing
- npm run check
- npx storybook@9.1.6 dev --smoke-test *(fails: Storybook config directory is missing in this repo snapshot)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe8bb7b20832cb3dcfb29a0395368