### PR TITLE
Hide progress ring SVG from accessibility tree

### DIFF
--- a/src/icons/ProgressRingIcon.tsx
+++ b/src/icons/ProgressRingIcon.tsx
@@ -21,6 +21,8 @@ export default function ProgressRingIcon({
     <svg
       className="h-full w-full rotate-[-90deg]"
       viewBox={`0 0 ${size} ${size}`}
+      aria-hidden="true"
+      focusable="false"
     >
       <circle
         cx={size / 2}


### PR DESCRIPTION
## Summary
- add aria-hidden and focusable=false attributes to the progress ring icon svg so assistive tech only announces textual progress

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d018740518832cbdffa5bb07b85747