### PR TITLE
Ensure radius preview has tokenized rounding

### DIFF
--- a/src/components/prompts/ColorsView.tsx
+++ b/src/components/prompts/ColorsView.tsx
@@ -347,7 +347,7 @@ function RadiusPreview({ name }: { name: string }) {
       aria-hidden="true"
     >
       <div
-        className="aspect-square w-full max-w-[var(--space-8)] border border-[var(--card-hairline)] bg-panel/70"
+        className="aspect-square w-full max-w-[var(--space-8)] overflow-hidden rounded-[var(--radius-md)] border border-[var(--card-hairline)] bg-panel/70"
         style={{ borderRadius: `var(--${name})` }}
       />
     </div>


### PR DESCRIPTION
## Summary
- add a rounded token fallback to the radius token preview swatch
- keep the per-token border radius style so each swatch still reflects its value

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cffe4f1324832ca670d2ab3714eccf