### PR TITLE
Fix jungle clears sticky header offset

### DIFF
--- a/src/components/team/JungleClears.tsx
+++ b/src/components/team/JungleClears.tsx
@@ -343,6 +343,7 @@ export default React.forwardRef<
             <SectionCard key={bucket} className="col-span-12 md:col-span-6">
               <SectionCard.Header
                 sticky
+                topClassName="top-[var(--header-stack)]"
                 title={
                   <div className="flex items-center gap-[var(--space-2)]">
                     <Timer className="opacity-80" />


### PR DESCRIPTION
## Summary
- set the Jungle Clears bucket header to use the shared header stack offset so sticky sections clear the global chrome
- confirmed the other Team tab sticky hero configs already rely on the `--header-stack` token

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d016708ae0832cb50943a9b8c35c39