### PR TITLE
Center Suspense fallback spinners

### DIFF
--- a/src/app/components/page.tsx
+++ b/src/app/components/page.tsx
@@ -13,7 +13,7 @@ export default function ComponentsRoute() {
     <Suspense
       fallback={
         <PageShell as="main" aria-busy="true">
-          <div className="flex justify-center p-[var(--space-5)]">
+          <div className="flex items-center justify-center p-[var(--space-5)]">
             <Spinner />
           </div>
         </PageShell>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -105,7 +105,7 @@ export default function Page() {
     <Suspense
       fallback={
         <PageShell as="main" aria-busy="true">
-          <div className="flex justify-center p-[var(--space-6)]">
+          <div className="flex items-center justify-center p-[var(--space-6)]">
             <Spinner />
           </div>
         </PageShell>


### PR DESCRIPTION
## Summary
- center the Suspense fallback spinners on the home and components routes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d11389a1f8832cb2ec53c518995a44