### PR TITLE
Use spacing token clamp for modal max width

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -46,7 +46,7 @@ export default function Modal({
         aria-modal="true"
         aria-labelledby={ariaLabelledby}
         aria-describedby={ariaDescribedby}
-        className={cn("relative w-full max-w-sm", className)}
+        className={cn("relative w-full max-w-[calc(var(--space-8)*6)]", className)}
         {...props}
       >
         <IconButton


### PR DESCRIPTION
## Summary
- replace the modal card's `max-w-sm` class with the spacing-token clamp `max-w-[calc(var(--space-8)*6)]`
- keep the class composed through `cn(...)` so downstream overrides still work

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68d102a18da8832c938fb82b0589a8ce