### PR TITLE
Index all gallery entry kinds in usage manifest

### DIFF
--- a/scripts/build-gallery-usage.ts
+++ b/scripts/build-gallery-usage.ts
@@ -192,24 +192,21 @@ type UsageMap = Record<string, readonly string[]>;
 type NameToIdsMap = Map<string, readonly string[]>;
 
 function buildNameLookup(sections: readonly GallerySerializableSection[]): {
-  readonly complexEntries: readonly GallerySerializableEntry[];
+  readonly entries: readonly GallerySerializableEntry[];
   readonly nameToIds: NameToIdsMap;
 } {
-  const complexEntries: GallerySerializableEntry[] = [];
+  const entries: GallerySerializableEntry[] = [];
   const nameToIds = new Map<string, string[]>();
   for (const section of sections) {
     for (const entry of section.entries) {
-      if (entry.kind !== "complex") {
-        continue;
-      }
-      complexEntries.push(entry);
+      entries.push(entry);
       const list = nameToIds.get(entry.name) ?? [];
       list.push(entry.id);
       nameToIds.set(entry.name, list);
     }
   }
   return {
-    complexEntries,
+    entries,
     nameToIds,
   };
 }
@@ -217,9 +214,9 @@ function buildNameLookup(sections: readonly GallerySerializableSection[]): {
 async function buildUsage(
   sections: readonly GallerySerializableSection[],
 ): Promise<UsageMap> {
-  const { complexEntries, nameToIds } = buildNameLookup(sections);
+  const { entries, nameToIds } = buildNameLookup(sections);
   const usage = new Map<string, Set<string>>();
-  for (const entry of complexEntries) {
+  for (const entry of entries) {
     usage.set(entry.id, new Set<string>());
   }
 
@@ -240,7 +237,7 @@ async function buildUsage(
   }
 
   const record: UsageMap = {};
-  for (const entry of complexEntries) {
+  for (const entry of entries) {
     const routes = Array.from(
       usage.get(entry.id) ?? new Set<string>(),
     ).sort((a, b) => a.localeCompare(b));
@@ -360,9 +357,7 @@ async function main(): Promise<void> {
   await fs.writeFile(usageFile, `${JSON.stringify(usage, null, 2)}\n`);
   await buildGalleryManifest(modules, registry.payload);
   await writeManifest([...new Set(trackedFiles)]);
-  console.log(
-    `Built gallery usage for ${Object.keys(usage).length} complex entries`,
-  );
+  console.log(`Built gallery usage for ${Object.keys(usage).length} entries`);
 }
 
 main().catch((error) => {

--- a/src/components/gallery/usage.json
+++ b/src/components/gallery/usage.json
@@ -1,5 +1,38 @@
 {
+  "prompt-list": [],
+  "prompts-header": [],
+  "prompts-compose-panel": [],
+  "prompts-demos": [],
   "bottom-nav": [],
+  "card-demo": [],
+  "neo-card-demo": [],
+  "section-card-variants": [],
+  "page-shell": [
+    "/",
+    "/components"
+  ],
+  "sheet-demo": [],
+  "modal-demo": [],
+  "split": [],
+  "title-bar": [],
+  "neomorphic-hero-frame": [],
+  "page-header-demo": [
+    "/"
+  ],
+  "demo-header": [],
+  "hero": [],
+  "progress": [],
+  "outline-glow": [],
+  "snackbar": [],
+  "toast-demo": [],
+  "skeleton": [],
+  "spinner": [
+    "/",
+    "/components"
+  ],
+  "toggle": [],
+  "animation-toggle": [],
+  "check-circle": [],
   "dashboard-card": [],
   "dashboard-list": [],
   "isometric-room": [],
@@ -34,5 +67,24 @@
   "settings-select": [],
   "theme-toggle": [
     "/"
-  ]
+  ],
+  "cat-companion": [
+    "/"
+  ],
+  "header-tabs": [],
+  "label": [],
+  "select": [],
+  "header": [],
+  "tab-bar": [],
+  "badge": [],
+  "button": [
+    "/"
+  ],
+  "field": [],
+  "icon-button": [],
+  "input": [],
+  "search-bar": [],
+  "segmented-button": [],
+  "tabs": [],
+  "textarea": []
 }


### PR DESCRIPTION
## Summary
- update the gallery usage builder to index all entry kinds instead of just complex entries
- regenerate the gallery usage data so primitives and components surface route usage alongside existing entries

## Testing
- npm run build-gallery-usage
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d106405f1c832c8b4f94fc3f04d7d7