### PR TITLE
Use semantic color for home hero icon

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -459,7 +459,7 @@ function HomePageContent() {
                       id: "home-header",
                       heading: "Welcome to Planner",
                       subtitle: "Plan your day, track goals, and review games.",
-                      icon: <Home className="opacity-80" />,
+                      icon: <Home className="text-muted-foreground" />,
                       sticky: false,
                     }}
                     hero={{


### PR DESCRIPTION
## Summary
- replace the home PageHeader icon opacity utility with the text-muted-foreground token
- verified adjacent hero icon usage so no raw opacity utilities remain

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cff1aa20b8832c99da3b103871e8e8