### PR TITLE
Delay theme application until hydration

### DIFF
--- a/src/lib/theme-context.tsx
+++ b/src/lib/theme-context.tsx
@@ -15,14 +15,22 @@ const ThemeContext = React.createContext<
 >(undefined);
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [hydrated, setHydrated] = React.useState(false);
   const [theme, setTheme] = usePersistentState<ThemeState>(
     THEME_STORAGE_KEY,
     defaultTheme(),
   );
 
   React.useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  React.useEffect(() => {
+    if (!hydrated) {
+      return;
+    }
     applyTheme(theme);
-  }, [theme]);
+  }, [theme, hydrated]);
 
   const value = React.useMemo(() => [theme, setTheme] as const, [theme, setTheme]);
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;


### PR DESCRIPTION
## Summary
- wait to apply persisted themes until after the client hydrates
- gate the theme side effect on a local hydrated flag to avoid boot theme flashes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d10789188c832cb88bfb749c86e056