### PR TITLE
Remove neo shadows from glitch team surfaces

### DIFF
--- a/src/components/team/Builder.tsx
+++ b/src/components/team/Builder.tsx
@@ -11,7 +11,6 @@ import "./style.css";
  */
 
 import * as React from "react";
-import SectionCard from "@/components/ui/layout/SectionCard";
 import Input from "@/components/ui/primitives/Input";
 import Textarea from "@/components/ui/primitives/Textarea";
 import IconButton from "@/components/ui/primitives/IconButton";
@@ -244,8 +243,8 @@ export default React.forwardRef<BuilderHandle, BuilderProps>(
 
   return (
     <div data-scope="team" className="w-full mt-[var(--space-6)]">
-      <SectionCard variant="glitch">
-        <SectionCard.Body>
+      <section className="rounded-card r-card-lg glitch-card text-card-foreground">
+        <div className="p-[var(--space-5)] text-ui">
           <div className="grid grid-cols-1 md:grid-cols-12 gap-[var(--space-6)]">
             {/* Allies */}
             <div className="md:col-span-5">
@@ -285,8 +284,8 @@ export default React.forwardRef<BuilderHandle, BuilderProps>(
               />
             </div>
           </div>
-        </SectionCard.Body>
-      </SectionCard>
+        </div>
+      </section>
     </div>
   );
 });
@@ -307,7 +306,7 @@ function SideEditor(props: {
   const { side, title, icon, value, onLane, onNotes, onClear, onCopy, count } = props;
 
   return (
-    <div className="rounded-card p-[var(--space-4)] glitch-card relative">
+    <div className="rounded-card r-card-lg p-[var(--space-4)] glitch-card relative text-card-foreground text-ui">
       {/* neon rail */}
       <span aria-hidden className="glitch-rail" />
 

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -242,7 +242,7 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
 
   return (
     <div data-scope="team">
-      <SectionCard className="card-neo-soft">
+      <SectionCard variant="glitch">
         <SectionCard.Header
           title="My Comps"
           actions={
@@ -306,7 +306,7 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
               return (
                 <article
                   key={c.id}
-                  className="col-span-12 md:col-span-6 xl:col-span-4 group glitch-card relative p-[var(--space-7)]"
+                  className="col-span-12 md:col-span-6 xl:col-span-4 group glitch-card rounded-card r-card-lg relative p-[var(--space-7)]"
                 >
                   {/* Action controls: copy, edit, delete, save */}
                   <div className={actionClasses}>


### PR DESCRIPTION
## Summary
- replace the team builder wrapper with a glitch-only section so the grid drops the neo inset shadow
- ensure the side editor panel and saved comps cards rely on rounded glitch surfaces without card-neo tokens

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d01c84ee84832c9b1d32ceea348308