### PR TITLE
Refine glitch card surfaces in team tools

### DIFF
--- a/src/components/team/Builder.tsx
+++ b/src/components/team/Builder.tsx
@@ -11,7 +11,6 @@ import "./style.css";
  */
 
 import * as React from "react";
-import SectionCard from "@/components/ui/layout/SectionCard";
 import Input from "@/components/ui/primitives/Input";
 import Textarea from "@/components/ui/primitives/Textarea";
 import IconButton from "@/components/ui/primitives/IconButton";
@@ -244,49 +243,47 @@ export default React.forwardRef<BuilderHandle, BuilderProps>(
 
   return (
     <div data-scope="team" className="w-full mt-[var(--space-6)]">
-      <SectionCard variant="glitch">
-        <SectionCard.Body>
-          <div className="grid grid-cols-1 md:grid-cols-12 gap-[var(--space-6)]">
-            {/* Allies */}
-            <div className="md:col-span-5">
-              <SideEditor
-                side="allies"
-                title="Allies"
-                icon={<Shield />}
-                value={state.allies}
-                onLane={handleAlliesLane}
-                onNotes={handleAlliesNotes}
-                onClear={handleAlliesClear}
-                onCopy={handleAlliesCopy}
-                count={filledCount.allies}
-              />
-            </div>
-
-              {/* Center spine (md+) */}
-            <div className="hidden md:block relative md:col-span-2">
-              <span
-                aria-hidden
-                className="absolute left-1/2 top-0 -translate-x-1/2 h-full w-px bg-border"
-              />
-            </div>
-
-              {/* Enemies */}
-            <div className="md:col-span-5">
-              <SideEditor
-                side="enemies"
-                title="Enemies"
-                icon={<Swords />}
-                value={state.enemies}
-                onLane={handleEnemiesLane}
-                onNotes={handleEnemiesNotes}
-                onClear={handleEnemiesClear}
-                onCopy={handleEnemiesCopy}
-                count={filledCount.enemies}
-              />
-            </div>
+      <section className="rounded-card r-card-lg glitch-card relative p-[var(--space-5)] text-card-foreground">
+        <div className="grid grid-cols-1 md:grid-cols-12 gap-[var(--space-6)]">
+          {/* Allies */}
+          <div className="md:col-span-5">
+            <SideEditor
+              side="allies"
+              title="Allies"
+              icon={<Shield />}
+              value={state.allies}
+              onLane={handleAlliesLane}
+              onNotes={handleAlliesNotes}
+              onClear={handleAlliesClear}
+              onCopy={handleAlliesCopy}
+              count={filledCount.allies}
+            />
           </div>
-        </SectionCard.Body>
-      </SectionCard>
+
+          {/* Center spine (md+) */}
+          <div className="hidden md:block relative md:col-span-2">
+            <span
+              aria-hidden
+              className="absolute left-1/2 top-0 -translate-x-1/2 h-full w-px bg-border"
+            />
+          </div>
+
+          {/* Enemies */}
+          <div className="md:col-span-5">
+            <SideEditor
+              side="enemies"
+              title="Enemies"
+              icon={<Swords />}
+              value={state.enemies}
+              onLane={handleEnemiesLane}
+              onNotes={handleEnemiesNotes}
+              onClear={handleEnemiesClear}
+              onCopy={handleEnemiesCopy}
+              count={filledCount.enemies}
+            />
+          </div>
+        </div>
+      </section>
     </div>
   );
 });
