### PR TITLE
Remove sticky container class from TeamComp header

### DIFF
--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -492,7 +492,7 @@ export default function TeamCompPage() {
       aria-labelledby="teamcomp-header"
     >
       <PageHeader
-        containerClassName="relative md:col-span-12"
+        containerClassName="md:col-span-12"
         className="rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-4)]"
         contentClassName="space-y-[var(--space-2)]"
         frameProps={{ variant: "unstyled" }}


### PR DESCRIPTION
## Summary
- remove the extra sticky container class from the TeamComp page header so the built-in header offset controls the stickiness

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d00758cbc4832c8a40147e56614878