### PR TITLE
Align home hero sticky offset with chrome

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -486,7 +486,7 @@ function HomePageContent() {
                       sticky: false,
                       barVariant: "raised",
                       glitch: "subtle",
-                      topClassName: "top-0",
+                      topClassName: "top-[var(--header-stack)]",
                       actions: (
                         <div className="grid w-full grid-cols-12 gap-[var(--space-4)] sm:items-center">
                           <div className="col-span-12 flex w-full flex-wrap items-center justify-end gap-[var(--space-2)] sm:flex-nowrap md:col-span-8 lg:col-span-7">


### PR DESCRIPTION
## Summary
- align the landing hero on the home page with the global header stack token so sticky elements respect the chrome offset

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d0075dd6f8832ca15fa68aa5f91da8