### PR TITLE
Adjust hero planner card spans

### DIFF
--- a/src/components/home/HeroPlannerCards.tsx
+++ b/src/components/home/HeroPlannerCards.tsx
@@ -65,7 +65,7 @@ export default function HeroPlannerCards({
         <div className="md:col-span-4">
           <ReviewsCard />
         </div>
-        <div className="md:col-span-4">
+        <div className="md:col-span-6 lg:col-span-4">
           <DashboardCard
             title="Weekly focus"
             cta={{ label: "Open planner", href: "/planner" }}
@@ -91,7 +91,7 @@ export default function HeroPlannerCards({
             />
           </DashboardCard>
         </div>
-        <div className="md:col-span-12">
+        <div className="md:col-span-6 lg:col-span-8">
           <TeamPromptsCard />
         </div>
       </section>


### PR DESCRIPTION
## Summary
- adjust the Weekly focus dashboard card to use a 6-column span at the medium breakpoint and return to 4 columns at large screens
- update the TeamPromptsCard wrapper to span 6 columns at medium and 8 at large so it pairs with the Weekly focus card on medium layouts

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d072d66ca4832c84a25f1368814692