### PR TITLE
Add borderless WelcomeHeroFigure variant

### DIFF
--- a/src/components/home/WelcomeHeroFigure.tsx
+++ b/src/components/home/WelcomeHeroFigure.tsx
@@ -77,6 +77,7 @@ export interface WelcomeHeroFigureProps {
   imageSizes?: string;
   haloTone?: WelcomeHeroFigureTone;
   showGlitchRail?: boolean;
+  framed?: boolean;
 }
 
 export default function WelcomeHeroFigure({
@@ -84,9 +85,26 @@ export default function WelcomeHeroFigure({
   imageSizes = defaultSizes,
   haloTone = "default",
   showGlitchRail,
+  framed = true,
 }: WelcomeHeroFigureProps) {
   const toneVariables = haloToneVariables[haloTone];
   const shouldShowGlitchRail = showGlitchRail ?? haloTone === "default";
+
+  const image = (
+    <Image
+      src="/BEST_ONE_EVAH.png"
+      alt="Planner assistant sharing a colorful dashboard scene"
+      fill
+      priority
+      loading="eager"
+      decoding="async"
+      sizes={imageSizes}
+      className={cn(
+        "relative z-[1] h-full w-full object-contain object-center",
+        framed && "rounded-full",
+      )}
+    />
+  );
 
   return (
     <figure
@@ -113,31 +131,26 @@ export default function WelcomeHeroFigure({
           className="glitch-rail pointer-events-none absolute -inset-[calc(var(--welcome-figure-rim)*1.05)] rounded-full mix-blend-screen opacity-[var(--welcome-figure-glitch-opacity)]"
         />
       ) : null}
-      <div
-        className="relative flex h-full w-full items-center justify-center rounded-full shadow-neoSoft ring-1 ring-border/50"
-        style={rimStyle}
-      >
+      {framed ? (
         <div
-          className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-full shadow-neo-inset"
-          style={innerStyle}
+          className="relative flex h-full w-full items-center justify-center rounded-full shadow-neoSoft ring-1 ring-border/50"
+          style={rimStyle}
         >
-          <span
-            aria-hidden
-            className="pointer-events-none absolute inset-0 rounded-full"
-            style={overlayStyle}
-          />
-          <Image
-            src="/BEST_ONE_EVAH.png"
-            alt="Planner assistant sharing a colorful dashboard scene"
-            fill
-            priority
-            loading="eager"
-            decoding="async"
-            sizes={imageSizes}
-            className="relative z-[1] h-full w-full object-contain object-center"
-          />
+          <div
+            className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-full shadow-neo-inset"
+            style={innerStyle}
+          >
+            <span
+              aria-hidden
+              className="pointer-events-none absolute inset-0 rounded-full"
+              style={overlayStyle}
+            />
+            {image}
+          </div>
         </div>
-      </div>
+      ) : (
+        image
+      )}
     </figure>
   );
 }

--- a/src/components/home/home-landing/HomeHeroSection.tsx
+++ b/src/components/home/home-landing/HomeHeroSection.tsx
@@ -36,11 +36,12 @@ export default function HomeHeroSection({ variant, actions }: HomeHeroSectionPro
             sticky: false,
             barClassName: "flex-wrap gap-y-[var(--space-3)] md:flex-nowrap",
             right: (
-              <div className="flex basis-full justify-center md:basis-auto md:justify-end">
+              <div className="flex basis-full items-center justify-center md:basis-auto md:justify-end md:pl-[var(--space-3)]">
                 <WelcomeHeroFigure
-                  className="w-full max-w-[calc(var(--space-7)*5)] md:w-[calc(var(--space-7)*5)] lg:w-[calc(var(--space-7)*6)]"
+                  className="w-full max-w-[calc(var(--space-8)*4)] md:max-w-[calc(var(--space-8)*4.5)] lg:max-w-[calc(var(--space-8)*5)]"
                   haloTone={haloTone}
                   showGlitchRail={showGlitchRail}
+                  framed={false}
                 />
               </div>
             ),

--- a/src/components/prompts/component-gallery/PromptsPanel.tsx
+++ b/src/components/prompts/component-gallery/PromptsPanel.tsx
@@ -86,7 +86,7 @@ export default function PromptsPanel({ data }: PromptsPanelProps) {
           label: "WelcomeHeroFigure",
           element: (
             <div className="w-full space-y-[var(--space-3)]">
-              <div className="grid grid-cols-1 gap-[var(--space-3)] sm:grid-cols-2">
+              <div className="grid grid-cols-1 gap-[var(--space-3)] sm:grid-cols-2 lg:grid-cols-3">
                 <div className="flex flex-col items-center gap-[var(--space-2)]">
                   <span className="text-label font-medium text-muted-foreground">Default halo</span>
                   <div className="w-full max-w-[calc(var(--space-8)*4)]">
@@ -97,6 +97,12 @@ export default function PromptsPanel({ data }: PromptsPanelProps) {
                   <span className="text-label font-medium text-muted-foreground">Toned-down halo</span>
                   <div className="w-full max-w-[calc(var(--space-8)*4)]">
                     <WelcomeHeroFigure haloTone="subtle" showGlitchRail={false} />
+                  </div>
+                </div>
+                <div className="flex flex-col items-center gap-[var(--space-2)]">
+                  <span className="text-label font-medium text-muted-foreground">Borderless mode</span>
+                  <div className="w-full max-w-[calc(var(--space-8)*4)]">
+                    <WelcomeHeroFigure framed={false} />
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- add an opt-in `framed` prop to `WelcomeHeroFigure` so the figure can render without rim and ring layers while keeping halo styling
- switch the home hero to the borderless variant and tune layout sizing/spacing for a clean header alignment
- refresh the component gallery entry to demonstrate the new borderless presentation alongside existing halos

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d058afd84c832ca89986801857b45b