### PR TITLE
Adjust ShowCode button elevation states

### DIFF
--- a/src/components/prompts/ComponentsView.tsx
+++ b/src/components/prompts/ComponentsView.tsx
@@ -69,15 +69,15 @@ function ShowCodeButton({
         "shadow-neo hover:shadow-neo-soft focus-visible:shadow-neo-soft",
         "transition-[transform,box-shadow,background,filter] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none",
         "hover:-translate-y-[var(--spacing-0-25)] focus-visible:-translate-y-[var(--spacing-0-25)]",
-        "active:translate-y-[var(--spacing-0-25)] active:shadow-neo-inset",
-        "data-[pressed=true]:translate-y-[var(--spacing-0-25)] data-[pressed=true]:shadow-neo-inset",
+        "active:translate-y-[var(--spacing-0-25)] active:shadow-neo-soft",
+        "data-[pressed=true]:translate-y-[var(--spacing-0-25)] data-[pressed=true]:shadow-neo-soft",
         "motion-reduce:hover:translate-y-0 motion-reduce:focus-visible:translate-y-0 motion-reduce:active:translate-y-0",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card",
         "before:pointer-events-none before:absolute before:-inset-px before:rounded-full before:border before:border-[hsl(var(--ring)/0.35)] before:opacity-0 before:transition-opacity before:duration-[var(--dur-quick)] before:ease-out",
         "focus-visible:before:opacity-100",
         "after:pointer-events-none after:absolute after:inset-0 after:rounded-full after:bg-[radial-gradient(120%_95%_at_50%_0%,hsl(var(--accent)/0.24),transparent_65%)] after:opacity-0 after:transition-opacity after:duration-[var(--dur-quick)] after:ease-out",
         "hover:after:opacity-100 focus-visible:after:opacity-100",
-        "disabled:cursor-not-allowed disabled:opacity-60 disabled:shadow-neo-inset disabled:translate-y-0",
+        "disabled:cursor-not-allowed disabled:opacity-60 disabled:shadow-outline-subtle disabled:translate-y-0",
       )}
     >
       {expanded ? "Hide code" : "Show code"}


### PR DESCRIPTION
## Summary
- align the ShowCode toggle button's pressed state shadow with the soft elevation token
- switch the disabled state to use the outline subtle token while preserving motion offsets

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfeb0995f4832cba88dd1f9ad959c5