### PR TITLE
Allow overriding AnimatedSelect container radius

### DIFF
--- a/src/components/ui/select/AnimatedSelect.tsx
+++ b/src/components/ui/select/AnimatedSelect.tsx
@@ -72,6 +72,7 @@ const AnimatedSelect = React.forwardRef<
       className = "",
       dropdownClassName = "",
       buttonClassName = "",
+      containerClassName,
       placeholder = "Select…",
       disabled = false,
       hideLabel = false,
@@ -427,6 +428,11 @@ const AnimatedSelect = React.forwardRef<
       buttonClassName,
     );
 
+    const containerCls = cn(
+      "group inline-flex rounded-[var(--control-radius)] border border-[var(--focus)] focus-within:ring-2 focus-within:ring-[var(--focus)] focus-within:ring-offset-0",
+      containerClassName,
+    );
+
     const caretCls = cn(
       styles.caret,
       "ml-auto shrink-0 opacity-75",
@@ -449,7 +455,7 @@ const AnimatedSelect = React.forwardRef<
           </div>
         ) : null}
 
-        <div className="group inline-flex rounded-[var(--control-radius)] border border-[var(--focus)] focus-within:ring-2 focus-within:ring-[var(--focus)] focus-within:ring-offset-0">
+        <div className={containerCls}>
           <button
             ref={setTriggerRef}
             type="button"

--- a/src/components/ui/select/shared.ts
+++ b/src/components/ui/select/shared.ts
@@ -26,6 +26,7 @@ type CommonSelectProps = {
 export type AnimatedSelectProps = CommonSelectProps & {
   dropdownClassName?: string;
   buttonClassName?: string;
+  containerClassName?: string;
   placeholder?: string;
   disabled?: boolean;
   hideLabel?: boolean;

--- a/src/components/ui/theme/SettingsSelect.tsx
+++ b/src/components/ui/theme/SettingsSelect.tsx
@@ -17,6 +17,7 @@ export type SettingsSelectProps = Omit<
 
 export default function SettingsSelect({
   buttonClassName,
+  containerClassName,
   ...props
 }: SettingsSelectProps) {
   return (
@@ -25,6 +26,7 @@ export default function SettingsSelect({
       size="sm"
       matchTriggerWidth={false}
       buttonClassName={cn(SETTINGS_SELECT_BUTTON_CLASS, buttonClassName)}
+      containerClassName={cn("rounded-full", containerClassName)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- add `containerClassName` to animated select props and wire it into the wrapper
- let `SettingsSelect` opt into a rounded container so focus and hover rings stay aligned with its trigger

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d020c68a90832c971ef75ebd5e3f6d