### PR TITLE
Fix planner focus rollover logic

### DIFF
--- a/src/components/planner/plannerContext.tsx
+++ b/src/components/planner/plannerContext.tsx
@@ -184,8 +184,20 @@ export function PlannerProvider({ children }: { children: React.ReactNode }) {
     const updateForNewDay = () => {
       if (cancelled) return;
       const nextToday = todayISO();
-      setToday(nextToday);
-      setFocus(nextToday);
+
+      setToday((prevToday) => {
+        setFocus((prevFocus) => {
+          if (
+            prevFocus === FOCUS_PLACEHOLDER ||
+            prevFocus === prevToday
+          ) {
+            return nextToday;
+          }
+          return prevFocus;
+        });
+
+        return nextToday;
+      });
     };
 
     const scheduleNextTick = () => {


### PR DESCRIPTION
## Summary
- update the midnight rollover effect to only retarget focus when it was pointing at the previous today or placeholder
- switch the rollover effect to updater-form setters so previous values are inspected before updating

## Testing
- npm test -- --run tests/planner
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d02a0313fc832caa52aec8f30e670d