### PR TITLE
chore: align goal card min height token

### DIFF
--- a/src/components/goals/GoalList.tsx
+++ b/src/components/goals/GoalList.tsx
@@ -85,7 +85,7 @@ export default function GoalList({
             <li key={g.id} className="flex">
               <article
                 className={[
-                  "relative flex min-h-8 w-full flex-1 flex-col overflow-hidden rounded-card r-card-lg p-[var(--space-6)]",
+                  "relative flex min-h-[var(--space-6)] w-full flex-1 flex-col overflow-hidden rounded-card r-card-lg p-[var(--space-6)]",
                   "bg-card/30 backdrop-blur-md",
                   "shadow-ring [--ring:var(--accent)]",
                   "transition-all duration-[var(--dur-quick)] hover:-translate-y-1 hover:shadow-ring",


### PR DESCRIPTION
## Summary
- replace the goal card's `min-h-8` utility with the spacing token equivalent to stay on the scale

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfeade928c832cbae762f0e6fc2df4