### PR TITLE
Ensure neo tablist defines card radius

### DIFF
--- a/src/components/components/ComponentsPageClient.tsx
+++ b/src/components/components/ComponentsPageClient.tsx
@@ -23,6 +23,8 @@ import { usePersistentState } from "@/lib/db";
 import { cn } from "@/lib/utils";
 
 const NEO_TABLIST_SHARED_CLASSES = [
+  "data-[variant=neo]:rounded-card",
+  "data-[variant=neo]:r-card-lg",
   "data-[variant=neo]:gap-[var(--space-2)]",
   "data-[variant=neo]:px-[var(--space-2)]",
   "data-[variant=neo]:py-[var(--space-2)]",


### PR DESCRIPTION
## Summary
- ensure the neo tablist variant applies the card radius helpers so `--radius-card` is defined

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d017451cb4832caffdb41fc5d19e42