### PR TITLE
Add explicit gallery state previews for interactive primitives

### DIFF
--- a/src/components/gallery/generated-manifest.ts
+++ b/src/components/gallery/generated-manifest.ts
@@ -1942,7 +1942,57 @@ export const galleryPayload = {
           "code": "const items = [\n  { value: \"one\", label: \"One\" },\n  { value: \"two\", label: \"Two\" },\n  { value: \"three\", label: \"Three\" },\n];\n\nconst SELECT_STATES = [\n  { label: \"Default\" },\n  { label: \"Hover\", buttonClassName: \"bg-[--hover]\" },\n  {\n    label: \"Focus-visible\",\n    className: \"rounded-[var(--control-radius)] ring-2 ring-[var(--theme-ring)] ring-offset-0\",\n  },\n  { label: \"Active\", buttonClassName: \"bg-[--active]\" },\n  { label: \"Disabled\", props: { disabled: true } },\n  {\n    label: \"Loading\",\n    buttonClassName: \"pointer-events-none opacity-[var(--loading)]\",\n  },\n];\n\nconst [value, setValue] = React.useState(items[0]?.value ?? \"\");\n\n<div className=\"flex flex-col gap-[var(--space-4)]\">\n  <div className=\"grid grid-cols-1 gap-[var(--space-3)] sm:grid-cols-2\">\n    <Select\n      items={items}\n      value={value}\n      onChange={setValue}\n      placeholder=\"Animated select\"\n      className=\"w-full sm:w-auto\"\n    />\n    <Select\n      items={items}\n      variant=\"native\"\n      value={value}\n      onChange={setValue}\n      aria-label=\"Native select\"\n      className=\"w-full sm:w-auto\"\n    />\n  </div>\n  <div className=\"flex flex-col gap-[var(--space-2)]\">\n    <p className=\"text-caption text-muted-foreground\">States</p>\n    <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n      {SELECT_STATES.map(({ label, buttonClassName, className, props }) => {\n        const { items: stateItems, ...restProps } = props ?? {};\n        const sampleItems = stateItems ?? items;\n        const baseClassName = \"w-full sm:w-auto\";\n        const finalClassName = className\n          ? baseClassName + \" \" + className\n          : baseClassName;\n\n        return (\n          <Select\n            key={label}\n            items={[...sampleItems]}\n            placeholder={label}\n            ariaLabel={label}\n            buttonClassName={buttonClassName}\n            className={finalClassName}\n            {...restProps}\n          />\n        );\n      })}\n    </div>\n  </div>\n</div>",
           "preview": {
             "id": "ui:select:variants"
-          }
+          },
+          "states": [
+            {
+              "id": "default",
+              "name": "Default",
+              "code": "<Select placeholder=\"Animated select\" items={items} />",
+              "preview": {
+                "id": "ui:select:state:default"
+              }
+            },
+            {
+              "id": "hover",
+              "name": "Hover",
+              "code": "<Select buttonClassName=\"bg-[--hover]\" placeholder=\"Hover\" items={items} />",
+              "preview": {
+                "id": "ui:select:state:hover"
+              }
+            },
+            {
+              "id": "focus-visible",
+              "name": "Focus-visible",
+              "code": "<Select className=\"rounded-[var(--control-radius)] ring-2 ring-[var(--theme-ring)] ring-offset-0\" placeholder=\"Focus-visible\" items={items} />",
+              "preview": {
+                "id": "ui:select:state:focus-visible"
+              }
+            },
+            {
+              "id": "active",
+              "name": "Active",
+              "code": "<Select buttonClassName=\"bg-[--active]\" placeholder=\"Active\" items={items} />",
+              "preview": {
+                "id": "ui:select:state:active"
+              }
+            },
+            {
+              "id": "disabled",
+              "name": "Disabled",
+              "code": "<Select placeholder=\"Disabled\" disabled items={items} />",
+              "preview": {
+                "id": "ui:select:state:disabled"
+              }
+            },
+            {
+              "id": "loading",
+              "name": "Loading",
+              "code": "<Select buttonClassName=\"pointer-events-none opacity-[var(--loading)]\" placeholder=\"Loading\" items={items} />",
+              "preview": {
+                "id": "ui:select:state:loading"
+              }
+            }
+          ]
         }
       ]
     },
@@ -2237,7 +2287,57 @@ export const galleryPayload = {
           "code": "<div className=\"flex flex-col gap-[var(--space-4)]\">\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Button tone=\"primary\">Primary tone</Button>\n    <Button tone=\"accent\">Accent tone</Button>\n    <Button tone=\"info\" variant=\"ghost\">\n      Info ghost\n    </Button>\n    <Button tone=\"danger\" variant=\"primary\">\n      Danger primary\n    </Button>\n    <Button disabled>Disabled</Button>\n  </div>\n  <div className=\"flex flex-wrap items-center gap-[var(--space-2)]\">\n    <Button size=\"sm\">\n      <Plus />\n      Small\n    </Button>\n    <Button size=\"md\">\n      <Plus />\n      Medium\n    </Button>\n    <Button size=\"lg\">\n      <Plus />\n      Large\n    </Button>\n    <Button size=\"xl\">\n      <Plus />\n      Extra large\n    </Button>\n  </div>\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Button>Default</Button>\n    <Button className=\"bg-[--hover]\">Hover</Button>\n    <Button className=\"ring-2 ring-[var(--focus)]\">Focus</Button>\n    <Button className=\"bg-[--active]\">Active</Button>\n    <Button disabled>Disabled</Button>\n    <Button loading>Loading</Button>\n  </div>\n</div>",
           "preview": {
             "id": "ui:button:matrix"
-          }
+          },
+          "states": [
+            {
+              "id": "default",
+              "name": "Default",
+              "code": "<Button>Default</Button>",
+              "preview": {
+                "id": "ui:button:state:default"
+              }
+            },
+            {
+              "id": "hover",
+              "name": "Hover",
+              "code": "<Button className=\"bg-[--hover]\">Hover</Button>",
+              "preview": {
+                "id": "ui:button:state:hover"
+              }
+            },
+            {
+              "id": "focus",
+              "name": "Focus",
+              "code": "<Button className=\"ring-2 ring-[var(--focus)]\">Focus</Button>",
+              "preview": {
+                "id": "ui:button:state:focus"
+              }
+            },
+            {
+              "id": "active",
+              "name": "Active",
+              "code": "<Button className=\"bg-[--active]\">Active</Button>",
+              "preview": {
+                "id": "ui:button:state:active"
+              }
+            },
+            {
+              "id": "disabled",
+              "name": "Disabled",
+              "code": "<Button disabled>Disabled</Button>",
+              "preview": {
+                "id": "ui:button:state:disabled"
+              }
+            },
+            {
+              "id": "loading",
+              "name": "Loading",
+              "code": "<Button loading>Loading</Button>",
+              "preview": {
+                "id": "ui:button:state:loading"
+              }
+            }
+          ]
         }
       ]
     },
@@ -2317,10 +2417,10 @@ export const galleryPayload = {
                   "value": "With counter"
                 },
                 {
-                  "value": "Search"
+                  "value": "Select"
                 },
                 {
-                  "value": "Select"
+                  "value": "Search"
                 }
               ]
             }
@@ -2328,7 +2428,73 @@ export const galleryPayload = {
           "code": "const [search, setSearch] = React.useState(\"Scouting\");\n\n<Field.Root helper=\"Compose primitives\">\n  <Field.Input placeholder=\"Default field\" />\n</Field.Root>\n<Field.Root\n  className=\"ring-2 ring-[hsl(var(--ring))]\"\n  helper=\"Helper text aligns with counter\"\n  helperId=\"field-focus-helper\"\n  counter=\"64 / 100\"\n  counterId=\"field-focus-counter\"\n>\n  <Field.Input\n    aria-describedby=\"field-focus-helper field-focus-counter\"\n    placeholder=\"Forced focus ring\"\n  />\n</Field.Root>\n<Field.Root invalid helper=\"Incorrect format\" helperTone=\"danger\">\n  <Field.Input placeholder=\"Invalid field\" aria-invalid />\n</Field.Root>\n<Field.Root loading helper=\"Loading state\">\n  <Field.Input placeholder=\"Loading field\" />\n</Field.Root>\n<Field.Root disabled helper=\"Disabled field\">\n  <Field.Input placeholder=\"Disabled field\" disabled />\n</Field.Root>\n<Field.Root\n  counter=\"120 / 200\"\n  counterId=\"field-counter\"\n  helper=\"Helper with counter\"\n  helperId=\"field-helper\"\n>\n  <Field.Textarea\n    aria-describedby=\"field-helper field-counter\"\n    placeholder=\"Textarea within a field\"\n    rows={3}\n  />\n</Field.Root>\n<Field.Root>\n  <Field.Select defaultValue=\"one\">\n    <option value=\"one\">One</option>\n    <option value=\"two\">Two</option>\n  </Field.Select>\n</Field.Root>\n<Field.Root>\n  <Field.Search\n    value={search}\n    onChange={(event) => setSearch(event.target.value)}\n    placeholder=\"Search fields\"\n    clearLabel=\"Clear search\"\n  />\n</Field.Root>",
           "preview": {
             "id": "ui:field:states"
-          }
+          },
+          "states": [
+            {
+              "id": "default",
+              "name": "Default",
+              "code": "<Field.Root helper=\"Compose primitives\">\n  <Field.Input placeholder=\"Default field\" />\n</Field.Root>",
+              "preview": {
+                "id": "ui:field:state:default"
+              }
+            },
+            {
+              "id": "focus-visible",
+              "name": "Focus visible",
+              "code": "<Field.Root\n  className=\"ring-2 ring-[hsl(var(--ring))]\"\n  helper=\"Helper text aligns with counter\"\n  helperId=\"field-focus-helper\"\n  counter=\"64 / 100\"\n  counterId=\"field-focus-counter\"\n>\n  <Field.Input\n    aria-describedby=\"field-focus-helper field-focus-counter\"\n    placeholder=\"Forced focus ring\"\n  />\n</Field.Root>",
+              "preview": {
+                "id": "ui:field:state:focus-visible"
+              }
+            },
+            {
+              "id": "invalid",
+              "name": "Invalid",
+              "code": "<Field.Root invalid helper=\"Incorrect format\" helperTone=\"danger\">\n  <Field.Input placeholder=\"Invalid field\" aria-invalid />\n</Field.Root>",
+              "preview": {
+                "id": "ui:field:state:invalid"
+              }
+            },
+            {
+              "id": "loading",
+              "name": "Loading",
+              "code": "<Field.Root loading helper=\"Loading state\">\n  <Field.Input placeholder=\"Loading field\" />\n</Field.Root>",
+              "preview": {
+                "id": "ui:field:state:loading"
+              }
+            },
+            {
+              "id": "disabled",
+              "name": "Disabled",
+              "code": "<Field.Root disabled helper=\"Disabled field\">\n  <Field.Input placeholder=\"Disabled field\" disabled />\n</Field.Root>",
+              "preview": {
+                "id": "ui:field:state:disabled"
+              }
+            },
+            {
+              "id": "with-counter",
+              "name": "With counter",
+              "code": "<Field.Root\n  counter=\"120 / 200\"\n  counterId=\"field-counter\"\n  helper=\"Helper with counter\"\n  helperId=\"field-helper\"\n>\n  <Field.Textarea\n    aria-describedby=\"field-helper field-counter\"\n    placeholder=\"Textarea within a field\"\n    rows={3}\n  />\n</Field.Root>",
+              "preview": {
+                "id": "ui:field:state:with-counter"
+              }
+            },
+            {
+              "id": "select",
+              "name": "Select",
+              "code": "const options = [\n  { value: \"one\", label: \"One\" },\n  { value: \"two\", label: \"Two\" },\n];\n\n<Field.Root>\n  <Field.Select defaultValue=\"one\">\n    {options.map((option) => (\n      <option key={option.value} value={option.value}>\n        {option.label}\n      </option>\n    ))}\n  </Field.Select>\n</Field.Root>",
+              "preview": {
+                "id": "ui:field:state:select"
+              }
+            },
+            {
+              "id": "search",
+              "name": "Search",
+              "code": "const [search, setSearch] = React.useState(\"Scouting\");\n\n<Field.Root>\n  <Field.Search\n    value={search}\n    onChange={(event) => setSearch(event.target.value)}\n    placeholder=\"Search fields\"\n    clearLabel=\"Clear search\"\n  />\n</Field.Root>",
+              "preview": {
+                "id": "ui:field:state:search"
+              }
+            }
+          ]
         }
       ]
     },
@@ -2406,7 +2572,57 @@ export const galleryPayload = {
           "code": "<div className=\"flex flex-col gap-[var(--space-4)]\">\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <IconButton size=\"sm\" variant=\"ghost\" aria-label=\"Add item sm\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"md\" variant=\"ghost\" aria-label=\"Add item md\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"lg\" variant=\"ghost\" aria-label=\"Add item lg\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"xl\" variant=\"ghost\" aria-label=\"Add item xl\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"md\" variant=\"secondary\" aria-label=\"Add item secondary\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"md\" variant=\"primary\" aria-label=\"Add item primary\">\n      <Plus />\n    </IconButton>\n  </div>\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <IconButton aria-label=\"Default\">\n      <Plus />\n    </IconButton>\n    <IconButton className=\"bg-[--hover]\" aria-label=\"Hover\">\n      <Plus />\n    </IconButton>\n    <IconButton className=\"ring-2 ring-[var(--focus)]\" aria-label=\"Focus\">\n      <Plus />\n    </IconButton>\n    <IconButton\n      className=\"bg-[--active]\"\n      aria-pressed\n      aria-label=\"Active\"\n    >\n      <Plus />\n    </IconButton>\n    <IconButton disabled aria-label=\"Disabled\">\n      <Plus />\n    </IconButton>\n    <IconButton loading aria-label=\"Loading\">\n      <Plus />\n    </IconButton>\n  </div>\n</div>",
           "preview": {
             "id": "ui:icon-button:matrix"
-          }
+          },
+          "states": [
+            {
+              "id": "default",
+              "name": "Default",
+              "code": "<IconButton aria-label=\"Default\">\n  <Plus />\n</IconButton>",
+              "preview": {
+                "id": "ui:icon-button:state:default"
+              }
+            },
+            {
+              "id": "hover",
+              "name": "Hover",
+              "code": "<IconButton className=\"bg-[--hover]\" aria-label=\"Hover\">\n  <Plus />\n</IconButton>",
+              "preview": {
+                "id": "ui:icon-button:state:hover"
+              }
+            },
+            {
+              "id": "focus",
+              "name": "Focus",
+              "code": "<IconButton className=\"ring-2 ring-[var(--focus)]\" aria-label=\"Focus\">\n  <Plus />\n</IconButton>",
+              "preview": {
+                "id": "ui:icon-button:state:focus"
+              }
+            },
+            {
+              "id": "active",
+              "name": "Active",
+              "code": "<IconButton\n  className=\"bg-[--active]\"\n  aria-label=\"Active\"\n  aria-pressed\n>\n  <Plus />\n</IconButton>",
+              "preview": {
+                "id": "ui:icon-button:state:active"
+              }
+            },
+            {
+              "id": "disabled",
+              "name": "Disabled",
+              "code": "<IconButton disabled aria-label=\"Disabled\">\n  <Plus />\n</IconButton>",
+              "preview": {
+                "id": "ui:icon-button:state:disabled"
+              }
+            },
+            {
+              "id": "loading",
+              "name": "Loading",
+              "code": "<IconButton loading aria-label=\"Loading\">\n  <Plus />\n</IconButton>",
+              "preview": {
+                "id": "ui:icon-button:state:loading"
+              }
+            }
+          ]
         }
       ]
     },
