### PR TITLE
Ensure skip link targets main content

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -78,7 +78,7 @@ export default async function RootLayout({
           </div>
           <SiteChrome />
           <CatCompanion />
-          <div id="main-content" tabIndex={-1} className="relative z-10">
+          <div className="relative z-10">
             {children}
           </div>
         </ThemeProvider>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -16,6 +16,8 @@ export default function NotFound() {
 
   return (
     <main
+      id="main-content"
+      tabIndex={-1}
       className="flex min-h-screen flex-col items-center justify-center gap-[var(--space-3)] px-[var(--space-4)] py-[var(--space-5)] text-center"
       aria-labelledby={headerId}
     >

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -372,7 +372,6 @@ function GoalsPageContent() {
   return (
     <PageShell
       as="main"
-      id="goals-main"
       aria-labelledby="goals-header"
       className="py-[var(--space-6)]"
     >

--- a/src/components/ui/layout/PageShell.tsx
+++ b/src/components/ui/layout/PageShell.tsx
@@ -36,9 +36,17 @@ export default function PageShell<T extends PageShellElement = "div">({
   ...rest
 }: PageShellProps<T>) {
   const Component = (as ?? "div") as PageShellElement;
+  const mainAccessibilityProps: Partial<React.ComponentPropsWithoutRef<"main">> =
+    Component === "main"
+      ? { id: "main-content", tabIndex: -1 }
+      : {};
 
   return (
-    <Component className={cn("page-shell", className)} {...rest}>
+    <Component
+      className={cn("page-shell", className)}
+      {...mainAccessibilityProps}
+      {...rest}
+    >
       {grid ? (
         <div
           className={cn(

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -5,6 +5,8 @@ exports[`ReviewsPage > renders default state 1`] = `
   <main
     aria-labelledby="reviews-header"
     class="page-shell py-[var(--space-6)] space-y-[var(--space-6)]"
+    id="main-content"
+    tabindex="-1"
   >
     <section>
       <style


### PR DESCRIPTION
## Summary
- default `PageShell` mains to expose a focusable `#main-content` landmark for the global skip link
- rely on each page’s real main element, adding the id/tabIndex to the not-found page and removing redundant overrides
- update the ReviewsPage snapshot to reflect the focusable main landmark

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfe9d2eeac832cb4eaf09dc2bd304e