### PR TITLE
Use token-based max width for notes tab

### DIFF
--- a/src/components/prompts/NotesTab.tsx
+++ b/src/components/prompts/NotesTab.tsx
@@ -13,7 +13,7 @@ export default function NotesTab({ value, onChange }: NotesTabProps) {
   const notesId = React.useId();
 
   return (
-    <div className="max-w-3xl space-y-[var(--space-3)]">
+    <div className="w-full max-w-[calc(var(--space-8)*12)] space-y-[var(--space-3)]">
       <div className="space-y-[var(--space-2)]">
         <Label htmlFor={notesId}>Scratchpad</Label>
         <Textarea


### PR DESCRIPTION
## Summary
- switch the Prompts notes panel max-width to a token-based calc expression and add w-full to keep the container filling available space

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d10275f59c832c9aebb6224fb3f64c