### PR TITLE
Adjust prompts header search variant

### DIFF
--- a/src/components/prompts/PromptsHeader.tsx
+++ b/src/components/prompts/PromptsHeader.tsx
@@ -82,6 +82,8 @@ export default function PromptsHeader({
           debounceMs: 300,
           placeholder: "Search prompts…",
           "aria-label": "Search prompts",
+          variant: "default",
+          round: false,
         },
         actions: (
           <Button type="button" variant="primary" onClick={onSave} disabled={disabled}>


### PR DESCRIPTION
## Summary
- set the prompts header search bar to use the default variant and standard height

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d01e8d02bc832c883c7c63a1407e09