### PR TITLE
Enhance nav active affordances

### DIFF
--- a/src/components/chrome/BottomNav.tsx
+++ b/src/components/chrome/BottomNav.tsx
@@ -40,7 +40,7 @@ export default function BottomNav({
                 aria-current={active ? "page" : undefined}
                 data-active={active}
                 className={cn(
-                  "group flex min-h-[var(--control-h-lg)] flex-col items-center gap-[var(--space-1)] rounded-card r-card-md px-[var(--space-5)] py-[var(--space-3)] text-label font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none",
+                  "group flex min-h-[var(--control-h-lg)] flex-col items-center gap-[var(--space-1)] rounded-card r-card-md px-[var(--space-5)] py-[var(--space-3)] text-label font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] focus-visible:ring-offset-0 motion-safe:hover:-translate-y-0.5 motion-reduce:transform-none hover:bg-interaction-accent-surfaceHover active:bg-interaction-accent-surfaceActive active:text-foreground",
                   active
                     ? "text-accent-3 ring-2 ring-[var(--focus)]"
                     : "text-muted-foreground hover:text-foreground"

--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -37,12 +37,12 @@ export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
                 href={href}
                 aria-current={active ? "page" : undefined}
                 className={cn(
-                  "group relative inline-flex min-h-[var(--control-h-lg)] items-center rounded-[var(--radius-2xl)] border px-[var(--space-4)] py-[var(--space-3)] font-mono text-ui transition motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  "group relative inline-flex min-h-[var(--control-h-lg)] items-center rounded-[var(--radius-2xl)] border px-[var(--space-4)] py-[var(--space-3)] font-mono text-ui transition motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:bg-interaction-focus-surfaceActive active:text-foreground",
                   "bg-[hsl(var(--card)/0.85)]",
                   "supports-[background:color-mix(in_oklab,hsl(var(--card))_85%,transparent)]:bg-[color:color-mix(in_oklab,hsl(var(--card))_85%,transparent)]",
                   active
                     ? "text-foreground border-ring shadow-nav-active"
-                    : "text-muted-foreground border-transparent hover:border-border",
+                    : "text-muted-foreground border-transparent hover:border-border hover:bg-interaction-focus-surfaceHover",
                 )}
               >
                 <span className="relative z-10">{label}</span>


### PR DESCRIPTION
## Summary
- add focus-surface active background and foreground tokens to the shared NavBar link class while tinting inactive links on hover
- extend BottomNav links with accent hover/active surface tokens for press states

## Testing
- npm run check
- manual desktop and mobile nav spot-check


------
https://chatgpt.com/codex/tasks/task_e_68d112a16c84832c99ca7b4f3117180e