@@ -2473,7 +2689,57 @@ export const galleryPayload = {
           "code": "<div className=\"flex flex-col gap-[var(--space-2)]\">\n  <Input placeholder=\"Default\" />\n  <Input placeholder=\"Hover\" className=\"bg-[--hover]\" />\n  <Input placeholder=\"Focus\" className=\"ring-2 ring-[var(--focus)]\" />\n  <Input placeholder=\"Active\" className=\"bg-[--active]\" />\n  <Input placeholder=\"Disabled\" disabled />\n  <Input placeholder=\"Loading\" data-loading />\n</div>",
           "preview": {
             "id": "ui:input:states"
-          }
+          },
+          "states": [
+            {
+              "id": "default",
+              "name": "Default",
+              "code": "<Input placeholder=\"Default\" />",
+              "preview": {
+                "id": "ui:input:state:default"
+              }
+            },
+            {
+              "id": "hover",
+              "name": "Hover",
+              "code": "<Input className=\"bg-[--hover]\" placeholder=\"Hover\" />",
+              "preview": {
+                "id": "ui:input:state:hover"
+              }
+            },
+            {
+              "id": "focus",
+              "name": "Focus",
+              "code": "<Input className=\"ring-2 ring-[var(--focus)]\" placeholder=\"Focus\" />",
+              "preview": {
+                "id": "ui:input:state:focus"
+              }
+            },
+            {
+              "id": "active",
+              "name": "Active",
+              "code": "<Input className=\"bg-[--active]\" placeholder=\"Active\" />",
+              "preview": {
+                "id": "ui:input:state:active"
+              }
+            },
+            {
+              "id": "disabled",
+              "name": "Disabled",
+              "code": "<Input placeholder=\"Disabled\" disabled />",
+              "preview": {
+                "id": "ui:input:state:disabled"
+              }
+            },
+            {
+              "id": "loading",
+              "name": "Loading",
+              "code": "<Input placeholder=\"Loading\" data-loading />",
+              "preview": {
+                "id": "ui:input:state:loading"
+              }
+            }
+          ]
         }
       ]
     },
@@ -2540,6 +2806,9 @@ export const galleryPayload = {
                   "value": "With label"
                 },
                 {
+                  "value": "Hover"
+                },
+                {
                   "value": "Focus-visible"
                 },
                 {
@@ -2554,10 +2823,68 @@ export const galleryPayload = {
               ]
             }
           ],
-          "code": "const [query, setQuery] = React.useState(\"Champion counters\");\nconst handleNoop = React.useCallback((_value: string) => {}, []);\n\n<SearchBar\n  value={query}\n  onValueChange={setQuery}\n  placeholder=\"Search components\"\n/>\n<SearchBar\n  value=\"\"\n  onValueChange={handleNoop}\n  label=\"Search library\"\n  placeholder=\"With label\"\n  right={<Button size=\"sm\">Filters</Button>}\n/>\n<SearchBar\n  value=\"Focus-visible\"\n  onValueChange={handleNoop}\n  placeholder=\"Focus-visible\"\n  fieldClassName=\"ring-2 ring-[hsl(var(--ring))] ring-offset-0 ring-offset-[hsl(var(--bg))]\"\n/>\n<SearchBar\n  value=\"Active\"\n  onValueChange={handleNoop}\n  placeholder=\"Active\"\n  fieldClassName=\"bg-[--active]\"\n/>\n<SearchBar\n  value=\"Disabled\"\n  onValueChange={handleNoop}\n  placeholder=\"Disabled\"\n  disabled\n/>\n<SearchBar\n  value=\"Loading\"\n  onValueChange={handleNoop}\n  placeholder=\"Loading\"\n  loading\n/>",
+          "code": "const [query, setQuery] = React.useState(\"Champion counters\");\nconst handleNoop = React.useCallback((_value: string) => {}, []);\n\n<SearchBar\n  value={query}\n  onValueChange={setQuery}\n  placeholder=\"Search components\"\n/>\n<SearchBar\n  value=\"\"\n  onValueChange={handleNoop}\n  label=\"Search library\"\n  placeholder=\"With label\"\n  right={<Button size=\"sm\">Filters</Button>}\n/>\n<SearchBar\n  value=\"Hover\"\n  onValueChange={handleNoop}\n  placeholder=\"Hover\"\n  fieldClassName=\"bg-[--hover]\"\n/>\n<SearchBar\n  value=\"Focus-visible\"\n  onValueChange={handleNoop}\n  placeholder=\"Focus-visible\"\n  fieldClassName=\"ring-2 ring-[hsl(var(--ring))] ring-offset-0 ring-offset-[hsl(var(--bg))]\"\n/>\n<SearchBar\n  value=\"Active\"\n  onValueChange={handleNoop}\n  placeholder=\"Active\"\n  fieldClassName=\"bg-[--active]\"\n/>\n<SearchBar\n  value=\"Disabled\"\n  onValueChange={handleNoop}\n  placeholder=\"Disabled\"\n  disabled\n/>\n<SearchBar\n  value=\"Loading\"\n  onValueChange={handleNoop}\n  placeholder=\"Loading\"\n  loading\n/>",
           "preview": {
             "id": "ui:search-bar:states"
-          }
+          },
+          "states": [
+            {
+              "id": "default",
+              "name": "Default",
+              "code": "<SearchBar value={query} onValueChange={setQuery} placeholder=\"Search components\" />",
+              "preview": {
+                "id": "ui:search-bar:state:default"
+              }
+            },
+            {
+              "id": "with-label",
+              "name": "With label",
+              "code": "<SearchBar label=\"Search library\" right={<Button size=\"sm\">Filters</Button>} />",
+              "preview": {
+                "id": "ui:search-bar:state:with-label"
+              }
+            },
+            {
+              "id": "hover",
+              "name": "Hover",
+              "code": "<SearchBar fieldClassName=\"bg-[--hover]\" placeholder=\"Hover\" />",
+              "preview": {
+                "id": "ui:search-bar:state:hover"
+              }
+            },
+            {
+              "id": "focus-visible",
+              "name": "Focus-visible",
+              "code": "<SearchBar fieldClassName=\"ring-2 ring-[hsl(var(--ring))] ring-offset-0 ring-offset-[hsl(var(--bg))]\" placeholder=\"Focus-visible\" />",
+              "preview": {
+                "id": "ui:search-bar:state:focus-visible"
+              }
+            },
+            {
+              "id": "active",
+              "name": "Active",
+              "code": "<SearchBar fieldClassName=\"bg-[--active]\" placeholder=\"Active\" />",
+              "preview": {
+                "id": "ui:search-bar:state:active"
+              }
+            },
+            {
+              "id": "disabled",
+              "name": "Disabled",
+              "code": "<SearchBar placeholder=\"Disabled\" disabled />",
+              "preview": {
+                "id": "ui:search-bar:state:disabled"
+              }
+            },
+            {
+              "id": "loading",
+              "name": "Loading",
+              "code": "<SearchBar placeholder=\"Loading\" loading />",
+              "preview": {
+                "id": "ui:search-bar:state:loading"
+              }
+            }
+          ]
         }
       ]
     },
@@ -2628,7 +2955,57 @@ export const galleryPayload = {
           "code": "<div className=\"flex flex-wrap gap-[var(--space-2)]\">\n  <SegmentedButton>Default</SegmentedButton>\n  <SegmentedButton className=\"[--hover:var(--seg-hover-base)] bg-[--hover] text-[hsl(var(--foreground))] [text-shadow:0_0_calc(var(--space-2)-var(--spacing-0-5))_hsl(var(--accent)/0.25)]\">Hover</SegmentedButton>\n  <SegmentedButton selected>Active</SegmentedButton>\n  <SegmentedButton className=\"ring-2 ring-[--theme-ring] ring-offset-0 outline-none\">Focus-visible</SegmentedButton>\n  <SegmentedButton disabled>Disabled</SegmentedButton>\n  <SegmentedButton loading>Loading</SegmentedButton>\n</div>",
           "preview": {
             "id": "ui:segmented-button:states"
-          }
+          },
+          "states": [
+            {
+              "id": "default",
+              "name": "Default",
+              "code": "<SegmentedButton>Default</SegmentedButton>",
+              "preview": {
+                "id": "ui:segmented-button:state:default"
+              }
+            },
+            {
+              "id": "hover",
+              "name": "Hover",
+              "code": "<SegmentedButton className=\"[--hover:var(--seg-hover-base)] bg-[--hover] text-[hsl(var(--foreground))] [text-shadow:0_0_calc(var(--space-2)-var(--spacing-0-5))_hsl(var(--accent)/0.25)]\">Hover</SegmentedButton>",
+              "preview": {
+                "id": "ui:segmented-button:state:hover"
+              }
+            },
+            {
+              "id": "active",
+              "name": "Active",
+              "code": "<SegmentedButton selected>Active</SegmentedButton>",
+              "preview": {
+                "id": "ui:segmented-button:state:active"
+              }
+            },
+            {
+              "id": "focus-visible",
+              "name": "Focus-visible",
+              "code": "<SegmentedButton className=\"ring-2 ring-[--theme-ring] ring-offset-0 outline-none\">Focus-visible</SegmentedButton>",
+              "preview": {
+                "id": "ui:segmented-button:state:focus-visible"
+              }
+            },
+            {
+              "id": "disabled",
+              "name": "Disabled",
+              "code": "<SegmentedButton disabled>Disabled</SegmentedButton>",
+              "preview": {
+                "id": "ui:segmented-button:state:disabled"
+              }
+            },
+            {
+              "id": "loading",
+              "name": "Loading",
+              "code": "<SegmentedButton loading>Loading</SegmentedButton>",
+              "preview": {
+                "id": "ui:segmented-button:state:loading"
+              }
+            }
+          ]
         }
       ]
     },
@@ -2681,7 +3058,41 @@ export const galleryPayload = {
           "code": "<Tabs defaultValue=\"overview\">\n  <div className=\"space-y-[var(--space-3)]\">\n    <TabList\n      items={[\n        { key: \"overview\", label: \"Overview\" },\n        { key: \"activity\", label: \"Activity\" },\n        { key: \"files\", label: \"Files\" },\n      ]}\n      ariaLabel=\"Project sections\"\n    />\n    <TabPanel value=\"overview\">\n      <Card className=\"space-y-[var(--space-2)]\">\n        <p className=\"text-title font-semibold tracking-[-0.01em]\">Overview</p>\n        <p className=\"text-ui text-muted-foreground\">\n          Keep a high-level summary of the plan visible for the team.\n        </p>\n      </Card>\n    </TabPanel>\n    <TabPanel value=\"activity\">\n      <Card className=\"space-y-[var(--space-2)]\">\n        <p className=\"text-title font-semibold tracking-[-0.01em]\">Activity</p>\n        <p className=\"text-ui text-muted-foreground\">\n          Show chronological activity without leaving the workspace.\n        </p>\n      </Card>\n    </TabPanel>\n    <TabPanel value=\"files\">\n      <Card className=\"space-y-[var(--space-2)]\">\n        <p className=\"text-title font-semibold tracking-[-0.01em]\">Files</p>\n        <p className=\"text-ui text-muted-foreground\">\n          Store briefs, shared assets, and notes alongside the plan.\n        </p>\n      </Card>\n    </TabPanel>\n  </div>\n</Tabs>\n\n<Tabs value=\"inbox\" onValueChange={() => {}}>\n  <div className=\"space-y-[var(--space-3)]\">\n    <TabList\n      ariaLabel=\"Notification filters\"\n      items={[\n        { key: \"inbox\", label: \"Inbox\" },\n        {\n          key: \"updates\",\n          label: \"Updates\",\n          className: \"ring-2 ring-[var(--theme-ring)] ring-offset-0 outline-none\",\n        },\n        { key: \"archive\", label: \"Archive\" },\n        { key: \"disabled\", label: \"Disabled\", disabled: true },\n        { key: \"sync\", label: \"Syncing\", loading: true },\n      ]}\n      linkPanels={false}\n      showBaseline\n    />\n    <Card className=\"text-ui text-muted-foreground\">\n      Active tab: <span className=\"font-medium text-foreground\">Inbox</span>\n    </Card>\n  </div>\n</Tabs>",
           "preview": {
             "id": "ui:tabs:wiring"
-          }
+          },
+          "states": [
+            {
+              "id": "active",
+              "name": "Active",
+              "code": "<Tabs value=\"updates\" onValueChange={() => {}}>\n  <TabList\n    ariaLabel=\"Tab state preview\"\n    items={[\n      { key: \"inbox\", label: \"Inbox\" },\n      { key: \"updates\", label: \"Updates\" },\n    ]}\n    linkPanels={false}\n    showBaseline\n  />\n</Tabs>",
+              "preview": {
+                "id": "ui:tabs:state:active"
+              }
+            },
+            {
+              "id": "focus-visible",
+              "name": "Focus-visible",
+              "code": "<Tabs value=\"inbox\" onValueChange={() => {}}>\n  <TabList\n    ariaLabel=\"Tab state preview\"\n    items={[\n      { key: \"inbox\", label: \"Inbox\" },\n      {\n        key: \"updates\",\n        label: \"Updates\",\n        className: \"ring-2 ring-[var(--theme-ring)] ring-offset-0 outline-none\",\n      },\n    ]}\n    linkPanels={false}\n    showBaseline\n  />\n</Tabs>",
+              "preview": {
+                "id": "ui:tabs:state:focus-visible"
+              }
+            },
+            {
+              "id": "disabled",
+              "name": "Disabled",
+              "code": "<Tabs value=\"inbox\" onValueChange={() => {}}>\n  <TabList\n    ariaLabel=\"Tab state preview\"\n    items={[\n      { key: \"inbox\", label: \"Inbox\" },\n      { key: \"disabled\", label: \"Disabled\", disabled: true },\n    ]}\n    linkPanels={false}\n    showBaseline\n  />\n</Tabs>",
+              "preview": {
+                "id": "ui:tabs:state:disabled"
+              }
+            },
+            {
+              "id": "loading",
+              "name": "Loading",
+              "code": "<Tabs value=\"inbox\" onValueChange={() => {}}>\n  <TabList\n    ariaLabel=\"Tab state preview\"\n    items={[\n      { key: \"inbox\", label: \"Inbox\" },\n      { key: \"sync\", label: \"Syncing\", loading: true },\n    ]}\n    linkPanels={false}\n    showBaseline\n  />\n</Tabs>",
+              "preview": {
+                "id": "ui:tabs:state:loading"
+              }
+            }
+          ]
         }
       ]
     },
