### PR TITLE
Keep main landmark during Suspense loading

### DIFF
--- a/src/app/components/page.tsx
+++ b/src/app/components/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import ComponentsPage from "@/components/components/ComponentsPage";
-import { Spinner } from "@/components/ui";
+import { PageShell, Spinner } from "@/components/ui";
 
 export const metadata: Metadata = {
   title: "Components",
@@ -12,9 +12,11 @@ export default function ComponentsRoute() {
   return (
     <Suspense
       fallback={
-        <div className="flex justify-center p-[var(--space-5)]">
-          <Spinner />
-        </div>
+        <PageShell as="main" aria-busy="true">
+          <div className="flex justify-center p-[var(--space-5)]">
+            <Spinner />
+          </div>
+        </PageShell>
       }
     >
       <ComponentsPage />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -563,9 +563,11 @@ export default function Page() {
   return (
     <Suspense
       fallback={
-        <div className="flex justify-center p-[var(--space-6)]">
-          <Spinner />
-        </div>
+        <PageShell as="main" aria-busy="true">
+          <div className="flex justify-center p-[var(--space-6)]">
+            <Spinner />
+          </div>
+        </PageShell>
       }
     >
       <HomePageContent />


### PR DESCRIPTION
## Summary
- wrap the root and components Suspense fallbacks in PageShell rendered as the main landmark
- keep the spinner visible during loading while marking the main region busy for assistive tech

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfe94e740c832c994978461e081813