### PR TITLE
Use outline styling for badges

### DIFF
--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -170,7 +170,7 @@ function PromptsHeaderChipStatePreview({ state }: { state: ChipState }) {
           state === "hover" && "bg-muted/28",
           state === "focus-visible" && CHIP_FOCUS_RING,
           state === "pressed" &&
-            "bg-muted/36 translate-y-[var(--space-1)] shadow-badge",
+            "bg-muted/36 translate-y-[var(--space-1)] shadow-outline-subtle",
           state === "loading" && "pointer-events-none",
         )}
         aria-pressed={state === "pressed" ? "true" : undefined}
@@ -1854,7 +1854,7 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
   <Badge
     interactive
     aria-pressed="true"
-    className="bg-muted/36 translate-y-[var(--space-1)] shadow-badge"
+    className="bg-muted/36 translate-y-[var(--space-1)] shadow-outline-subtle"
   >
     Pressed
   </Badge>

--- a/src/components/ui/primitives/Badge.tsx
+++ b/src/components/ui/primitives/Badge.tsx
@@ -133,7 +133,7 @@ export default function Badge<T extends React.ElementType = "span">(
       className={cn(
         "inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em]",
         "border bg-muted/18",
-        "shadow-badge",
+        "shadow-outline-subtle",
         "transition-[background,box-shadow,transform] duration-140 ease-out",
         sizeMap[size],
         toneBorder[tone],
@@ -143,7 +143,7 @@ export default function Badge<T extends React.ElementType = "span">(
             !isButtonElement && "data-[disabled=true]:pointer-events-none",
           ),
         isSelected &&
-          "bg-primary-soft/36 border-[var(--ring-contrast)] shadow-inset-contrast shadow-glow-xl text-[var(--text-on-accent)]",
+          "bg-primary-soft/36 border-[var(--ring-contrast)] shadow-glow-xl text-[var(--text-on-accent)]",
         glitch &&
           "shadow-inset-hairline shadow-glow-md hover:shadow-inset-contrast hover:shadow-glow-lg",
         className,

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`ReviewListItem > renders default state 1`] = `
             class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
+            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
           >
             MID
           </span>
@@ -91,7 +91,7 @@ exports[`ReviewListItem > renders disabled state 1`] = `
             class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
+            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
           >
             MID
           </span>
@@ -163,7 +163,7 @@ exports[`ReviewListItem > renders selected state 1`] = `
             class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
+            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
           >
             MID
           </span>
@@ -218,7 +218,7 @@ exports[`ReviewListItem > renders untitled state 1`] = `
             class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-success ring-success"
           />
           <span
-            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
+            class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
           >
             MID
           </span>

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -441,7 +441,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                         class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
                       />
                       <span
-                        class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
+                        class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
                       >
                         MID
                       </span>
@@ -485,7 +485,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                         class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
                       />
                       <span
-                        class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
+                        class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
                       >
                         BOT
                       </span>
@@ -529,7 +529,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                         class="h-[var(--space-2)] w-[var(--space-2)] rounded-full ring-2 motion-safe:animate-[blink_1s_steps(2)_infinite] motion-reduce:animate-none bg-muted-foreground ring-muted-foreground"
                       />
                       <span
-                        class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-badge transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
+                        class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[-0.01em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out py-[var(--space-1)] text-label leading-none [&_svg]:size-[var(--icon-size-xs)] border-card-hairline px-[var(--space-1)]"
                       >
                         TOP
                       </span>


### PR DESCRIPTION
## Summary
- update the badge primitive to use the outline shadow token and remove the inset contrast layer from selected badges
- align the prompts gallery pressed chip example with the new outline shadow treatment
- refresh review snapshots so tests expect the outline shadow on rendered badges

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfed1745fc832c8924777439d27bfc