@@ -2762,7 +3173,73 @@ export const galleryPayload = {
           "code": "<Textarea placeholder=\"Share your thoughts\" />\n<Textarea placeholder=\"Hover\" className=\"bg-[--hover]\" />\n<Textarea placeholder=\"Focus-visible\" className=\"ring-2 ring-[hsl(var(--ring))]\" />\n<Textarea placeholder=\"Active\" className=\"bg-[--active]\" />\n<Textarea\n  placeholder=\"Needs attention\"\n  className=\"ring-2 ring-[hsl(var(--danger))]\"\n  aria-invalid\n/> \n<Textarea\n  placeholder=\"Read-only\"\n  className=\"bg-[hsl(var(--card)/0.72)]\"\n  textareaClassName=\"text-muted-foreground\"\n  readOnly\n/> \n<Textarea placeholder=\"Disabled\" disabled />\n<Textarea placeholder=\"Loading\" data-loading />\n<Textarea placeholder=\"Resizable textarea\" resize=\"resize-y\" aria-label=\"Resizable textarea\" />",
           "preview": {
             "id": "ui:textarea:states"
-          }
+          },
+          "states": [
+            {
+              "id": "default",
+              "name": "Default",
+              "code": "<Textarea placeholder=\"Share your thoughts\" />",
+              "preview": {
+                "id": "ui:textarea:state:default"
+              }
+            },
+            {
+              "id": "hover",
+              "name": "Hover",
+              "code": "<Textarea className=\"bg-[--hover]\" placeholder=\"Hover\" />",
+              "preview": {
+                "id": "ui:textarea:state:hover"
+              }
+            },
+            {
+              "id": "focus-visible",
+              "name": "Focus-visible",
+              "code": "<Textarea className=\"ring-2 ring-[hsl(var(--ring))]\" placeholder=\"Focus-visible\" />",
+              "preview": {
+                "id": "ui:textarea:state:focus-visible"
+              }
+            },
+            {
+              "id": "active",
+              "name": "Active",
+              "code": "<Textarea className=\"bg-[--active]\" placeholder=\"Active\" />",
+              "preview": {
+                "id": "ui:textarea:state:active"
+              }
+            },
+            {
+              "id": "invalid",
+              "name": "Invalid",
+              "code": "<Textarea\n  className=\"ring-2 ring-[hsl(var(--danger))]\"\n  placeholder=\"Needs attention\"\n  aria-invalid\n/>",
+              "preview": {
+                "id": "ui:textarea:state:invalid"
+              }
+            },
+            {
+              "id": "read-only",
+              "name": "Read-only",
+              "code": "<Textarea\n  className=\"bg-[hsl(var(--card)/0.72)]\"\n  textareaClassName=\"text-muted-foreground\"\n  readOnly\n  placeholder=\"Read-only\"\n/>",
+              "preview": {
+                "id": "ui:textarea:state:read-only"
+              }
+            },
+            {
+              "id": "disabled",
+              "name": "Disabled",
+              "code": "<Textarea placeholder=\"Disabled\" disabled />",
+              "preview": {
+                "id": "ui:textarea:state:disabled"
+              }
+            },
+            {
+              "id": "loading",
+              "name": "Loading",
+              "code": "<Textarea placeholder=\"Loading\" data-loading />",
+              "preview": {
+                "id": "ui:textarea:state:loading"
+              }
+            }
+          ]
         }
       ]
     }
@@ -3008,7 +3485,57 @@ export const galleryPayload = {
         "code": "const items = [\n  { value: \"one\", label: \"One\" },\n  { value: \"two\", label: \"Two\" },\n  { value: \"three\", label: \"Three\" },\n];\n\nconst SELECT_STATES = [\n  { label: \"Default\" },\n  { label: \"Hover\", buttonClassName: \"bg-[--hover]\" },\n  {\n    label: \"Focus-visible\",\n    className: \"rounded-[var(--control-radius)] ring-2 ring-[var(--theme-ring)] ring-offset-0\",\n  },\n  { label: \"Active\", buttonClassName: \"bg-[--active]\" },\n  { label: \"Disabled\", props: { disabled: true } },\n  {\n    label: \"Loading\",\n    buttonClassName: \"pointer-events-none opacity-[var(--loading)]\",\n  },\n];\n\nconst [value, setValue] = React.useState(items[0]?.value ?? \"\");\n\n<div className=\"flex flex-col gap-[var(--space-4)]\">\n  <div className=\"grid grid-cols-1 gap-[var(--space-3)] sm:grid-cols-2\">\n    <Select\n      items={items}\n      value={value}\n      onChange={setValue}\n      placeholder=\"Animated select\"\n      className=\"w-full sm:w-auto\"\n    />\n    <Select\n      items={items}\n      variant=\"native\"\n      value={value}\n      onChange={setValue}\n      aria-label=\"Native select\"\n      className=\"w-full sm:w-auto\"\n    />\n  </div>\n  <div className=\"flex flex-col gap-[var(--space-2)]\">\n    <p className=\"text-caption text-muted-foreground\">States</p>\n    <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n      {SELECT_STATES.map(({ label, buttonClassName, className, props }) => {\n        const { items: stateItems, ...restProps } = props ?? {};\n        const sampleItems = stateItems ?? items;\n        const baseClassName = \"w-full sm:w-auto\";\n        const finalClassName = className\n          ? baseClassName + \" \" + className\n          : baseClassName;\n\n        return (\n          <Select\n            key={label}\n            items={[...sampleItems]}\n            placeholder={label}\n            ariaLabel={label}\n            buttonClassName={buttonClassName}\n            className={finalClassName}\n            {...restProps}\n          />\n        );\n      })}\n    </div>\n  </div>\n</div>",
         "preview": {
           "id": "ui:select:variants"
-        }
+        },
+        "states": [
+          {
+            "id": "default",
+            "name": "Default",
+            "code": "<Select placeholder=\"Animated select\" items={items} />",
+            "preview": {
+              "id": "ui:select:state:default"
+            }
+          },
+          {
+            "id": "hover",
+            "name": "Hover",
+            "code": "<Select buttonClassName=\"bg-[--hover]\" placeholder=\"Hover\" items={items} />",
+            "preview": {
+              "id": "ui:select:state:hover"
+            }
+          },
+          {
+            "id": "focus-visible",
+            "name": "Focus-visible",
+            "code": "<Select className=\"rounded-[var(--control-radius)] ring-2 ring-[var(--theme-ring)] ring-offset-0\" placeholder=\"Focus-visible\" items={items} />",
+            "preview": {
+              "id": "ui:select:state:focus-visible"
+            }
+          },
+          {
+            "id": "active",
+            "name": "Active",
+            "code": "<Select buttonClassName=\"bg-[--active]\" placeholder=\"Active\" items={items} />",
+            "preview": {
+              "id": "ui:select:state:active"
+            }
+          },
+          {
+            "id": "disabled",
+            "name": "Disabled",
+            "code": "<Select placeholder=\"Disabled\" disabled items={items} />",
+            "preview": {
+              "id": "ui:select:state:disabled"
+            }
+          },
+          {
+            "id": "loading",
+            "name": "Loading",
+            "code": "<Select buttonClassName=\"pointer-events-none opacity-[var(--loading)]\" placeholder=\"Loading\" items={items} />",
+            "preview": {
+              "id": "ui:select:state:loading"
+            }
+          }
+        ]
       },
       {
         "id": "tab-bar",
@@ -3251,7 +3778,57 @@ export const galleryPayload = {
         "code": "<div className=\"flex flex-col gap-[var(--space-4)]\">\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Button tone=\"primary\">Primary tone</Button>\n    <Button tone=\"accent\">Accent tone</Button>\n    <Button tone=\"info\" variant=\"ghost\">\n      Info ghost\n    </Button>\n    <Button tone=\"danger\" variant=\"primary\">\n      Danger primary\n    </Button>\n    <Button disabled>Disabled</Button>\n  </div>\n  <div className=\"flex flex-wrap items-center gap-[var(--space-2)]\">\n    <Button size=\"sm\">\n      <Plus />\n      Small\n    </Button>\n    <Button size=\"md\">\n      <Plus />\n      Medium\n    </Button>\n    <Button size=\"lg\">\n      <Plus />\n      Large\n    </Button>\n    <Button size=\"xl\">\n      <Plus />\n      Extra large\n    </Button>\n  </div>\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Button>Default</Button>\n    <Button className=\"bg-[--hover]\">Hover</Button>\n    <Button className=\"ring-2 ring-[var(--focus)]\">Focus</Button>\n    <Button className=\"bg-[--active]\">Active</Button>\n    <Button disabled>Disabled</Button>\n    <Button loading>Loading</Button>\n  </div>\n</div>",
         "preview": {
           "id": "ui:button:matrix"
-        }
+        },
+        "states": [
+          {
+            "id": "default",
+            "name": "Default",
+            "code": "<Button>Default</Button>",
+            "preview": {
+              "id": "ui:button:state:default"
+            }
+          },
+          {
+            "id": "hover",
+            "name": "Hover",
+            "code": "<Button className=\"bg-[--hover]\">Hover</Button>",
+            "preview": {
+              "id": "ui:button:state:hover"
+            }
+          },
+          {
+            "id": "focus",
+            "name": "Focus",
+            "code": "<Button className=\"ring-2 ring-[var(--focus)]\">Focus</Button>",
+            "preview": {
+              "id": "ui:button:state:focus"
+            }
+          },
+          {
+            "id": "active",
+            "name": "Active",
+            "code": "<Button className=\"bg-[--active]\">Active</Button>",
+            "preview": {
+              "id": "ui:button:state:active"
+            }
+          },
+          {
+            "id": "disabled",
+            "name": "Disabled",
+            "code": "<Button disabled>Disabled</Button>",
+            "preview": {
+              "id": "ui:button:state:disabled"
+            }
+          },
+          {
+            "id": "loading",
+            "name": "Loading",
+            "code": "<Button loading>Loading</Button>",
+            "preview": {
+              "id": "ui:button:state:loading"
+            }
+          }
+        ]
       },
       {
         "id": "field",
@@ -3326,10 +3903,10 @@ export const galleryPayload = {
                 "value": "With counter"
               },
               {
-                "value": "Search"
+                "value": "Select"
               },
               {
-                "value": "Select"
+                "value": "Search"
               }
             ]
           }
