### PR TITLE
Add WeekPicker gallery demo

### DIFF
--- a/src/components/gallery/usage.json
+++ b/src/components/gallery/usage.json
@@ -34,5 +34,8 @@
   "settings-select": [],
   "theme-toggle": [
     "/"
+  ],
+  "week-picker": [
+    "/prompts"
   ]
 }

--- a/src/components/prompts/component-gallery/PlannerPanel.tsx
+++ b/src/components/prompts/component-gallery/PlannerPanel.tsx
@@ -21,6 +21,7 @@ import {
   demoTasksById,
   demoTasksByProject,
 } from "./ComponentGallery.demoData";
+import WeekPickerDemo from "./WeekPickerDemo";
 import type { PlannerPanelData } from "./useComponentGalleryState";
 
 const GRID_CLASS =
@@ -46,6 +47,11 @@ export default function PlannerPanel({ data }: PlannerPanelProps) {
               <GoalsTabs value={data.goalFilter.value} onChange={data.goalFilter.onChange} />
             </div>
           ),
+        },
+        {
+          label: "WeekPicker",
+          element: <WeekPickerDemo />,
+          className: "sm:col-span-2 md:col-span-12",
         },
         {
           label: "DayCardHeader",

--- a/src/components/prompts/component-gallery/WeekPickerDemo.tsx
+++ b/src/components/prompts/component-gallery/WeekPickerDemo.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import * as React from "react";
+import { ArrowUpToLine } from "lucide-react";
+
+import { Hero, Button } from "@/components/ui";
+import { fromISODate } from "@/lib/date";
+import { cn } from "@/lib/utils";
+
+const dmy = new Intl.DateTimeFormat(undefined, {
+  day: "2-digit",
+  month: "short",
+});
+
+const chipDisplayFormatter = new Intl.DateTimeFormat(undefined, {
+  weekday: "short",
+  month: "short",
+  day: "2-digit",
+});
+
+const chipAccessibleFormatter = new Intl.DateTimeFormat(undefined, {
+  weekday: "long",
+  month: "long",
+  day: "numeric",
+});
+
+type DemoDay = {
+  iso: string;
+  done: number;
+  total: number;
+};
+
+const DEMO_DAYS: DemoDay[] = [
+  { iso: "2024-04-22", done: 3, total: 5 },
+  { iso: "2024-04-23", done: 2, total: 4 },
+  { iso: "2024-04-24", done: 4, total: 4 },
+  { iso: "2024-04-25", done: 1, total: 3 },
+  { iso: "2024-04-26", done: 0, total: 4 },
+  { iso: "2024-04-27", done: 1, total: 1 },
+  { iso: "2024-04-28", done: 0, total: 0 },
+];
+
+const SELECTED_ISO = "2024-04-24";
+const TODAY_ISO = "2024-04-26";
+
+const formatChipDisplayLabel = (iso: string): string => {
+  const dt = fromISODate(iso);
+  if (!dt) return iso;
+  return chipDisplayFormatter.format(dt);
+};
+
+const formatChipAccessibleLabel = (iso: string): string => {
+  const dt = fromISODate(iso);
+  if (!dt) return iso;
+  return chipAccessibleFormatter.format(dt);
+};
+
+type DayChipMockProps = {
+  iso: string;
+  done: number;
+  total: number;
+  selected: boolean;
+  today: boolean;
+  tabIndex: number;
+};
+
+function DayChipMock({ iso, done, total, selected, today, tabIndex }: DayChipMockProps) {
+  const displayLabel = React.useMemo(() => formatChipDisplayLabel(iso), [iso]);
+  const accessibleLabel = React.useMemo(
+    () => formatChipAccessibleLabel(iso),
+    [iso],
+  );
+  const completionRatio = React.useMemo(() => {
+    if (total <= 0) return 0;
+    const ratio = done / total;
+    if (!Number.isFinite(ratio)) return 0;
+    if (ratio <= 0) return 0;
+    if (ratio >= 1) return 1;
+    return ratio;
+  }, [done, total]);
+  const { tint: completionTint, text: completionTextClass } = React.useMemo(() => {
+    if (total === 0) {
+      return { tint: "bg-card", text: "text-muted-foreground" } as const;
+    }
+    if (completionRatio >= 2 / 3) {
+      return { tint: "bg-success-soft", text: "text-foreground" } as const;
+    }
+    if (completionRatio >= 1 / 3) {
+      return { tint: "bg-accent-3/20", text: "text-foreground" } as const;
+    }
+    return { tint: "bg-accent-3/30", text: "text-foreground" } as const;
+  }, [completionRatio, total]);
+  const instructionsId = React.useId();
+  const countsId = React.useId();
+  const instructionsText = selected
+    ? "Press Enter again or double-click to jump."
+    : "Press Enter to select.";
+  const describedBy = `${countsId} ${instructionsId}`;
+
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={selected}
+      aria-label={`Select ${accessibleLabel}`}
+      aria-describedby={describedBy}
+      title={
+        selected
+          ? "Press Enter again or double-click to jump"
+          : "Click or press Enter to focus"
+      }
+      tabIndex={tabIndex}
+      className={cn(
+        "chip relative flex-none w-[--chip-width] rounded-card r-card-lg border text-left px-[var(--space-3)] py-[var(--space-2)] transition snap-start",
+        "border-card-hairline",
+        completionTint,
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        "active:border-primary/60 active:bg-card/85",
+        today && "chip--today",
+        selected ? "border-dashed border-primary/75" : "hover:border-primary/40",
+      )}
+      data-today={today || undefined}
+      data-active={selected || undefined}
+    >
+      <div
+        className={cn(
+          "chip__date",
+          completionTextClass,
+          today && completionTint === "bg-card" ? "text-accent-3" : undefined,
+        )}
+        data-text={displayLabel}
+      >
+        <span aria-hidden="true">{displayLabel}</span>
+        <span className="sr-only" data-chip-label="full">
+          {accessibleLabel}
+        </span>
+      </div>
+      <div id={countsId} className="chip__counts text-foreground">
+        <span className="tabular-nums">{done}</span>
+        <span className="text-foreground/70"> / {total}</span>
+      </div>
+      <span id={instructionsId} className="sr-only" aria-live="polite" aria-atomic="true">
+        {instructionsText}
+      </span>
+      <span aria-hidden className="chip__scan" />
+      <span aria-hidden className="chip__edge" />
+    </button>
+  );
+}
+
+export default function WeekPickerDemo() {
+  const start = React.useMemo(() => fromISODate(DEMO_DAYS[0]?.iso ?? ""), []);
+  const end = React.useMemo(() => fromISODate(DEMO_DAYS[DEMO_DAYS.length - 1]?.iso ?? ""), []);
+
+  const heading = React.useMemo(() => {
+    if (!start || !end) return "Week";
+    return `${dmy.format(start)} — ${dmy.format(end)}`;
+  }, [start, end]);
+
+  const subtitle = React.useMemo(() => {
+    const startIso = DEMO_DAYS[0]?.iso;
+    const endIso = DEMO_DAYS[DEMO_DAYS.length - 1]?.iso;
+    if (!startIso || !endIso) return "";
+    return `${startIso} → ${endIso}`;
+  }, []);
+
+  const rangeLabel = React.useMemo(() => {
+    if (!start || !end) return "";
+    return `${dmy.format(start)} → ${dmy.format(end)}`;
+  }, [start, end]);
+
+  const { weekDone, weekTotal } = React.useMemo(() => {
+    return DEMO_DAYS.reduce(
+      (acc, day) => {
+        acc.weekDone += day.done;
+        acc.weekTotal += day.total;
+        return acc;
+      },
+      { weekDone: 0, weekTotal: 0 },
+    );
+  }, []);
+
+  return (
+    <Hero
+      heading={heading}
+      subtitle={subtitle}
+      actions={
+        <Button
+          variant="primary"
+          size="sm"
+          aria-label="Jump to top"
+          className="px-[var(--space-4)]"
+        >
+          <ArrowUpToLine />
+          <span>Top</span>
+        </Button>
+      }
+      rail
+      sticky
+      dividerTint="primary"
+    >
+      <div className="grid flex-1 gap-[var(--space-3)]">
+        <div className="flex items-center justify-end gap-[var(--space-3)]">
+          <span className="sr-only" aria-live="polite">
+            Week range {rangeLabel}
+          </span>
+          <span className="inline-flex items-baseline gap-[var(--space-1)] text-ui text-muted-foreground">
+            <span>Total tasks:</span>
+            <span className="font-medium tabular-nums text-foreground">
+              {weekDone} / {weekTotal}
+            </span>
+          </span>
+        </div>
+        <div
+          role="listbox"
+          aria-label={`Select a focus day between ${rangeLabel}`}
+          className="flex gap-[var(--space-3)] overflow-x-auto snap-x snap-mandatory lg:overflow-visible"
+        >
+          {DEMO_DAYS.map((day, index) => (
+            <DayChipMock
+              key={day.iso}
+              iso={day.iso}
+              done={day.done}
+              total={day.total}
+              today={day.iso === TODAY_ISO}
+              selected={day.iso === SELECTED_ISO}
+              tabIndex={day.iso === SELECTED_ISO ? 0 : index === 0 ? 0 : -1}
+            />
+          ))}
+        </div>
+      </div>
+    </Hero>
+  );
+}

