### PR TITLE
Add borderless welcome hero figure variant

### DIFF
--- a/src/components/home/WelcomeHeroFigure.tsx
+++ b/src/components/home/WelcomeHeroFigure.tsx
@@ -77,6 +77,7 @@ export interface WelcomeHeroFigureProps {
   imageSizes?: string;
   haloTone?: WelcomeHeroFigureTone;
   showGlitchRail?: boolean;
+  framed?: boolean;
 }
 
 export default function WelcomeHeroFigure({
@@ -84,9 +85,22 @@ export default function WelcomeHeroFigure({
   imageSizes = defaultSizes,
   haloTone = "default",
   showGlitchRail,
+  framed = true,
 }: WelcomeHeroFigureProps) {
   const toneVariables = haloToneVariables[haloTone];
   const shouldShowGlitchRail = showGlitchRail ?? haloTone === "default";
+  const image = (
+    <Image
+      src="/BEST_ONE_EVAH.png"
+      alt="Planner assistant sharing a colorful dashboard scene"
+      fill
+      priority
+      loading="eager"
+      decoding="async"
+      sizes={imageSizes}
+      className="relative z-[1] h-full w-full object-contain object-center"
+    />
+  );
 
   return (
     <figure
@@ -113,31 +127,28 @@ export default function WelcomeHeroFigure({
           className="glitch-rail pointer-events-none absolute -inset-[calc(var(--welcome-figure-rim)*1.05)] rounded-full mix-blend-screen opacity-[var(--welcome-figure-glitch-opacity)]"
         />
       ) : null}
-      <div
-        className="relative flex h-full w-full items-center justify-center rounded-full shadow-neoSoft ring-1 ring-border/50"
-        style={rimStyle}
-      >
+      {framed ? (
         <div
-          className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-full shadow-neo-inset"
-          style={innerStyle}
+          className="relative flex h-full w-full items-center justify-center rounded-full shadow-neoSoft ring-1 ring-border/50"
+          style={rimStyle}
         >
-          <span
-            aria-hidden
-            className="pointer-events-none absolute inset-0 rounded-full"
-            style={overlayStyle}
-          />
-          <Image
-            src="/BEST_ONE_EVAH.png"
-            alt="Planner assistant sharing a colorful dashboard scene"
-            fill
-            priority
-            loading="eager"
-            decoding="async"
-            sizes={imageSizes}
-            className="relative z-[1] h-full w-full object-contain object-center"
-          />
+          <div
+            className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-full shadow-neo-inset"
+            style={innerStyle}
+          >
+            <span
+              aria-hidden
+              className="pointer-events-none absolute inset-0 rounded-full"
+              style={overlayStyle}
+            />
+            {image}
+          </div>
         </div>
-      </div>
+      ) : (
+        <div className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-full">
+          {image}
+        </div>
+      )}
     </figure>
   );
 }

--- a/src/components/home/home-landing/HomeHeroSection.tsx
+++ b/src/components/home/home-landing/HomeHeroSection.tsx
@@ -46,11 +46,14 @@ export default function HomeHeroSection({ variant, actions }: HomeHeroSectionPro
                 <div className="col-span-12 flex w-full flex-wrap items-center justify-end gap-[var(--space-2)] sm:flex-nowrap md:col-span-8 lg:col-span-7">
                   {actions}
                 </div>
-                <WelcomeHeroFigure
-                  className="col-span-12 md:col-span-4 lg:col-span-5"
-                  haloTone={haloTone}
-                  showGlitchRail={showGlitchRail}
-                />
+                <div className="col-span-12 flex justify-center md:col-span-4 md:justify-end lg:col-span-5">
+                  <WelcomeHeroFigure
+                    className="w-full max-w-[calc(var(--space-8)*5)]"
+                    haloTone={haloTone}
+                    showGlitchRail={showGlitchRail}
+                    framed={false}
+                  />
+                </div>
               </div>
             ),
           }}

--- a/src/components/prompts/component-gallery/PromptsPanel.tsx
+++ b/src/components/prompts/component-gallery/PromptsPanel.tsx
@@ -86,9 +86,9 @@ export default function PromptsPanel({ data }: PromptsPanelProps) {
           label: "WelcomeHeroFigure",
           element: (
             <div className="w-full space-y-[var(--space-3)]">
-              <div className="grid grid-cols-1 gap-[var(--space-3)] sm:grid-cols-2">
+              <div className="grid grid-cols-1 gap-[var(--space-3)] sm:grid-cols-2 lg:grid-cols-3">
                 <div className="flex flex-col items-center gap-[var(--space-2)]">
-                  <span className="text-label font-medium text-muted-foreground">Default halo</span>
+                  <span className="text-label font-medium text-muted-foreground">Framed halo</span>
                   <div className="w-full max-w-[calc(var(--space-8)*4)]">
                     <WelcomeHeroFigure />
                   </div>
@@ -97,6 +97,12 @@ export default function PromptsPanel({ data }: PromptsPanelProps) {
                   <span className="text-label font-medium text-muted-foreground">Toned-down halo</span>
                   <div className="w-full max-w-[calc(var(--space-8)*4)]">
                     <WelcomeHeroFigure haloTone="subtle" showGlitchRail={false} />
+                  </div>
+                </div>
+                <div className="flex flex-col items-center gap-[var(--space-2)]">
+                  <span className="text-label font-medium text-muted-foreground">Borderless halo</span>
+                  <div className="w-full max-w-[calc(var(--space-8)*4)]">
+                    <WelcomeHeroFigure framed={false} />
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- add a `framed` prop to `WelcomeHeroFigure` so the halo can render without the rim treatment
- update the home hero layout to consume the borderless variant and tighten sizing
- extend the component gallery demo to showcase the new rimless mode

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d053f75be8832cb8bba34fc2e35f11