### PR TITLE
Adjust SiteChrome globals import order

### DIFF
--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import "@/app/globals.css";
 import * as React from "react";
 import NavBar from "@/components/chrome/NavBar";
 import BottomNav from "@/components/chrome/BottomNav";
@@ -8,7 +9,6 @@ import ThemeToggle from "@/components/ui/theme/ThemeToggle";
 import AnimationToggle from "@/components/ui/AnimationToggle";
 import { PageShell } from "@/components/ui";
 import Link from "next/link";
-import "@/app/globals.css";
 
 /**
  * SiteChrome — sticky top bar with Lavender-Glitch hairline


### PR DESCRIPTION
## Summary
- move the globals stylesheet import immediately below the client directive in `SiteChrome` to avoid duplicate entries

## Testing
- npm run lint
- CI=1 npm run build
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d112aec8dc832cae836a6e72dc646d