### PR TITLE
Disable TabBar panel linking for reminders filters

### DIFF
--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -199,6 +199,7 @@ export default function Reminders() {
               onValueChange={(k) => setGroup((k === "all" ? "all" : k) as Group | "all")}
               size="md"
               ariaLabel="Group filter"
+              linkPanels={false}
             />
 
             {/* pinned */}

--- a/src/components/goals/reminders/ReminderFilters.tsx
+++ b/src/components/goals/reminders/ReminderFilters.tsx
@@ -32,6 +32,7 @@ export default function ReminderFilters() {
           size="md"
           align="between"
           className="overflow-x-auto"
+          linkPanels={false}
           right={
             <SegmentedButton
               className="inline-flex items-center gap-[var(--space-1)]"
@@ -55,6 +56,7 @@ export default function ReminderFilters() {
             onValueChange={(key) => setSource(key as SourceFilter)}
             ariaLabel="Reminder source filter"
             size="sm"
+            linkPanels={false}
           />
           <SegmentedButton
             onClick={togglePinned}


### PR DESCRIPTION
## Summary
- disable TabBar panel linking for the reminders group filter
- disable TabBar panel linking for the reminders group/source filters component to avoid aria-controls on buttons

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d01e496ab8832cb6862ce62095200b