### PR TITLE
Ensure goals card renders empty state

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -423,35 +423,36 @@ function GoalsPageContent() {
           {tab === "goals" && (
             <div className="grid gap-[var(--space-4)]">
               <div className="space-y-[var(--space-2)]">
-                {totalCount === 0 ? (
-                  <GoalsProgress
-                    total={totalCount}
-                    pct={pctDone}
-                    onAddFirst={handleAddFirst}
-                  />
-                ) : (
-                  <SectionCard className="card-neo-soft">
-                    <SectionCard.Header
-                      sticky
-                      topClassName="top-0"
-                      className="flex items-center justify-between"
-                    >
-                      <div className="flex items-center gap-[var(--space-2)] sm:gap-[var(--space-4)]">
-                        <h2 className="text-title font-semibold tracking-[-0.01em]">Your Goals</h2>
-                        <GoalsProgress total={totalCount} pct={pctDone} />
+                <SectionCard className="card-neo-soft">
+                  <SectionCard.Header
+                    sticky
+                    topClassName="top-0"
+                    className="flex items-center justify-between"
+                  >
+                    <div className="flex items-center gap-[var(--space-2)] sm:gap-[var(--space-4)]">
+                      <h2 className="text-title font-semibold tracking-[-0.01em]">Your Goals</h2>
+                      <GoalsProgress total={totalCount} pct={pctDone} />
+                    </div>
+                    <GoalsTabs value={filter} onChange={setFilter} />
+                  </SectionCard.Header>
+                  <SectionCard.Body>
+                    {totalCount === 0 ? (
+                      <div className="flex flex-col items-center gap-[var(--space-4)] py-[var(--space-6)] text-center">
+                        <p className="text-ui font-medium text-muted-foreground">No goals yet.</p>
+                        <Button onClick={handleAddFirst} size="sm">
+                          Add a first goal
+                        </Button>
                       </div>
-                      <GoalsTabs value={filter} onChange={setFilter} />
-                    </SectionCard.Header>
-                    <SectionCard.Body>
+                    ) : (
                       <GoalList
                         goals={filtered}
                         onToggleDone={toggleDone}
                         onRemove={removeGoal}
                         onUpdate={updateGoal}
                       />
-                    </SectionCard.Body>
-                  </SectionCard>
-                )}
+                    )}
+                  </SectionCard.Body>
+                </SectionCard>
               </div>
 
               <div ref={formRef}>

--- a/src/components/goals/GoalsProgress.tsx
+++ b/src/components/goals/GoalsProgress.tsx
@@ -1,35 +1,19 @@
 "use client";
 
 import * as React from "react";
-import Button from "@/components/ui/primitives/Button";
 import ProgressRingIcon from "@/icons/ProgressRingIcon";
 
 interface GoalsProgressProps {
   total: number;
   pct: number; // 0..100
-  onAddFirst?: () => void;
   maxWidth?: number | string;
 }
 
 export default function GoalsProgress({
   total,
   pct,
-  onAddFirst,
   maxWidth,
 }: GoalsProgressProps) {
-  if (total === 0) {
-    return (
-      <div className="rounded-card r-card-md border border-border bg-surface-2 p-[var(--space-6)] text-center">
-        <p className="mb-[var(--space-4)] text-muted-foreground text-ui font-medium">No goals yet.</p>
-        {onAddFirst && (
-          <Button onClick={onAddFirst} size="sm" className="mx-auto">
-            Add a first goal
-          </Button>
-        )}
-      </div>
-    );
-  }
-
   const v = Math.max(0, Math.min(100, Math.round(pct)));
   const customSize =
     maxWidth == null
@@ -38,6 +22,10 @@ export default function GoalsProgress({
         ? `${maxWidth}px`
         : maxWidth;
   const ringSize = typeof maxWidth === "number" ? maxWidth : undefined;
+  const ariaLabel =
+    total === 0
+      ? "Goals progress: no goals yet"
+      : `Goals progress: ${v}% complete`;
   return (
     <div
       className="relative inline-flex size-[var(--goals-progress-size,var(--space-8))] items-center justify-center"
@@ -48,7 +36,7 @@ export default function GoalsProgress({
             } as React.CSSProperties)
           : undefined
       }
-      aria-label="Progress"
+      aria-label={ariaLabel}
     >
       <ProgressRingIcon pct={v} size={ringSize} />
       <span


### PR DESCRIPTION
## Summary
- always render the Goals section card and move the empty state into the card body
- simplify `GoalsProgress` to only render the neutral ring indicator with accessible labeling

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfefcbb164832cb94719eff581c0b0