### PR TITLE
Ensure hero tabs use deterministic ids

### DIFF
--- a/src/components/ui/layout/hero/Hero.tsx
+++ b/src/components/ui/layout/hero/Hero.tsx
@@ -59,6 +59,7 @@ export interface HeroProps<Key extends string = string>
     className?: string;
     showBaseline?: boolean;
     right?: React.ReactNode;
+    idBase?: string;
   };
 
   /** @deprecated Use `subTabs` instead. */
@@ -185,6 +186,7 @@ function Hero<Key extends string = string>({
             className={cn("justify-end", subTabs.className)}
             {...accessibilityProps}
             linkPanels={subTabs.linkPanels}
+            idBase={subTabs.idBase}
           />
         );
       })()

--- a/src/components/ui/layout/hero/HeroTabs.tsx
+++ b/src/components/ui/layout/hero/HeroTabs.tsx
@@ -22,6 +22,11 @@ export type HeroTabsProps<K extends string> = TabBarA11yProps & {
   showBaseline?: boolean;
   variant?: TabBarProps["variant"];
   linkPanels?: boolean;
+  /**
+   * Base string applied to tab and panel ids when linking panels.
+   * Mirrors the TabBar `idBase` prop for deterministic aria wiring.
+   */
+  idBase?: string;
 };
 
 export function HeroTabs<K extends string>(props: HeroTabsProps<K>) {
@@ -38,6 +43,7 @@ export function HeroTabs<K extends string>(props: HeroTabsProps<K>) {
     showBaseline = false,
     variant,
     linkPanels = false,
+    idBase,
   } = props;
 
   const sanitizedAriaLabel =
@@ -84,6 +90,7 @@ export function HeroTabs<K extends string>(props: HeroTabsProps<K>) {
       showBaseline={showBaseline}
       variant={variant}
       linkPanels={linkPanels}
+      idBase={idBase}
     />
   );
 }

--- a/tests/ui/HeroTabs.test.tsx
+++ b/tests/ui/HeroTabs.test.tsx
@@ -18,7 +18,7 @@ describe("HeroTabs", () => {
             key: "overview",
             label: "Overview",
             loading: true,
-            className: "custom-tab", 
+            className: "custom-tab",
             id: "custom-id",
             controls: "panel-id",
           },
@@ -37,6 +37,33 @@ describe("HeroTabs", () => {
     expect(activeTab).toHaveAttribute(
       "aria-controls",
       expect.stringMatching(/panel-id$/),
+    );
+  });
+
+  it("uses the provided idBase for deterministic tab ids", () => {
+    render(
+      <HeroTabs
+        activeKey="overview"
+        onChange={() => {}}
+        linkPanels
+        idBase="components"
+        ariaLabel="Hero tabs demo"
+        tabs={[
+          {
+            key: "overview",
+            label: "Overview",
+          },
+          { key: "timeline", label: "Timeline" },
+        ]}
+      />,
+    );
+
+    const overviewTab = screen.getByRole("tab", { name: "Overview" });
+
+    expect(overviewTab.id).toBe("components-overview-tab");
+    expect(overviewTab).toHaveAttribute(
+      "aria-controls",
+      "components-overview-panel",
     );
   });
 });

--- a/tests/ui/TabBar.test.tsx
+++ b/tests/ui/TabBar.test.tsx
@@ -47,10 +47,17 @@ describe("TabBar", () => {
           ],
           value: "buttons",
           onChange: () => {},
+          idBase: "components",
         }}
       />,
     );
-    expect(screen.getByRole("tab", { name: "Buttons" })).toBeInTheDocument();
+    const firstTab = screen.getByRole("tab", { name: "Buttons" });
+    expect(firstTab).toBeInTheDocument();
+    expect(firstTab.id).toBe("components-buttons-tab");
+    expect(firstTab).toHaveAttribute(
+      "aria-controls",
+      "components-buttons-panel",
+    );
   });
 
   it("renders the animated header rail when enabled", () => {


### PR DESCRIPTION
## Summary
- allow hero tabs to accept an optional `idBase` and pass it through so generated tab ids are deterministic
- forward the `idBase` value from hero sub-tabs to the shared TabBar to align aria labelling
- add regression tests that cover `idBase` wiring for hero tabs and hero sub-tabs

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d103904520832c8ea7209f82a96fb7