### PR TITLE
Tighten hero frame slot spacing

### DIFF
--- a/src/components/ui/layout/NeomorphicHeroFrame.tsx
+++ b/src/components/ui/layout/NeomorphicHeroFrame.tsx
@@ -40,16 +40,22 @@ export interface NeomorphicHeroFrameProps
   children?: React.ReactNode;
 }
 
+type VariantSlotConfig = {
+  marginTop: string;
+  paddingTop: string;
+  gapY: string;
+  gapMd: string;
+  single: {
+    marginTop: string;
+    paddingTop: string;
+  };
+};
+
 type VariantConfig = {
   radius: string;
   padding: string;
   contentSpacing: string;
-  slot: {
-    marginTop: string;
-    paddingTop: string;
-    gapY: string;
-    gapMd: string;
-  };
+  slot: VariantSlotConfig;
 };
 
 const variantMap: Record<Exclude<HeroVariant, "unstyled">, VariantConfig> = {
@@ -64,6 +70,10 @@ const variantMap: Record<Exclude<HeroVariant, "unstyled">, VariantConfig> = {
       paddingTop: "pt-[var(--space-5)] md:pt-[var(--space-6)]",
       gapY: "gap-[var(--space-3)]",
       gapMd: "md:gap-[var(--space-4)]",
+      single: {
+        marginTop: "mt-[var(--space-4)] md:mt-[var(--space-5)]",
+        paddingTop: "pt-[var(--space-4)] md:pt-[var(--space-5)]",
+      },
     },
   },
   compact: {
@@ -77,6 +87,10 @@ const variantMap: Record<Exclude<HeroVariant, "unstyled">, VariantConfig> = {
       paddingTop: "pt-[var(--space-4)] md:pt-[var(--space-5)]",
       gapY: "gap-[var(--space-3)]",
       gapMd: "md:gap-[var(--space-3)]",
+      single: {
+        marginTop: "mt-[var(--space-4)]",
+        paddingTop: "pt-[var(--space-3)] md:pt-[var(--space-4)]",
+      },
     },
   },
   dense: {
@@ -90,6 +104,10 @@ const variantMap: Record<Exclude<HeroVariant, "unstyled">, VariantConfig> = {
       paddingTop: "pt-[var(--space-3)] md:pt-[var(--space-4)]",
       gapY: "gap-[var(--space-2)]",
       gapMd: "md:gap-[var(--space-3)]",
+      single: {
+        marginTop: "mt-[var(--space-3)]",
+        paddingTop: "pt-[var(--space-2)] md:pt-[var(--space-3)]",
+      },
     },
   },
 };
@@ -334,6 +352,7 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
     const hasTabs = Boolean(normalizedSlots?.tabs);
     const hasSearch = Boolean(normalizedSlots?.search);
     const hasActions = Boolean(normalizedSlots?.actions);
+    const slotCount = Number(hasTabs) + Number(hasSearch) + Number(hasActions);
 
     const layout = React.useMemo(
       () =>
@@ -390,13 +409,22 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
       children
     );
 
+    const slotMarginTopClass =
+      slotCount === 1
+        ? variantStyles?.slot.single.marginTop ?? variantStyles?.slot.marginTop
+        : variantStyles?.slot.marginTop;
+    const slotPaddingTopClass =
+      slotCount === 1
+        ? variantStyles?.slot.single.paddingTop ?? variantStyles?.slot.paddingTop
+        : variantStyles?.slot.paddingTop;
+
     const slotArea = normalizedSlots ? (
       <div
         role="group"
         className={cn(
           "group/hero-slots relative z-[1] isolate w-full grid grid-cols-1",
-          variantStyles?.slot.marginTop,
-          variantStyles?.slot.paddingTop,
+          slotMarginTopClass,
+          slotPaddingTopClass,
           variantStyles?.slot.gapY,
           variantStyles?.slot.gapMd,
           "md:grid-cols-12",

--- a/src/stories/planner/NeomorphicHeroFrame.stories.tsx
+++ b/src/stories/planner/NeomorphicHeroFrame.stories.tsx
@@ -175,6 +175,66 @@ function HeroPreview({
   );
 }
 
+function SingleSlotPreview({
+  variant = "default",
+  align = "between",
+  label,
+  ...rest
+}: Partial<NeomorphicHeroFrameProps>) {
+  const [searchValue, setSearchValue] = React.useState("");
+  const variantKey: Exclude<HeroVariant, "unstyled"> =
+    variant === "unstyled" ? "default" : variant;
+  const frameLabel = label ?? "Planner quick search";
+
+  return (
+    <NeomorphicHeroFrame
+      {...rest}
+      variant={variant}
+      align={align}
+      label={frameLabel}
+      slots={{
+        search: {
+          node: (
+            <SearchBar
+              value={searchValue}
+              onValueChange={setSearchValue}
+              placeholder="Search workstreams…"
+              aria-label="Search workstreams"
+            />
+          ),
+          label: "Search workstreams",
+        },
+      }}
+    >
+      <div className="grid gap-[var(--space-4)] md:grid-cols-2 md:gap-[var(--space-6)]">
+        <div className="space-y-[var(--space-3)]">
+          <h3 className="text-title font-semibold tracking-[-0.01em] text-foreground">
+            Compact slot spacing
+          </h3>
+          <p className="text-ui text-muted-foreground">
+            When a single slot renders, the hero frame automatically tightens the
+            divider margin and padding so controls stay closer to the hero copy
+            while preserving the twelve-column rhythm.
+          </p>
+        </div>
+        <div className="space-y-[var(--space-2)] text-ui text-muted-foreground">
+          <p>
+            Adjust the alignment knobs to confirm the search slot still resolves
+            to the full-width column at medium breakpoints.
+          </p>
+          <p>
+            The compact top spacing pairs with the existing gap tokens, keeping
+            the visual cadence consistent with multi-slot layouts.
+          </p>
+          <p className="text-label font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+            Variant: {variantDescriptions[variantKey].title}
+          </p>
+        </div>
+      </div>
+    </NeomorphicHeroFrame>
+  );
+}
+
 export const DefaultVariant: Story = {
   args: {
     variant: "default",
@@ -197,6 +257,14 @@ export const DenseVariant: Story = {
     align: "between",
   },
   render: (args) => <HeroPreview {...args} />,
+};
+
+export const SingleSlotSearch: Story = {
+  args: {
+    variant: "default",
+    align: "between",
+  },
+  render: (args) => <SingleSlotPreview {...args} />,
 };
 
 export const AlignStart: Story = {


### PR DESCRIPTION
## Summary
- add compact single-slot margin and padding tokens to the hero frame variant map
- detect how many hero slots are populated and apply the tighter spacing when only one is rendered
- showcase the single-slot spacing in the NeomorphicHeroFrame story for the component gallery

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d072c3436c832c81758409904b6941