### PR TITLE
Add coverage for useThemeQuerySync query handling

### DIFF
--- a/tests/lib/useThemeQuerySync.test.tsx
+++ b/tests/lib/useThemeQuerySync.test.tsx
@@ -1,0 +1,108 @@
+import * as React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ThemeProvider, useTheme } from "@/lib/theme-context";
+import { useThemeQuerySync } from "@/lib/theme-hooks";
+import { resetLocalStorage } from "../setup";
+
+const replaceSpy = vi.fn<(url: string, options?: { scroll: boolean }) => void>();
+let pathname = "/planner";
+let searchParamsString = "";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: replaceSpy,
+  }),
+  usePathname: () => pathname,
+  useSearchParams: () => new URLSearchParams(searchParamsString),
+}));
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <ThemeProvider>{children}</ThemeProvider>;
+}
+
+function renderThemeSync() {
+  return renderHook(() => {
+    useThemeQuerySync();
+    return useTheme();
+  }, { wrapper: Wrapper });
+}
+
+describe("useThemeQuerySync", () => {
+  beforeEach(() => {
+    document.documentElement.className = "";
+    searchParamsString = "";
+    pathname = "/planner";
+    replaceSpy.mockClear();
+    resetLocalStorage();
+  });
+
+  it("applies valid theme and background query params", async () => {
+    searchParamsString = new URLSearchParams({ theme: "ocean", bg: "3" }).toString();
+
+    const { result } = renderThemeSync();
+
+    await waitFor(() => {
+      const [theme] = result.current;
+      expect(theme.variant).toBe("ocean");
+      expect(theme.bg).toBe(3);
+    });
+  });
+
+  it("ignores invalid query params", async () => {
+    searchParamsString = new URLSearchParams({ theme: "unknown", bg: "99" }).toString();
+
+    const { result } = renderThemeSync();
+
+    await waitFor(() => {
+      const [theme] = result.current;
+      expect(theme.variant).toBe("lg");
+      expect(theme.bg).toBe(0);
+    });
+
+    await waitFor(() => {
+      expect(replaceSpy).toHaveBeenCalledWith("/planner?theme=lg&bg=0", {
+        scroll: false,
+      });
+    });
+  });
+
+  it("updates the URL when the theme changes without looping", async () => {
+    searchParamsString = new URLSearchParams({ theme: "lg", bg: "0" }).toString();
+
+    const { result, rerender } = renderThemeSync();
+
+    await waitFor(() => {
+      const [theme] = result.current;
+      expect(theme.variant).toBe("lg");
+      expect(theme.bg).toBe(0);
+    });
+
+    act(() => {
+      const [, setTheme] = result.current;
+      setTheme((prev) => ({ ...prev, variant: "noir", bg: 2 }));
+    });
+
+    await waitFor(() => {
+      expect(replaceSpy).toHaveBeenCalledWith("/planner?theme=noir&bg=2", {
+        scroll: false,
+      });
+    });
+
+    expect(replaceSpy).toHaveBeenCalledTimes(1);
+
+    searchParamsString = new URLSearchParams({ theme: "noir", bg: "2" }).toString();
+
+    act(() => {
+      rerender();
+    });
+
+    await waitFor(() => {
+      const [theme] = result.current;
+      expect(theme.variant).toBe("noir");
+      expect(theme.bg).toBe(2);
+    });
+
+    expect(replaceSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a vitest suite for useThemeQuerySync that renders the hook inside ThemeProvider
- mock next/navigation utilities to drive query params and assert router.replace behavior
- verify valid params hydrate theme context, invalid params are ignored, and theme updates sync the URL without looping

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d025de2194832c8cae473abf89906f