@@ -3337,7 +3914,73 @@ export const galleryPayload = {
         "code": "const [search, setSearch] = React.useState(\"Scouting\");\n\n<Field.Root helper=\"Compose primitives\">\n  <Field.Input placeholder=\"Default field\" />\n</Field.Root>\n<Field.Root\n  className=\"ring-2 ring-[hsl(var(--ring))]\"\n  helper=\"Helper text aligns with counter\"\n  helperId=\"field-focus-helper\"\n  counter=\"64 / 100\"\n  counterId=\"field-focus-counter\"\n>\n  <Field.Input\n    aria-describedby=\"field-focus-helper field-focus-counter\"\n    placeholder=\"Forced focus ring\"\n  />\n</Field.Root>\n<Field.Root invalid helper=\"Incorrect format\" helperTone=\"danger\">\n  <Field.Input placeholder=\"Invalid field\" aria-invalid />\n</Field.Root>\n<Field.Root loading helper=\"Loading state\">\n  <Field.Input placeholder=\"Loading field\" />\n</Field.Root>\n<Field.Root disabled helper=\"Disabled field\">\n  <Field.Input placeholder=\"Disabled field\" disabled />\n</Field.Root>\n<Field.Root\n  counter=\"120 / 200\"\n  counterId=\"field-counter\"\n  helper=\"Helper with counter\"\n  helperId=\"field-helper\"\n>\n  <Field.Textarea\n    aria-describedby=\"field-helper field-counter\"\n    placeholder=\"Textarea within a field\"\n    rows={3}\n  />\n</Field.Root>\n<Field.Root>\n  <Field.Select defaultValue=\"one\">\n    <option value=\"one\">One</option>\n    <option value=\"two\">Two</option>\n  </Field.Select>\n</Field.Root>\n<Field.Root>\n  <Field.Search\n    value={search}\n    onChange={(event) => setSearch(event.target.value)}\n    placeholder=\"Search fields\"\n    clearLabel=\"Clear search\"\n  />\n</Field.Root>",
         "preview": {
           "id": "ui:field:states"
-        }
+        },
+        "states": [
+          {
+            "id": "default",
+            "name": "Default",
+            "code": "<Field.Root helper=\"Compose primitives\">\n  <Field.Input placeholder=\"Default field\" />\n</Field.Root>",
+            "preview": {
+              "id": "ui:field:state:default"
+            }
+          },
+          {
+            "id": "focus-visible",
+            "name": "Focus visible",
+            "code": "<Field.Root\n  className=\"ring-2 ring-[hsl(var(--ring))]\"\n  helper=\"Helper text aligns with counter\"\n  helperId=\"field-focus-helper\"\n  counter=\"64 / 100\"\n  counterId=\"field-focus-counter\"\n>\n  <Field.Input\n    aria-describedby=\"field-focus-helper field-focus-counter\"\n    placeholder=\"Forced focus ring\"\n  />\n</Field.Root>",
+            "preview": {
+              "id": "ui:field:state:focus-visible"
+            }
+          },
+          {
+            "id": "invalid",
+            "name": "Invalid",
+            "code": "<Field.Root invalid helper=\"Incorrect format\" helperTone=\"danger\">\n  <Field.Input placeholder=\"Invalid field\" aria-invalid />\n</Field.Root>",
+            "preview": {
+              "id": "ui:field:state:invalid"
+            }
+          },
+          {
+            "id": "loading",
+            "name": "Loading",
+            "code": "<Field.Root loading helper=\"Loading state\">\n  <Field.Input placeholder=\"Loading field\" />\n</Field.Root>",
+            "preview": {
+              "id": "ui:field:state:loading"
+            }
+          },
+          {
+            "id": "disabled",
+            "name": "Disabled",
+            "code": "<Field.Root disabled helper=\"Disabled field\">\n  <Field.Input placeholder=\"Disabled field\" disabled />\n</Field.Root>",
+            "preview": {
+              "id": "ui:field:state:disabled"
+            }
+          },
+          {
+            "id": "with-counter",
+            "name": "With counter",
+            "code": "<Field.Root\n  counter=\"120 / 200\"\n  counterId=\"field-counter\"\n  helper=\"Helper with counter\"\n  helperId=\"field-helper\"\n>\n  <Field.Textarea\n    aria-describedby=\"field-helper field-counter\"\n    placeholder=\"Textarea within a field\"\n    rows={3}\n  />\n</Field.Root>",
+            "preview": {
+              "id": "ui:field:state:with-counter"
+            }
+          },
+          {
+            "id": "select",
+            "name": "Select",
+            "code": "const options = [\n  { value: \"one\", label: \"One\" },\n  { value: \"two\", label: \"Two\" },\n];\n\n<Field.Root>\n  <Field.Select defaultValue=\"one\">\n    {options.map((option) => (\n      <option key={option.value} value={option.value}>\n        {option.label}\n      </option>\n    ))}\n  </Field.Select>\n</Field.Root>",
+            "preview": {
+              "id": "ui:field:state:select"
+            }
+          },
+          {
+            "id": "search",
+            "name": "Search",
+            "code": "const [search, setSearch] = React.useState(\"Scouting\");\n\n<Field.Root>\n  <Field.Search\n    value={search}\n    onChange={(event) => setSearch(event.target.value)}\n    placeholder=\"Search fields\"\n    clearLabel=\"Clear search\"\n  />\n</Field.Root>",
+            "preview": {
+              "id": "ui:field:state:search"
+            }
+          }
+        ]
       },
       {
         "id": "icon-button",
@@ -3410,7 +4053,57 @@ export const galleryPayload = {
         "code": "<div className=\"flex flex-col gap-[var(--space-4)]\">\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <IconButton size=\"sm\" variant=\"ghost\" aria-label=\"Add item sm\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"md\" variant=\"ghost\" aria-label=\"Add item md\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"lg\" variant=\"ghost\" aria-label=\"Add item lg\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"xl\" variant=\"ghost\" aria-label=\"Add item xl\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"md\" variant=\"secondary\" aria-label=\"Add item secondary\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"md\" variant=\"primary\" aria-label=\"Add item primary\">\n      <Plus />\n    </IconButton>\n  </div>\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <IconButton aria-label=\"Default\">\n      <Plus />\n    </IconButton>\n    <IconButton className=\"bg-[--hover]\" aria-label=\"Hover\">\n      <Plus />\n    </IconButton>\n    <IconButton className=\"ring-2 ring-[var(--focus)]\" aria-label=\"Focus\">\n      <Plus />\n    </IconButton>\n    <IconButton\n      className=\"bg-[--active]\"\n      aria-pressed\n      aria-label=\"Active\"\n    >\n      <Plus />\n    </IconButton>\n    <IconButton disabled aria-label=\"Disabled\">\n      <Plus />\n    </IconButton>\n    <IconButton loading aria-label=\"Loading\">\n      <Plus />\n    </IconButton>\n  </div>\n</div>",
         "preview": {
           "id": "ui:icon-button:matrix"
-        }
+        },
+        "states": [
+          {
+            "id": "default",
+            "name": "Default",
+            "code": "<IconButton aria-label=\"Default\">\n  <Plus />\n</IconButton>",
+            "preview": {
+              "id": "ui:icon-button:state:default"
+            }
+          },
+          {
+            "id": "hover",
+            "name": "Hover",
+            "code": "<IconButton className=\"bg-[--hover]\" aria-label=\"Hover\">\n  <Plus />\n</IconButton>",
+            "preview": {
+              "id": "ui:icon-button:state:hover"
+            }
+          },
+          {
+            "id": "focus",
+            "name": "Focus",
+            "code": "<IconButton className=\"ring-2 ring-[var(--focus)]\" aria-label=\"Focus\">\n  <Plus />\n</IconButton>",
+            "preview": {
+              "id": "ui:icon-button:state:focus"
+            }
+          },
+          {
+            "id": "active",
+            "name": "Active",
+            "code": "<IconButton\n  className=\"bg-[--active]\"\n  aria-label=\"Active\"\n  aria-pressed\n>\n  <Plus />\n</IconButton>",
+            "preview": {
+              "id": "ui:icon-button:state:active"
+            }
+          },
+          {
+            "id": "disabled",
+            "name": "Disabled",
+            "code": "<IconButton disabled aria-label=\"Disabled\">\n  <Plus />\n</IconButton>",
+            "preview": {
+              "id": "ui:icon-button:state:disabled"
+            }
+          },
+          {
+            "id": "loading",
+            "name": "Loading",
+            "code": "<IconButton loading aria-label=\"Loading\">\n  <Plus />\n</IconButton>",
+            "preview": {
+              "id": "ui:icon-button:state:loading"
+            }
+          }
+        ]
       },
       {
         "id": "input",
@@ -3472,7 +4165,57 @@ export const galleryPayload = {
         "code": "<div className=\"flex flex-col gap-[var(--space-2)]\">\n  <Input placeholder=\"Default\" />\n  <Input placeholder=\"Hover\" className=\"bg-[--hover]\" />\n  <Input placeholder=\"Focus\" className=\"ring-2 ring-[var(--focus)]\" />\n  <Input placeholder=\"Active\" className=\"bg-[--active]\" />\n  <Input placeholder=\"Disabled\" disabled />\n  <Input placeholder=\"Loading\" data-loading />\n</div>",
         "preview": {
           "id": "ui:input:states"
-        }
+        },
+        "states": [
+          {
+            "id": "default",
+            "name": "Default",
+            "code": "<Input placeholder=\"Default\" />",
+            "preview": {
+              "id": "ui:input:state:default"
+            }
+          },
+          {
+            "id": "hover",
+            "name": "Hover",
+            "code": "<Input className=\"bg-[--hover]\" placeholder=\"Hover\" />",
+            "preview": {
+              "id": "ui:input:state:hover"
+            }
+          },
+          {
+            "id": "focus",
+            "name": "Focus",
+            "code": "<Input className=\"ring-2 ring-[var(--focus)]\" placeholder=\"Focus\" />",
+            "preview": {
+              "id": "ui:input:state:focus"
+            }
+          },
+          {
+            "id": "active",
+            "name": "Active",
+            "code": "<Input className=\"bg-[--active]\" placeholder=\"Active\" />",
+            "preview": {
+              "id": "ui:input:state:active"
+            }
+          },
+          {
+            "id": "disabled",
+            "name": "Disabled",
+            "code": "<Input placeholder=\"Disabled\" disabled />",
+            "preview": {
+              "id": "ui:input:state:disabled"
+            }
+          },
+          {
+            "id": "loading",
+            "name": "Loading",
+            "code": "<Input placeholder=\"Loading\" data-loading />",
+            "preview": {
+              "id": "ui:input:state:loading"
+            }
+          }
+        ]
       },
       {
         "id": "search-bar",
@@ -3534,6 +4277,9 @@ export const galleryPayload = {
                 "value": "With label"
               },
               {
+                "value": "Hover"
+              },
+              {
                 "value": "Focus-visible"
               },
               {
@@ -3548,10 +4294,68 @@ export const galleryPayload = {
             ]
           }
         ],
