### PR TITLE
Refactor components gallery state handling

### DIFF
--- a/src/components/components/ComponentsGalleryPanels.tsx
+++ b/src/components/components/ComponentsGalleryPanels.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import * as React from "react";
+
+import ColorsView from "@/components/prompts/ColorsView";
+import ComponentSpecView from "@/components/prompts/ComponentsView";
+import type { GallerySerializableEntry } from "@/components/gallery/registry";
+import type { DesignTokenGroup } from "@/components/gallery/types";
+import { Card, CardContent } from "@/components/ui";
+import Badge from "@/components/ui/primitives/Badge";
+
+import type { ComponentsView } from "./useComponentsGalleryState";
+
+interface ComponentsGalleryPanelsProps {
+  readonly view: ComponentsView;
+  readonly filteredSpecs: readonly GallerySerializableEntry[];
+  readonly sectionLabel: string;
+  readonly countLabel: string;
+  readonly countDescriptionId: string;
+  readonly componentsPanelLabelledBy: string;
+  readonly componentsPanelRef: React.Ref<HTMLDivElement>;
+  readonly tokensPanelRef: React.Ref<HTMLDivElement>;
+  readonly tokenGroups: readonly DesignTokenGroup[];
+}
+
+export default function ComponentsGalleryPanels({
+  view,
+  filteredSpecs,
+  sectionLabel,
+  countLabel,
+  countDescriptionId,
+  componentsPanelLabelledBy,
+  componentsPanelRef,
+  tokensPanelRef,
+  tokenGroups,
+}: ComponentsGalleryPanelsProps) {
+  const isTokensView = view === "tokens";
+
+  return (
+    <section className="col-span-full grid gap-[var(--space-6)] md:gap-[var(--space-7)] lg:gap-[var(--space-8)]">
+      <div
+        id="components-components-panel"
+        role="tabpanel"
+        aria-labelledby={componentsPanelLabelledBy}
+        tabIndex={isTokensView ? -1 : 0}
+        ref={componentsPanelRef}
+        hidden={isTokensView}
+        aria-hidden={isTokensView}
+        className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      >
+        <div
+          className="flex flex-col gap-[var(--space-6)]"
+          aria-describedby={countDescriptionId}
+        >
+          <header className="flex flex-wrap items-center justify-between gap-[var(--space-3)]">
+            <h2 className="text-ui font-semibold tracking-[-0.01em] text-muted-foreground">
+              {sectionLabel} specs
+            </h2>
+            <Badge
+              id={countDescriptionId}
+              tone="support"
+              size="md"
+              className="text-muted-foreground"
+            >
+              {countLabel}
+            </Badge>
+          </header>
+          <div className="grid gap-[var(--space-6)]">
+            {filteredSpecs.length === 0 ? (
+              <Card>
+                <CardContent className="text-ui text-muted-foreground">
+                  No results found
+                </CardContent>
+              </Card>
+            ) : (
+              filteredSpecs.map((spec) => (
+                <ComponentSpecView key={spec.id} entry={spec} />
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+      <div
+        id="components-tokens-panel"
+        role="tabpanel"
+        aria-labelledby={`components-${view}-tab`}
+        tabIndex={isTokensView ? 0 : -1}
+        ref={tokensPanelRef}
+        hidden={!isTokensView}
+        aria-hidden={!isTokensView}
+        className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      >
+        <ColorsView groups={tokenGroups} />
+      </div>
+    </section>
+  );
+}

--- a/src/components/components/ComponentsPageClient.tsx
+++ b/src/components/components/ComponentsPageClient.tsx
@@ -1,26 +1,14 @@
 "use client";
 
 import * as React from "react";
-import Fuse from "fuse.js";
 import { PanelsTopLeft } from "lucide-react";
-import { useRouter, useSearchParams } from "next/navigation";
 
-import ComponentSpecView from "@/components/prompts/ComponentsView";
-import { getGallerySectionEntries } from "@/components/prompts/constants";
-import ColorsView from "@/components/prompts/ColorsView";
-import {
-  type DesignTokenGroup,
-  type GalleryHeroCopy,
-  type GalleryNavigationData,
-  type GalleryNavigationSection,
-  type GallerySectionGroupKey,
-} from "@/components/gallery/types";
-import { formatGallerySectionLabel } from "@/components/gallery/registry";
-import type { GallerySerializableEntry } from "@/components/gallery/registry";
-import { Card, CardContent, PageHeader, PageShell } from "@/components/ui";
-import Badge from "@/components/ui/primitives/Badge";
-import { usePersistentState } from "@/lib/db";
+import type { DesignTokenGroup, GalleryNavigationData } from "@/components/gallery/types";
+import { PageHeader, PageShell } from "@/components/ui";
 import { cn } from "@/lib/utils";
+
+import ComponentsGalleryPanels from "./ComponentsGalleryPanels";
+import { useComponentsGalleryState } from "./useComponentsGalleryState";
 
 const NEO_TABLIST_SHARED_CLASSES = [
   "data-[variant=neo]:rounded-card",
@@ -55,394 +43,36 @@ const HEADER_FRAME_CLASSNAME = [
   "motion-reduce:before:opacity-60 motion-reduce:after:opacity-50",
 ].join(" ");
 
-type Section = GalleryNavigationSection["id"];
-type ComponentsView = GallerySectionGroupKey;
-
 interface ComponentsPageClientProps {
-  navigation: GalleryNavigationData;
-  tokenGroups: readonly DesignTokenGroup[];
+  readonly navigation: GalleryNavigationData;
+  readonly tokenGroups: readonly DesignTokenGroup[];
 }
-
-const DEFAULT_FALLBACK_COPY: GalleryHeroCopy = {
-  eyebrow: "Gallery",
-  heading: "Planner component gallery",
-  subtitle: "Browse Planner UI building blocks by category.",
-};
 
 export default function ComponentsPageClient({
   navigation,
   tokenGroups,
 }: ComponentsPageClientProps) {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const paramsString = searchParams.toString();
-  const sectionParam = searchParams.get("section");
-  const queryParam = searchParams.get("q");
-  const viewParam = searchParams.get("view");
-  const [, startTransition] = React.useTransition();
-  const [query, setQuery] = usePersistentState("components-query", "");
-
-  const groups = navigation.groups;
-
-  const viewOrder = React.useMemo<ComponentsView[]>(
-    () => groups.map((group) => group.id as ComponentsView),
-    [groups],
-  );
-
-  const defaultView = React.useMemo<ComponentsView>(
-    () => (viewOrder[0] ?? "primitives") as ComponentsView,
-    [viewOrder],
-  );
-
-  const navSectionEntries = React.useMemo(
-    () => groups.flatMap((group) => group.sections),
-    [groups],
-  );
-
-  const sectionMap = React.useMemo(() => {
-    const map = new Map<Section, GalleryNavigationSection>();
-    for (const section of navSectionEntries) {
-      map.set(section.id, section);
-    }
-    return map;
-  }, [navSectionEntries]);
-
-  const sectionGroupMap = React.useMemo(() => {
-    const map = new Map<Section, ComponentsView>();
-    for (const group of groups) {
-      for (const section of group.sections) {
-        map.set(section.id, group.id);
-      }
-    }
-    return map;
-  }, [groups]);
-
-  const groupSectionIds = React.useMemo(() => {
-    const map = new Map<ComponentsView, Set<Section>>();
-    for (const group of groups) {
-      map.set(
-        group.id,
-        new Set(group.sections.map((section) => section.id)),
-      );
-    }
-    return map;
-  }, [groups]);
-
-  const defaultSection = React.useMemo<Section>(() => {
-    for (const group of groups) {
-      if (group.sections.length > 0) {
-        return group.sections[0].id;
-      }
-    }
-    return (navSectionEntries[0]?.id ?? "buttons") as Section;
-  }, [groups, navSectionEntries]);
-
-  const fallbackCopy = React.useMemo<GalleryHeroCopy>(() => {
-    const firstSection = navSectionEntries[0];
-    if (firstSection) {
-      return firstSection.copy;
-    }
-    const firstGroup = groups[0];
-    if (firstGroup) {
-      return firstGroup.copy;
-    }
-    return DEFAULT_FALLBACK_COPY;
-  }, [groups, navSectionEntries]);
-
-  const normalizeView = React.useCallback(
-    (value: string | null): ComponentsView => {
-      if (value === "colors") {
-        return "tokens";
-      }
-      if (value && (viewOrder as readonly string[]).includes(value)) {
-        return value as ComponentsView;
-      }
-      return defaultView;
-    },
-    [defaultView, viewOrder],
-  );
-
-  const normalizeSection = React.useCallback(
-    (value: string | null): Section => {
-      if (value && sectionMap.has(value as Section)) {
-        return value as Section;
-      }
-      return defaultSection;
-    },
-    [defaultSection, sectionMap],
-  );
-
-  const [view, setView] = React.useState<ComponentsView>(() =>
-    normalizeView(viewParam),
-  );
-  const [section, setSection] = React.useState<Section>(() =>
-    normalizeSection(sectionParam),
-  );
-
-  const previousSectionParamRef = React.useRef<string | null | undefined>(
-    undefined,
-  );
-  const previousViewParamRef = React.useRef<string | null | undefined>(
-    undefined,
-  );
-  const previousQueryParamRef = React.useRef<string | null | undefined>(
-    undefined,
-  );
-
-  const componentsPanelRef = React.useRef<HTMLDivElement>(null);
-  const tokensPanelRef = React.useRef<HTMLDivElement>(null);
-  const previousViewRef = React.useRef<ComponentsView | null>(null);
-
-  const currentGroup = React.useMemo(
-    () => groups.find((group) => group.id === view) ?? null,
-    [groups, view],
-  );
-
-  const heroTabs = React.useMemo(
-    () =>
-      currentGroup
-        ? currentGroup.sections.map((section) => ({
-            key: section.id,
-            label: section.label,
-            controls: "components-panel",
-          }))
-        : [],
-    [currentGroup],
-  );
-
-  const sectionMeta = React.useMemo(
-    () => sectionMap.get(section) ?? null,
-    [section, sectionMap],
-  );
-
-  const currentGroupLabel = currentGroup?.label ?? "";
-  const activeSectionLabel = sectionMeta?.label ?? "";
-  const sectionMetaLabel = sectionMeta?.label;
-
-  const sectionSpecs = React.useMemo<readonly GallerySerializableEntry[]>(
-    () => getGallerySectionEntries(section),
-    [section],
-  );
-
-  const sectionFuse = React.useMemo(() => {
-    return new Fuse<GallerySerializableEntry>(sectionSpecs, {
-      keys: ["name", "tags", "description", "props.name", "props.type"],
-      threshold: 0.3,
-    });
-  }, [sectionSpecs]);
-
-  const filteredSpecs = React.useMemo(() => {
-    if (!query) {
-      return sectionSpecs;
-    }
-    return sectionFuse.search(query).map((result) => result.item);
-  }, [query, sectionFuse, sectionSpecs]);
-
-  const filteredCount = filteredSpecs.length;
-
-  const sectionLabel = React.useMemo(() => {
-    if (sectionMetaLabel) {
-      return sectionMetaLabel;
-    }
-    return formatGallerySectionLabel(section);
-  }, [section, sectionMetaLabel]);
-
-  const countLabel = React.useMemo(() => {
-    const suffix = filteredCount === 1 ? "spec" : "specs";
-    return `${filteredCount} ${sectionLabel.toLowerCase()} ${suffix}`;
-  }, [filteredCount, sectionLabel]);
-
-  const countDescriptionId = React.useId();
-
-  const heroCopy = React.useMemo(() => {
-    if (view === "tokens") {
-      return currentGroup?.copy ?? fallbackCopy;
-    }
-    if (sectionMeta) {
-      return sectionMeta.copy;
-    }
-    return currentGroup?.copy ?? fallbackCopy;
-  }, [currentGroup, fallbackCopy, sectionMeta, view]);
-
-  const sectionCopy = React.useMemo(() => {
-    if (sectionMeta) {
-      return sectionMeta.copy;
-    }
-    if (currentGroup && view !== "tokens") {
-      return currentGroup.copy;
-    }
-    return heroCopy;
-  }, [currentGroup, heroCopy, sectionMeta, view]);
-
-  const searchLabel = React.useMemo(
-    () => `Search ${sectionCopy.heading}`,
-    [sectionCopy.heading],
-  );
-
-  const searchPlaceholder = React.useMemo(() => {
-    const baseLabel = activeSectionLabel || currentGroupLabel || "gallery";
-    return `Search ${baseLabel.toLowerCase()} specs…`;
-  }, [activeSectionLabel, currentGroupLabel]);
-
-  const viewTabs = React.useMemo(
-    () =>
-      groups.map((group) => ({
-        key: group.id,
-        label: group.label,
-        controls: group.id === "tokens" ? "tokens-panel" : "components-panel",
-      })),
-    [groups],
-  );
-
-  const componentsPanelLabelledBy = React.useMemo(() => {
-    const base = `components-${view}-tab`;
-    if (heroTabs.length > 0) {
-      return `${base} components-${section}-tab`;
-    }
-    return base;
-  }, [heroTabs.length, section, view]);
-
-  const handleViewChange = React.useCallback(
-    (key: string | number) => {
-      const rawValue = typeof key === "string" ? key : String(key);
-      const nextView = normalizeView(rawValue);
-      if (nextView === view) {
-        return;
-      }
-      setView(nextView);
-      if (nextView === "tokens") {
-        return;
-      }
-      const allowedSections = groupSectionIds.get(nextView);
-      if (allowedSections?.has(section)) {
-        return;
-      }
-      const fallbackSection = groups
-        .find((group) => group.id === nextView)
-        ?.sections[0]?.id;
-      if (fallbackSection && fallbackSection !== section) {
-        setSection(fallbackSection);
-      }
-    },
-    [groupSectionIds, groups, normalizeView, section, view],
-  );
-
-  React.useEffect(() => {
-    if (previousSectionParamRef.current === sectionParam) {
-      return;
-    }
-    previousSectionParamRef.current = sectionParam;
-    const next = normalizeSection(sectionParam);
-    setSection((prev) => (prev === next ? prev : next));
-  }, [normalizeSection, sectionParam]);
-
-  React.useEffect(() => {
-    if (previousViewParamRef.current === viewParam) {
-      return;
-    }
-    previousViewParamRef.current = viewParam;
-    const next = normalizeView(viewParam);
-    setView((prev) => (prev === next ? prev : next));
-  }, [normalizeView, viewParam]);
-
-  React.useEffect(() => {
-    if (previousQueryParamRef.current === queryParam) {
-      return;
-    }
-    previousQueryParamRef.current = queryParam;
-    const next = queryParam ?? "";
-    if (next !== query) {
-      setQuery(next);
-    }
-  }, [queryParam, query, setQuery]);
-
-  React.useEffect(() => {
-    const current = sectionParam ?? "";
-    if (current === section) return;
-    const next = new URLSearchParams(paramsString);
-    next.set("section", section);
-    startTransition(() => {
-      router.replace(`?${next.toString()}`, { scroll: false });
-    });
-  }, [paramsString, router, section, sectionParam, startTransition]);
-
-  React.useEffect(() => {
-    const current = normalizeView(viewParam);
-    if (current === view) return;
-    const next = new URLSearchParams(paramsString);
-    if (view === defaultView) {
-      next.delete("view");
-    } else {
-      next.set("view", view);
-    }
-    startTransition(() => {
-      router.replace(`?${next.toString()}`, { scroll: false });
-    });
-  }, [defaultView, normalizeView, paramsString, router, startTransition, view, viewParam]);
-
-  React.useEffect(() => {
-    const current = queryParam ?? "";
-    if (current === query) return;
-    const next = new URLSearchParams(paramsString);
-    if (query) {
-      next.set("q", query);
-    } else {
-      next.delete("q");
-    }
-    startTransition(() => {
-      router.replace(`?${next.toString()}`, { scroll: false });
-    });
-  }, [paramsString, query, queryParam, router, startTransition]);
-
-  React.useEffect(() => {
-    if (view === "tokens") {
-      return;
-    }
-    const allowed = groupSectionIds.get(view);
-    if (!allowed || allowed.size === 0) {
-      return;
-    }
-    if (!allowed.has(section)) {
-      const fallback = groups.find((group) => group.id === view)?.sections[0]?.id;
-      if (fallback && fallback !== section) {
-        setSection(fallback);
-      }
-    }
-  }, [groupSectionIds, groups, section, view]);
-
-  React.useEffect(() => {
-    if (view === "tokens") {
-      return;
-    }
-    const owner = sectionGroupMap.get(section);
-    if (!owner) {
-      return;
-    }
-    if (owner === view) {
-      return;
-    }
-    const allowed = groupSectionIds.get(view);
-    if (allowed?.has(section)) {
-      return;
-    }
-    setView(owner);
-  }, [groupSectionIds, section, sectionGroupMap, view]);
-
-  React.useEffect(() => {
-    const previousView = previousViewRef.current;
-    if (view !== "tokens" && previousView === "tokens") {
-      componentsPanelRef.current?.focus({ preventScroll: true });
-    }
-    previousViewRef.current = view;
-  }, [view]);
-
-  React.useEffect(() => {
-    if (view === "tokens") {
-      tokensPanelRef.current?.focus({ preventScroll: true });
-    }
-  }, [view]);
-
-  const showSectionTabs = heroTabs.length > 0 && view !== "tokens";
+  const {
+    view,
+    section,
+    query,
+    setQuery,
+    heroCopy,
+    heroTabs,
+    viewTabs,
+    showSectionTabs,
+    searchLabel,
+    searchPlaceholder,
+    filteredSpecs,
+    sectionLabel,
+    countLabel,
+    countDescriptionId,
+    componentsPanelLabelledBy,
+    handleViewChange,
+    handleSectionChange,
+    componentsPanelRef,
+    tokensPanelRef,
+  } = useComponentsGalleryState({ navigation });
 
   return (
     <PageShell
@@ -491,7 +121,7 @@ export default function ComponentsPageClient({
                 ariaLabel: "Component section",
                 items: heroTabs,
                 value: section,
-                onChange: (key) => setSection(key as Section),
+                onChange: handleSectionChange,
                 idBase: "components",
                 linkPanels: true,
                 size: "sm",
@@ -515,11 +145,10 @@ export default function ComponentsPageClient({
                     event,
                   ) => {
                     onClick?.(event);
+                    handleSectionChange(item.key);
                   };
                   const labelText =
-                    typeof item.label === "string" || typeof item.label === "number"
-                      ? String(item.label)
-                      : undefined;
+                    typeof item.label === "string" ? item.label : undefined;
                   const computedTitle = titleProp ?? labelText;
                   const computedAriaLabel =
                     ariaLabelProp ??
@@ -579,64 +208,17 @@ export default function ComponentsPageClient({
               : undefined,
         }}
       />
-      <section
-        className="col-span-full grid gap-[var(--space-6)] md:gap-[var(--space-7)] lg:gap-[var(--space-8)]"
-      >
-        <div
-          id="components-components-panel"
-          role="tabpanel"
-          aria-labelledby={componentsPanelLabelledBy}
-          tabIndex={view === "tokens" ? -1 : 0}
-          ref={componentsPanelRef}
-          hidden={view === "tokens"}
-          aria-hidden={view === "tokens"}
-          className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-        >
-          <div
-            className="flex flex-col gap-[var(--space-6)]"
-            aria-describedby={countDescriptionId}
-          >
-            <header className="flex flex-wrap items-center justify-between gap-[var(--space-3)]">
-              <h2 className="text-ui font-semibold tracking-[-0.01em] text-muted-foreground">
-                {sectionLabel} specs
-              </h2>
-              <Badge
-                id={countDescriptionId}
-                tone="support"
-                size="md"
-                className="text-muted-foreground"
-              >
-                {countLabel}
-              </Badge>
-            </header>
-            <div className="grid gap-[var(--space-6)]">
-              {filteredSpecs.length === 0 ? (
-                <Card>
-                  <CardContent className="text-ui text-muted-foreground">
-                    No results found
-                  </CardContent>
-                </Card>
-              ) : (
-                filteredSpecs.map((spec) => (
-                  <ComponentSpecView key={spec.id} entry={spec} />
-                ))
-              )}
-            </div>
-          </div>
-        </div>
-        <div
-          id="components-tokens-panel"
-          role="tabpanel"
-          aria-labelledby={`components-${view}-tab`}
-          tabIndex={view === "tokens" ? 0 : -1}
-          ref={tokensPanelRef}
-          hidden={view !== "tokens"}
-          aria-hidden={view !== "tokens"}
-          className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-        >
-          <ColorsView groups={tokenGroups} />
-        </div>
-      </section>
+      <ComponentsGalleryPanels
+        view={view}
+        filteredSpecs={filteredSpecs}
+        sectionLabel={sectionLabel}
+        countLabel={countLabel}
+        countDescriptionId={countDescriptionId}
+        componentsPanelLabelledBy={componentsPanelLabelledBy}
+        componentsPanelRef={componentsPanelRef}
+        tokensPanelRef={tokensPanelRef}
+        tokenGroups={tokenGroups}
+      />
     </PageShell>
   );
 }

--- a/src/components/components/useComponentsGalleryState.ts
+++ b/src/components/components/useComponentsGalleryState.ts
@@ -1,0 +1,462 @@
+"use client";
+
+import * as React from "react";
+import Fuse from "fuse.js";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { getGallerySectionEntries } from "@/components/prompts/constants";
+import {
+  type GalleryHeroCopy,
+  type GalleryNavigationData,
+  type GalleryNavigationSection,
+  type GallerySectionGroupKey,
+} from "@/components/gallery/types";
+import { formatGallerySectionLabel } from "@/components/gallery/registry";
+import type { GallerySerializableEntry } from "@/components/gallery/registry";
+import { usePersistentState } from "@/lib/db";
+
+export type Section = GalleryNavigationSection["id"];
+export type ComponentsView = GallerySectionGroupKey;
+
+interface TabItem {
+  readonly key: string;
+  readonly label: string;
+  readonly controls: string;
+}
+
+interface UseComponentsGalleryStateParams {
+  readonly navigation: GalleryNavigationData;
+}
+
+export interface ComponentsGalleryState {
+  readonly view: ComponentsView;
+  readonly section: Section;
+  readonly query: string;
+  readonly setQuery: React.Dispatch<React.SetStateAction<string>>;
+  readonly heroCopy: GalleryHeroCopy;
+  readonly heroTabs: TabItem[];
+  readonly viewTabs: TabItem[];
+  readonly showSectionTabs: boolean;
+  readonly searchLabel: string;
+  readonly searchPlaceholder: string;
+  readonly filteredSpecs: readonly GallerySerializableEntry[];
+  readonly sectionLabel: string;
+  readonly countLabel: string;
+  readonly countDescriptionId: string;
+  readonly componentsPanelLabelledBy: string;
+  readonly handleViewChange: (key: string | number) => void;
+  readonly handleSectionChange: (key: string | number) => void;
+  readonly componentsPanelRef: React.Ref<HTMLDivElement>;
+  readonly tokensPanelRef: React.Ref<HTMLDivElement>;
+}
+
+const DEFAULT_FALLBACK_COPY: GalleryHeroCopy = {
+  eyebrow: "Gallery",
+  heading: "Planner component gallery",
+  subtitle: "Browse Planner UI building blocks by category.",
+};
+
+export function useComponentsGalleryState({
+  navigation,
+}: UseComponentsGalleryStateParams): ComponentsGalleryState {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const paramsString = searchParams.toString();
+  const sectionParam = searchParams.get("section");
+  const queryParam = searchParams.get("q");
+  const viewParam = searchParams.get("view");
+  const [, startTransition] = React.useTransition();
+  const [query, setQuery] = usePersistentState("components-query", "");
+
+  const groups = navigation.groups;
+
+  const viewOrder = React.useMemo<ComponentsView[]>(
+    () => groups.map((group) => group.id as ComponentsView),
+    [groups],
+  );
+
+  const defaultView = React.useMemo<ComponentsView>(
+    () => (viewOrder[0] ?? "primitives") as ComponentsView,
+    [viewOrder],
+  );
+
+  const navSectionEntries = React.useMemo(
+    () => groups.flatMap((group) => group.sections),
+    [groups],
+  );
+
+  const sectionMap = React.useMemo(() => {
+    const map = new Map<Section, GalleryNavigationSection>();
+    for (const section of navSectionEntries) {
+      map.set(section.id, section);
+    }
+    return map;
+  }, [navSectionEntries]);
+
+  const sectionGroupMap = React.useMemo(() => {
+    const map = new Map<Section, ComponentsView>();
+    for (const group of groups) {
+      for (const section of group.sections) {
+        map.set(section.id, group.id);
+      }
+    }
+    return map;
+  }, [groups]);
+
+  const groupSectionIds = React.useMemo(() => {
+    const map = new Map<ComponentsView, Set<Section>>();
+    for (const group of groups) {
+      map.set(
+        group.id,
+        new Set(group.sections.map((section) => section.id)),
+      );
+    }
+    return map;
+  }, [groups]);
+
+  const defaultSection = React.useMemo<Section>(() => {
+    for (const group of groups) {
+      if (group.sections.length > 0) {
+        return group.sections[0].id;
+      }
+    }
+    return (navSectionEntries[0]?.id ?? "buttons") as Section;
+  }, [groups, navSectionEntries]);
+
+  const fallbackCopy = React.useMemo<GalleryHeroCopy>(() => {
+    const firstSection = navSectionEntries[0];
+    if (firstSection) {
+      return firstSection.copy;
+    }
+    const firstGroup = groups[0];
+    if (firstGroup) {
+      return firstGroup.copy;
+    }
+    return DEFAULT_FALLBACK_COPY;
+  }, [groups, navSectionEntries]);
+
+  const normalizeView = React.useCallback(
+    (value: string | null): ComponentsView => {
+      if (value === "colors") {
+        return "tokens";
+      }
+      if (value && (viewOrder as readonly string[]).includes(value)) {
+        return value as ComponentsView;
+      }
+      return defaultView;
+    },
+    [defaultView, viewOrder],
+  );
+
+  const normalizeSection = React.useCallback(
+    (value: string | null): Section => {
+      if (value && sectionMap.has(value as Section)) {
+        return value as Section;
+      }
+      return defaultSection;
+    },
+    [defaultSection, sectionMap],
+  );
+
+  const [view, setView] = React.useState<ComponentsView>(() =>
+    normalizeView(viewParam),
+  );
+  const [section, setSection] = React.useState<Section>(() =>
+    normalizeSection(sectionParam),
+  );
+
+  const previousSectionParamRef = React.useRef<string | null | undefined>(
+    undefined,
+  );
+  const previousViewParamRef = React.useRef<string | null | undefined>(
+    undefined,
+  );
+  const previousQueryParamRef = React.useRef<string | null | undefined>(
+    undefined,
+  );
+
+  const componentsPanelRef = React.useRef<HTMLDivElement>(null);
+  const tokensPanelRef = React.useRef<HTMLDivElement>(null);
+  const previousViewRef = React.useRef<ComponentsView | null>(null);
+
+  const currentGroup = React.useMemo(
+    () => groups.find((group) => group.id === view) ?? null,
+    [groups, view],
+  );
+
+  const heroTabs = React.useMemo<TabItem[]>(
+    () =>
+      currentGroup
+        ? currentGroup.sections.map((section) => ({
+            key: section.id,
+            label: section.label,
+            controls: "components-panel",
+          }))
+        : [],
+    [currentGroup],
+  );
+
+  const sectionMeta = React.useMemo(
+    () => sectionMap.get(section) ?? null,
+    [section, sectionMap],
+  );
+
+  const currentGroupLabel = currentGroup?.label ?? "";
+  const activeSectionLabel = sectionMeta?.label ?? "";
+  const sectionMetaLabel = sectionMeta?.label;
+
+  const sectionSpecs = React.useMemo<readonly GallerySerializableEntry[]>(
+    () => getGallerySectionEntries(section),
+    [section],
+  );
+
+  const sectionFuse = React.useMemo(() => {
+    return new Fuse<GallerySerializableEntry>(sectionSpecs, {
+      keys: ["name", "tags", "description", "props.name", "props.type"],
+      threshold: 0.3,
+    });
+  }, [sectionSpecs]);
+
+  const filteredSpecs = React.useMemo(() => {
+    if (!query) {
+      return sectionSpecs;
+    }
+    return sectionFuse.search(query).map((result) => result.item);
+  }, [query, sectionFuse, sectionSpecs]);
+
+  const filteredCount = filteredSpecs.length;
+
+  const sectionLabel = React.useMemo(() => {
+    if (sectionMetaLabel) {
+      return sectionMetaLabel;
+    }
+    return formatGallerySectionLabel(section);
+  }, [section, sectionMetaLabel]);
+
+  const countLabel = React.useMemo(() => {
+    const suffix = filteredCount === 1 ? "spec" : "specs";
+    return `${filteredCount} ${sectionLabel.toLowerCase()} ${suffix}`;
+  }, [filteredCount, sectionLabel]);
+
+  const countDescriptionId = React.useId();
+
+  const heroCopy = React.useMemo(() => {
+    if (view === "tokens") {
+      return currentGroup?.copy ?? fallbackCopy;
+    }
+    if (sectionMeta) {
+      return sectionMeta.copy;
+    }
+    return currentGroup?.copy ?? fallbackCopy;
+  }, [currentGroup, fallbackCopy, sectionMeta, view]);
+
+  const sectionCopy = React.useMemo(() => {
+    if (sectionMeta) {
+      return sectionMeta.copy;
+    }
+    if (currentGroup && view !== "tokens") {
+      return currentGroup.copy;
+    }
+    return heroCopy;
+  }, [currentGroup, heroCopy, sectionMeta, view]);
+
+  const searchLabel = React.useMemo(
+    () => `Search ${sectionCopy.heading}`,
+    [sectionCopy.heading],
+  );
+
+  const searchPlaceholder = React.useMemo(() => {
+    const baseLabel = activeSectionLabel || currentGroupLabel || "gallery";
+    return `Search ${baseLabel.toLowerCase()} specs…`;
+  }, [activeSectionLabel, currentGroupLabel]);
+
+  const viewTabs = React.useMemo<TabItem[]>(
+    () =>
+      groups.map((group) => ({
+        key: group.id,
+        label: group.label,
+        controls: group.id === "tokens" ? "tokens-panel" : "components-panel",
+      })),
+    [groups],
+  );
+
+  const componentsPanelLabelledBy = React.useMemo(() => {
+    const base = `components-${view}-tab`;
+    if (heroTabs.length > 0) {
+      return `${base} components-${section}-tab`;
+    }
+    return base;
+  }, [heroTabs.length, section, view]);
+
+  const handleViewChange = React.useCallback(
+    (key: string | number) => {
+      const rawValue = typeof key === "string" ? key : String(key);
+      const nextView = normalizeView(rawValue);
+      if (nextView === view) {
+        return;
+      }
+      setView(nextView);
+      if (nextView === "tokens") {
+        return;
+      }
+      const allowedSections = groupSectionIds.get(nextView);
+      if (allowedSections?.has(section)) {
+        return;
+      }
+      const fallbackSection = groups
+        .find((group) => group.id === nextView)
+        ?.sections[0]?.id;
+      if (fallbackSection && fallbackSection !== section) {
+        setSection(fallbackSection);
+      }
+    },
+    [groupSectionIds, groups, normalizeView, section, view],
+  );
+
+  const handleSectionChange = React.useCallback(
+    (key: string | number) => {
+      const rawValue = typeof key === "string" ? key : String(key);
+      setSection(normalizeSection(rawValue));
+    },
+    [normalizeSection],
+  );
+
+  React.useEffect(() => {
+    if (previousSectionParamRef.current === sectionParam) {
+      return;
+    }
+    previousSectionParamRef.current = sectionParam;
+    const next = normalizeSection(sectionParam);
+    setSection((prev) => (prev === next ? prev : next));
+  }, [normalizeSection, sectionParam]);
+
+  React.useEffect(() => {
+    if (previousViewParamRef.current === viewParam) {
+      return;
+    }
+    previousViewParamRef.current = viewParam;
+    const next = normalizeView(viewParam);
+    setView((prev) => (prev === next ? prev : next));
+  }, [normalizeView, viewParam]);
+
+  React.useEffect(() => {
+    if (previousQueryParamRef.current === queryParam) {
+      return;
+    }
+    previousQueryParamRef.current = queryParam;
+    const next = queryParam ?? "";
+    if (next !== query) {
+      setQuery(next);
+    }
+  }, [queryParam, query, setQuery]);
+
+  React.useEffect(() => {
+    const current = sectionParam ?? "";
+    if (current === section) return;
+    const next = new URLSearchParams(paramsString);
+    next.set("section", section);
+    startTransition(() => {
+      router.replace(`?${next.toString()}`, { scroll: false });
+    });
+  }, [paramsString, router, section, sectionParam, startTransition]);
+
+  React.useEffect(() => {
+    const current = normalizeView(viewParam);
+    if (current === view) return;
+    const next = new URLSearchParams(paramsString);
+    if (view === defaultView) {
+      next.delete("view");
+    } else {
+      next.set("view", view);
+    }
+    startTransition(() => {
+      router.replace(`?${next.toString()}`, { scroll: false });
+    });
+  }, [defaultView, normalizeView, paramsString, router, startTransition, view, viewParam]);
+
+  React.useEffect(() => {
+    const current = queryParam ?? "";
+    if (current === query) return;
+    const next = new URLSearchParams(paramsString);
+    if (query) {
+      next.set("q", query);
+    } else {
+      next.delete("q");
+    }
+    startTransition(() => {
+      router.replace(`?${next.toString()}`, { scroll: false });
+    });
+  }, [paramsString, query, queryParam, router, startTransition]);
+
+  React.useEffect(() => {
+    if (view === "tokens") {
+      return;
+    }
+    const allowed = groupSectionIds.get(view);
+    if (!allowed || allowed.size === 0) {
+      return;
+    }
+    if (!allowed.has(section)) {
+      const fallback = groups.find((group) => group.id === view)?.sections[0]?.id;
+      if (fallback && fallback !== section) {
+        setSection(fallback);
+      }
+    }
+  }, [groupSectionIds, groups, section, view]);
+
+  React.useEffect(() => {
+    if (view === "tokens") {
+      return;
+    }
+    const owner = sectionGroupMap.get(section);
+    if (!owner) {
+      return;
+    }
+    if (owner === view) {
+      return;
+    }
+    const allowed = groupSectionIds.get(view);
+    if (allowed?.has(section)) {
+      return;
+    }
+    setView(owner);
+  }, [groupSectionIds, section, sectionGroupMap, view]);
+
+  React.useEffect(() => {
+    const previousView = previousViewRef.current;
+    if (view !== "tokens" && previousView === "tokens") {
+      componentsPanelRef.current?.focus({ preventScroll: true });
+    }
+    previousViewRef.current = view;
+  }, [view]);
+
+  React.useEffect(() => {
+    if (view === "tokens") {
+      tokensPanelRef.current?.focus({ preventScroll: true });
+    }
+  }, [view]);
+
+  const showSectionTabs = heroTabs.length > 0 && view !== "tokens";
+
+  return {
+    view,
+    section,
+    query,
+    setQuery,
+    heroCopy,
+    heroTabs,
+    viewTabs,
+    showSectionTabs,
+    searchLabel,
+    searchPlaceholder,
+    filteredSpecs,
+    sectionLabel,
+    countLabel,
+    countDescriptionId,
+    componentsPanelLabelledBy,
+    handleViewChange,
+    handleSectionChange,
+    componentsPanelRef,
+    tokensPanelRef,
+  };
+}


### PR DESCRIPTION
## Summary
- extract a `useComponentsGalleryState` hook to manage view/section normalization, filtering, and URL synchronization
- move the tab panel markup into a presentational `ComponentsGalleryPanels` component
- update `ComponentsPageClient` to compose the header with the new hook output and panels module

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d02912fcec832ca11bf6b3dd6f73d9