### PR TITLE
Keep hero wells inset on focus

### DIFF
--- a/src/components/ui/layout/NeomorphicHeroFrame.tsx
+++ b/src/components/ui/layout/NeomorphicHeroFrame.tsx
@@ -205,7 +205,7 @@ function normalizeSlot(value: HeroSlotInput | undefined): HeroSlot | null {
 }
 
 const slotWellBaseClass =
-  "group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md border border-border/45 bg-card/75 px-[var(--space-3)] py-[var(--space-2)] neo-inset hero-focus shadow-neo-inset transition-shadow focus-within:shadow-neoSoft focus-within:ring-1 focus-within:ring-ring/60";
+  "group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md border border-border/45 bg-card/75 px-[var(--space-3)] py-[var(--space-2)] neo-inset hero-focus shadow-neo-inset transition-shadow focus-within:shadow-neo-inset focus-within:ring-1 focus-within:ring-ring/60";
 
 const slotContentClass = "relative z-[1] flex w-full min-w-0 flex-col";
 

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -179,7 +179,7 @@ exports[`ReviewsPage > renders default state 1`] = `
         >
           <div
             aria-label="Search reviews"
-            class="group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md border border-border/45 bg-card/75 px-[var(--space-3)] py-[var(--space-2)] neo-inset hero-focus shadow-neo-inset transition-shadow focus-within:shadow-neoSoft focus-within:ring-1 focus-within:ring-ring/60 md:col-span-7 md:justify-self-center"
+            class="group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md border border-border/45 bg-card/75 px-[var(--space-3)] py-[var(--space-2)] neo-inset hero-focus shadow-neo-inset transition-shadow focus-within:shadow-neo-inset focus-within:ring-1 focus-within:ring-ring/60 md:col-span-7 md:justify-self-center"
             data-slot="search"
             role="group"
           >
@@ -268,7 +268,7 @@ exports[`ReviewsPage > renders default state 1`] = `
             </div>
           </div>
           <div
-            class="group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md border border-border/45 bg-card/75 px-[var(--space-3)] py-[var(--space-2)] neo-inset hero-focus shadow-neo-inset transition-shadow focus-within:shadow-neoSoft focus-within:ring-1 focus-within:ring-ring/60 md:col-span-5 md:justify-self-center"
+            class="group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md border border-border/45 bg-card/75 px-[var(--space-3)] py-[var(--space-2)] neo-inset hero-focus shadow-neo-inset transition-shadow focus-within:shadow-neo-inset focus-within:ring-1 focus-within:ring-ring/60 md:col-span-5 md:justify-self-center"
             data-slot="actions"
             role="group"
           >


### PR DESCRIPTION
## Summary
- keep hero slot wells inset on focus by retaining the neo inset shadow
- update the reviews page snapshot to reflect the preserved inset shadow class

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfedcb79b0832c8da0254ea79548dc