### PR TITLE
Fix goals sticky header offsets

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -401,7 +401,7 @@ function GoalsPageContent() {
             heading: heroHeading,
             subtitle: heroSubtitle,
             sticky: false,
-            topClassName: "top-0",
+            topClassName: "top-[var(--header-stack)]",
             dividerTint: heroDividerTint,
             "aria-labelledby": heroHeadingId,
             "aria-describedby": heroAriaDescribedby,
@@ -426,7 +426,7 @@ function GoalsPageContent() {
                 <SectionCard className="card-neo-soft">
                   <SectionCard.Header
                     sticky
-                    topClassName="top-0"
+                    topClassName="top-[var(--header-stack)]"
                     className="flex items-center justify-between"
                   >
                     <div className="flex items-center gap-[var(--space-2)] sm:gap-[var(--space-4)]">

--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -167,7 +167,7 @@ export default function Reminders() {
   return (
     <div className="grid gap-[var(--space-3)]">
       <SectionCard className="card-neo-soft">
-        <SectionCard.Header sticky topClassName="top-0">
+        <SectionCard.Header sticky topClassName="top-[var(--header-stack)]">
           {/* header row (no Quick Add here anymore) */}
           <div className="flex flex-wrap items-center gap-[var(--space-2)] sm:gap-[var(--space-3)] w-full">
             {/* search */}


### PR DESCRIPTION
## Summary
- adjust the GoalsPage hero and goals panel headers to respect the shared header stack offset
- update the Reminders panel header to use the header stack top offset so it clears the site chrome

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cff9581ea8832cb1780e689de2f001