### PR TITLE
Adjust scroll-to-top button inset

### DIFF
--- a/src/components/planner/ScrollTopFloatingButton.tsx
+++ b/src/components/planner/ScrollTopFloatingButton.tsx
@@ -65,7 +65,7 @@ export default function ScrollTopFloatingButton({
     <IconButton
       aria-label="Scroll to top"
       onClick={scrollTop}
-      className="fixed bottom-[var(--space-8)] right-[max(var(--space-2),calc((100vw-var(--shell-max,var(--shell-width)))/2+var(--space-2)))] z-50"
+      className="fixed bottom-[var(--space-8)] right-[max(var(--space-2),calc((100vw - var(--shell-max, var(--shell-width))) / 2 + var(--space-2)))] z-50"
     >
       <ArrowUp />
     </IconButton>


### PR DESCRIPTION
## Summary
- align the planner scroll-to-top floating button with the page shell by mirroring shell insets using spacing tokens
- ensure the right inset calc() expression includes required whitespace so the value is applied

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cffbdac230832cbd3390a69231b221