### PR TITLE
Refactor planner persistence to per-day storage

### DIFF
--- a/src/components/planner/plannerSerialization.ts
+++ b/src/components/planner/plannerSerialization.ts
@@ -90,6 +90,10 @@ function decodeDayRecord(value: unknown): DayRecord | null {
   return day;
 }
 
+export function decodePlannerDay(value: unknown): DayRecord | null {
+  return decodeDayRecord(value);
+}
+
 export function decodePlannerDays(value: unknown): Record<ISODate, DayRecord> {
   if (!isRecord(value)) return {};
   const result: Record<ISODate, DayRecord> = {};


### PR DESCRIPTION
## Summary
- replace the planner days persistent state with an in-memory store that queues per-day writes and removals and flushes them via the existing storage helpers
- hydrate planner state by reading per-day keys, migrating legacy snapshots, pruning stale entries, and ensuring per-day keys are repopulated when needed
- update planner integration tests to expect per-day storage keys and dynamic ISO dates

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d0291e7518832cbb0d6087548ca378