--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -61,6 +61,7 @@ import SkeletonShowcase from "./SkeletonShowcase";
 import ToggleShowcase from "./ToggleShowcase";
 import PageHeaderDemo from "./PageHeaderDemo";
 import NeomorphicHeroFrameDemo from "./NeomorphicHeroFrameDemo";
+import WeekPickerDemo from "./component-gallery/WeekPickerDemo";
 import {
   DashboardCard,
   DashboardList,
@@ -2513,6 +2514,29 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
     },
   ],
   planner: [
+    {
+      id: "week-picker",
+      name: "WeekPicker",
+      description:
+        "Sticky hero shell preview showing week totals, mock chips, and the jump-to-top action.",
+      element: <WeekPickerDemo />,
+      tags: ["planner", "navigation", "week"],
+      code: `<WeekPickerDemo />`,
+      usage: [
+        {
+          kind: "do",
+          title: "Keep week totals visible",
+          description:
+            "Pair the hero subtitle with aggregated task counts so the picker summarizes week progress at a glance.",
+        },
+        {
+          kind: "do",
+          title: "Highlight today's chip",
+          description:
+            "Use the accent token on the current day to anchor focus while other chips mock mixed completion states.",
+        },
+      ],
+    },
     {
       id: "bottom-nav",
       name: "BottomNav",


### PR DESCRIPTION
## Summary
- add a WeekPicker shell demo with representative totals to the planner component gallery
- register the WeekPicker preview in prompts.gallery and usage metadata so the prompts gallery surfaces it

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d103955b44832c83d29b1f314d1418