### PR TITLE
Prevent prompts previews from scrolling when focusing

### DIFF
--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -408,7 +408,16 @@ function PromptsHeaderSearchStatePreview({ state }: { state: SearchState }) {
     }
 
     const frame = requestAnimationFrame(() => {
-      inputRef.current?.focus();
+      const input = inputRef.current;
+      if (!input) {
+        return;
+      }
+
+      try {
+        input.focus({ preventScroll: true });
+      } catch {
+        input.focus();
+      }
     });
 
     return () => cancelAnimationFrame(frame);
@@ -480,8 +489,15 @@ function PromptsComposePanelStatePreview({ state }: { state: ComposeState }) {
     }
 
     const frame = requestAnimationFrame(() => {
-      if (titleRef.current) {
-        titleRef.current.focus();
+      const titleInput = titleRef.current;
+      if (!titleInput) {
+        return;
+      }
+
+      try {
+        titleInput.focus({ preventScroll: true });
+      } catch {
+        titleInput.focus();
       }
     });
 


### PR DESCRIPTION
## Summary
- focus the prompts header search preview without scrolling the gallery
- prevent the compose panel title preview from scrolling when showing focus-visible

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d06b7d9fa0832c91b9c82fafa5caa0