### PR TITLE
Refine WeekPicker chip formatting

### DIFF
--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -26,16 +26,28 @@ const dmy = new Intl.DateTimeFormat(undefined, {
   month: "short",
 });
 
-const chipDateFormatter = new Intl.DateTimeFormat(undefined, {
+const chipDisplayFormatter = new Intl.DateTimeFormat(undefined, {
+  weekday: "short",
+  month: "short",
+  day: "2-digit",
+});
+
+const chipAccessibleFormatter = new Intl.DateTimeFormat(undefined, {
   weekday: "long",
   month: "long",
   day: "numeric",
 });
 
-const formatChipLabel = (value: ISODate): string => {
+const formatChipDisplayLabel = (value: ISODate): string => {
   const dt = fromISODate(value);
   if (!dt) return value;
-  return chipDateFormatter.format(dt);
+  return chipDisplayFormatter.format(dt);
+};
+
+const formatChipAccessibleLabel = (value: ISODate): string => {
+  const dt = fromISODate(value);
+  if (!dt) return value;
+  return chipAccessibleFormatter.format(dt);
 };
 
 /* ───────── presentational chip (no hooks) ───────── */
@@ -70,7 +82,11 @@ const DayChip = React.forwardRef<HTMLButtonElement, DayChipProps>(function DayCh
   },
   ref,
 ) {
-  const localizedLabel = React.useMemo(() => formatChipLabel(iso), [iso]);
+  const displayLabel = React.useMemo(() => formatChipDisplayLabel(iso), [iso]);
+  const accessibleLabel = React.useMemo(
+    () => formatChipAccessibleLabel(iso),
+    [iso],
+  );
   const completionRatio = React.useMemo(() => {
     if (total <= 0) {
       return 0;
@@ -149,7 +165,7 @@ const DayChip = React.forwardRef<HTMLButtonElement, DayChipProps>(function DayCh
       onFocus={onFocus}
       tabIndex={tabIndex}
       aria-selected={selected}
-      aria-label={`Select ${localizedLabel}`}
+      aria-label={`Select ${accessibleLabel}`}
       aria-describedby={describedBy}
       title={
         selected
@@ -177,9 +193,12 @@ const DayChip = React.forwardRef<HTMLButtonElement, DayChipProps>(function DayCh
           completionTextClass,
           today && completionTint === "bg-card" ? "text-accent-3" : undefined,
         )}
-        data-text={localizedLabel}
+        data-text={displayLabel}
       >
-        {localizedLabel}
+        <span aria-hidden="true">{displayLabel}</span>
+        <span className="sr-only" data-chip-label="full">
+          {accessibleLabel}
+        </span>
       </div>
       <div id={countsId} className="chip__counts text-foreground">
         <span className="tabular-nums">{done}</span>

--- a/tests/planner/WeekPicker.test.tsx
+++ b/tests/planner/WeekPicker.test.tsx
@@ -125,6 +125,36 @@ describe("WeekPicker", () => {
     expect(totalsBlock).toHaveTextContent(/Total tasks:\s*\d+\s*\/\s*\d+/);
   });
 
+  it("renders compact chip labels with descriptive accessibility text", () => {
+    renderWeekPicker();
+
+    const options = screen.getAllByRole("option");
+    const firstOption = options[0];
+    const displayFormatter = new Intl.DateTimeFormat(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "2-digit",
+    });
+    const accessibleFormatter = new Intl.DateTimeFormat(undefined, {
+      weekday: "long",
+      month: "long",
+      day: "numeric",
+    });
+    const targetDate = new Date(2024, 0, 1);
+
+    const displaySpan = firstOption.querySelector(
+      "[data-text] span[aria-hidden=\"true\"]",
+    );
+    expect(displaySpan?.textContent).toBe(displayFormatter.format(targetDate));
+
+    const accessibleText = accessibleFormatter.format(targetDate);
+    expect(firstOption).toHaveAttribute("aria-label", `Select ${accessibleText}`);
+    expect(firstOption).toHaveAccessibleName(`Select ${accessibleText}`);
+
+    const srOnlyLabel = firstOption.querySelector('[data-chip-label="full"]');
+    expect(srOnlyLabel?.textContent).toBe(accessibleText);
+  });
+
   it("updates selected day on single click", () => {
     renderWeekPicker();
     const getOptions = () => screen.getAllByRole("option");


### PR DESCRIPTION
## Summary
- add dedicated Intl formatters so WeekPicker chips show compact text while exposing full spoken labels
- embed the full-text label in an sr-only span and wire aria-labels to the accessible formatter
- extend WeekPicker tests to assert the compact text and descriptive aria labeling

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d0ff3c106c832c9d99bbd12bfb0242