### PR TITLE
Simplify weekly calendar ARIA semantics

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -367,7 +367,7 @@ function HeroPlannerCards() {
             </p>
           </header>
           <div className="flex overflow-x-auto rounded-card r-card-lg border border-border/60 p-[var(--space-2)]">
-            <ul className="flex w-full min-w-0 gap-[var(--space-2)]" role="listbox" aria-label="Select focus day">
+            <ul className="flex w-full min-w-0 gap-[var(--space-2)]" aria-label="Select focus day">
               {per.map((day) => {
                 const dayDate = fromISODate(day.iso);
                 const weekday = dayDate
@@ -385,8 +385,7 @@ function HeroPlannerCards() {
                   >
                     <button
                       type="button"
-                      role="option"
-                      aria-selected={selected}
+                      aria-pressed={selected}
                       aria-current={todayMarker ? "date" : undefined}
                       onClick={() => handleSelectDay(day.iso)}
                       className={cn(


### PR DESCRIPTION
## Summary
- remove the listbox/option roles from the weekly calendar day picker
- use aria-pressed to communicate the selected day while keeping the today marker

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfe9e678d8832ca3f4e5798da29d77