### PR TITLE
Expand gallery usage coverage

### DIFF
--- a/scripts/build-gallery-usage.ts
+++ b/scripts/build-gallery-usage.ts
@@ -192,24 +192,21 @@ type UsageMap = Record<string, readonly string[]>;
 type NameToIdsMap = Map<string, readonly string[]>;
 
 function buildNameLookup(sections: readonly GallerySerializableSection[]): {
-  readonly complexEntries: readonly GallerySerializableEntry[];
+  readonly entries: readonly GallerySerializableEntry[];
   readonly nameToIds: NameToIdsMap;
 } {
-  const complexEntries: GallerySerializableEntry[] = [];
+  const entries: GallerySerializableEntry[] = [];
   const nameToIds = new Map<string, string[]>();
   for (const section of sections) {
     for (const entry of section.entries) {
-      if (entry.kind !== "complex") {
-        continue;
-      }
-      complexEntries.push(entry);
+      entries.push(entry);
       const list = nameToIds.get(entry.name) ?? [];
       list.push(entry.id);
       nameToIds.set(entry.name, list);
     }
   }
   return {
-    complexEntries,
+    entries,
     nameToIds,
   };
 }
@@ -217,9 +214,9 @@ function buildNameLookup(sections: readonly GallerySerializableSection[]): {
 async function buildUsage(
   sections: readonly GallerySerializableSection[],
 ): Promise<UsageMap> {
-  const { complexEntries, nameToIds } = buildNameLookup(sections);
+  const { entries, nameToIds } = buildNameLookup(sections);
   const usage = new Map<string, Set<string>>();
-  for (const entry of complexEntries) {
+  for (const entry of entries) {
     usage.set(entry.id, new Set<string>());
   }
 
@@ -240,7 +237,7 @@ async function buildUsage(
   }
 
   const record: UsageMap = {};
-  for (const entry of complexEntries) {
+  for (const entry of entries) {
     const routes = Array.from(
       usage.get(entry.id) ?? new Set<string>(),
     ).sort((a, b) => a.localeCompare(b));
@@ -360,9 +357,7 @@ async function main(): Promise<void> {
   await fs.writeFile(usageFile, `${JSON.stringify(usage, null, 2)}\n`);
   await buildGalleryManifest(modules, registry.payload);
   await writeManifest([...new Set(trackedFiles)]);
-  console.log(
-    `Built gallery usage for ${Object.keys(usage).length} complex entries`,
-  );
+  console.log(`Built gallery usage for ${Object.keys(usage).length} entries`);
 }
 
 main().catch((error) => {

--- a/src/components/gallery/generated-manifest.ts
+++ b/src/components/gallery/generated-manifest.ts
@@ -300,6 +300,33 @@ export const galleryPayload = {
       "id": "planner",
       "entries": [
         {
+          "id": "week-picker",
+          "name": "WeekPicker",
+          "description": "Sticky hero shell preview showing week totals, mock chips, and the jump-to-top action.",
+          "tags": [
+            "planner",
+            "navigation",
+            "week"
+          ],
+          "kind": "complex",
+          "code": "<WeekPickerDemo />",
+          "usage": [
+            {
+              "kind": "do",
+              "title": "Keep week totals visible",
+              "description": "Pair the hero subtitle with aggregated task counts so the picker summarizes week progress at a glance."
+            },
+            {
+              "kind": "do",
+              "title": "Highlight today's chip",
+              "description": "Use the accent token on the current day to anchor focus while other chips mock mixed completion states."
+            }
+          ],
+          "preview": {
+            "id": "prompts:planner:week-picker"
+          }
+        },
+        {
           "id": "bottom-nav",
           "name": "BottomNav",
           "description": "Mobile Planner nav demo showing active, hover, focus-visible, disabled, and syncing tabs styled with tokens.",
@@ -4524,6 +4551,33 @@ export const galleryPayload = {
     ],
     "complex": [
       {
+        "id": "week-picker",
+        "name": "WeekPicker",
+        "description": "Sticky hero shell preview showing week totals, mock chips, and the jump-to-top action.",
+        "tags": [
+          "planner",
+          "navigation",
+          "week"
+        ],
+        "kind": "complex",
+        "code": "<WeekPickerDemo />",
+        "usage": [
+          {
+            "kind": "do",
+            "title": "Keep week totals visible",
+            "description": "Pair the hero subtitle with aggregated task counts so the picker summarizes week progress at a glance."
+          },
+          {
+            "kind": "do",
+            "title": "Highlight today's chip",
+            "description": "Use the accent token on the current day to anchor focus while other chips mock mixed completion states."
+          }
+        ],
+        "preview": {
+          "id": "prompts:planner:week-picker"
+        }
+      },
+      {
         "id": "bottom-nav",
         "name": "BottomNav",
         "description": "Mobile Planner nav demo showing active, hover, focus-visible, disabled, and syncing tabs styled with tokens.",
@@ -5417,6 +5471,7 @@ export const galleryPreviewModules = [
       "prompts:prompts:prompts-compose-panel:state:compose-error",
       "prompts:prompts:prompts-compose-panel:state:compose-empty",
       "prompts:prompts:prompts-demos",
+      "prompts:planner:week-picker",
       "prompts:planner:bottom-nav",
       "prompts:planner:bottom-nav:state:active",
       "prompts:planner:bottom-nav:state:hover",

--- a/src/components/gallery/usage.json
+++ b/src/components/gallery/usage.json
@@ -1,5 +1,39 @@
 {
+  "prompt-list": [],
+  "prompts-header": [],
+  "prompts-compose-panel": [],
+  "prompts-demos": [],
+  "week-picker": [],
   "bottom-nav": [],
+  "card-demo": [],
+  "neo-card-demo": [],
+  "section-card-variants": [],
+  "page-shell": [
+    "/",
+    "/components"
+  ],
+  "sheet-demo": [],
+  "modal-demo": [],
+  "split": [],
+  "title-bar": [],
+  "neomorphic-hero-frame": [],
+  "page-header-demo": [
+    "/"
+  ],
+  "demo-header": [],
+  "hero": [],
+  "progress": [],
+  "outline-glow": [],
+  "snackbar": [],
+  "toast-demo": [],
+  "skeleton": [],
+  "spinner": [
+    "/",
+    "/components"
+  ],
+  "toggle": [],
+  "animation-toggle": [],
+  "check-circle": [],
   "dashboard-card": [],
   "dashboard-list": [],
   "isometric-room": [],
@@ -35,7 +69,23 @@
   "theme-toggle": [
     "/"
   ],
-  "week-picker": [
-    "/prompts"
-  ]
+  "cat-companion": [
+    "/"
+  ],
+  "header-tabs": [],
+  "label": [],
+  "select": [],
+  "header": [],
+  "tab-bar": [],
+  "badge": [],
+  "button": [
+    "/"
+  ],
+  "field": [],
+  "icon-button": [],
+  "input": [],
+  "search-bar": [],
+  "segmented-button": [],
+  "tabs": [],
+  "textarea": []
 }

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -96,5 +96,6 @@ export { default as IconButtonGallery } from "./primitives/IconButton.gallery";
 export { default as InputGallery } from "./primitives/Input.gallery";
 export { default as SearchBarGallery } from "./primitives/SearchBar.gallery";
 export { default as SegmentedButtonGallery } from "./primitives/SegmentedButton.gallery";
+export { default as TabsGallery } from "./primitives/Tabs.gallery";
 export { default as TextareaGallery } from "./primitives/Textarea.gallery";
 export { default as SelectGallery } from "./Select.gallery";


### PR DESCRIPTION
## Summary
- index all gallery entries when building the name lookup so usage can be tracked for primitives, components, complex entries, and tokens
- regenerate the usage manifest so every gallery entry id is present with its associated routes
- refresh the gallery manifest/UI index by rerunning the gallery usage build script

## Testing
- `npm run build-gallery-usage`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68d10878d290832ca42c28bacfb01130