### PR TITLE
Refine MyComps panel spacing token

### DIFF
--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -46,6 +46,7 @@ export type TeamComp = {
 };
 
 const DB_KEY = "team:mycomps.v1";
+const PANEL_STACK_SPACE = "space-y-[var(--space-6)]" as const;
 
 /* ───────────── Seeds ───────────── */
 
@@ -250,7 +251,7 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
             </span>
           }
         />
-        <SectionCard.Body className="space-y-[var(--space-6)]">
+        <SectionCard.Body className={PANEL_STACK_SPACE}>
           {/* Add bar (inside the same panel) */}
           {editing && (
             <form


### PR DESCRIPTION
## Summary
- reuse a named constant for the MyComps panel stack spacing so the body stays on the spacing scale

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfec71d344832cbf02caadfeaaa10d