### PR TITLE
Add accessible labels to planner composers

### DIFF
--- a/src/components/planner/ProjectList.tsx
+++ b/src/components/planner/ProjectList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import Label from "@/components/ui/Label";
 import Input from "@/components/ui/primitives/Input";
 import IconButton from "@/components/ui/primitives/IconButton";
 import CheckCircle from "@/components/ui/toggles/CheckCircle";
@@ -31,6 +32,7 @@ export default function ProjectList({
   deleteProject,
   addProject,
 }: Props) {
+  const newProjectInputId = React.useId();
   const [editingProjectId, setEditingProjectId] = React.useState<string | null>(
     null,
   );
@@ -115,17 +117,21 @@ export default function ProjectList({
       className="gap-[var(--space-2)]"
       renderComposer={() => (
         <form
+          className="grid gap-[var(--space-2)]"
           onSubmit={(e) => {
             e.preventDefault();
             addProjectCommit();
           }}
         >
+          <Label htmlFor={newProjectInputId} className="mb-0">
+            New project
+          </Label>
           <Input
+            id={newProjectInputId}
             className="w-full"
             placeholder="> new project…"
             value={draftProject}
             onChange={(e) => setDraftProject(e.target.value)}
-            aria-label="Add project"
           />
         </form>
       )}

--- a/src/components/planner/TaskList.tsx
+++ b/src/components/planner/TaskList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import Label from "@/components/ui/Label";
 import Input from "@/components/ui/primitives/Input";
 import EmptyRow from "./EmptyRow";
 import PlannerListPanel from "./PlannerListPanel";
@@ -33,6 +34,7 @@ export default function TaskList({
   setSelectedTaskId,
 }: Props) {
   const [draftTask, setDraftTask] = React.useState("");
+  const newTaskInputId = React.useId();
   const tasksForSelected = React.useMemo(
     () => {
       if (!selectedProjectId) return [] as DayTask[];
@@ -63,13 +65,16 @@ export default function TaskList({
       renderComposer={
         hasSelectedProject
           ? () => (
-              <form onSubmit={onSubmit}>
+              <form onSubmit={onSubmit} className="grid gap-[var(--space-2)]">
+                <Label htmlFor={newTaskInputId} className="mb-0">
+                  New task
+                </Label>
                 <Input
+                  id={newTaskInputId}
                   className="w-full"
                   placeholder="> add task…"
                   value={draftTask}
                   onChange={(e) => setDraftTask(e.target.value)}
-                  aria-label="Add task"
                 />
               </form>
             )

--- a/src/components/planner/TodayHeroProjects.tsx
+++ b/src/components/planner/TodayHeroProjects.tsx
@@ -4,6 +4,7 @@ import { Pencil, Trash2 } from "lucide-react";
 import type { FormEvent } from "react";
 
 import { cn } from "@/lib/utils";
+import Label from "@/components/ui/Label";
 import Button from "@/components/ui/primitives/Button";
 import IconButton from "@/components/ui/primitives/IconButton";
 import Input from "@/components/ui/primitives/Input";
@@ -55,6 +56,7 @@ export default function TodayHeroProjects({
   onProjectRenameCancel,
   onToggleShowAllProjects,
 }: TodayHeroProjectsProps) {
+  const newProjectInputId = `${projectsListId}-new-project`;
   const activeProjectOptionId = visibleProjects.some(
     (project) => project.id === selectedProjectId,
   )
@@ -63,13 +65,16 @@ export default function TodayHeroProjects({
 
   return (
     <div className="mt-[var(--space-4)] space-y-[var(--space-4)]">
-      <form onSubmit={onProjectFormSubmit}>
+      <form onSubmit={onProjectFormSubmit} className="grid gap-[var(--space-2)]">
+        <Label htmlFor={newProjectInputId} className="mb-0">
+          New project
+        </Label>
         <Input
+          id={newProjectInputId}
           name="new-project"
           placeholder="> new project…"
           value={projectName}
           onChange={(event) => onProjectNameChange(event.target.value)}
-          aria-label="New project"
           className="w-full"
         />
       </form>


### PR DESCRIPTION
## Summary
- add the shared Label component to the project composer inputs in list and hero views for accessible naming
- label the task composer input and align spacing with the planner design tokens

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d02a798e18832ca9e0f5e41d7905c5