### PR TITLE
Add hover state preview to tabs gallery

### DIFF
--- a/src/components/gallery/generated-manifest.ts
+++ b/src/components/gallery/generated-manifest.ts
@@ -2195,6 +2195,9 @@ export const galleryPayload = {
                   "value": "Active"
                 },
                 {
+                  "value": "Hover"
+                },
+                {
                   "value": "Focus-visible"
                 },
                 {
@@ -2217,6 +2220,14 @@ export const galleryPayload = {
               "code": "<Tabs value=\"updates\" onValueChange={() => {}}>\n  <TabList\n    ariaLabel=\"Tab state preview\"\n    items={[\n      { key: \"inbox\", label: \"Inbox\" },\n      { key: \"updates\", label: \"Updates\" },\n    ]}\n    linkPanels={false}\n    showBaseline\n  />\n</Tabs>",
               "preview": {
                 "id": "ui:tabs:state:active"
+              }
+            },
+            {
+              "id": "hover",
+              "name": "Hover",
+              "code": "<Tabs value=\"inbox\" onValueChange={() => {}}>\n  <TabList\n    ariaLabel=\"Tab state preview\"\n    items={[\n      { key: \"inbox\", label: \"Inbox\" },\n      {\n        key: \"updates\",\n        label: \"Updates\",\n        className: \"text-foreground bg-[--hover] shadow-[var(--tab-shadow-hover,var(--tab-shadow))]\",\n      },\n    ]}\n    linkPanels={false}\n    showBaseline\n  />\n</Tabs>",
+              "preview": {
+                "id": "ui:tabs:state:hover"
               }
             },
             {
@@ -4493,6 +4504,9 @@ export const galleryPayload = {
                 "value": "Active"
               },
               {
+                "value": "Hover"
+              },
+              {
                 "value": "Focus-visible"
               },
               {
@@ -4515,6 +4529,14 @@ export const galleryPayload = {
             "code": "<Tabs value=\"updates\" onValueChange={() => {}}>\n  <TabList\n    ariaLabel=\"Tab state preview\"\n    items={[\n      { key: \"inbox\", label: \"Inbox\" },\n      { key: \"updates\", label: \"Updates\" },\n    ]}\n    linkPanels={false}\n    showBaseline\n  />\n</Tabs>",
             "preview": {
               "id": "ui:tabs:state:active"
+            }
+          },
+          {
+            "id": "hover",
+            "name": "Hover",
+            "code": "<Tabs value=\"inbox\" onValueChange={() => {}}>\n  <TabList\n    ariaLabel=\"Tab state preview\"\n    items={[\n      { key: \"inbox\", label: \"Inbox\" },\n      {\n        key: \"updates\",\n        label: \"Updates\",\n        className: \"text-foreground bg-[--hover] shadow-[var(--tab-shadow-hover,var(--tab-shadow))]\",\n      },\n    ]}\n    linkPanels={false}\n    showBaseline\n  />\n</Tabs>",
+            "preview": {
+              "id": "ui:tabs:state:hover"
             }
           },
           {
@@ -6606,6 +6628,7 @@ export const galleryPreviewModules = [
     previewIds: [
       "ui:tabs:wiring",
       "ui:tabs:state:active",
+      "ui:tabs:state:hover",
       "ui:tabs:state:focus-visible",
       "ui:tabs:state:disabled",
       "ui:tabs:state:loading",

--- a/src/components/ui/primitives/Tabs.gallery.tsx
+++ b/src/components/ui/primitives/Tabs.gallery.tsx
@@ -9,6 +9,8 @@ type ProjectTabKey = "overview" | "activity" | "files";
 type StatusTabKey = "inbox" | "updates" | "archive" | "disabled" | "sync";
 
 const focusVisibleClassName = "ring-2 ring-[var(--theme-ring)] ring-offset-0 outline-none";
+const hoverClassName =
+  "text-foreground bg-[--hover] shadow-[var(--tab-shadow-hover,var(--tab-shadow))]";
 
 const projectTabs: TabListItem<ProjectTabKey>[] = [
   { key: "overview", label: "Overview" },
@@ -46,12 +48,16 @@ type TabsStateSpec = {
 };
 
 const TABS_STATE_ITEMS: Record<
-  "active" | "focus-visible" | "disabled" | "loading",
+  "active" | "hover" | "focus-visible" | "disabled" | "loading",
   readonly TabListItem<StatusTabKey>[]
 > = {
   active: [
     { key: "inbox", label: "Inbox" },
     { key: "updates", label: "Updates" },
+  ],
+  hover: [
+    { key: "inbox", label: "Inbox" },
+    { key: "updates", label: "Updates", className: hoverClassName },
   ],
   "focus-visible": [
     { key: "inbox", label: "Inbox" },
@@ -79,6 +85,27 @@ const TABS_STATES: readonly TabsStateSpec[] = [
     items={[
       { key: "inbox", label: "Inbox" },
       { key: "updates", label: "Updates" },
+    ]}
+    linkPanels={false}
+    showBaseline
+  />
+</Tabs>`,
+  },
+  {
+    id: "hover",
+    name: "Hover",
+    value: "inbox",
+    items: TABS_STATE_ITEMS.hover,
+    code: `<Tabs value="inbox" onValueChange={() => {}}>
+  <TabList
+    ariaLabel="Tab state preview"
+    items={[
+      { key: "inbox", label: "Inbox" },
+      {
+        key: "updates",
+        label: "Updates",
+        className: "${hoverClassName}",
+      },
     ]}
     linkPanels={false}
     showBaseline


### PR DESCRIPTION
## Summary
- add a hover state entry for the Tabs gallery that reuses the live hover styling
- regenerate the gallery manifest so the new hover preview and axis value are registered

## Testing
- npm run build-gallery-usage
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d11f85d04c832c8b1dd03ff60196b7