### PR TITLE
refactor: extract hero planner cards component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,31 +4,17 @@ import * as React from "react";
 import { Suspense } from "react";
 import Link from "next/link";
 import {
-  DashboardCard,
-  QuickActions,
-  TodayCard,
-  GoalsCard,
-  ReviewsCard,
-  TeamPromptsCard,
-  IsometricRoom,
-  DashboardList,
+  HeroPlannerCards,
   HomeHeroSection,
-  PlannerOverview,
   useHomePlannerOverview,
 } from "@/components/home";
+import type { HeroPlannerHighlight } from "@/components/home";
 import { PageShell, Button, ThemeToggle, Spinner } from "@/components/ui";
 import { PlannerProvider } from "@/components/planner";
 import { useTheme } from "@/lib/theme-context";
 import { useThemeQuerySync } from "@/lib/theme-hooks";
 import type { Variant } from "@/lib/theme";
 import { cn } from "@/lib/utils";
-
-type WeeklyHighlight = {
-  id: string;
-  title: string;
-  schedule: string;
-  summary: string;
-};
 
 const weeklyHighlights = [
   {
@@ -49,7 +35,7 @@ const weeklyHighlights = [
     schedule: "Fri · All day",
     summary: "Encourage the team to log highlights before the week wraps.",
   },
-] as const satisfies readonly WeeklyHighlight[];
+] as const satisfies readonly HeroPlannerHighlight[];
 
 function HomePageContent() {
   const [theme] = useTheme();
@@ -84,8 +70,6 @@ function HomePageBody({ themeVariant }: { themeVariant: Variant }) {
 
   const heroSurfaceClass =
     "relative z-10 isolate rounded-[var(--radius-2xl)] bg-card/30 shadow-neoSoft backdrop-blur-lg";
-  const contentSurfaceClass =
-    "relative z-10 isolate rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 shadow-neoSoft backdrop-blur-lg";
   const floatingPaddingClass =
     "p-[var(--space-4)] md:p-[var(--space-5)]";
 
@@ -104,65 +88,12 @@ function HomePageBody({ themeVariant }: { themeVariant: Variant }) {
           <div className={cn(heroSurfaceClass, floatingPaddingClass)}>
             <HomeHeroSection variant={themeVariant} actions={heroActions} />
           </div>
-          <div
-            className={cn(
-              "space-y-[var(--space-7)]",
-              contentSurfaceClass,
-              floatingPaddingClass,
-            )}
-          >
-            <div className="grid items-start gap-[var(--space-4)] md:grid-cols-12">
-              <div className="md:col-span-6">
-                <QuickActions />
-              </div>
-              <div className="md:col-span-6">
-                <IsometricRoom variant={themeVariant} />
-              </div>
-            </div>
-            <div className="pt-[var(--space-4)]">
-              <PlannerOverview {...plannerOverviewProps} />
-            </div>
-            <section className="grid grid-cols-1 gap-[var(--space-6)] md:grid-cols-12">
-              <div className="md:col-span-4">
-                <TodayCard />
-              </div>
-              <div className="md:col-span-4">
-                <GoalsCard />
-              </div>
-              <div className="md:col-span-4">
-                <ReviewsCard />
-              </div>
-              <div className="md:col-span-4">
-                <DashboardCard
-                  title="Weekly focus"
-                  cta={{ label: "Open planner", href: "/planner" }}
-                >
-                  <DashboardList
-                    items={weeklyHighlights}
-                    getKey={(highlight) => highlight.id}
-                    itemClassName="py-[var(--space-2)]"
-                    empty="No highlights scheduled"
-                    renderItem={(highlight) => (
-                      <div className="flex flex-col gap-[var(--space-2)]">
-                        <div className="flex items-baseline justify-between gap-[var(--space-3)]">
-                          <p className="text-ui font-medium">{highlight.title}</p>
-                          <span className="text-label text-muted-foreground">
-                            {highlight.schedule}
-                          </span>
-                        </div>
-                        <p className="text-body text-muted-foreground">
-                          {highlight.summary}
-                        </p>
-                      </div>
-                    )}
-                  />
-                </DashboardCard>
-              </div>
-              <div className="md:col-span-12">
-                <TeamPromptsCard />
-              </div>
-            </section>
-          </div>
+          <HeroPlannerCards
+            variant={themeVariant}
+            plannerOverviewProps={plannerOverviewProps}
+            highlights={weeklyHighlights}
+            className={floatingPaddingClass}
+          />
         </div>
       </div>
     </PageShell>

--- a/src/components/home/HeroPlannerCards.tsx
+++ b/src/components/home/HeroPlannerCards.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import * as React from "react";
+
+import DashboardCard from "./DashboardCard";
+import DashboardList from "./DashboardList";
+import GoalsCard from "./GoalsCard";
+import IsometricRoom from "./IsometricRoom";
+import PlannerOverview from "./home-landing/PlannerOverview";
+import type { PlannerOverviewProps } from "./home-landing";
+import QuickActions from "./QuickActions";
+import ReviewsCard from "./ReviewsCard";
+import TeamPromptsCard from "./TeamPromptsCard";
+import TodayCard from "./TodayCard";
+import type { Variant } from "@/lib/theme";
+import { cn } from "@/lib/utils";
+
+export interface HeroPlannerHighlight {
+  id: string;
+  title: string;
+  schedule: string;
+  summary: string;
+}
+
+export interface HeroPlannerCardsProps {
+  variant: Variant;
+  plannerOverviewProps: PlannerOverviewProps;
+  highlights: readonly HeroPlannerHighlight[];
+  className?: string;
+}
+
+export default function HeroPlannerCards({
+  variant,
+  plannerOverviewProps,
+  highlights,
+  className,
+}: HeroPlannerCardsProps) {
+  return (
+    <div
+      className={cn(
+        "space-y-[var(--space-7)]",
+        "relative z-10 isolate rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 shadow-neoSoft backdrop-blur-lg",
+        "p-[var(--space-4)] md:p-[var(--space-5)]",
+        className,
+      )}
+    >
+      <div className="grid items-start gap-[var(--space-4)] md:grid-cols-12">
+        <div className="md:col-span-6">
+          <QuickActions />
+        </div>
+        <div className="md:col-span-6">
+          <IsometricRoom variant={variant} />
+        </div>
+      </div>
+      <div className="pt-[var(--space-4)]">
+        <PlannerOverview {...plannerOverviewProps} />
+      </div>
+      <section className="grid grid-cols-1 gap-[var(--space-6)] md:grid-cols-12">
+        <div className="md:col-span-4">
+          <TodayCard />
+        </div>
+        <div className="md:col-span-4">
+          <GoalsCard />
+        </div>
+        <div className="md:col-span-4">
+          <ReviewsCard />
+        </div>
+        <div className="md:col-span-4">
+          <DashboardCard
+            title="Weekly focus"
+            cta={{ label: "Open planner", href: "/planner" }}
+          >
+            <DashboardList
+              items={highlights}
+              getKey={(highlight) => highlight.id}
+              itemClassName="py-[var(--space-2)]"
+              empty="No highlights scheduled"
+              renderItem={(highlight) => (
+                <div className="flex flex-col gap-[var(--space-2)]">
+                  <div className="flex items-baseline justify-between gap-[var(--space-3)]">
+                    <p className="text-ui font-medium">{highlight.title}</p>
+                    <span className="text-label text-muted-foreground">
+                      {highlight.schedule}
+                    </span>
+                  </div>
+                  <p className="text-body text-muted-foreground">
+                    {highlight.summary}
+                  </p>
+                </div>
+              )}
+            />
+          </DashboardCard>
+        </div>
+        <div className="md:col-span-12">
+          <TeamPromptsCard />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -9,6 +9,7 @@ export { default as TeamPromptsCard } from "./TeamPromptsCard";
 export { default as QuickActionGrid } from "./QuickActionGrid";
 export { default as BottomNav } from "../chrome/BottomNav";
 export { default as IsometricRoom } from "./IsometricRoom";
+export { default as HeroPlannerCards } from "./HeroPlannerCards";
 export { default as HeroPortraitFrame } from "./HeroPortraitFrame";
 export type { HeroPortraitFrameProps } from "./HeroPortraitFrame";
 export { default as WelcomeHeroFigure } from "./WelcomeHeroFigure";
@@ -17,6 +18,7 @@ export {
   PlannerOverview,
   useHomePlannerOverview,
 } from "./home-landing";
+export type { HeroPlannerCardsProps, HeroPlannerHighlight } from "./HeroPlannerCards";
 export type {
   PlannerOverviewProps,
   PlannerOverviewSummaryProps,

--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -64,6 +64,7 @@ import NeomorphicHeroFrameDemo from "./NeomorphicHeroFrameDemo";
 import {
   DashboardCard,
   DashboardList,
+  HeroPlannerCards,
   IsometricRoom,
   QuickActionGrid,
   HeroPortraitFrame,
@@ -82,6 +83,7 @@ import {
   ReviewSliderTrack,
   ScoreMeter,
 } from "@/components/reviews";
+import type { HeroPlannerHighlight, PlannerOverviewProps } from "@/components/home";
 import type { PromptWithTitle } from "./types";
 import type { Review, Role, Pillar } from "@/lib/types";
 import { VARIANTS, defaultTheme } from "@/lib/theme";
@@ -135,6 +137,197 @@ const demoReview: Review = {
   score: 8,
   result: "Win",
 };
+
+const heroPlannerHighlightsDemo = [
+  {
+    id: "strategy-sync",
+    title: "Strategy sync",
+    schedule: "Today · 3:00 PM",
+    summary: "Align backlog for the Q2 milestone and confirm owners.",
+  },
+  {
+    id: "retro",
+    title: "Sprint retro",
+    schedule: "Wed · 11:00 AM",
+    summary: "Collect insights for the retro and lock the next sprint goals.",
+  },
+  {
+    id: "review-window",
+    title: "Review window",
+    schedule: "Fri · All day",
+    summary: "Encourage everyone to log highlights before the week wraps.",
+  },
+] as const satisfies readonly HeroPlannerHighlight[];
+
+const heroPlannerOverviewDemo = {
+  summary: {
+    label: "Planner overview",
+    title: "Week of April 22",
+    items: [
+      {
+        key: "focus",
+        label: "Next focus",
+        value: "Design review · 2:00 PM",
+        href: "/planner",
+        cta: "Open planner",
+      },
+      {
+        key: "reviews",
+        label: "Open reviews",
+        value: "2 flagged reviews",
+        href: "/reviews",
+        cta: "Review now",
+      },
+      {
+        key: "prompts",
+        label: "Team prompts",
+        value: "8 saved",
+        href: "/prompts",
+        cta: "Browse prompts",
+      },
+    ],
+  },
+  focus: {
+    label: "Focus day",
+    title: "Monday, April 22",
+    doneCount: 2,
+    totalCount: 5,
+    tasks: [
+      {
+        id: "focus-1",
+        title: "Prep launch checklist",
+        projectName: "Launchpad",
+        done: false,
+        toggleLabel: "Mark Prep launch checklist as done",
+      },
+      {
+        id: "focus-2",
+        title: "Team standup notes",
+        projectName: "Operations",
+        done: true,
+        toggleLabel: "Mark Team standup notes as not done",
+      },
+      {
+        id: "focus-3",
+        title: "Sync with research",
+        projectName: "Insights",
+        done: false,
+        toggleLabel: "Mark Sync with research as done",
+      },
+    ],
+    remainingTasks: 2,
+    onToggleTask: () => {},
+  },
+  goals: {
+    label: "Goals",
+    title: "Quarterly progress",
+    completed: 3,
+    total: 5,
+    percentage: 60,
+    active: [
+      {
+        id: "goal-1",
+        title: "Improve trial activation",
+        detail: "Target 45%",
+      },
+      {
+        id: "goal-2",
+        title: "Ship planner sharing",
+        detail: null,
+      },
+    ],
+    emptyMessage: "No goals yet",
+    allCompleteMessage: "All goals complete",
+  },
+  calendar: {
+    label: "Week progress",
+    title: "Schedule",
+    summary: "12/20 tasks complete",
+    doneCount: 12,
+    totalCount: 20,
+    hasPlannedTasks: true,
+    days: [
+      {
+        iso: "2024-04-22",
+        weekday: "Mon",
+        dayNumber: "22",
+        done: 2,
+        total: 4,
+        disabled: false,
+        loading: false,
+        selected: true,
+        today: false,
+      },
+      {
+        iso: "2024-04-23",
+        weekday: "Tue",
+        dayNumber: "23",
+        done: 1,
+        total: 3,
+        disabled: false,
+        loading: false,
+        selected: false,
+        today: false,
+      },
+      {
+        iso: "2024-04-24",
+        weekday: "Wed",
+        dayNumber: "24",
+        done: 3,
+        total: 3,
+        disabled: false,
+        loading: false,
+        selected: false,
+        today: false,
+      },
+      {
+        iso: "2024-04-25",
+        weekday: "Thu",
+        dayNumber: "25",
+        done: 2,
+        total: 4,
+        disabled: false,
+        loading: false,
+        selected: false,
+        today: false,
+      },
+      {
+        iso: "2024-04-26",
+        weekday: "Fri",
+        dayNumber: "26",
+        done: 1,
+        total: 3,
+        disabled: false,
+        loading: false,
+        selected: false,
+        today: true,
+      },
+      {
+        iso: "2024-04-27",
+        weekday: "Sat",
+        dayNumber: "27",
+        done: 2,
+        total: 3,
+        disabled: false,
+        loading: false,
+        selected: false,
+        today: false,
+      },
+      {
+        iso: "2024-04-28",
+        weekday: "Sun",
+        dayNumber: "28",
+        done: 1,
+        total: 2,
+        disabled: true,
+        loading: false,
+        selected: false,
+        today: false,
+      },
+    ],
+    onSelectDay: () => {},
+  },
+} satisfies PlannerOverviewProps;
 
 const FIELD_HOVER_SHADOW =
   "shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.12),inset_0_calc(var(--hairline-w)*-1)_0_hsl(var(--border)/0.45)]";
@@ -3672,6 +3865,25 @@ React.useEffect(() => {
   layout="inline"
   buttonSize="lg"
   hoverLift
+/>`,
+    },
+    {
+      id: "hero-planner-cards",
+      name: "HeroPlannerCards",
+      description:
+        "Composite hero surface combining quick actions, overview metrics, and planner highlights for the landing page.",
+      element: (
+        <HeroPlannerCards
+          variant="aurora"
+          plannerOverviewProps={heroPlannerOverviewDemo}
+          highlights={heroPlannerHighlightsDemo}
+        />
+      ),
+      tags: ["planner", "homepage", "hero"],
+      code: `<HeroPlannerCards
+  variant="aurora"
+  plannerOverviewProps={plannerOverviewProps}
+  highlights={weeklyHighlights}
 />`,
     },
     {


### PR DESCRIPTION
## Summary
- extract the hero planner cards layout into `src/components/home/HeroPlannerCards.tsx`
- update the home page to consume the shared component and keep the page lean
- document the component in the prompts gallery with representative demo data

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d029ea9684832c8510c1e87983271f