### PR TITLE
Refine WeekPicker layout and add neomorphic shell

### DIFF
--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -14,10 +14,11 @@ import Button from "@/components/ui/primitives/Button";
 import { useFocusDate, useWeek } from "./useFocusDate";
 import type { ISODate } from "./plannerTypes";
 import { useWeekData } from "./useWeekData";
-import { cn } from "@/lib/utils";
 import { usePrefersReducedMotion } from "@/lib/useReducedMotion";
 import { ArrowUpToLine } from "lucide-react";
 import { fromISODate, toISODate } from "@/lib/date";
+import { cn } from "@/lib/utils";
+import WeekPickerShell from "./WeekPickerShell";
 
 /* ───────── date helpers ───────── */
 
@@ -173,7 +174,7 @@ const DayChip = React.forwardRef<HTMLButtonElement, DayChipProps>(function DayCh
           : "Click or press Enter to focus"
       }
       className={cn(
-        "chip relative flex-none w-[--chip-width] rounded-card r-card-lg border text-left px-[var(--space-3)] py-[var(--space-2)] transition snap-start",
+        "chip relative rounded-card r-card-lg border text-left px-[var(--space-3)] py-[var(--space-2)] transition snap-start",
         // default border is NOT white; use card hairline tint
         "border-card-hairline",
         completionTint,
@@ -386,9 +387,8 @@ export default function WeekPicker() {
       sticky
       dividerTint="primary"
     >
-      <div className="grid gap-[var(--space-3)] flex-1">
-        {/* Totals */}
-        <div className="flex items-center justify-end gap-[var(--space-3)]">
+      <WeekPickerShell>
+        <WeekPickerShell.Totals>
           <span className="sr-only" aria-live="polite">
             Week range {rangeLabel}
           </span>
@@ -398,34 +398,34 @@ export default function WeekPicker() {
               {weekDone} / {weekTotal}
             </span>
           </span>
-        </div>
-
-        {/* Day chips */}
-        <div
-          role="listbox"
-          aria-label={`Select a focus day between ${rangeLabel}`}
-          className="flex gap-[var(--space-3)] overflow-x-auto snap-x snap-mandatory lg:overflow-visible"
-        >
-          {days.map((d, i) => (
-            <DayChip
-              key={d}
-              iso={d}
-              selected={d === iso}
-              today={d === today}
-              done={per[i]?.done ?? 0}
-              total={per[i]?.total ?? 0}
-              onClick={selectOnly}
-              onDoubleClick={jumpToDay}
-              onNavigate={(direction) => handleNavigate(i, direction)}
-              onFocus={() => setFocusIndex(i)}
-              tabIndex={focusIndex === i ? 0 : -1}
-              ref={(el) => {
-                chipRefs.current[i] = el;
-              }}
-            />
-          ))}
-        </div>
-      </div>
+        </WeekPickerShell.Totals>
+        <WeekPickerShell.Chips>
+          <div
+            role="listbox"
+            aria-label={`Select a focus day between ${rangeLabel}`}
+            className="flex flex-nowrap gap-[var(--space-3)] overflow-x-auto snap-x snap-mandatory lg:flex-wrap lg:gap-y-[var(--space-3)] lg:overflow-visible lg:[scroll-snap-type:none]"
+          >
+            {days.map((d, i) => (
+              <DayChip
+                key={d}
+                iso={d}
+                selected={d === iso}
+                today={d === today}
+                done={per[i]?.done ?? 0}
+                total={per[i]?.total ?? 0}
+                onClick={selectOnly}
+                onDoubleClick={jumpToDay}
+                onNavigate={(direction) => handleNavigate(i, direction)}
+                onFocus={() => setFocusIndex(i)}
+                tabIndex={focusIndex === i ? 0 : -1}
+                ref={(el) => {
+                  chipRefs.current[i] = el;
+                }}
+              />
+            ))}
+          </div>
+        </WeekPickerShell.Chips>
+      </WeekPickerShell>
     </Hero>
   );
 }

--- a/src/components/planner/WeekPickerShell.tsx
+++ b/src/components/planner/WeekPickerShell.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type WeekPickerShellProps = React.HTMLAttributes<HTMLDivElement>;
+
+interface WeekPickerShellSlotProps {
+  readonly children: React.ReactNode;
+}
+
+const WeekPickerShellTotals = ({ children }: WeekPickerShellSlotProps) => (
+  <>{children}</>
+);
+WeekPickerShellTotals.displayName = "WeekPickerShellTotals";
+
+const WeekPickerShellChips = ({ children }: WeekPickerShellSlotProps) => (
+  <>{children}</>
+);
+WeekPickerShellChips.displayName = "WeekPickerShellChips";
+
+type WeekPickerShellComponent = React.ForwardRefExoticComponent<
+  WeekPickerShellProps & React.RefAttributes<HTMLDivElement>
+> & {
+  readonly Totals: typeof WeekPickerShellTotals;
+  readonly Chips: typeof WeekPickerShellChips;
+};
+
+const WeekPickerShellBase = React.forwardRef<HTMLDivElement, WeekPickerShellProps>(
+  function WeekPickerShell({ children, className, ...props }, ref) {
+    const totals: React.ReactElement<WeekPickerShellSlotProps>[] = [];
+    const chips: React.ReactElement<WeekPickerShellSlotProps>[] = [];
+    const remainder: React.ReactNode[] = [];
+
+    React.Children.forEach(children, (child) => {
+      if (!React.isValidElement(child)) {
+        if (child != null) {
+          remainder.push(child);
+        }
+        return;
+      }
+
+      if (child.type === WeekPickerShellTotals) {
+        totals.push(child as React.ReactElement<WeekPickerShellSlotProps>);
+        return;
+      }
+
+      if (child.type === WeekPickerShellChips) {
+        chips.push(child as React.ReactElement<WeekPickerShellSlotProps>);
+        return;
+      }
+
+      remainder.push(child);
+    });
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "week-picker-shell grid flex-1 min-w-0 w-full gap-[var(--space-3)] rounded-card r-card-lg border border-border/45 bg-card/70 p-[var(--space-3)] shadow-neo-soft",
+          "md:gap-[var(--space-4)] md:p-[var(--space-4)]",
+          className,
+        )}
+        {...props}
+      >
+        {totals.length > 0 ? (
+          <div className="week-picker-shell__totals flex flex-wrap items-center justify-end gap-[var(--space-3)]">
+            {totals.map((slot, index) => (
+              <React.Fragment key={slot.key ?? index}>
+                {slot.props.children}
+              </React.Fragment>
+            ))}
+          </div>
+        ) : null}
+        {chips.map((slot, index) => (
+          <React.Fragment key={slot.key ?? index}>
+            {slot.props.children}
+          </React.Fragment>
+        ))}
+        {remainder}
+      </div>
+    );
+  },
+);
+
+WeekPickerShellBase.displayName = "WeekPickerShell";
+
+const WeekPickerShell = Object.assign(WeekPickerShellBase, {
+  Totals: WeekPickerShellTotals,
+  Chips: WeekPickerShellChips,
+}) as WeekPickerShellComponent;
+
+export default WeekPickerShell;

