### PR TITLE
Preserve hash when syncing theme query

### DIFF
--- a/src/lib/theme-hooks.ts
+++ b/src/lib/theme-hooks.ts
@@ -52,6 +52,10 @@ export function useThemeQuerySync() {
     const nextParams = new URLSearchParams(params);
     nextParams.set("theme", theme.variant);
     nextParams.set("bg", String(theme.bg));
-    router.replace(`${pathname}?${nextParams.toString()}`, { scroll: false });
+    const queryString = nextParams.toString();
+    const hashFragment =
+      typeof window !== "undefined" ? window.location.hash ?? "" : "";
+    const nextUrl = queryString ? `${pathname}?${queryString}` : pathname;
+    router.replace(`${nextUrl}${hashFragment}`, { scroll: false });
   }, [theme, router, pathname, params]);
 }

--- a/tests/lib/useThemeQuerySync.test.tsx
+++ b/tests/lib/useThemeQuerySync.test.tsx
@@ -35,6 +35,7 @@ describe("useThemeQuerySync", () => {
     pathname = "/planner";
     replaceSpy.mockClear();
     resetLocalStorage();
+    window.location.hash = "";
   });
 
   it("applies valid theme and background query params", async () => {
@@ -104,5 +105,29 @@ describe("useThemeQuerySync", () => {
     });
 
     expect(replaceSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the current hash fragment when toggling the theme", async () => {
+    searchParamsString = new URLSearchParams({ theme: "lg", bg: "0" }).toString();
+    window.location.hash = "#section-42";
+
+    const { result } = renderThemeSync();
+
+    await waitFor(() => {
+      const [theme] = result.current;
+      expect(theme.variant).toBe("lg");
+      expect(theme.bg).toBe(0);
+    });
+
+    act(() => {
+      const [, setTheme] = result.current;
+      setTheme((prev) => ({ ...prev, variant: "ocean", bg: 1 }));
+    });
+
+    await waitFor(() => {
+      expect(replaceSpy).toHaveBeenCalledWith("/planner?theme=ocean&bg=1#section-42", {
+        scroll: false,
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- append the current hash fragment when syncing theme query parameters to the URL
- guard the hash retrieval for server builds while keeping existing SSR safety
- add a test ensuring theme toggles keep any existing hash fragment

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d127d5c1b4832c8417307c71a56c26