### PR TITLE
Refine goal list styling to use semantic card classes

### DIFF
--- a/src/components/goals/GoalList.tsx
+++ b/src/components/goals/GoalList.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import * as React from "react";
-import { Card, IconButton, Input, Textarea, CheckCircle } from "@/components/ui";
+import {
+  Card,
+  IconButton,
+  Input,
+  Textarea,
+  CheckCircle,
+} from "@/components/ui";
 import { Trash2, Flag, Pencil, X, Check } from "lucide-react";
 import { shortDate } from "@/lib/date";
 import type { Goal } from "@/lib/types";
@@ -52,27 +58,12 @@ export default function GoalList({
   }
 
   return (
-    <ul
-      className="grid grid-cols-1 gap-[var(--space-4)] sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 [grid-auto-rows:minmax(0,1fr)] list-none m-0 p-0"
-    >
+    <ul className="grid grid-cols-1 gap-[var(--space-4)] sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 [grid-auto-rows:minmax(0,1fr)] list-none m-0 p-0">
       {goals.length === 0 ? (
         <li className="flex">
-          <Card
-            className={[
-              "relative isolate flex h-full w-full flex-1 flex-col items-center justify-center gap-[var(--space-2)] overflow-hidden text-center text-ui font-medium text-muted-foreground",
-              "border border-border/50 bg-[radial-gradient(115%_90%_at_50%_0%,hsl(var(--accent)/0.24),transparent_70%),linear-gradient(160deg,hsl(var(--card)/0.86),hsl(var(--surface-2)/0.72))] shadow-neoSoft backdrop-blur-lg",
-            ].join(" ")}
-          >
-            <span
-              aria-hidden
-              className="pointer-events-none absolute inset-0 -z-10 rounded-[inherit] p-[var(--spacing-0-25)] [background:var(--edge-iris)] [mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] [mask-composite:exclude]"
-            />
-            <span
-              aria-hidden
-              className="pointer-events-none absolute inset-0 -z-20 rounded-[inherit] bg-[radial-gradient(120%_85%_at_50%_0%,hsl(var(--accent)/0.32),transparent_75%)] opacity-80"
-            />
-            <Flag aria-hidden className="relative z-[1] mb-[var(--space-1)] h-6 w-6 text-accent" />
-            <p className="relative z-[1] max-w-[30ch]">
+          <Card className="card-neo-soft card-pad flex h-full w-full flex-1 flex-col items-center justify-center gap-[var(--space-2)] text-center text-ui font-medium text-muted-foreground">
+            <Flag aria-hidden className="h-6 w-6 text-accent" />
+            <p className="max-w-[30ch]">
               No goals here. Add one simple, finishable thing.
             </p>
           </Card>
@@ -83,163 +74,160 @@ export default function GoalList({
           const headingId = `goal-${g.id}-heading`;
           return (
             <li key={g.id} className="flex">
-              <article
-                className={[
-                  "relative flex min-h-[var(--space-6)] w-full flex-1 flex-col overflow-hidden rounded-card r-card-lg p-[var(--space-6)]",
-                  "bg-card/30 backdrop-blur-md",
-                  "shadow-ring [--ring:var(--accent)]",
-                  "transition-all duration-[var(--dur-quick)] hover:-translate-y-1 hover:shadow-ring",
-                ].join(" ")}
+              <Card
+                asChild
+                className="card-neo-soft card-pad flex min-h-[var(--space-6)] w-full flex-1 flex-col"
               >
-                <span
-                  aria-hidden
-                  className="pointer-events-none absolute inset-0 rounded-card r-card-lg p-px [background:linear-gradient(135deg,hsl(var(--primary)),hsl(var(--accent)),transparent)] [mask:linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))_content-box,linear-gradient(hsl(var(--foreground)),hsl(var(--foreground)))] [mask-composite:exclude]"
-                />
-                <header className="relative z-[1] flex items-start justify-between gap-[var(--space-2)]">
-                  <div className="flex-1 pr-[var(--space-6)]">
-                    <h3
-                      id={headingId}
-                      className={[
-                        "text-title font-semibold tracking-[-0.01em] leading-tight",
-                        isEditing ? "sr-only" : "line-clamp-2",
-                      ].join(" ")}
-                    >
-                      {isEditing
-                        ? draft.title || g.title || "Goal title"
-                        : g.title}
-                    </h3>
+                <article>
+                  <header className="flex items-start justify-between gap-[var(--space-2)]">
+                    <div className="flex-1 pr-[var(--space-6)]">
+                      <h3
+                        id={headingId}
+                        className={[
+                          "text-title font-semibold tracking-[-0.01em] leading-tight",
+                          isEditing ? "sr-only" : "line-clamp-2",
+                        ].join(" ")}
+                      >
+                        {isEditing
+                          ? draft.title || g.title || "Goal title"
+                          : g.title}
+                      </h3>
+                      {isEditing ? (
+                        <Input
+                          aria-labelledby={headingId}
+                          value={draft.title}
+                          onChange={(e) =>
+                            setDraft((d) => ({ ...d, title: e.target.value }))
+                          }
+                          className="font-semibold"
+                          placeholder="Title"
+                        />
+                      ) : null}
+                    </div>
+                    <div className="flex items-center gap-[var(--space-2)]">
+                      {isEditing ? (
+                        <>
+                          <IconButton
+                            aria-label="Cancel"
+                            onClick={cancelEdit}
+                            size="sm"
+                            variant="ghost"
+                            tone="accent"
+                            className="transition-transform hover:-translate-y-0.5"
+                          >
+                            <X />
+                          </IconButton>
+                          <IconButton
+                            aria-label="Save"
+                            onClick={() => saveEdit(g.id)}
+                            size="sm"
+                            variant="secondary"
+                            tone="accent"
+                            className="transition-transform hover:-translate-y-0.5"
+                          >
+                            <Check />
+                          </IconButton>
+                        </>
+                      ) : (
+                        <>
+                          <CheckCircle
+                            aria-label={g.done ? "Mark active" : "Mark done"}
+                            checked={g.done}
+                            onChange={() => onToggleDone(g.id)}
+                            size="sm"
+                            className="transition-transform hover:-translate-y-0.5"
+                          />
+                          <IconButton
+                            title="Edit"
+                            aria-label="Edit goal"
+                            onClick={() => startEdit(g)}
+                            size="sm"
+                            variant="ghost"
+                            tone="accent"
+                            className="transition-transform hover:-translate-y-0.5"
+                          >
+                            <Pencil />
+                          </IconButton>
+                          <IconButton
+                            title="Delete"
+                            aria-label="Delete goal"
+                            onClick={() => onRemove(g.id)}
+                            size="sm"
+                            variant="secondary"
+                            tone="accent"
+                            className="transition-transform hover:-translate-y-0.5"
+                          >
+                            <Trash2 />
+                          </IconButton>
+                        </>
+                      )}
+                    </div>
+                  </header>
+                  <div className="mt-[var(--space-4)] space-y-[var(--space-2)] text-ui font-medium text-muted-foreground">
                     {isEditing ? (
-                      <Input
-                        aria-labelledby={headingId}
-                        value={draft.title}
-                        onChange={(e) =>
-                          setDraft((d) => ({ ...d, title: e.target.value }))
-                        }
-                        className="font-semibold"
-                        placeholder="Title"
-                      />
-                    ) : null}
-                  </div>
-                  <div className="flex items-center gap-[var(--space-2)]">
-                    {isEditing ? (
-                      <>
-                        <IconButton
-                          aria-label="Cancel"
-                          onClick={cancelEdit}
-                          size="sm"
-                          variant="ghost"
-                          tone="accent"
-                          className="transition-transform hover:-translate-y-0.5"
-                        >
-                          <X />
-                        </IconButton>
-                        <IconButton
-                          aria-label="Save"
-                          onClick={() => saveEdit(g.id)}
-                          size="sm"
-                          variant="secondary"
-                          tone="accent"
-                          className="transition-transform hover:-translate-y-0.5"
-                        >
-                          <Check />
-                        </IconButton>
-                      </>
+                      <div className="space-y-[var(--space-2)]">
+                        <Input
+                          aria-label="Metric"
+                          value={draft.metric}
+                          onChange={(e) =>
+                            setDraft((d) => ({ ...d, metric: e.target.value }))
+                          }
+                          className="tabular-nums"
+                          placeholder="Metric"
+                        />
+                        <Textarea
+                          aria-label="Notes"
+                          value={draft.notes}
+                          onChange={(e) =>
+                            setDraft((d) => ({ ...d, notes: e.target.value }))
+                          }
+                          placeholder="Notes"
+                          className="resize-none"
+                          rows={3}
+                        />
+                      </div>
                     ) : (
                       <>
-                        <CheckCircle
-                          aria-label={g.done ? "Mark active" : "Mark done"}
-                          checked={g.done}
-                          onChange={() => onToggleDone(g.id)}
-                          size="sm"
-                          className="transition-transform shadow-ring hover:-translate-y-0.5 hover:shadow-ring [--ring:var(--accent)]"
-                        />
-                        <IconButton
-                          title="Edit"
-                          aria-label="Edit goal"
-                          onClick={() => startEdit(g)}
-                          size="sm"
-                          variant="ghost"
-                          tone="accent"
-                          className="transition-transform hover:-translate-y-0.5"
-                        >
-                          <Pencil />
-                        </IconButton>
-                        <IconButton
-                          title="Delete"
-                          aria-label="Delete goal"
-                          onClick={() => onRemove(g.id)}
-                          size="sm"
-                          variant="secondary"
-                          tone="accent"
-                          className="transition-transform hover:-translate-y-0.5"
-                        >
-                          <Trash2 />
-                        </IconButton>
+                        {g.metric ? (
+                          <div className="tabular-nums">
+                            <span className="opacity-70">Metric:</span>{" "}
+                            {g.metric}
+                          </div>
+                        ) : null}
+                        {g.notes ? (
+                          <p className="text-body leading-relaxed">{g.notes}</p>
+                        ) : null}
                       </>
                     )}
                   </div>
-                </header>
-                <div className="relative z-[1] mt-[var(--space-4)] space-y-[var(--space-2)] text-ui font-medium text-muted-foreground">
-                  {isEditing ? (
-                    <div className="space-y-[var(--space-2)]">
-                      <Input
-                        aria-label="Metric"
-                        value={draft.metric}
-                        onChange={(e) =>
-                          setDraft((d) => ({ ...d, metric: e.target.value }))
-                        }
+                  <footer className="mt-auto flex items-center justify-between pt-[var(--space-3)] text-label font-medium tracking-[0.02em] text-muted-foreground">
+                    <span className="inline-flex items-center gap-[var(--space-2)]">
+                      <span
+                        aria-hidden
+                        className={[
+                          "h-2 w-2 rounded-full transition-all",
+                          g.done
+                            ? "bg-muted-foreground/40"
+                            : "bg-accent shadow-ring motion-safe:animate-pulse",
+                        ].join(" ")}
+                      />
+                      <time
                         className="tabular-nums"
-                        placeholder="Metric"
-                      />
-                      <Textarea
-                        aria-label="Notes"
-                        value={draft.notes}
-                        onChange={(e) =>
-                          setDraft((d) => ({ ...d, notes: e.target.value }))
-                        }
-                        placeholder="Notes"
-                        className="resize-none"
-                        rows={3}
-                      />
-                    </div>
-                  ) : (
-                    <>
-                      {g.metric ? (
-                        <div className="tabular-nums">
-                          <span className="opacity-70">Metric:</span> {g.metric}
-                        </div>
-                      ) : null}
-                      {g.notes ? (
-                        <p className="text-body leading-relaxed">{g.notes}</p>
-                      ) : null}
-                    </>
-                  )}
-                </div>
-                <footer className="relative z-[1] mt-auto pt-[var(--space-3)] flex items-center justify-between text-label font-medium tracking-[0.02em] text-muted-foreground">
-                  <span className="inline-flex items-center gap-[var(--space-2)]">
+                        dateTime={new Date(g.createdAt).toISOString()}
+                      >
+                        {shortDate.format(new Date(g.createdAt))}
+                      </time>
+                    </span>
                     <span
-                      aria-hidden
-                      className={[
-                        "h-2 w-2 rounded-full transition-all",
-                        g.done
-                          ? "bg-muted-foreground/40"
-                          : "bg-accent shadow-ring motion-safe:animate-pulse [--ring:var(--accent)]",
-                      ].join(" ")}
-                    />
-                    <time
-                      className="tabular-nums"
-                      dateTime={new Date(g.createdAt).toISOString()}
+                      className={
+                        g.done ? "text-muted-foreground" : "text-accent-3"
+                      }
                     >
-                      {shortDate.format(new Date(g.createdAt))}
-                    </time>
-                  </span>
-                  <span
-                    className={g.done ? "text-muted-foreground" : "text-accent-3"}
-                  >
-                    {g.done ? "Done" : "Active"}
-                  </span>
-                </footer>
-              </article>
+                      {g.done ? "Done" : "Active"}
+                    </span>
+                  </footer>
+                </article>
+              </Card>
             </li>
           );
         })


### PR DESCRIPTION
## Summary
- update the goals empty state to reuse the `card-neo-soft` and `card-pad` primitives instead of bespoke gradient spans
- render each goal tile through the card primitive so the layout inherits standard neon card styling and spacing tokens
- drop custom ring variables from interactive controls and rely on design-system accent and ring tokens

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68cff005e6a4832c94b87b011047e0a7