### PR TITLE
Adjust review live regions

### DIFF
--- a/src/components/reviews/ReviewPanel.tsx
+++ b/src/components/reviews/ReviewPanel.tsx
@@ -8,7 +8,6 @@ export default function ReviewPanel({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <Card
-      aria-live="polite"
       className={cn("w-full container", className)}
       {...props}
     />

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -171,9 +171,10 @@ export default function ReviewsPage({
             hoverRing
           />
         </nav>
-        <div aria-live="polite" className="md:col-span-4 lg:col-span-8">
+        <div className="md:col-span-4 lg:col-span-8">
           {!active ? (
             <ReviewPanel
+              aria-live="polite"
               className={cn(
                 panelClass,
                 "flex flex-col items-center justify-center gap-[var(--space-2)] py-[var(--space-8)] text-ui text-muted-foreground",

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -542,7 +542,6 @@ exports[`ReviewsPage > renders default state 1`] = `
         </section>
       </nav>
       <div
-        aria-live="polite"
         class="md:col-span-4 lg:col-span-8"
       >
         <div


### PR DESCRIPTION
## Summary
- remove the default live region from the shared ReviewPanel container
- scope polite announcements to the empty-state ghost message when no review is selected

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d01e676ac4832ca4ea64d31823c01e