### PR TITLE
Adjust scroll-top button inset calculation

### DIFF
--- a/src/components/planner/ScrollTopFloatingButton.tsx
+++ b/src/components/planner/ScrollTopFloatingButton.tsx
@@ -65,7 +65,7 @@ export default function ScrollTopFloatingButton({
     <IconButton
       aria-label="Scroll to top"
       onClick={scrollTop}
-      className="fixed bottom-[var(--space-8)] right-[max(var(--space-2),calc((100vw-var(--shell-max,var(--shell-width)))/2+var(--space-2)))] z-50"
+      className="fixed bottom-[var(--space-8)] right-[calc(var(--space-2)+max(0px,(100vw-var(--shell-max,var(--shell-width)))/2))] z-50"
     >
       <ArrowUp />
     </IconButton>


### PR DESCRIPTION
## Summary
- update the scroll-to-top floating button to offset its right edge by the shell inset while keeping spacing tokens

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cffbf4b140832c8e07839af7f8beb7