### PR TITLE
Add card radius helpers to team cheat sheet

### DIFF
--- a/src/components/team/CheatSheet.tsx
+++ b/src/components/team/CheatSheet.tsx
@@ -596,7 +596,7 @@ export default function CheatSheet({
           <article
             key={a.id}
             className={[
-              "group glitch-card relative h-full",
+              "group glitch-card rounded-card r-card-lg relative h-full",
               dense
                 ? "p-[var(--space-4)]"
                 : "p-[var(--space-5)]",


### PR DESCRIPTION
## Summary
- add rounded-card and r-card-lg helpers to the team cheat sheet glitch card so --radius-card is defined

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d00997ef60832cb3207ab1d8233029