### PR TITLE
Adjust hero subtabs radius

### DIFF
--- a/src/components/components/ComponentsPageClient.tsx
+++ b/src/components/components/ComponentsPageClient.tsx
@@ -498,7 +498,7 @@ export default function ComponentsPageClient({
                 variant: "default",
                 showBaseline: true,
                 tablistClassName: cn(
-                  "max-w-full shadow-neo-inset",
+                  "max-w-full shadow-neo-inset rounded-card r-card-lg",
                   "w-full md:w-auto",
                 ),
                 className: "max-w-full w-full md:w-auto",


### PR DESCRIPTION
## Summary
- add the card radius tokens to the components hero sub-tab list so the inset shadow follows the rounded shell

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d019dbe3fc832c8e25c06b2bf309fd