### PR TITLE
Fix components gallery section copy

### DIFF
--- a/src/components/components/useComponentsGalleryState.ts
+++ b/src/components/components/useComponentsGalleryState.ts
@@ -270,10 +270,15 @@ export function useComponentsGalleryState({
     [currentGroup],
   );
 
-  const sectionMeta = React.useMemo(
-    () => sectionMap.get(section) ?? null,
-    [section, sectionMap],
-  );
+  const sectionMeta = React.useMemo(() => {
+    const groupSection = currentGroup?.sections.find(
+      (groupSectionEntry) => groupSectionEntry.id === section,
+    );
+    if (groupSection) {
+      return groupSection;
+    }
+    return sectionMap.get(section) ?? null;
+  }, [currentGroup, section, sectionMap]);
 
   const currentGroupLabel = currentGroup?.label ?? "";
   const activeSectionLabel = sectionMeta?.label ?? "";


### PR DESCRIPTION
## Summary
- ensure the components gallery resolves the active section metadata from the current group before falling back to the global map so hero copy reflects the selected tab

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1057d51ec832c9f509423f7bfd933