### PR TITLE
Adjust glitch card shadows

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1302,10 +1302,8 @@ textarea:-webkit-autofill {
   border-radius: var(--radius-xl);
   border: 1px solid hsl(var(--card-hairline));
   background: hsl(var(--card) / 0.7);
-  box-shadow:
-    inset 0 var(--spacing-0-25) 0 hsl(var(--foreground) / 0.05),
-    0 calc(var(--space-3) - var(--spacing-0-5)) var(--space-5)
-      hsl(var(--shadow-color) / 0.35);
+  box-shadow: 0 calc(var(--space-3) - var(--spacing-0-5)) var(--space-5)
+    hsl(var(--shadow-color) / 0.35);
   transition:
     transform 0.12s ease,
     box-shadow 0.2s ease,


### PR DESCRIPTION
## Summary
- remove the inset layer from the glitch card shadow so the holographic overlays provide the inner glow
- keep the hover state focused on a stronger drop shadow for consistent cards across the team builder panes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfeaba7690832c951e8e531c86b964