--- a/src/components/planner/index.ts
+++ b/src/components/planner/index.ts
@@ -34,5 +34,6 @@ export * from "./useTodayHeroProjects";
 export * from "./useTodayHeroTasks";
 export * from "./useWeekData";
 export { default as WeekNotes } from "./WeekNotes";
+export { default as WeekPickerShell } from "./WeekPickerShell";
 export { default as WeekPicker } from "./WeekPicker";
 export { default as WeekSummary } from "./WeekSummary";

--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -407,7 +407,19 @@
 }
 
 .chip {
-  --chip-width: min(calc(var(--space-4) * 10), 40%);
+  --chip-min: clamp(
+    10ch,
+    calc(12ch + var(--space-2)),
+    calc(14ch + var(--space-3))
+  );
+  --chip-max: clamp(
+    16ch,
+    calc(18ch + var(--space-3)),
+    calc(22ch + var(--space-4))
+  );
+  flex: 1 1 var(--chip-min);
+  min-inline-size: var(--chip-min);
+  max-inline-size: var(--chip-max);
   position: relative;
   background-clip: padding-box;
   isolation: isolate;

--- a/src/components/prompts/component-gallery/PlannerPanel.tsx
+++ b/src/components/prompts/component-gallery/PlannerPanel.tsx
@@ -12,6 +12,7 @@ import {
   ScrollTopFloatingButton,
   TaskList,
   TaskRow,
+  WeekPickerShell,
 } from "@/components/planner";
 import { Input } from "@/components/ui";
 import { cn } from "@/lib/utils";
@@ -25,6 +26,161 @@ import type { PlannerPanelData } from "./useComponentGalleryState";
 
 const GRID_CLASS =
   "grid grid-cols-1 gap-[var(--space-6)] sm:grid-cols-2 md:grid-cols-12 md:gap-[var(--space-8)]";
+
+type WeekPickerShellDemoDay = {
+  readonly iso: string;
+  readonly display: string;
+  readonly accessible: string;
+  readonly done: number;
+  readonly total: number;
+  readonly today?: boolean;
+  readonly selected?: boolean;
+};
+
+const weekPickerShellDemoTotals = {
+  range: "Jan 01 → Jan 07",
+  done: 21,
+  total: 35,
+} as const;
+
+const weekPickerShellDemoDays: readonly WeekPickerShellDemoDay[] = [
+  {
+    iso: "2024-01-01",
+    display: "Mon, Jan 01",
+    accessible: "Monday, January 1",
+    done: 3,
+    total: 5,
+    today: true,
+    selected: true,
+  },
+  {
+    iso: "2024-01-02",
+    display: "Tue, Jan 02",
+    accessible: "Tuesday, January 2",
+    done: 2,
+    total: 6,
+  },
+  {
+    iso: "2024-01-03",
+    display: "Wed, Jan 03",
+    accessible: "Wednesday, January 3",
+    done: 4,
+    total: 4,
+  },
+  {
+    iso: "2024-01-04",
+    display: "Thu, Jan 04",
+    accessible: "Thursday, January 4",
+    done: 1,
+    total: 3,
+  },
+  {
+    iso: "2024-01-05",
+    display: "Fri, Jan 05",
+    accessible: "Friday, January 5",
+    done: 0,
+    total: 2,
+  },
+] as const;
+
+function getWeekPickerShellDemoAppearance(done: number, total: number) {
+  if (total === 0) {
+    return { tint: "bg-card", text: "text-muted-foreground" } as const;
+  }
+
+  const ratio = done / total;
+
+  if (!Number.isFinite(ratio) || ratio <= 0) {
+    return { tint: "bg-accent-3/30", text: "text-foreground" } as const;
+  }
+
+  if (ratio >= 2 / 3) {
+    return { tint: "bg-success-soft", text: "text-foreground" } as const;
+  }
+
+  if (ratio >= 1 / 3) {
+    return { tint: "bg-accent-3/20", text: "text-foreground" } as const;
+  }
+
+  return { tint: "bg-accent-3/30", text: "text-foreground" } as const;
+}
+
+function WeekPickerShellPreview() {
+  return (
+    <WeekPickerShell>
+      <WeekPickerShell.Totals>
+        <span className="sr-only" aria-live="polite">
+          Week range {weekPickerShellDemoTotals.range}
+        </span>
+        <span className="inline-flex items-baseline gap-[var(--space-1)] text-ui text-muted-foreground">
+          <span>Total tasks:</span>
+          <span className="font-medium tabular-nums text-foreground">
+            {weekPickerShellDemoTotals.done} / {weekPickerShellDemoTotals.total}
+          </span>
+        </span>
+      </WeekPickerShell.Totals>
+      <WeekPickerShell.Chips>
+        <div
+          role="listbox"
+          aria-label="Select a focus day for the shell preview"
+          className="flex flex-nowrap gap-[var(--space-3)] overflow-x-auto snap-x snap-mandatory lg:flex-wrap lg:gap-y-[var(--space-3)] lg:overflow-visible lg:[scroll-snap-type:none]"
+        >
+          {weekPickerShellDemoDays.map((day) => {
+            const { tint, text } = getWeekPickerShellDemoAppearance(
+              day.done,
+              day.total,
+            );
+
+            return (
+              <button
+                key={day.iso}
+                type="button"
+                role="option"
+                tabIndex={day.selected ? 0 : -1}
+                aria-selected={day.selected ?? false}
+                aria-label={`Select ${day.accessible}`}
+                className={cn(
+                  "chip relative rounded-card r-card-lg border text-left px-[var(--space-3)] py-[var(--space-2)] transition snap-start",
+                  "border-card-hairline",
+                  tint,
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  "active:border-primary/60 active:bg-card/85",
+                  day.today && "chip--today",
+                  day.selected
+                    ? "border-dashed border-primary/75"
+                    : "hover:border-primary/40",
+                )}
+                data-today={day.today || undefined}
+                data-active={day.selected || undefined}
+              >
+                <div
+                  className={cn(
+                    "chip__date",
+                    text,
+                    day.today && tint === "bg-card"
+                      ? "text-accent-3"
+                      : undefined,
+                  )}
+                  data-text={day.display}
+                >
+                  <span aria-hidden="true">{day.display}</span>
+                  <span className="sr-only">{day.accessible}</span>
+                </div>
+                <div className="chip__counts text-foreground">
+                  <span className="tabular-nums">{day.done}</span>
+                  <span className="text-foreground/70"> / {day.total}</span>
+                </div>
+                <span aria-hidden className="chip__scan" />
+                <span aria-hidden className="chip__edge" />
+              </button>
+            );
+          })}
+        </div>
+      </WeekPickerShell.Chips>
+    </WeekPickerShell>
+  );
+}
+
 type PanelItem = { label: string; element: React.ReactNode; className?: string };
 
 interface PlannerPanelProps {
@@ -78,6 +234,11 @@ export default function PlannerPanel({ data }: PlannerPanelProps) {
               />
             </ul>
           ),
+        },
+        {
+          label: "WeekPickerShell",
+          element: <WeekPickerShellPreview />,
+          className: "sm:col-span-2 md:col-span-12",
         },
         {
           label: "PlannerListPanel",


### PR DESCRIPTION
## Summary
- add a slot-based `WeekPickerShell` wrapper that composes totals and chip content while applying the planner’s neomorphic card treatment【F:src/components/planner/WeekPickerShell.tsx†L12-L91】
- refactor `WeekPicker` to render the new shell and let the chip list wrap on large screens without losing small-screen horizontal scrolling【F:src/components/planner/WeekPicker.tsx†L176-L428】
- replace the fixed chip width with clamp-driven flex sizing and showcase the shell in the planner component gallery preview【F:src/components/planner/style.css†L409-L434】【F:src/components/prompts/component-gallery/PlannerPanel.tsx†L30-L347】

## Testing
- ✅ `npm run check`【47be4a†L1-L9】

------
https://chatgpt.com/codex/tasks/task_e_68d1017c0e0c832c91e4aa1f7a9674dc