### PR TITLE
Make hero search bar responsive within slot

### DIFF
--- a/src/components/ui/layout/hero/HeroSearchBar.tsx
+++ b/src/components/ui/layout/hero/HeroSearchBar.tsx
@@ -23,11 +23,7 @@ export function HeroSearchBar({
     <SearchBar
       {...props}
       variant={resolvedVariant}
-      className={cn(
-        "w-full max-w-[calc(var(--space-8)*10)]",
-        round && "rounded-full",
-        className,
-      )}
+      className={cn("w-full flex-1 min-w-0", round && "rounded-full", className)}
       fieldClassName={cn(
         round && "rounded-full [&>input]:rounded-full",
         isNeo && "overflow-hidden hero2-frame",

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -187,7 +187,7 @@ exports[`ReviewsPage > renders default state 1`] = `
               class="relative z-[1] flex w-full min-w-0 flex-col"
             >
               <form
-                class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-[var(--space-2)] data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full max-w-[calc(var(--space-8)*10)] rounded-full flex-1"
+                class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-[var(--space-2)] data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full min-w-0 rounded-full flex-1"
                 role="search"
               >
                 <div


### PR DESCRIPTION
## Summary
- allow the hero search bar to flex with its slot by swapping the fixed max-width for flex grow/min-width utilities
- refresh the reviews page snapshot to capture the responsive search markup

## Testing
- npm run build-gallery-usage
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d045e14b74832ca43ea334344126d3