### PR TITLE
Ensure new reviews open in edit mode

### DIFF
--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -43,6 +43,11 @@ export default function ReviewsPage({
   const [sort, setSort] = React.useState<SortKey>("newest");
   const [detailMode, setDetailMode] = React.useState<DetailMode>("summary");
 
+  const handleCreateReview = React.useCallback(() => {
+    setDetailMode("edit");
+    onCreate();
+  }, [onCreate]);
+
   const base = React.useMemo<Review[]>(
     () => (Array.isArray(reviews) ? reviews : []),
     [reviews],
@@ -135,8 +140,7 @@ export default function ReviewsPage({
                 onClick={() => {
                   setQ("");
                   setSort("newest");
-                  setDetailMode("edit");
-                  onCreate();
+                  handleCreateReview();
                 }}
               >
                 <Plus />
@@ -163,7 +167,7 @@ export default function ReviewsPage({
               setDetailMode("summary");
               onSelect(id);
             }}
-            onCreate={onCreate}
+            onCreate={handleCreateReview}
             className="h-auto overflow-auto p-[var(--space-2)] md:h-[calc(100vh-var(--header-stack)-var(--space-6))]"
             header={`${filtered.length} shown`}
             hoverRing


### PR DESCRIPTION
## Summary
- add a helper that flips the review detail mode to edit before triggering creation
- reuse the helper for both the page header action and list create callback so new reviews open in the editor

## Testing
- npm run check


------
https://chatgpt.com/codex/tasks/task_e_68cff927c394832c9b6e0e518d7ac29e