-        "code": "const [query, setQuery] = React.useState(\"Champion counters\");\nconst handleNoop = React.useCallback((_value: string) => {}, []);\n\n<SearchBar\n  value={query}\n  onValueChange={setQuery}\n  placeholder=\"Search components\"\n/>\n<SearchBar\n  value=\"\"\n  onValueChange={handleNoop}\n  label=\"Search library\"\n  placeholder=\"With label\"\n  right={<Button size=\"sm\">Filters</Button>}\n/>\n<SearchBar\n  value=\"Focus-visible\"\n  onValueChange={handleNoop}\n  placeholder=\"Focus-visible\"\n  fieldClassName=\"ring-2 ring-[hsl(var(--ring))] ring-offset-0 ring-offset-[hsl(var(--bg))]\"\n/>\n<SearchBar\n  value=\"Active\"\n  onValueChange={handleNoop}\n  placeholder=\"Active\"\n  fieldClassName=\"bg-[--active]\"\n/>\n<SearchBar\n  value=\"Disabled\"\n  onValueChange={handleNoop}\n  placeholder=\"Disabled\"\n  disabled\n/>\n<SearchBar\n  value=\"Loading\"\n  onValueChange={handleNoop}\n  placeholder=\"Loading\"\n  loading\n/>",
+        "code": "const [query, setQuery] = React.useState(\"Champion counters\");\nconst handleNoop = React.useCallback((_value: string) => {}, []);\n\n<SearchBar\n  value={query}\n  onValueChange={setQuery}\n  placeholder=\"Search components\"\n/>\n<SearchBar\n  value=\"\"\n  onValueChange={handleNoop}\n  label=\"Search library\"\n  placeholder=\"With label\"\n  right={<Button size=\"sm\">Filters</Button>}\n/>\n<SearchBar\n  value=\"Hover\"\n  onValueChange={handleNoop}\n  placeholder=\"Hover\"\n  fieldClassName=\"bg-[--hover]\"\n/>\n<SearchBar\n  value=\"Focus-visible\"\n  onValueChange={handleNoop}\n  placeholder=\"Focus-visible\"\n  fieldClassName=\"ring-2 ring-[hsl(var(--ring))] ring-offset-0 ring-offset-[hsl(var(--bg))]\"\n/>\n<SearchBar\n  value=\"Active\"\n  onValueChange={handleNoop}\n  placeholder=\"Active\"\n  fieldClassName=\"bg-[--active]\"\n/>\n<SearchBar\n  value=\"Disabled\"\n  onValueChange={handleNoop}\n  placeholder=\"Disabled\"\n  disabled\n/>\n<SearchBar\n  value=\"Loading\"\n  onValueChange={handleNoop}\n  placeholder=\"Loading\"\n  loading\n/>",
         "preview": {
           "id": "ui:search-bar:states"
-        }
+        },
+        "states": [
+          {
+            "id": "default",
+            "name": "Default",
+            "code": "<SearchBar value={query} onValueChange={setQuery} placeholder=\"Search components\" />",
+            "preview": {
+              "id": "ui:search-bar:state:default"
+            }
+          },
+          {
+            "id": "with-label",
+            "name": "With label",
+            "code": "<SearchBar label=\"Search library\" right={<Button size=\"sm\">Filters</Button>} />",
+            "preview": {
+              "id": "ui:search-bar:state:with-label"
+            }
+          },
+          {
+            "id": "hover",
+            "name": "Hover",
+            "code": "<SearchBar fieldClassName=\"bg-[--hover]\" placeholder=\"Hover\" />",
+            "preview": {
+              "id": "ui:search-bar:state:hover"
+            }
+          },
+          {
+            "id": "focus-visible",
+            "name": "Focus-visible",
+            "code": "<SearchBar fieldClassName=\"ring-2 ring-[hsl(var(--ring))] ring-offset-0 ring-offset-[hsl(var(--bg))]\" placeholder=\"Focus-visible\" />",
+            "preview": {
+              "id": "ui:search-bar:state:focus-visible"
+            }
+          },
+          {
+            "id": "active",
+            "name": "Active",
+            "code": "<SearchBar fieldClassName=\"bg-[--active]\" placeholder=\"Active\" />",
+            "preview": {
+              "id": "ui:search-bar:state:active"
+            }
+          },
+          {
+            "id": "disabled",
+            "name": "Disabled",
+            "code": "<SearchBar placeholder=\"Disabled\" disabled />",
+            "preview": {
+              "id": "ui:search-bar:state:disabled"
+            }
+          },
+          {
+            "id": "loading",
+            "name": "Loading",
+            "code": "<SearchBar placeholder=\"Loading\" loading />",
+            "preview": {
+              "id": "ui:search-bar:state:loading"
+            }
+          }
+        ]
       },
       {
         "id": "segmented-button",
@@ -3617,7 +4421,57 @@ export const galleryPayload = {
         "code": "<div className=\"flex flex-wrap gap-[var(--space-2)]\">\n  <SegmentedButton>Default</SegmentedButton>\n  <SegmentedButton className=\"[--hover:var(--seg-hover-base)] bg-[--hover] text-[hsl(var(--foreground))] [text-shadow:0_0_calc(var(--space-2)-var(--spacing-0-5))_hsl(var(--accent)/0.25)]\">Hover</SegmentedButton>\n  <SegmentedButton selected>Active</SegmentedButton>\n  <SegmentedButton className=\"ring-2 ring-[--theme-ring] ring-offset-0 outline-none\">Focus-visible</SegmentedButton>\n  <SegmentedButton disabled>Disabled</SegmentedButton>\n  <SegmentedButton loading>Loading</SegmentedButton>\n</div>",
         "preview": {
           "id": "ui:segmented-button:states"
-        }
+        },
+        "states": [
+          {
+            "id": "default",
+            "name": "Default",
+            "code": "<SegmentedButton>Default</SegmentedButton>",
+            "preview": {
+              "id": "ui:segmented-button:state:default"
+            }
+          },
+          {
+            "id": "hover",
+            "name": "Hover",
+            "code": "<SegmentedButton className=\"[--hover:var(--seg-hover-base)] bg-[--hover] text-[hsl(var(--foreground))] [text-shadow:0_0_calc(var(--space-2)-var(--spacing-0-5))_hsl(var(--accent)/0.25)]\">Hover</SegmentedButton>",
+            "preview": {
+              "id": "ui:segmented-button:state:hover"
+            }
+          },
+          {
+            "id": "active",
+            "name": "Active",
+            "code": "<SegmentedButton selected>Active</SegmentedButton>",
+            "preview": {
+              "id": "ui:segmented-button:state:active"
+            }
+          },
+          {
+            "id": "focus-visible",
+            "name": "Focus-visible",
+            "code": "<SegmentedButton className=\"ring-2 ring-[--theme-ring] ring-offset-0 outline-none\">Focus-visible</SegmentedButton>",
+            "preview": {
+              "id": "ui:segmented-button:state:focus-visible"
+            }
+          },
+          {
+            "id": "disabled",
+            "name": "Disabled",
+            "code": "<SegmentedButton disabled>Disabled</SegmentedButton>",
+            "preview": {
+              "id": "ui:segmented-button:state:disabled"
+            }
+          },
+          {
+            "id": "loading",
+            "name": "Loading",
+            "code": "<SegmentedButton loading>Loading</SegmentedButton>",
+            "preview": {
+              "id": "ui:segmented-button:state:loading"
+            }
+          }
+        ]
       },
       {
         "id": "tabs",
@@ -3665,7 +4519,41 @@ export const galleryPayload = {
         "code": "<Tabs defaultValue=\"overview\">\n  <div className=\"space-y-[var(--space-3)]\">\n    <TabList\n      items={[\n        { key: \"overview\", label: \"Overview\" },\n        { key: \"activity\", label: \"Activity\" },\n        { key: \"files\", label: \"Files\" },\n      ]}\n      ariaLabel=\"Project sections\"\n    />\n    <TabPanel value=\"overview\">\n      <Card className=\"space-y-[var(--space-2)]\">\n        <p className=\"text-title font-semibold tracking-[-0.01em]\">Overview</p>\n        <p className=\"text-ui text-muted-foreground\">\n          Keep a high-level summary of the plan visible for the team.\n        </p>\n      </Card>\n    </TabPanel>\n    <TabPanel value=\"activity\">\n      <Card className=\"space-y-[var(--space-2)]\">\n        <p className=\"text-title font-semibold tracking-[-0.01em]\">Activity</p>\n        <p className=\"text-ui text-muted-foreground\">\n          Show chronological activity without leaving the workspace.\n        </p>\n      </Card>\n    </TabPanel>\n    <TabPanel value=\"files\">\n      <Card className=\"space-y-[var(--space-2)]\">\n        <p className=\"text-title font-semibold tracking-[-0.01em]\">Files</p>\n        <p className=\"text-ui text-muted-foreground\">\n          Store briefs, shared assets, and notes alongside the plan.\n        </p>\n      </Card>\n    </TabPanel>\n  </div>\n</Tabs>\n\n<Tabs value=\"inbox\" onValueChange={() => {}}>\n  <div className=\"space-y-[var(--space-3)]\">\n    <TabList\n      ariaLabel=\"Notification filters\"\n      items={[\n        { key: \"inbox\", label: \"Inbox\" },\n        {\n          key: \"updates\",\n          label: \"Updates\",\n          className: \"ring-2 ring-[var(--theme-ring)] ring-offset-0 outline-none\",\n        },\n        { key: \"archive\", label: \"Archive\" },\n        { key: \"disabled\", label: \"Disabled\", disabled: true },\n        { key: \"sync\", label: \"Syncing\", loading: true },\n      ]}\n      linkPanels={false}\n      showBaseline\n    />\n    <Card className=\"text-ui text-muted-foreground\">\n      Active tab: <span className=\"font-medium text-foreground\">Inbox</span>\n    </Card>\n  </div>\n</Tabs>",
         "preview": {
           "id": "ui:tabs:wiring"
-        }
+        },
+        "states": [
+          {
+            "id": "active",
+            "name": "Active",
+            "code": "<Tabs value=\"updates\" onValueChange={() => {}}>\n  <TabList\n    ariaLabel=\"Tab state preview\"\n    items={[\n      { key: \"inbox\", label: \"Inbox\" },\n      { key: \"updates\", label: \"Updates\" },\n    ]}\n    linkPanels={false}\n    showBaseline\n  />\n</Tabs>",
+            "preview": {
+              "id": "ui:tabs:state:active"
+            }
+          },
+          {
+            "id": "focus-visible",
+            "name": "Focus-visible",
+            "code": "<Tabs value=\"inbox\" onValueChange={() => {}}>\n  <TabList\n    ariaLabel=\"Tab state preview\"\n    items={[\n      { key: \"inbox\", label: \"Inbox\" },\n      {\n        key: \"updates\",\n        label: \"Updates\",\n        className: \"ring-2 ring-[var(--theme-ring)] ring-offset-0 outline-none\",\n      },\n    ]}\n    linkPanels={false}\n    showBaseline\n  />\n</Tabs>",
+            "preview": {
+              "id": "ui:tabs:state:focus-visible"
+            }
+          },
+          {
+            "id": "disabled",
+            "name": "Disabled",
+            "code": "<Tabs value=\"inbox\" onValueChange={() => {}}>\n  <TabList\n    ariaLabel=\"Tab state preview\"\n    items={[\n      { key: \"inbox\", label: \"Inbox\" },\n      { key: \"disabled\", label: \"Disabled\", disabled: true },\n    ]}\n    linkPanels={false}\n    showBaseline\n  />\n</Tabs>",
+            "preview": {
+              "id": "ui:tabs:state:disabled"
+            }
+          },
+          {
+            "id": "loading",
+            "name": "Loading",
+            "code": "<Tabs value=\"inbox\" onValueChange={() => {}}>\n  <TabList\n    ariaLabel=\"Tab state preview\"\n    items={[\n      { key: \"inbox\", label: \"Inbox\" },\n      { key: \"sync\", label: \"Syncing\", loading: true },\n    ]}\n    linkPanels={false}\n    showBaseline\n  />\n</Tabs>",
+            "preview": {
+              "id": "ui:tabs:state:loading"
+            }
+          }
+        ]
       },
       {
         "id": "textarea",
@@ -3741,7 +4629,73 @@ export const galleryPayload = {
         "code": "<Textarea placeholder=\"Share your thoughts\" />\n<Textarea placeholder=\"Hover\" className=\"bg-[--hover]\" />\n<Textarea placeholder=\"Focus-visible\" className=\"ring-2 ring-[hsl(var(--ring))]\" />\n<Textarea placeholder=\"Active\" className=\"bg-[--active]\" />\n<Textarea\n  placeholder=\"Needs attention\"\n  className=\"ring-2 ring-[hsl(var(--danger))]\"\n  aria-invalid\n/> \n<Textarea\n  placeholder=\"Read-only\"\n  className=\"bg-[hsl(var(--card)/0.72)]\"\n  textareaClassName=\"text-muted-foreground\"\n  readOnly\n/> \n<Textarea placeholder=\"Disabled\" disabled />\n<Textarea placeholder=\"Loading\" data-loading />\n<Textarea placeholder=\"Resizable textarea\" resize=\"resize-y\" aria-label=\"Resizable textarea\" />",
         "preview": {
           "id": "ui:textarea:states"
-        }
+        },
+        "states": [
+          {
+            "id": "default",
+            "name": "Default",
+            "code": "<Textarea placeholder=\"Share your thoughts\" />",
+            "preview": {
+              "id": "ui:textarea:state:default"
+            }
+          },
+          {
+            "id": "hover",
+            "name": "Hover",
+            "code": "<Textarea className=\"bg-[--hover]\" placeholder=\"Hover\" />",
+            "preview": {
+              "id": "ui:textarea:state:hover"
+            }
+          },
+          {
+            "id": "focus-visible",
+            "name": "Focus-visible",
+            "code": "<Textarea className=\"ring-2 ring-[hsl(var(--ring))]\" placeholder=\"Focus-visible\" />",
+            "preview": {
+              "id": "ui:textarea:state:focus-visible"
+            }
+          },
+          {
+            "id": "active",
+            "name": "Active",
+            "code": "<Textarea className=\"bg-[--active]\" placeholder=\"Active\" />",
+            "preview": {
+              "id": "ui:textarea:state:active"
+            }
+          },
+          {
+            "id": "invalid",
+            "name": "Invalid",
+            "code": "<Textarea\n  className=\"ring-2 ring-[hsl(var(--danger))]\"\n  placeholder=\"Needs attention\"\n  aria-invalid\n/>",
+            "preview": {
+              "id": "ui:textarea:state:invalid"
+            }
+          },
+          {
+            "id": "read-only",
+            "name": "Read-only",
+            "code": "<Textarea\n  className=\"bg-[hsl(var(--card)/0.72)]\"\n  textareaClassName=\"text-muted-foreground\"\n  readOnly\n  placeholder=\"Read-only\"\n/>",
+            "preview": {
+              "id": "ui:textarea:state:read-only"
+            }
+          },
+          {
+            "id": "disabled",
+            "name": "Disabled",
+            "code": "<Textarea placeholder=\"Disabled\" disabled />",
+            "preview": {
+              "id": "ui:textarea:state:disabled"
+            }
+          },
+          {
+            "id": "loading",
+            "name": "Loading",
+            "code": "<Textarea placeholder=\"Loading\" data-loading />",
+            "preview": {
+              "id": "ui:textarea:state:loading"
+            }
+          }
+        ]
       }
     ],
     "component": [
@@ -5559,6 +6513,12 @@ export const galleryPreviewModules = [
     loader: () => import("../ui/Select.gallery"),
     previewIds: [
       "ui:select:variants",
+      "ui:select:state:default",
+      "ui:select:state:hover",
+      "ui:select:state:focus-visible",
+      "ui:select:state:active",
+      "ui:select:state:disabled",
+      "ui:select:state:loading",
     ],
   },
   {
@@ -5583,48 +6543,99 @@ export const galleryPreviewModules = [
     loader: () => import("../ui/primitives/Button.gallery"),
     previewIds: [
       "ui:button:matrix",
+      "ui:button:state:default",
+      "ui:button:state:hover",
+      "ui:button:state:focus",
+      "ui:button:state:active",
+      "ui:button:state:disabled",
+      "ui:button:state:loading",
     ],
   },
   {
     loader: () => import("../ui/primitives/Field.gallery"),
     previewIds: [
       "ui:field:states",
+      "ui:field:state:default",
+      "ui:field:state:focus-visible",
+      "ui:field:state:invalid",
+      "ui:field:state:loading",
+      "ui:field:state:disabled",
+      "ui:field:state:with-counter",
+      "ui:field:state:select",
+      "ui:field:state:search",
     ],
   },
   {
     loader: () => import("../ui/primitives/IconButton.gallery"),
     previewIds: [
       "ui:icon-button:matrix",
+      "ui:icon-button:state:default",
+      "ui:icon-button:state:hover",
+      "ui:icon-button:state:focus",
+      "ui:icon-button:state:active",
+      "ui:icon-button:state:disabled",
+      "ui:icon-button:state:loading",
     ],
   },
   {
     loader: () => import("../ui/primitives/Input.gallery"),
     previewIds: [
       "ui:input:states",
+      "ui:input:state:default",
+      "ui:input:state:hover",
+      "ui:input:state:focus",
+      "ui:input:state:active",
+      "ui:input:state:disabled",
+      "ui:input:state:loading",
     ],
   },
   {
     loader: () => import("../ui/primitives/SearchBar.gallery"),
     previewIds: [
       "ui:search-bar:states",
+      "ui:search-bar:state:default",
+      "ui:search-bar:state:with-label",
+      "ui:search-bar:state:hover",
+      "ui:search-bar:state:focus-visible",
+      "ui:search-bar:state:active",
+      "ui:search-bar:state:disabled",
+      "ui:search-bar:state:loading",
     ],
   },
   {
     loader: () => import("../ui/primitives/SegmentedButton.gallery"),
     previewIds: [
       "ui:segmented-button:states",
+      "ui:segmented-button:state:default",
+      "ui:segmented-button:state:hover",
+      "ui:segmented-button:state:active",
+      "ui:segmented-button:state:focus-visible",
+      "ui:segmented-button:state:disabled",
+      "ui:segmented-button:state:loading",
     ],
   },
   {
     loader: () => import("../ui/primitives/Tabs.gallery"),
     previewIds: [
       "ui:tabs:wiring",
+      "ui:tabs:state:active",
+      "ui:tabs:state:focus-visible",
+      "ui:tabs:state:disabled",
+      "ui:tabs:state:loading",
     ],
   },
   {
     loader: () => import("../ui/primitives/Textarea.gallery"),
     previewIds: [
       "ui:textarea:states",
+      "ui:textarea:state:default",
+      "ui:textarea:state:hover",
+      "ui:textarea:state:focus-visible",
+      "ui:textarea:state:active",
+      "ui:textarea:state:invalid",
+      "ui:textarea:state:read-only",
+      "ui:textarea:state:disabled",
+      "ui:textarea:state:loading",
     ],
   },
 ] satisfies readonly GalleryPreviewModuleManifest[];

--- a/src/components/ui/Select.gallery.tsx
+++ b/src/components/ui/Select.gallery.tsx
@@ -5,8 +5,9 @@ import { createGalleryPreview, defineGallerySection } from "@/components/gallery
 import Select from "./Select";
 import type { AnimatedSelectProps } from "./select/shared";
 
-type SelectStateConfig = {
-  label: string;
+type SelectStateSpec = {
+  id: string;
+  name: string;
   buttonClassName?: string;
   className?: string;
   props?:
@@ -14,32 +15,45 @@ type SelectStateConfig = {
         items?: AnimatedSelectProps["items"];
       })
     | undefined;
+  code?: string;
 };
 
-const SELECT_STATES: ReadonlyArray<SelectStateConfig> = [
+const SELECT_STATES: readonly SelectStateSpec[] = [
   {
-    label: "Default",
+    id: "default",
+    name: "Default",
+    code: "<Select placeholder=\"Animated select\" items={items} />",
   },
   {
-    label: "Hover",
+    id: "hover",
+    name: "Hover",
     buttonClassName: "bg-[--hover]",
+    code: "<Select buttonClassName=\"bg-[--hover]\" placeholder=\"Hover\" items={items} />",
   },
   {
-    label: "Focus-visible",
+    id: "focus-visible",
+    name: "Focus-visible",
     className:
       "rounded-[var(--control-radius)] ring-2 ring-[var(--theme-ring)] ring-offset-0",
+    code: "<Select className=\"rounded-[var(--control-radius)] ring-2 ring-[var(--theme-ring)] ring-offset-0\" placeholder=\"Focus-visible\" items={items} />",
   },
   {
-    label: "Active",
+    id: "active",
+    name: "Active",
     buttonClassName: "bg-[--active]",
+    code: "<Select buttonClassName=\"bg-[--active]\" placeholder=\"Active\" items={items} />",
   },
   {
-    label: "Disabled",
+    id: "disabled",
+    name: "Disabled",
     props: { disabled: true },
+    code: "<Select placeholder=\"Disabled\" disabled items={items} />",
   },
   {
-    label: "Loading",
+    id: "loading",
+    name: "Loading",
     buttonClassName: "pointer-events-none opacity-[var(--loading)]",
+    code: "<Select buttonClassName=\"pointer-events-none opacity-[var(--loading)]\" placeholder=\"Loading\" items={items} />",
   },
 ];
 
@@ -50,6 +64,25 @@ const ITEMS = [
 ] as const;
 
 type ItemValue = (typeof ITEMS)[number]["value"];
+
+function SelectStatePreview({ state }: { state: SelectStateSpec }) {
+  const { props, className, buttonClassName, name } = state;
+  const { items: stateItems, placeholder, ariaLabel, ...restProps } = props ?? {};
+  const sampleItems = stateItems ?? ITEMS;
+  const baseClassName = "w-full sm:w-auto";
+  const finalClassName = className ? `${baseClassName} ${className}` : baseClassName;
+
+  return (
+    <Select
+      items={[...sampleItems]}
+      placeholder={placeholder ?? name}
+      ariaLabel={ariaLabel ?? name}
+      buttonClassName={buttonClassName}
+      className={finalClassName}
+      {...restProps}
+    />
+  );
+}
 
 function SelectGalleryPreview() {
   const [value, setValue] = React.useState<ItemValue>(ITEMS[0]?.value ?? "one");
@@ -76,26 +109,9 @@ function SelectGalleryPreview() {
       <div className="flex flex-col gap-[var(--space-2)]">
         <p className="text-caption text-muted-foreground">States</p>
         <div className="flex flex-wrap gap-[var(--space-2)]">
-          {SELECT_STATES.map(({ label, buttonClassName, className, props }) => {
-            const { items: stateItems, ...restProps } = props ?? {};
-            const sampleItems = stateItems ?? ITEMS;
-            const baseClassName = "w-full sm:w-auto";
-            const finalClassName = className
-              ? `${baseClassName} ${className}`
-              : baseClassName;
-
-            return (
-              <Select
-                key={label}
-                items={[...sampleItems]}
-                placeholder={label}
-                ariaLabel={label}
-                buttonClassName={buttonClassName}
-                className={finalClassName}
-                {...restProps}
-              />
-            );
-          })}
+          {SELECT_STATES.map((state) => (
+            <SelectStatePreview key={state.id} state={state} />
+          ))}
         </div>
       </div>
     </div>
@@ -137,13 +153,22 @@ export default defineGallerySection({
           id: "state",
           label: "State",
           type: "state",
-          values: SELECT_STATES.map(({ label }) => ({ value: label })),
+          values: SELECT_STATES.map(({ name }) => ({ value: name })),
         },
       ],
       preview: createGalleryPreview({
         id: "ui:select:variants",
         render: () => <SelectGalleryPreview />,
       }),
+      states: SELECT_STATES.map((state) => ({
+        id: state.id,
+        name: state.name,
+        code: state.code,
+        preview: createGalleryPreview({
+          id: `ui:select:state:${state.id}`,
+          render: () => <SelectStatePreview state={state} />,
+        }),
+      })),
       code: `const items = [
   { value: "one", label: "One" },
   { value: "two", label: "Two" },

--- a/src/components/ui/primitives/Button.gallery.tsx
+++ b/src/components/ui/primitives/Button.gallery.tsx
@@ -5,38 +5,60 @@ import { createGalleryPreview, defineGallerySection } from "@/components/gallery
 
 import Button from "./Button";
 
-const BUTTON_STATES = [
-  { label: "Default", className: undefined, props: { children: "Default" } },
-  {
-    label: "Hover",
-    className: "bg-[--hover]",
-    props: { children: "Hover" },
-  },
-  {
-    label: "Focus",
-    className: "ring-2 ring-[var(--focus)]",
-    props: { children: "Focus" },
-  },
-  {
-    label: "Active",
-    className: "bg-[--active]",
-    props: { children: "Active" },
-  },
-  {
-    label: "Disabled",
-    className: undefined,
-    props: { children: "Disabled", disabled: true },
-  },
-  {
-    label: "Loading",
-    className: undefined,
-    props: { children: "Loading", loading: true },
-  },
-] satisfies ReadonlyArray<{
-  label: string;
+type ButtonStateSpec = {
+  id: string;
+  name: string;
   className?: string;
   props: React.ComponentProps<typeof Button>;
-}>;
+  code?: string;
+};
+
+const BUTTON_STATES: readonly ButtonStateSpec[] = [
+  {
+    id: "default",
+    name: "Default",
+    props: { children: "Default" },
+    code: "<Button>Default</Button>",
+  },
+  {
+    id: "hover",
+    name: "Hover",
+    className: "bg-[--hover]",
+    props: { children: "Hover" },
+    code: "<Button className=\"bg-[--hover]\">Hover</Button>",
+  },
+  {
+    id: "focus",
+    name: "Focus",
+    className: "ring-2 ring-[var(--focus)]",
+    props: { children: "Focus" },
+    code: "<Button className=\"ring-2 ring-[var(--focus)]\">Focus</Button>",
+  },
+  {
+    id: "active",
+    name: "Active",
+    className: "bg-[--active]",
+    props: { children: "Active" },
+    code: "<Button className=\"bg-[--active]\">Active</Button>",
+  },
+  {
+    id: "disabled",
+    name: "Disabled",
+    props: { children: "Disabled", disabled: true },
+    code: "<Button disabled>Disabled</Button>",
+  },
+  {
+    id: "loading",
+    name: "Loading",
+    props: { children: "Loading", loading: true },
+    code: "<Button loading>Loading</Button>",
+  },
+];
+
+function ButtonStatePreview({ state }: { state: ButtonStateSpec }) {
+  const { className, props } = state;
+  return <Button className={className} {...props} />;
+}
 
 function ButtonGalleryPreview() {
   return (
@@ -71,8 +93,8 @@ function ButtonGalleryPreview() {
         </Button>
       </div>
       <div className="flex flex-wrap gap-[var(--space-2)]">
-        {BUTTON_STATES.map(({ label, className, props }) => (
-          <Button key={label} className={className} {...props} />
+        {BUTTON_STATES.map((state) => (
+          <ButtonStatePreview key={state.id} state={state} />
         ))}
       </div>
     </div>
@@ -123,13 +145,22 @@ export default defineGallerySection({
           id: "state",
           label: "State",
           type: "state",
-          values: BUTTON_STATES.map(({ label }) => ({ value: label })),
+          values: BUTTON_STATES.map(({ name }) => ({ value: name })),
         },
       ],
       preview: createGalleryPreview({
         id: "ui:button:matrix",
         render: () => <ButtonGalleryPreview />,
       }),
+      states: BUTTON_STATES.map((state) => ({
+        id: state.id,
+        name: state.name,
+        code: state.code,
+        preview: createGalleryPreview({
+          id: `ui:button:state:${state.id}`,
+          render: () => <ButtonStatePreview state={state} />,
+        }),
+      })),
       code: `<div className="flex flex-col gap-[var(--space-4)]">
   <div className="flex flex-wrap gap-[var(--space-2)]">
     <Button tone="primary">Primary tone</Button>

--- a/src/components/ui/primitives/Field.gallery.tsx
+++ b/src/components/ui/primitives/Field.gallery.tsx
@@ -9,71 +9,203 @@ const options = [
   { value: "two", label: "Two" },
 ];
 
-function FieldGalleryPreview() {
+type FieldStateSpec = {
+  id: string;
+  name: string;
+  Component: React.ComponentType;
+  code?: string;
+};
+
+const DefaultFieldState: React.FC = () => (
+  <Field.Root helper="Compose primitives">
+    <Field.Input placeholder="Default field" />
+  </Field.Root>
+);
+
+const FocusVisibleFieldState: React.FC = () => (
+  <Field.Root
+    className="ring-2 ring-[hsl(var(--ring))]"
+    helper="Helper text aligns with counter"
+    helperId="field-focus-helper"
+    counter="64 / 100"
+    counterId="field-focus-counter"
+  >
+    <Field.Input
+      aria-describedby="field-focus-helper field-focus-counter"
+      placeholder="Forced focus ring"
+    />
+  </Field.Root>
+);
+
+const InvalidFieldState: React.FC = () => (
+  <Field.Root invalid helper="Incorrect format" helperTone="danger">
+    <Field.Input placeholder="Invalid field" aria-invalid />
+  </Field.Root>
+);
+
+const LoadingFieldState: React.FC = () => (
+  <Field.Root loading helper="Loading state">
+    <Field.Input placeholder="Loading field" />
+  </Field.Root>
+);
+
+const DisabledFieldState: React.FC = () => (
+  <Field.Root disabled helper="Disabled field">
+    <Field.Input placeholder="Disabled field" disabled />
+  </Field.Root>
+);
+
+const FieldWithCounterState: React.FC = () => (
+  <Field.Root
+    counter="120 / 200"
+    counterId="field-counter"
+    helper="Helper with counter"
+    helperId="field-helper"
+  >
+    <Field.Textarea
+      aria-describedby="field-helper field-counter"
+      placeholder="Textarea within a field"
+      rows={3}
+    />
+  </Field.Root>
+);
+
+const SelectFieldState: React.FC = () => (
+  <Field.Root>
+    <Field.Select defaultValue="one">
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </Field.Select>
+  </Field.Root>
+);
+
+const SearchFieldState: React.FC = () => {
   const [search, setSearch] = React.useState("Scouting");
 
   return (
+    <Field.Root>
+      <Field.Search
+        value={search}
+        onChange={(event) => setSearch(event.target.value)}
+        placeholder="Search fields"
+        clearLabel="Clear search"
+      />
+    </Field.Root>
+  );
+};
+
+const FIELD_STATES: readonly FieldStateSpec[] = [
+  {
+    id: "default",
+    name: "Default",
+    Component: DefaultFieldState,
+    code: `<Field.Root helper="Compose primitives">
+  <Field.Input placeholder="Default field" />
+</Field.Root>`,
+  },
+  {
+    id: "focus-visible",
+    name: "Focus visible",
+    Component: FocusVisibleFieldState,
+    code: `<Field.Root
+  className="ring-2 ring-[hsl(var(--ring))]"
+  helper="Helper text aligns with counter"
+  helperId="field-focus-helper"
+  counter="64 / 100"
+  counterId="field-focus-counter"
+>
+  <Field.Input
+    aria-describedby="field-focus-helper field-focus-counter"
+    placeholder="Forced focus ring"
+  />
+</Field.Root>`,
+  },
+  {
+    id: "invalid",
+    name: "Invalid",
+    Component: InvalidFieldState,
+    code: `<Field.Root invalid helper="Incorrect format" helperTone="danger">
+  <Field.Input placeholder="Invalid field" aria-invalid />
+</Field.Root>`,
+  },
+  {
+    id: "loading",
+    name: "Loading",
+    Component: LoadingFieldState,
+    code: `<Field.Root loading helper="Loading state">
+  <Field.Input placeholder="Loading field" />
+</Field.Root>`,
+  },
+  {
+    id: "disabled",
+    name: "Disabled",
+    Component: DisabledFieldState,
+    code: `<Field.Root disabled helper="Disabled field">
+  <Field.Input placeholder="Disabled field" disabled />
+</Field.Root>`,
+  },
+  {
+    id: "with-counter",
+    name: "With counter",
+    Component: FieldWithCounterState,
+    code: `<Field.Root
+  counter="120 / 200"
+  counterId="field-counter"
+  helper="Helper with counter"
+  helperId="field-helper"
+>
+  <Field.Textarea
+    aria-describedby="field-helper field-counter"
+    placeholder="Textarea within a field"
+    rows={3}
+  />
+</Field.Root>`,
+  },
+  {
+    id: "select",
+    name: "Select",
+    Component: SelectFieldState,
+    code: `const options = [
+  { value: "one", label: "One" },
+  { value: "two", label: "Two" },
+];
+
+<Field.Root>
+  <Field.Select defaultValue="one">
+    {options.map((option) => (
+      <option key={option.value} value={option.value}>
+        {option.label}
+      </option>
+    ))}
+  </Field.Select>
+</Field.Root>`,
+  },
+  {
+    id: "search",
+    name: "Search",
+    Component: SearchFieldState,
+    code: `const [search, setSearch] = React.useState("Scouting");
+
+<Field.Root>
+  <Field.Search
+    value={search}
+    onChange={(event) => setSearch(event.target.value)}
+    placeholder="Search fields"
+    clearLabel="Clear search"
+  />
+</Field.Root>`,
+  },
+];
+
+function FieldGalleryPreview() {
+  return (
     <div className="flex flex-col gap-[var(--space-3)]">
-      <Field.Root helper="Compose primitives">
-        <Field.Input placeholder="Default field" />
-      </Field.Root>
-
-      <Field.Root
-        className="ring-2 ring-[hsl(var(--ring))]"
-        helper="Helper text aligns with counter"
-        helperId="field-focus-helper"
-        counter="64 / 100"
-        counterId="field-focus-counter"
-      >
-        <Field.Input
-          aria-describedby="field-focus-helper field-focus-counter"
-          placeholder="Forced focus ring"
-        />
-      </Field.Root>
-
-      <Field.Root invalid helper="Incorrect format" helperTone="danger">
-        <Field.Input placeholder="Invalid field" aria-invalid />
-      </Field.Root>
-
-      <Field.Root loading helper="Loading state">
-        <Field.Input placeholder="Loading field" />
-      </Field.Root>
-
-      <Field.Root disabled helper="Disabled field">
-        <Field.Input placeholder="Disabled field" disabled />
-      </Field.Root>
-
-      <Field.Root
-        counter="120 / 200"
-        counterId="field-counter"
-        helper="Helper with counter"
-        helperId="field-helper"
-      >
-        <Field.Textarea
-          aria-describedby="field-helper field-counter"
-          placeholder="Textarea within a field"
-          rows={3}
-        />
-      </Field.Root>
-
-      <Field.Root>
-        <Field.Select defaultValue="one">
-          {options.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </Field.Select>
-      </Field.Root>
-
-      <Field.Root>
-        <Field.Search
-          value={search}
-          onChange={(event) => setSearch(event.target.value)}
-          placeholder="Search fields"
-          clearLabel="Clear search"
-        />
-      </Field.Root>
+      {FIELD_STATES.map(({ id, Component }) => (
+        <Component key={id} />
+      ))}
     </div>
   );
 }
@@ -102,22 +234,22 @@ export default defineGallerySection({
           id: "state",
           label: "State",
           type: "state",
-          values: [
-            { value: "Default" },
-            { value: "Focus visible" },
-            { value: "Invalid" },
-            { value: "Loading" },
-            { value: "Disabled" },
-            { value: "With counter" },
-            { value: "Search" },
-            { value: "Select" },
-          ],
+          values: FIELD_STATES.map(({ name }) => ({ value: name })),
         },
       ],
       preview: createGalleryPreview({
         id: "ui:field:states",
         render: () => <FieldGalleryPreview />,
       }),
+      states: FIELD_STATES.map((state) => ({
+        id: state.id,
+        name: state.name,
+        code: state.code,
+        preview: createGalleryPreview({
+          id: `ui:field:state:${state.id}`,
+          render: () => <state.Component />,
+        }),
+      })),
       code: `const [search, setSearch] = React.useState("Scouting");
 
 <Field.Root helper="Compose primitives">

--- a/src/components/ui/primitives/IconButton.gallery.tsx
+++ b/src/components/ui/primitives/IconButton.gallery.tsx
@@ -5,54 +5,72 @@ import { createGalleryPreview, defineGallerySection } from "@/components/gallery
 
 import IconButton from "./IconButton";
 
-const ICON_BUTTON_STATES = [
+type IconButtonStateSpec = {
+  id: string;
+  name: string;
+  className?: string;
+  props: React.ComponentProps<typeof IconButton>;
+  code?: string;
+};
+
+const ICON_BUTTON_STATES: readonly IconButtonStateSpec[] = [
   {
-    label: "Default",
-    className: undefined,
+    id: "default",
+    name: "Default",
     props: { "aria-label": "Default", children: <Plus aria-hidden /> },
+    code: "<IconButton aria-label=\"Default\">\n  <Plus />\n</IconButton>",
   },
   {
-    label: "Hover",
+    id: "hover",
+    name: "Hover",
     className: "bg-[--hover]",
     props: { "aria-label": "Hover", children: <Plus aria-hidden /> },
+    code: "<IconButton className=\"bg-[--hover]\" aria-label=\"Hover\">\n  <Plus />\n</IconButton>",
   },
   {
-    label: "Focus",
+    id: "focus",
+    name: "Focus",
     className: "ring-2 ring-[var(--focus)]",
     props: { "aria-label": "Focus", children: <Plus aria-hidden /> },
+    code: "<IconButton className=\"ring-2 ring-[var(--focus)]\" aria-label=\"Focus\">\n  <Plus />\n</IconButton>",
   },
   {
-    label: "Active",
+    id: "active",
+    name: "Active",
     className: "bg-[--active]",
     props: {
       "aria-label": "Active",
       "aria-pressed": true,
       children: <Plus aria-hidden />,
     },
+    code: "<IconButton\n  className=\"bg-[--active]\"\n  aria-label=\"Active\"\n  aria-pressed\n>\n  <Plus />\n</IconButton>",
   },
   {
-    label: "Disabled",
-    className: undefined,
+    id: "disabled",
+    name: "Disabled",
     props: {
       "aria-label": "Disabled",
       children: <Plus aria-hidden />,
       disabled: true,
     },
+    code: "<IconButton disabled aria-label=\"Disabled\">\n  <Plus />\n</IconButton>",
   },
   {
-    label: "Loading",
-    className: undefined,
+    id: "loading",
+    name: "Loading",
     props: {
       "aria-label": "Loading",
       children: <Plus aria-hidden />,
       loading: true,
     },
+    code: "<IconButton loading aria-label=\"Loading\">\n  <Plus />\n</IconButton>",
   },
-] satisfies ReadonlyArray<{
-  label: string;
-  className?: string;
-  props: React.ComponentProps<typeof IconButton>;
-}>;
+];
+
+function IconButtonStatePreview({ state }: { state: IconButtonStateSpec }) {
+  const { className, props } = state;
+  return <IconButton className={className} {...props} />;
+}
 
 const ICON_BUTTON_SIZES = ["sm", "md", "lg", "xl"] as const;
 
@@ -86,8 +104,8 @@ function IconButtonGalleryPreview() {
         </IconButton>
       </div>
       <div className="flex flex-wrap gap-[var(--space-2)]">
-        {ICON_BUTTON_STATES.map(({ label, className, props }) => (
-          <IconButton key={label} className={className} {...props} />
+        {ICON_BUTTON_STATES.map((state) => (
+          <IconButtonStatePreview key={state.id} state={state} />
         ))}
       </div>
     </div>
@@ -135,13 +153,22 @@ export default defineGallerySection({
           id: "state",
           label: "State",
           type: "state",
-          values: ICON_BUTTON_STATES.map(({ label }) => ({ value: label })),
+          values: ICON_BUTTON_STATES.map(({ name }) => ({ value: name })),
         },
       ],
       preview: createGalleryPreview({
         id: "ui:icon-button:matrix",
         render: () => <IconButtonGalleryPreview />,
       }),
+      states: ICON_BUTTON_STATES.map((state) => ({
+        id: state.id,
+        name: state.name,
+        code: state.code,
+        preview: createGalleryPreview({
+          id: `ui:icon-button:state:${state.id}`,
+          render: () => <IconButtonStatePreview state={state} />,
+        }),
+      })),
       code: `<div className="flex flex-col gap-[var(--space-4)]">
   <div className="flex flex-wrap gap-[var(--space-2)]">
     <IconButton size="sm" variant="ghost" aria-label="Add item sm">

--- a/src/components/ui/primitives/Input.gallery.tsx
+++ b/src/components/ui/primitives/Input.gallery.tsx
@@ -4,48 +4,66 @@ import { createGalleryPreview, defineGallerySection } from "@/components/gallery
 
 import Input from "./Input";
 
-const INPUT_STATES = [
-  {
-    label: "Default",
-    className: undefined,
-    props: { placeholder: "Default" },
-  },
-  {
-    label: "Hover",
-    className: "bg-[--hover]",
-    props: { placeholder: "Hover" },
-  },
-  {
-    label: "Focus",
-    className: "ring-2 ring-[var(--focus)]",
-    props: { placeholder: "Focus" },
-  },
-  {
-    label: "Active",
-    className: "bg-[--active]",
-    props: { placeholder: "Active" },
-  },
-  {
-    label: "Disabled",
-    className: undefined,
-    props: { placeholder: "Disabled", disabled: true },
-  },
-  {
-    label: "Loading",
-    className: undefined,
-    props: { placeholder: "Loading", "data-loading": true },
-  },
-] satisfies ReadonlyArray<{
-  label: string;
+type InputStateSpec = {
+  id: string;
+  name: string;
   className?: string;
   props: React.ComponentProps<typeof Input>;
-}>;
+  code?: string;
+};
+
+const INPUT_STATES: readonly InputStateSpec[] = [
+  {
+    id: "default",
+    name: "Default",
+    props: { placeholder: "Default" },
+    code: "<Input placeholder=\"Default\" />",
+  },
+  {
+    id: "hover",
+    name: "Hover",
+    className: "bg-[--hover]",
+    props: { placeholder: "Hover" },
+    code: "<Input className=\"bg-[--hover]\" placeholder=\"Hover\" />",
+  },
+  {
+    id: "focus",
+    name: "Focus",
+    className: "ring-2 ring-[var(--focus)]",
+    props: { placeholder: "Focus" },
+    code: "<Input className=\"ring-2 ring-[var(--focus)]\" placeholder=\"Focus\" />",
+  },
+  {
+    id: "active",
+    name: "Active",
+    className: "bg-[--active]",
+    props: { placeholder: "Active" },
+    code: "<Input className=\"bg-[--active]\" placeholder=\"Active\" />",
+  },
+  {
+    id: "disabled",
+    name: "Disabled",
+    props: { placeholder: "Disabled", disabled: true },
+    code: "<Input placeholder=\"Disabled\" disabled />",
+  },
+  {
+    id: "loading",
+    name: "Loading",
+    props: { placeholder: "Loading", "data-loading": true },
+    code: "<Input placeholder=\"Loading\" data-loading />",
+  },
+];
+
+function InputStatePreview({ state }: { state: InputStateSpec }) {
+  const { className, props } = state;
+  return <Input className={className} {...props} />;
+}
 
 function InputGalleryPreview() {
   return (
     <div className="flex flex-col gap-[var(--space-2)]">
-      {INPUT_STATES.map(({ label, className, props }) => (
-        <Input key={label} className={className} {...props} />
+      {INPUT_STATES.map((state) => (
+        <InputStatePreview key={state.id} state={state} />
       ))}
     </div>
   );
@@ -71,13 +89,22 @@ export default defineGallerySection({
           id: "state",
           label: "State",
           type: "state",
-          values: INPUT_STATES.map(({ label }) => ({ value: label })),
+          values: INPUT_STATES.map(({ name }) => ({ value: name })),
         },
       ],
       preview: createGalleryPreview({
         id: "ui:input:states",
         render: () => <InputGalleryPreview />,
       }),
+      states: INPUT_STATES.map((state) => ({
+        id: state.id,
+        name: state.name,
+        code: state.code,
+        preview: createGalleryPreview({
+          id: `ui:input:state:${state.id}`,
+          render: () => <InputStatePreview state={state} />,
+        }),
+      })),
       code: `<div className="flex flex-col gap-[var(--space-2)]">
   <Input placeholder="Default" />
   <Input placeholder="Hover" className="bg-[--hover]" />

--- a/src/components/ui/primitives/SearchBar.gallery.tsx
+++ b/src/components/ui/primitives/SearchBar.gallery.tsx
@@ -5,50 +5,139 @@ import { Button } from "@/components/ui";
 
 import SearchBar from "./SearchBar";
 
+type SearchBarStateHelpers = {
+  interactiveValue: string;
+  onInteractiveChange: (value: string) => void;
+  noop: (value: string) => void;
+  renderFiltersButton: () => React.ReactNode;
+};
+
+type SearchBarStateSpec = {
+  id: string;
+  name: string;
+  getProps: (
+    helpers: SearchBarStateHelpers,
+  ) => React.ComponentProps<typeof SearchBar>;
+  code?: string;
+};
+
+const SEARCH_BAR_NOOP = (value: string) => {
+  void value;
+};
+
+const SEARCH_BAR_STATES: readonly SearchBarStateSpec[] = [
+  {
+    id: "default",
+    name: "Default",
+    getProps: ({ interactiveValue, onInteractiveChange }) => ({
+      value: interactiveValue,
+      onValueChange: onInteractiveChange,
+      placeholder: "Search components",
+    }),
+    code: "<SearchBar value={query} onValueChange={setQuery} placeholder=\"Search components\" />",
+  },
+  {
+    id: "with-label",
+    name: "With label",
+    getProps: ({ noop, renderFiltersButton }) => ({
+      value: "",
+      onValueChange: noop,
+      label: "Search library",
+      placeholder: "With label",
+      right: renderFiltersButton(),
+    }),
+    code: "<SearchBar label=\"Search library\" right={<Button size=\"sm\">Filters</Button>} />",
+  },
+  {
+    id: "hover",
+    name: "Hover",
+    getProps: ({ noop }) => ({
+      value: "Hover",
+      onValueChange: noop,
+      placeholder: "Hover",
+      fieldClassName: "bg-[--hover]",
+    }),
+    code: "<SearchBar fieldClassName=\"bg-[--hover]\" placeholder=\"Hover\" />",
+  },
+  {
+    id: "focus-visible",
+    name: "Focus-visible",
+    getProps: ({ noop }) => ({
+      value: "Focus-visible",
+      onValueChange: noop,
+      placeholder: "Focus-visible",
+      fieldClassName:
+        "ring-2 ring-[hsl(var(--ring))] ring-offset-0 ring-offset-[hsl(var(--bg))]",
+    }),
+    code: "<SearchBar fieldClassName=\"ring-2 ring-[hsl(var(--ring))] ring-offset-0 ring-offset-[hsl(var(--bg))]\" placeholder=\"Focus-visible\" />",
+  },
+  {
+    id: "active",
+    name: "Active",
+    getProps: ({ noop }) => ({
+      value: "Active",
+      onValueChange: noop,
+      placeholder: "Active",
+      fieldClassName: "bg-[--active]",
+    }),
+    code: "<SearchBar fieldClassName=\"bg-[--active]\" placeholder=\"Active\" />",
+  },
+  {
+    id: "disabled",
+    name: "Disabled",
+    getProps: ({ noop }) => ({
+      value: "Disabled",
+      onValueChange: noop,
+      placeholder: "Disabled",
+      disabled: true,
+    }),
+    code: "<SearchBar placeholder=\"Disabled\" disabled />",
+  },
+  {
+    id: "loading",
+    name: "Loading",
+    getProps: ({ noop }) => ({
+      value: "Loading",
+      onValueChange: noop,
+      placeholder: "Loading",
+      loading: true,
+    }),
+    code: "<SearchBar placeholder=\"Loading\" loading />",
+  },
+];
+
+function SearchBarStatePreview({
+  state,
+  helpers,
+}: {
+  state: SearchBarStateSpec;
+  helpers: SearchBarStateHelpers;
+}) {
+  const props = state.getProps(helpers);
+  return <SearchBar {...props} />;
+}
+
 function SearchBarGalleryPreview() {
   const [query, setQuery] = React.useState("Champion counters");
-  const handleNoop = React.useCallback((_value: string) => {
-    void _value;
-  }, []);
+  const renderFiltersButton = React.useCallback(
+    () => <Button size="sm">Filters</Button>,
+    [],
+  );
+  const helpers = React.useMemo(
+    () => ({
+      interactiveValue: query,
+      onInteractiveChange: setQuery,
+      noop: SEARCH_BAR_NOOP,
+      renderFiltersButton,
+    }),
+    [query, renderFiltersButton, setQuery],
+  );
 
   return (
     <div className="flex flex-col gap-[var(--space-3)]">
-      <SearchBar
-        value={query}
-        onValueChange={setQuery}
-        placeholder="Search components"
-      />
-      <SearchBar
-        value=""
-        onValueChange={handleNoop}
-        label="Search library"
-        placeholder="With label"
-        right={<Button size="sm">Filters</Button>}
-      />
-      <SearchBar
-        value="Focus-visible"
-        onValueChange={handleNoop}
-        placeholder="Focus-visible"
-        fieldClassName="ring-2 ring-[hsl(var(--ring))] ring-offset-0 ring-offset-[hsl(var(--bg))]"
-      />
-      <SearchBar
-        value="Active"
-        onValueChange={handleNoop}
-        placeholder="Active"
-        fieldClassName="bg-[--active]"
-      />
-      <SearchBar
-        value="Disabled"
-        onValueChange={handleNoop}
-        placeholder="Disabled"
-        disabled
-      />
-      <SearchBar
-        value="Loading"
-        onValueChange={handleNoop}
-        placeholder="Loading"
-        loading
-      />
+      {SEARCH_BAR_STATES.map((state) => (
+        <SearchBarStatePreview key={state.id} state={state} helpers={helpers} />
+      ))}
     </div>
   );
 }
@@ -77,20 +166,32 @@ export default defineGallerySection({
           id: "state",
           label: "State",
           type: "state",
-          values: [
-            { value: "Default" },
-            { value: "With label" },
-            { value: "Focus-visible" },
-            { value: "Active" },
-            { value: "Disabled" },
-            { value: "Loading" },
-          ],
+          values: SEARCH_BAR_STATES.map(({ name }) => ({ value: name })),
         },
       ],
       preview: createGalleryPreview({
         id: "ui:search-bar:states",
         render: () => <SearchBarGalleryPreview />,
       }),
+      states: SEARCH_BAR_STATES.map((state) => ({
+        id: state.id,
+        name: state.name,
+        code: state.code,
+        preview: createGalleryPreview({
+          id: `ui:search-bar:state:${state.id}`,
+          render: () => (
+            <SearchBarStatePreview
+              state={state}
+              helpers={{
+                interactiveValue: "Champion counters",
+                onInteractiveChange: SEARCH_BAR_NOOP,
+                noop: SEARCH_BAR_NOOP,
+                renderFiltersButton: () => <Button size="sm">Filters</Button>,
+              }}
+            />
+          ),
+        }),
+      })),
       code: `const [query, setQuery] = React.useState("Champion counters");
 const handleNoop = React.useCallback((_value: string) => {}, []);
 
@@ -105,6 +206,12 @@ const handleNoop = React.useCallback((_value: string) => {}, []);
   label="Search library"
   placeholder="With label"
   right={<Button size="sm">Filters</Button>}
+/>
+<SearchBar
+  value="Hover"
+  onValueChange={handleNoop}
+  placeholder="Hover"
+  fieldClassName="bg-[--hover]"
 />
 <SearchBar
   value="Focus-visible"

--- a/src/components/ui/primitives/SegmentedButton.gallery.tsx
+++ b/src/components/ui/primitives/SegmentedButton.gallery.tsx
@@ -10,35 +10,71 @@ const SEGMENTED_BUTTON_HOVER_STATE_CLASSNAME =
 const SEGMENTED_BUTTON_FOCUS_VISIBLE_STATE_CLASSNAME =
   "ring-2 ring-[--theme-ring] ring-offset-0 outline-none";
 
-const SEGMENTED_BUTTON_STATES: ReadonlyArray<{
-  label: string;
+type SegmentedButtonStateSpec = {
+  id: string;
+  name: string;
   props: React.ComponentProps<typeof SegmentedButton>;
-}> = [
-  { label: "Default", props: { children: "Default" } },
+  code?: string;
+};
+
+const SEGMENTED_BUTTON_STATES: readonly SegmentedButtonStateSpec[] = [
   {
-    label: "Hover",
+    id: "default",
+    name: "Default",
+    props: { children: "Default" },
+    code: "<SegmentedButton>Default</SegmentedButton>",
+  },
+  {
+    id: "hover",
+    name: "Hover",
     props: {
       children: "Hover",
       className: SEGMENTED_BUTTON_HOVER_STATE_CLASSNAME,
     },
+    code: `<SegmentedButton className="${SEGMENTED_BUTTON_HOVER_STATE_CLASSNAME}">Hover</SegmentedButton>`,
   },
-  { label: "Active", props: { children: "Active", selected: true } },
   {
-    label: "Focus-visible",
+    id: "active",
+    name: "Active",
+    props: { children: "Active", selected: true },
+    code: "<SegmentedButton selected>Active</SegmentedButton>",
+  },
+  {
+    id: "focus-visible",
+    name: "Focus-visible",
     props: {
       children: "Focus-visible",
       className: SEGMENTED_BUTTON_FOCUS_VISIBLE_STATE_CLASSNAME,
     },
+    code: `<SegmentedButton className="${SEGMENTED_BUTTON_FOCUS_VISIBLE_STATE_CLASSNAME}">Focus-visible</SegmentedButton>`,
   },
-  { label: "Disabled", props: { children: "Disabled", disabled: true } },
-  { label: "Loading", props: { children: "Loading", loading: true } },
+  {
+    id: "disabled",
+    name: "Disabled",
+    props: { children: "Disabled", disabled: true },
+    code: "<SegmentedButton disabled>Disabled</SegmentedButton>",
+  },
+  {
+    id: "loading",
+    name: "Loading",
+    props: { children: "Loading", loading: true },
+    code: "<SegmentedButton loading>Loading</SegmentedButton>",
+  },
 ];
+
+function SegmentedButtonStatePreview({
+  state,
+}: {
+  state: SegmentedButtonStateSpec;
+}) {
+  return <SegmentedButton {...state.props} />;
+}
 
 function SegmentedButtonGalleryPreview() {
   return (
     <div className="flex flex-wrap gap-[var(--space-2)]">
-      {SEGMENTED_BUTTON_STATES.map(({ label, props }) => (
-        <SegmentedButton key={label} {...props} />
+      {SEGMENTED_BUTTON_STATES.map((state) => (
+        <SegmentedButtonStatePreview key={state.id} state={state} />
       ))}
     </div>
   );
@@ -65,13 +101,22 @@ export default defineGallerySection({
           id: "state",
           label: "State",
           type: "state",
-          values: SEGMENTED_BUTTON_STATES.map(({ label }) => ({ value: label })),
+          values: SEGMENTED_BUTTON_STATES.map(({ name }) => ({ value: name })),
         },
       ],
       preview: createGalleryPreview({
         id: "ui:segmented-button:states",
         render: () => <SegmentedButtonGalleryPreview />,
       }),
+      states: SEGMENTED_BUTTON_STATES.map((state) => ({
+        id: state.id,
+        name: state.name,
+        code: state.code,
+        preview: createGalleryPreview({
+          id: `ui:segmented-button:state:${state.id}`,
+          render: () => <SegmentedButtonStatePreview state={state} />,
+        }),
+      })),
       code: `<div className="flex flex-wrap gap-[var(--space-2)]">
   <SegmentedButton>Default</SegmentedButton>
   <SegmentedButton className="${SEGMENTED_BUTTON_HOVER_STATE_CLASSNAME}">Hover</SegmentedButton>

--- a/src/components/ui/primitives/Tabs.gallery.tsx
+++ b/src/components/ui/primitives/Tabs.gallery.tsx
@@ -37,6 +37,111 @@ type PanelCardProps = {
   description: string;
 };
 
+type TabsStateSpec = {
+  id: string;
+  name: string;
+  value: StatusTabKey;
+  items: readonly TabListItem<StatusTabKey>[];
+  code?: string;
+};
+
+const TABS_STATE_ITEMS: Record<
+  "active" | "focus-visible" | "disabled" | "loading",
+  readonly TabListItem<StatusTabKey>[]
+> = {
+  active: [
+    { key: "inbox", label: "Inbox" },
+    { key: "updates", label: "Updates" },
+  ],
+  "focus-visible": [
+    { key: "inbox", label: "Inbox" },
+    { key: "updates", label: "Updates", className: focusVisibleClassName },
+  ],
+  disabled: [
+    { key: "inbox", label: "Inbox" },
+    { key: "disabled", label: "Disabled", disabled: true },
+  ],
+  loading: [
+    { key: "inbox", label: "Inbox" },
+    { key: "sync", label: "Syncing", loading: true },
+  ],
+};
+
+const TABS_STATES: readonly TabsStateSpec[] = [
+  {
+    id: "active",
+    name: "Active",
+    value: "updates",
+    items: TABS_STATE_ITEMS.active,
+    code: `<Tabs value="updates" onValueChange={() => {}}>
+  <TabList
+    ariaLabel="Tab state preview"
+    items={[
+      { key: "inbox", label: "Inbox" },
+      { key: "updates", label: "Updates" },
+    ]}
+    linkPanels={false}
+    showBaseline
+  />
+</Tabs>`,
+  },
+  {
+    id: "focus-visible",
+    name: "Focus-visible",
+    value: "inbox",
+    items: TABS_STATE_ITEMS["focus-visible"],
+    code: `<Tabs value="inbox" onValueChange={() => {}}>
+  <TabList
+    ariaLabel="Tab state preview"
+    items={[
+      { key: "inbox", label: "Inbox" },
+      {
+        key: "updates",
+        label: "Updates",
+        className: "${focusVisibleClassName}",
+      },
+    ]}
+    linkPanels={false}
+    showBaseline
+  />
+</Tabs>`,
+  },
+  {
+    id: "disabled",
+    name: "Disabled",
+    value: "inbox",
+    items: TABS_STATE_ITEMS.disabled,
+    code: `<Tabs value="inbox" onValueChange={() => {}}>
+  <TabList
+    ariaLabel="Tab state preview"
+    items={[
+      { key: "inbox", label: "Inbox" },
+      { key: "disabled", label: "Disabled", disabled: true },
+    ]}
+    linkPanels={false}
+    showBaseline
+  />
+</Tabs>`,
+  },
+  {
+    id: "loading",
+    name: "Loading",
+    value: "inbox",
+    items: TABS_STATE_ITEMS.loading,
+    code: `<Tabs value="inbox" onValueChange={() => {}}>
+  <TabList
+    ariaLabel="Tab state preview"
+    items={[
+      { key: "inbox", label: "Inbox" },
+      { key: "sync", label: "Syncing", loading: true },
+    ]}
+    linkPanels={false}
+    showBaseline
+  />
+</Tabs>`,
+  },
+];
+
 function PanelCard({ title, description }: PanelCardProps) {
   return (
     <Card className="space-y-[var(--space-2)]">
@@ -92,6 +197,21 @@ function TabsGalleryPreview() {
   );
 }
 
+function TabsStatePreview({ state }: { state: TabsStateSpec }) {
+  return (
+    <Tabs value={state.value} onValueChange={() => {}}>
+      <div className="space-y-[var(--space-3)]">
+        <TabList
+          ariaLabel="Tab state preview"
+          items={[...state.items]}
+          linkPanels={false}
+          showBaseline
+        />
+      </div>
+    </Tabs>
+  );
+}
+
 export default defineGallerySection({
   id: "toggles",
   entries: [
@@ -115,18 +235,22 @@ export default defineGallerySection({
           id: "state",
           label: "State",
           type: "state",
-          values: [
-            { value: "Active" },
-            { value: "Focus-visible" },
-            { value: "Disabled" },
-            { value: "Loading" },
-          ],
+          values: TABS_STATES.map(({ name }) => ({ value: name })),
         },
       ],
       preview: createGalleryPreview({
         id: "ui:tabs:wiring",
         render: () => <TabsGalleryPreview />,
       }),
+      states: TABS_STATES.map((state) => ({
+        id: state.id,
+        name: state.name,
+        code: state.code,
+        preview: createGalleryPreview({
+          id: `ui:tabs:state:${state.id}`,
+          render: () => <TabsStatePreview state={state} />,
+        }),
+      })),
       code: `<Tabs defaultValue="overview">
   <div className="space-y-[var(--space-3)]">
     <TabList

--- a/src/components/ui/primitives/Textarea.gallery.tsx
+++ b/src/components/ui/primitives/Textarea.gallery.tsx
@@ -4,72 +4,88 @@ import { createGalleryPreview, defineGallerySection } from "@/components/gallery
 
 import Textarea from "./Textarea";
 
-const TEXTAREA_STATES = [
-  {
-    label: "Default",
-    className: undefined,
-    textareaClassName: undefined,
-    props: { placeholder: "Share your thoughts" },
-  },
-  {
-    label: "Hover",
-    className: "bg-[--hover]",
-    textareaClassName: undefined,
-    props: { placeholder: "Hover" },
-  },
-  {
-    label: "Focus-visible",
-    className: "ring-2 ring-[hsl(var(--ring))]",
-    textareaClassName: undefined,
-    props: { placeholder: "Focus-visible" },
-  },
-  {
-    label: "Active",
-    className: "bg-[--active]",
-    textareaClassName: undefined,
-    props: { placeholder: "Active" },
-  },
-  {
-    label: "Invalid",
-    className: "ring-2 ring-[hsl(var(--danger))]",
-    textareaClassName: undefined,
-    props: { placeholder: "Needs attention", "aria-invalid": true },
-  },
-  {
-    label: "Read-only",
-    className: "bg-[hsl(var(--card)/0.72)]",
-    textareaClassName: "text-muted-foreground",
-    props: { placeholder: "Read-only", readOnly: true },
-  },
-  {
-    label: "Disabled",
-    className: undefined,
-    textareaClassName: undefined,
-    props: { placeholder: "Disabled", disabled: true },
-  },
-  {
-    label: "Loading",
-    className: undefined,
-    textareaClassName: undefined,
-    props: { placeholder: "Loading", "data-loading": true },
-  },
-] satisfies ReadonlyArray<{
-  label: string;
+type TextareaStateSpec = {
+  id: string;
+  name: string;
   className?: string;
   textareaClassName?: string;
   props: React.ComponentProps<typeof Textarea>;
-}>;
+  code?: string;
+};
+
+const TEXTAREA_STATES: readonly TextareaStateSpec[] = [
+  {
+    id: "default",
+    name: "Default",
+    props: { placeholder: "Share your thoughts" },
+    code: "<Textarea placeholder=\"Share your thoughts\" />",
+  },
+  {
+    id: "hover",
+    name: "Hover",
+    className: "bg-[--hover]",
+    props: { placeholder: "Hover" },
+    code: "<Textarea className=\"bg-[--hover]\" placeholder=\"Hover\" />",
+  },
+  {
+    id: "focus-visible",
+    name: "Focus-visible",
+    className: "ring-2 ring-[hsl(var(--ring))]",
+    props: { placeholder: "Focus-visible" },
+    code: "<Textarea className=\"ring-2 ring-[hsl(var(--ring))]\" placeholder=\"Focus-visible\" />",
+  },
+  {
+    id: "active",
+    name: "Active",
+    className: "bg-[--active]",
+    props: { placeholder: "Active" },
+    code: "<Textarea className=\"bg-[--active]\" placeholder=\"Active\" />",
+  },
+  {
+    id: "invalid",
+    name: "Invalid",
+    className: "ring-2 ring-[hsl(var(--danger))]",
+    props: { placeholder: "Needs attention", "aria-invalid": true },
+    code: "<Textarea\n  className=\"ring-2 ring-[hsl(var(--danger))]\"\n  placeholder=\"Needs attention\"\n  aria-invalid\n/>",
+  },
+  {
+    id: "read-only",
+    name: "Read-only",
+    className: "bg-[hsl(var(--card)/0.72)]",
+    textareaClassName: "text-muted-foreground",
+    props: { placeholder: "Read-only", readOnly: true },
+    code: "<Textarea\n  className=\"bg-[hsl(var(--card)/0.72)]\"\n  textareaClassName=\"text-muted-foreground\"\n  readOnly\n  placeholder=\"Read-only\"\n/>",
+  },
+  {
+    id: "disabled",
+    name: "Disabled",
+    props: { placeholder: "Disabled", disabled: true },
+    code: "<Textarea placeholder=\"Disabled\" disabled />",
+  },
+  {
+    id: "loading",
+    name: "Loading",
+    props: { placeholder: "Loading", "data-loading": true },
+    code: "<Textarea placeholder=\"Loading\" data-loading />",
+  },
+];
+
+function TextareaStatePreview({ state }: { state: TextareaStateSpec }) {
+  const { className, textareaClassName, props } = state;
+  return (
+    <Textarea
+      className={className}
+      textareaClassName={textareaClassName}
+      {...props}
+    />
+  );
+}
 
 function TextareaGalleryPreview() {
   return (
     <div className="flex flex-col gap-[var(--space-2)]">
-      {TEXTAREA_STATES.map(({ label, className, textareaClassName, props }) => (
-        <Textarea
-          key={label}
-          className={className}
-          textareaClassName={textareaClassName}
-          {...props}
-        />
+      {TEXTAREA_STATES.map((state) => (
+        <TextareaStatePreview key={state.id} state={state} />
       ))}
       <Textarea
         placeholder="Resizable textarea"
@@ -105,13 +121,22 @@ export default defineGallerySection({
           id: "state",
           label: "State",
           type: "state",
-          values: TEXTAREA_STATES.map(({ label }) => ({ value: label })),
+          values: TEXTAREA_STATES.map(({ name }) => ({ value: name })),
         },
       ],
       preview: createGalleryPreview({
         id: "ui:textarea:states",
         render: () => <TextareaGalleryPreview />,
       }),
+      states: TEXTAREA_STATES.map((state) => ({
+        id: state.id,
+        name: state.name,
+        code: state.code,
+        preview: createGalleryPreview({
+          id: `ui:textarea:state:${state.id}`,
+          render: () => <TextareaStatePreview state={state} />,
+        }),
+      })),
       code: `<Textarea placeholder="Share your thoughts" />
 <Textarea placeholder="Hover" className="bg-[--hover]" />
 <Textarea placeholder="Focus-visible" className="ring-2 ring-[hsl(var(--ring))]" />


### PR DESCRIPTION
## Summary
- add explicit state specs and previews for the interactive primitive galleries so hover, focus, active, disabled, and loading demos are named and reusable
- reuse shared helpers for field and search bar state cards while adding the hover state and keeping previews in sync with their real components
- update the select and tabs galleries and regenerate the gallery manifest so the new state previews are registered

## Testing
- npm run build-gallery-usage
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d10646a938832ca9dac8091f8e8f9d