### PR TITLE
Flatten reminders surfaces

### DIFF
--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -434,7 +434,7 @@ export default function TimerTab() {
 
       <SectionCard className="no-hover">
         <SectionCard.Body>
-          <div className="relative mx-auto w-full max-w-[calc(var(--space-8)*6)] rounded-[var(--radius-2xl)] border border-card-hairline/60 bg-background/30 p-[var(--space-8)] backdrop-blur-xl">
+          <div className="relative mx-auto flex w-full max-w-[calc(var(--space-8)*6)] flex-col items-stretch p-[var(--space-8)]">
             {/* plus/minus */}
             <IconButton
               aria-label="Minus 1 minute"

--- a/src/components/goals/reminders/ReminderList.tsx
+++ b/src/components/goals/reminders/ReminderList.tsx
@@ -42,7 +42,7 @@ export default function ReminderList() {
 
 function EmptyState() {
   return (
-    <div className="rounded-card ds-card-pad text-ui font-medium text-muted-foreground grid place-items-center">
+    <div className="grid place-items-center rounded-card border border-card-hairline/60 bg-surface card-pad text-ui font-medium text-muted-foreground">
       <p>Nothing here. Add one clear sentence you’ll read in champ select.</p>
     </div>
   );
@@ -102,7 +102,7 @@ function RemTile({
   }, [value.title]);
 
   return (
-    <article className="card-neo rounded-card card-pad relative group">
+    <article className="group relative rounded-card border border-card-hairline/60 bg-surface card-pad transition-colors hover:bg-surface-2 focus-within:bg-surface-2">
       <div className="flex items-center justify-between gap-[var(--space-2)]">
         <div className="flex-1 min-w-0">
           {editing ? (


### PR DESCRIPTION
## Summary
- keep reminders empty state and tiles on the SectionCard surface by swapping to flat surface tokens
- simplify the timer tab container to rely on the SectionCard padding while preserving control layout

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d01c909bc0832ca20dbdd37c352d2a