### PR TITLE
Align PageHeader spacing with frame variant

### DIFF
--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -34,6 +34,17 @@ type FrameSlotPresence = {
   actions: boolean;
 };
 
+type FrameVariantWithSpacing = Exclude<
+  NeomorphicHeroFrameProps["variant"],
+  "unstyled" | undefined
+>;
+
+const frameContentSpacingByVariant = {
+  default: "space-y-[var(--space-5)] md:space-y-[var(--space-6)]",
+  compact: "space-y-[var(--space-4)] md:space-y-[var(--space-5)]",
+  dense: "space-y-[var(--space-3)] md:space-y-[var(--space-4)]",
+} as const satisfies Record<FrameVariantWithSpacing, string>;
+
 const hasRenderableNode = (node: React.ReactNode): boolean => {
   if (node === null || node === undefined) {
     return false;
@@ -241,6 +252,17 @@ const PageHeaderInner = <
 
   const heroTabVariant: TabBarProps["variant"] | undefined =
     resolvedHeroFrame ? "neo" : undefined;
+
+  const computedContentSpacing = React.useMemo(() => {
+    const variant = frameVariant ?? "default";
+    if (variant === "unstyled") {
+      return undefined;
+    }
+    return (
+      frameContentSpacingByVariant[variant] ??
+      frameContentSpacingByVariant.default
+    );
+  }, [frameVariant]);
 
   const actionAreaTabsSlot = React.useMemo<HeroSlot | null | undefined>(() => {
     if (!resolvedSubTabs || heroShouldRenderTabs) return undefined;
@@ -552,8 +574,8 @@ const PageHeaderInner = <
         <div
           className={cn(
             "relative z-[2]",
-            contentClassName ??
-              "space-y-[var(--space-5)] md:space-y-[var(--space-6)]",
+            computedContentSpacing,
+            contentClassName,
           )}
         >
           <Header

--- a/tests/components/PageHeader.test.tsx
+++ b/tests/components/PageHeader.test.tsx
@@ -238,6 +238,38 @@ describe("PageHeader", () => {
     expect(container.querySelector('[data-slot="actions"]')).toBeNull();
   });
 
+  it("synchronizes content spacing with the frame variant", () => {
+    const { container, rerender } = render(
+      <PageHeader
+        header={baseHeader}
+        hero={baseHero}
+        frameProps={{ variant: "compact" }}
+      />,
+    );
+
+    const queryContentWrapper = () =>
+      container.querySelector("div[class*='z-[2]']") as HTMLElement | null;
+
+    const compactWrapper = queryContentWrapper();
+    expect(compactWrapper).not.toBeNull();
+    expect(compactWrapper).toHaveClass("space-y-[var(--space-4)]");
+    expect(compactWrapper).toHaveClass("md:space-y-[var(--space-5)]");
+
+    rerender(
+      <PageHeader
+        header={baseHeader}
+        hero={baseHero}
+        frameProps={{ variant: "dense" }}
+      />,
+    );
+
+    const denseWrapper = queryContentWrapper();
+    expect(denseWrapper).not.toBeNull();
+    expect(denseWrapper).toHaveClass("space-y-[var(--space-3)]");
+    expect(denseWrapper).toHaveClass("md:space-y-[var(--space-4)]");
+    expect(denseWrapper).not.toHaveClass("space-y-[var(--space-4)]");
+  });
+
   describe("frame alignment fallbacks", () => {
     const createSubTabs = () => ({
       items: [

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`ReviewsPage > renders default state 1`] = `
           class="relative z-[1] space-y-[var(--space-5)] md:space-y-[var(--space-6)]"
         >
           <div
-            class="relative z-[2] space-y-[var(--space-2)]"
+            class="relative z-[2] md:space-y-[var(--space-6)] space-y-[var(--space-2)]"
           >
             <header
               class="z-[999] relative isolate after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent after:z-[2]"


### PR DESCRIPTION
## Summary
- derive the PageHeader content spacing from the frame variant and merge it with custom classes
- cover compact and dense variants with a regression test for the expected spacing classes
- update the reviews page snapshot for the new spacing behavior

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d039dbcac4832ca3ac5bbde6436c28