### PR TITLE
Fix build failures by marking animated select modules as client components

### DIFF
--- a/src/components/ui/layout/hero/HeroGlitchStyles.tsx
+++ b/src/components/ui/layout/hero/HeroGlitchStyles.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // src/components/ui/layout/hero/HeroGlitchStyles.tsx
 
 import * as React from "react";

--- a/src/components/ui/select/AnimatedSelectList.tsx
+++ b/src/components/ui/select/AnimatedSelectList.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { Check } from "lucide-react";

--- a/src/components/ui/select/useAnimatedSelect.ts
+++ b/src/components/ui/select/useAnimatedSelect.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import { useReducedMotion } from "framer-motion";
 


### PR DESCRIPTION
## Summary
- mark the hero glitch styles helper as a client component so styled-jsx renders during static export
- convert the animated select list and hook modules into client components so framer-motion stays in a client boundary

## Testing
- npm run build
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d0348c0f88832c9a50827d97ca8c19