### PR TITLE
Add aria-label to TodayHeroTasks toggle

### DIFF
--- a/src/components/planner/TodayHeroTasks.tsx
+++ b/src/components/planner/TodayHeroTasks.tsx
@@ -132,6 +132,7 @@ export default function TodayHeroTasks({
                       onChange={() => {
                         onTaskToggle(task.id);
                       }}
+                      aria-label={`Toggle ${task.title} done`}
                       size="sm"
                     />
                     {isEditing ? (


### PR DESCRIPTION
## Summary
- add task-specific aria-label to the TodayHeroTasks completion toggle to match planner phrasing

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d02dcb4c94832ca5f046db6823163d