@@ -307,7 +304,7 @@ function SideEditor(props: {
   const { side, title, icon, value, onLane, onNotes, onClear, onCopy, count } = props;
 
   return (
-    <div className="rounded-card p-[var(--space-4)] glitch-card relative">
+    <div className="rounded-card r-card-lg glitch-card relative p-[var(--space-4)] text-card-foreground">
       {/* neon rail */}
       <span aria-hidden className="glitch-rail" />
 

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -3,7 +3,7 @@
 
 /**
  * MyComps — CRUD for custom comps, single-panel version.
- * - One SectionCard: header + add bar + cards grid inside the same panel
+ * - Single glitch panel: header + add bar + cards grid inside the same surface
  * - Add comp (title), edit per-role champs (inline chips), notes
  * - Actions stay reachable on touch: Copy / Edit / Delete; Save when editing
  * - Local-first via usePersistentState("team:mycomps.v1")
@@ -17,7 +17,6 @@ import { usePersistentState, uid } from "@/lib/db";
 import { isRecord, isStringArray, safeNumber } from "@/lib/validators";
 import { copyText } from "@/lib/clipboard";
 import { useCoarsePointer } from "@/lib/useCoarsePointer";
-import SectionCard from "@/components/ui/layout/SectionCard";
 import IconButton from "@/components/ui/primitives/IconButton";
 import Input from "@/components/ui/primitives/Input";
 import Textarea from "@/components/ui/primitives/Textarea";
@@ -242,82 +241,86 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
 
   return (
     <div data-scope="team">
-      <SectionCard className="card-neo-soft">
-        <SectionCard.Header
-          title="My Comps"
-          actions={
-            <span className="text-label font-medium text-muted-foreground tabular-nums">
+      <section className="rounded-card r-card-lg glitch-card relative text-card-foreground">
+        <div className="p-[var(--space-5)]">
+          <header className="flex flex-wrap items-center gap-[var(--space-2)] sm:gap-[var(--space-3)] w-full">
+            <h2 className="text-title sm:text-title-lg font-semibold tracking-[-0.01em]">
+              My Comps
+            </h2>
+            <span className="ml-auto text-label font-medium text-muted-foreground tabular-nums">
               {compCountLabel}
             </span>
-          }
-        />
-        <SectionCard.Body className={PANEL_STACK_SPACE}>
-          {/* Add bar (inside the same panel) */}
-          {editing && (
-            <form
-              onSubmit={addNew}
-              className="rounded-card flex items-center gap-[var(--space-6)] glitch"
-            >
-              <Input
-                dir="ltr"
-                name="comp-title"
-                value={draft}
-                onChange={(e) => setDraft(e.currentTarget.value)}
-                placeholder="New comp title…"
-                aria-label="New comp title"
-                className="flex-1"
-              />
-              <IconButton
-                type="submit"
-                title="Add comp"
-                aria-label="Add comp"
-                size="md"
-                className="shrink-0"
-                variant="primary"
+          </header>
+
+          <div
+            className={["mt-[var(--space-5)] text-ui", PANEL_STACK_SPACE].join(" ")}
+          >
+            {/* Add bar (inside the same panel) */}
+            {editing && (
+              <form
+                onSubmit={addNew}
+                className="rounded-card flex items-center gap-[var(--space-6)] glitch"
               >
-                <Plus />
-              </IconButton>
-            </form>
-          )}
-
-          {/* Empty states */}
-          {items.length === 0 ? (
-            <div className="rounded-card r-card-lg p-[var(--space-6)] text-ui font-medium text-muted-foreground border border-border">
-              No comps yet. Type a title above and press Enter.
-            </div>
-          ) : filtered.length === 0 ? (
-            <div className="rounded-card r-card-lg p-[var(--space-6)] text-ui font-medium text-muted-foreground border border-border">
-              Nothing matches your search.
-            </div>
-          ) : null}
-
-          {/* Cards grid */}
-          <div className="grid grid-cols-12 gap-[var(--space-4)]">
-            {filtered.map((c) => {
-              const editingCard = editingId === c.id;
-              const showActions = isCoarsePointer || editing || editingCard;
-              const actionClasses = [
-                "absolute right-[var(--space-2)] top-[var(--space-2)] z-10 flex items-center gap-[var(--space-1)] transition-opacity",
-                showActions
-                  ? "opacity-100 pointer-events-auto"
-                  : "opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto",
-              ].join(" ");
-
-              return (
-                <article
-                  key={c.id}
-                  className="col-span-12 md:col-span-6 xl:col-span-4 group glitch-card relative p-[var(--space-7)]"
+                <Input
+                  dir="ltr"
+                  name="comp-title"
+                  value={draft}
+                  onChange={(e) => setDraft(e.currentTarget.value)}
+                  placeholder="New comp title…"
+                  aria-label="New comp title"
+                  className="flex-1"
+                />
+                <IconButton
+                  type="submit"
+                  title="Add comp"
+                  aria-label="Add comp"
+                  size="md"
+                  className="shrink-0"
+                  variant="primary"
                 >
-                  {/* Action controls: copy, edit, delete, save */}
-                  <div className={actionClasses}>
-                    {!editingCard ? (
-                      <>
-                        <IconButton
-                          title="Copy"
-                          aria-label="Copy"
-                          size="sm"
-                          onClick={() => copyOne(c)}
-                        >
+                  <Plus />
+                </IconButton>
+              </form>
+            )}
+
+            {/* Empty states */}
+            {items.length === 0 ? (
+              <div className="rounded-card r-card-lg p-[var(--space-6)] text-ui font-medium text-muted-foreground border border-border">
+                No comps yet. Type a title above and press Enter.
+              </div>
+            ) : filtered.length === 0 ? (
+              <div className="rounded-card r-card-lg p-[var(--space-6)] text-ui font-medium text-muted-foreground border border-border">
+                Nothing matches your search.
+              </div>
+            ) : null}
+
+            {/* Cards grid */}
+            <div className="grid grid-cols-12 gap-[var(--space-4)]">
+              {filtered.map((c) => {
+                const editingCard = editingId === c.id;
+                const showActions = isCoarsePointer || editing || editingCard;
+                const actionClasses = [
+                  "absolute right-[var(--space-2)] top-[var(--space-2)] z-10 flex items-center gap-[var(--space-1)] transition-opacity",
+                  showActions
+                    ? "opacity-100 pointer-events-auto"
+                    : "opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto",
+                ].join(" ");
+
+                return (
+                  <article
+                    key={c.id}
+                    className="col-span-12 md:col-span-6 xl:col-span-4 group rounded-card r-card-lg glitch-card relative p-[var(--space-7)]"
+                  >
+                    {/* Action controls: copy, edit, delete, save */}
+                    <div className={actionClasses}>
+                      {!editingCard ? (
+                        <>
+                          <IconButton
+                            title="Copy"
+                            aria-label="Copy"
+                            size="sm"
+                            onClick={() => copyOne(c)}
+                          >
                           {copiedId === c.id ? (
                             <ClipboardCheck />
                           ) : (
@@ -443,9 +446,10 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
                 </article>
               );
             })}
+            </div>
           </div>
-        </SectionCard.Body>
-      </SectionCard>
+        </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the team builder wrapper with a dedicated glitch card container so the grid only renders the glitch elevation treatment
- align the builder side panels and My Comps surfaces with rounded glitch cards, including new header/layout markup for the comps list

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d01dcf799c832c82e31ba882ffdb56