### PR TITLE
Align goals sticky surfaces with header stack offset

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -30,6 +30,7 @@ import GoalsTabs, { FilterKey } from "./GoalsTabs";
 import GoalForm, { GoalFormHandle } from "./GoalForm";
 import GoalsProgress from "./GoalsProgress";
 import GoalList from "./GoalList";
+import { GOALS_STICKY_TOP_CLASS } from "./constants";
 
 import { usePersistentState } from "@/lib/db";
 import type { Pillar } from "@/lib/types";
@@ -401,7 +402,7 @@ function GoalsPageContent() {
             heading: heroHeading,
             subtitle: heroSubtitle,
             sticky: false,
-            topClassName: "top-[var(--header-stack)]",
+            topClassName: GOALS_STICKY_TOP_CLASS,
             dividerTint: heroDividerTint,
             "aria-labelledby": heroHeadingId,
             "aria-describedby": heroAriaDescribedby,
@@ -426,7 +427,7 @@ function GoalsPageContent() {
                 <SectionCard className="card-neo-soft">
                   <SectionCard.Header
                     sticky
-                    topClassName="top-[var(--header-stack)]"
+                    topClassName={GOALS_STICKY_TOP_CLASS}
                     className="flex items-center justify-between"
                   >
                     <div className="flex items-center gap-[var(--space-2)] sm:gap-[var(--space-4)]">

--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -23,6 +23,7 @@ import TabBar from "@/components/ui/layout/TabBar";
 import SegmentedButton from "@/components/ui/primitives/SegmentedButton";
 import { uid, usePersistentState } from "@/lib/db";
 import useAutoFocus from "@/lib/useAutoFocus";
+import { GOALS_STICKY_TOP_CLASS } from "./constants";
 import {
   Search,
   Plus,
@@ -167,7 +168,7 @@ export default function Reminders() {
   return (
     <div className="grid gap-[var(--space-3)]">
       <SectionCard className="card-neo-soft">
-        <SectionCard.Header sticky topClassName="top-[var(--header-stack)]">
+        <SectionCard.Header sticky topClassName={GOALS_STICKY_TOP_CLASS}>
           {/* header row (no Quick Add here anymore) */}
           <div className="flex flex-wrap items-center gap-[var(--space-2)] sm:gap-[var(--space-3)] w-full">
             {/* search */}

--- a/src/components/goals/constants.ts
+++ b/src/components/goals/constants.ts
@@ -1,0 +1,1 @@
+export const GOALS_STICKY_TOP_CLASS = "top-[var(--header-stack)]";


### PR DESCRIPTION
## Summary
- add a shared `GOALS_STICKY_TOP_CLASS` constant for the goals feature
- use the shared offset on the goals hero and card header so sticky states clear the chrome
- reuse the shared offset in the reminders header to keep its sticky behavior aligned

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d007549940832c894e48ff53511c14