### PR TITLE
Add noopener rel default for Button blank targets

### DIFF
--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -524,6 +524,11 @@ export const Button = React.forwardRef<
     };
     let resolvedHref = href;
 
+    const resolvedRel =
+      target === "_blank" && typeof rel === "undefined"
+        ? "noopener noreferrer"
+        : rel;
+
     if (typeof href === "string") {
       const trimmedHref = href.trim();
       const hasScheme = /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmedHref);
@@ -544,7 +549,7 @@ export const Button = React.forwardRef<
         ref={ref as React.ForwardedRef<HTMLAnchorElement>}
         href={resolvedHref}
         target={target}
-        rel={rel}
+        rel={resolvedRel}
         download={download}
         aria-disabled={isDisabled ? true : undefined}
       >

--- a/tests/ui/ButtonBasePath.test.tsx
+++ b/tests/ui/ButtonBasePath.test.tsx
@@ -40,6 +40,35 @@ describe("ButtonBasePath", () => {
   });
 });
 
+describe("Button anchor security defaults", () => {
+  it("applies noopener rel for blank targets without rel", async () => {
+    vi.resetModules();
+    const { default: Button } = await import("@/components/ui/primitives/Button");
+    const { getByRole } = render(
+      <Button href="https://example.com" target="_blank">
+        External
+      </Button>,
+    );
+
+    expect(getByRole("link")).toHaveAttribute(
+      "rel",
+      "noopener noreferrer",
+    );
+  });
+
+  it("preserves a provided rel for blank targets", async () => {
+    vi.resetModules();
+    const { default: Button } = await import("@/components/ui/primitives/Button");
+    const { getByRole } = render(
+      <Button href="https://example.com" rel="external" target="_blank">
+        External
+      </Button>,
+    );
+
+    expect(getByRole("link")).toHaveAttribute("rel", "external");
+  });
+});
+
 describe("QuickActions base path integration", () => {
   it("uses the base path for its internal shortcuts", async () => {
     process.env.NEXT_PUBLIC_BASE_PATH = "/beta";


### PR DESCRIPTION
## Summary
- default Button anchors to `rel="noopener noreferrer"` when opened in a new tab without an explicit rel
- cover the new default and override behavior with unit tests

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d029fda77c832c812364dda62c1544