### PR TITLE
Simplify goals card elevation

### DIFF
--- a/src/components/goals/RemindersTab.tsx
+++ b/src/components/goals/RemindersTab.tsx
@@ -9,7 +9,7 @@ import ReminderQuickAddForm from "./reminders/ReminderQuickAddForm";
 
 export default function RemindersTab() {
   return (
-    <SectionCard className="goal-card">
+    <SectionCard>
       <SectionCard.Body>
         <div className="grid gap-[var(--space-3)]">
           <ReminderQuickAddForm />

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -432,9 +432,9 @@ export default function TimerTab() {
         }}
       />
 
-      <SectionCard className="goal-card no-hover">
+      <SectionCard className="no-hover">
         <SectionCard.Body>
-          <div className="relative mx-auto w-full max-w-[calc(var(--space-8)*6)] rounded-[var(--radius-2xl)] border border-card-hairline/60 bg-background/30 p-[var(--space-8)] backdrop-blur-xl shadow-neoSoft">
+          <div className="relative mx-auto w-full max-w-[calc(var(--space-8)*6)] rounded-[var(--radius-2xl)] border border-card-hairline/60 bg-background/30 p-[var(--space-8)] backdrop-blur-xl">
             {/* plus/minus */}
             <IconButton
               aria-label="Minus 1 minute"

--- a/src/components/goals/reminders/ReminderList.tsx
+++ b/src/components/goals/reminders/ReminderList.tsx
@@ -42,7 +42,7 @@ export default function ReminderList() {
 
 function EmptyState() {
   return (
-    <div className="goal-card rounded-card ds-card-pad text-ui font-medium text-muted-foreground grid place-items-center">
+    <div className="rounded-card ds-card-pad text-ui font-medium text-muted-foreground grid place-items-center">
       <p>Nothing here. Add one clear sentence you’ll read in champ select.</p>
     </div>
   );


### PR DESCRIPTION
## Summary
- drop the goal-card styling from the goals reminders and timer section cards so they rely on the base SectionCard surface
- remove the extra shadow from the timer layout container to keep a single elevated surface
- update the reminders empty state to avoid goal-card and align with the single-elevation pattern

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cff19bd8e4832c92d018aad5501584