### PR TITLE
Add TabBar gallery states

### DIFF
--- a/src/components/gallery/generated-manifest.ts
+++ b/src/components/gallery/generated-manifest.ts
@@ -2144,6 +2144,12 @@ export const galleryPayload = {
               "type": "state",
               "values": [
                 {
+                  "value": "Default"
+                },
+                {
+                  "value": "Hover"
+                },
+                {
                   "value": "Active"
                 },
                 {
@@ -2161,7 +2167,57 @@ export const galleryPayload = {
           "code": "<TabBar\n  items={[\n    { key: \"all\", label: \"All\", icon: <Circle aria-hidden=\"true\" /> },\n    { key: \"active\", label: \"Active\", icon: <CircleDot aria-hidden=\"true\" /> },\n    { key: \"done\", label: \"Done\", icon: <CircleCheck aria-hidden=\"true\" /> },\n    {\n      key: \"focus\",\n      label: \"Focus-visible\",\n      icon: <Circle aria-hidden=\"true\" />,\n      className: \"ring-2 ring-[var(--theme-ring)] ring-offset-0 outline-none\",\n    },\n  ]}\n  value=\"active\"\n  onValueChange={() => {}}\n  ariaLabel=\"Filter goals\"\n/>\n\n<TabBar\n  items={[\n    { key: \"a\", label: \"A\" },\n    { key: \"b\", label: \"B\" },\n    { key: \"focus\", label: \"Focus-visible\", className: \"ring-2 ring-[var(--theme-ring)] ring-offset-0 outline-none\" },\n    { key: \"c\", label: \"Disabled\", disabled: true },\n    { key: \"d\", label: \"Syncing\", loading: true },\n  ]}\n  value=\"a\"\n  onValueChange={() => {}}\n  ariaLabel=\"Example tabs\"\n/>\n\n<TabBar\n  items={[\n    { key: \"reviews\", label: \"Reviews\" },\n    { key: \"planner\", label: \"Planner\" },\n    { key: \"goals\", label: \"Goals\" },\n    { key: \"focus\", label: \"Focus-visible\", className: \"ring-2 ring-[var(--theme-ring)] ring-offset-0 outline-none\" },\n  ]}\n  value=\"reviews\"\n  onValueChange={() => {}}\n  ariaLabel=\"Planner areas\"\n/>",
           "preview": {
             "id": "ui:tab-bar:variants"
-          }
+          },
+          "states": [
+            {
+              "id": "default",
+              "name": "Default",
+              "code": "<TabBar\n  items={[\n    { key: \"today\", label: \"Today\" },\n    { key: \"upcoming\", label: \"Upcoming\" },\n    { key: \"backlog\", label: \"Backlog\" },\n  ]}\n  value=\"today\"\n  onValueChange={() => {}}\n  ariaLabel=\"Tab state preview\"\n/>",
+              "preview": {
+                "id": "ui:tab-bar:state:default"
+              }
+            },
+            {
+              "id": "hover",
+              "name": "Hover",
+              "code": "<TabBar\n  items={[\n    { key: \"today\", label: \"Today\" },\n    { key: \"hover\", label: \"Hover\", className: \"text-foreground bg-[--hover] shadow-[var(--tab-shadow-hover,var(--tab-shadow))]\" },\n    { key: \"backlog\", label: \"Backlog\" },\n  ]}\n  value=\"today\"\n  onValueChange={() => {}}\n  ariaLabel=\"Tab state preview\"\n/>",
+              "preview": {
+                "id": "ui:tab-bar:state:hover"
+              }
+            },
+            {
+              "id": "active",
+              "name": "Active",
+              "code": "<TabBar\n  items={[\n    { key: \"today\", label: \"Today\" },\n    { key: \"active\", label: \"Active\" },\n    { key: \"backlog\", label: \"Backlog\" },\n  ]}\n  value=\"active\"\n  onValueChange={() => {}}\n  ariaLabel=\"Tab state preview\"\n/>",
+              "preview": {
+                "id": "ui:tab-bar:state:active"
+              }
+            },
+            {
+              "id": "focus-visible",
+              "name": "Focus-visible",
+              "code": "<TabBar\n  items={[\n    { key: \"today\", label: \"Today\" },\n    { key: \"focus\", label: \"Focus-visible\", className: \"ring-2 ring-[var(--theme-ring)] ring-offset-0 outline-none\" },\n    { key: \"backlog\", label: \"Backlog\" },\n  ]}\n  value=\"today\"\n  onValueChange={() => {}}\n  ariaLabel=\"Tab state preview\"\n/>",
+              "preview": {
+                "id": "ui:tab-bar:state:focus-visible"
+              }
+            },
+            {
+              "id": "disabled",
+              "name": "Disabled",
+              "code": "<TabBar\n  items={[\n    { key: \"today\", label: \"Today\" },\n    { key: \"disabled\", label: \"Disabled\", disabled: true },\n    { key: \"backlog\", label: \"Backlog\" },\n  ]}\n  value=\"today\"\n  onValueChange={() => {}}\n  ariaLabel=\"Tab state preview\"\n/>",
+              "preview": {
+                "id": "ui:tab-bar:state:disabled"
+              }
+            },
+            {
+              "id": "loading",
+              "name": "Loading",
+              "code": "<TabBar\n  items={[\n    { key: \"today\", label: \"Today\" },\n    { key: \"loading\", label: \"Loading\", loading: true },\n    { key: \"backlog\", label: \"Backlog\" },\n  ]}\n  value=\"today\"\n  onValueChange={() => {}}\n  ariaLabel=\"Tab state preview\"\n/>",
+              "preview": {
+                "id": "ui:tab-bar:state:loading"
+              }
+            }
+          ]
         },
         {
           "id": "tabs",
@@ -4442,6 +4498,12 @@ export const galleryPayload = {
             "type": "state",
             "values": [
               {
+                "value": "Default"
+              },
+              {
+                "value": "Hover"
+              },
+              {
                 "value": "Active"
               },
               {
@@ -4459,7 +4521,57 @@ export const galleryPayload = {
         "code": "<TabBar\n  items={[\n    { key: \"all\", label: \"All\", icon: <Circle aria-hidden=\"true\" /> },\n    { key: \"active\", label: \"Active\", icon: <CircleDot aria-hidden=\"true\" /> },\n    { key: \"done\", label: \"Done\", icon: <CircleCheck aria-hidden=\"true\" /> },\n    {\n      key: \"focus\",\n      label: \"Focus-visible\",\n      icon: <Circle aria-hidden=\"true\" />,\n      className: \"ring-2 ring-[var(--theme-ring)] ring-offset-0 outline-none\",\n    },\n  ]}\n  value=\"active\"\n  onValueChange={() => {}}\n  ariaLabel=\"Filter goals\"\n/>\n\n<TabBar\n  items={[\n    { key: \"a\", label: \"A\" },\n    { key: \"b\", label: \"B\" },\n    { key: \"focus\", label: \"Focus-visible\", className: \"ring-2 ring-[var(--theme-ring)] ring-offset-0 outline-none\" },\n    { key: \"c\", label: \"Disabled\", disabled: true },\n    { key: \"d\", label: \"Syncing\", loading: true },\n  ]}\n  value=\"a\"\n  onValueChange={() => {}}\n  ariaLabel=\"Example tabs\"\n/>\n\n<TabBar\n  items={[\n    { key: \"reviews\", label: \"Reviews\" },\n    { key: \"planner\", label: \"Planner\" },\n    { key: \"goals\", label: \"Goals\" },\n    { key: \"focus\", label: \"Focus-visible\", className: \"ring-2 ring-[var(--theme-ring)] ring-offset-0 outline-none\" },\n  ]}\n  value=\"reviews\"\n  onValueChange={() => {}}\n  ariaLabel=\"Planner areas\"\n/>",
         "preview": {
           "id": "ui:tab-bar:variants"
-        }
+        },
+        "states": [
+          {
+            "id": "default",
+            "name": "Default",
+            "code": "<TabBar\n  items={[\n    { key: \"today\", label: \"Today\" },\n    { key: \"upcoming\", label: \"Upcoming\" },\n    { key: \"backlog\", label: \"Backlog\" },\n  ]}\n  value=\"today\"\n  onValueChange={() => {}}\n  ariaLabel=\"Tab state preview\"\n/>",
+            "preview": {
+              "id": "ui:tab-bar:state:default"
+            }
+          },
+          {
+            "id": "hover",
+            "name": "Hover",
+            "code": "<TabBar\n  items={[\n    { key: \"today\", label: \"Today\" },\n    { key: \"hover\", label: \"Hover\", className: \"text-foreground bg-[--hover] shadow-[var(--tab-shadow-hover,var(--tab-shadow))]\" },\n    { key: \"backlog\", label: \"Backlog\" },\n  ]}\n  value=\"today\"\n  onValueChange={() => {}}\n  ariaLabel=\"Tab state preview\"\n/>",
+            "preview": {
+              "id": "ui:tab-bar:state:hover"
+            }
+          },
+          {
+            "id": "active",
+            "name": "Active",
+            "code": "<TabBar\n  items={[\n    { key: \"today\", label: \"Today\" },\n    { key: \"active\", label: \"Active\" },\n    { key: \"backlog\", label: \"Backlog\" },\n  ]}\n  value=\"active\"\n  onValueChange={() => {}}\n  ariaLabel=\"Tab state preview\"\n/>",
+            "preview": {
+              "id": "ui:tab-bar:state:active"
+            }
+          },
+          {
+            "id": "focus-visible",
+            "name": "Focus-visible",
+            "code": "<TabBar\n  items={[\n    { key: \"today\", label: \"Today\" },\n    { key: \"focus\", label: \"Focus-visible\", className: \"ring-2 ring-[var(--theme-ring)] ring-offset-0 outline-none\" },\n    { key: \"backlog\", label: \"Backlog\" },\n  ]}\n  value=\"today\"\n  onValueChange={() => {}}\n  ariaLabel=\"Tab state preview\"\n/>",
+            "preview": {
+              "id": "ui:tab-bar:state:focus-visible"
+            }
+          },
+          {
+            "id": "disabled",
+            "name": "Disabled",
+            "code": "<TabBar\n  items={[\n    { key: \"today\", label: \"Today\" },\n    { key: \"disabled\", label: \"Disabled\", disabled: true },\n    { key: \"backlog\", label: \"Backlog\" },\n  ]}\n  value=\"today\"\n  onValueChange={() => {}}\n  ariaLabel=\"Tab state preview\"\n/>",
+            "preview": {
+              "id": "ui:tab-bar:state:disabled"
+            }
+          },
+          {
+            "id": "loading",
+            "name": "Loading",
+            "code": "<TabBar\n  items={[\n    { key: \"today\", label: \"Today\" },\n    { key: \"loading\", label: \"Loading\", loading: true },\n    { key: \"backlog\", label: \"Backlog\" },\n  ]}\n  value=\"today\"\n  onValueChange={() => {}}\n  ariaLabel=\"Tab state preview\"\n/>",
+            "preview": {
+              "id": "ui:tab-bar:state:loading"
+            }
+          }
+        ]
       },
       {
         "id": "tabs",
@@ -6518,6 +6630,12 @@ export const galleryPreviewModules = [
     loader: () => import("../ui/layout/TabBar.gallery"),
     previewIds: [
       "ui:tab-bar:variants",
+      "ui:tab-bar:state:default",
+      "ui:tab-bar:state:hover",
+      "ui:tab-bar:state:active",
+      "ui:tab-bar:state:focus-visible",
+      "ui:tab-bar:state:disabled",
+      "ui:tab-bar:state:loading",
     ],
   },
   {

--- a/src/components/ui/layout/TabBar.gallery.tsx
+++ b/src/components/ui/layout/TabBar.gallery.tsx
@@ -6,6 +6,8 @@ import { createGalleryPreview, defineGallerySection } from "@/components/gallery
 import TabBar, { type TabItem } from "./TabBar";
 
 const focusVisibleClassName = "ring-2 ring-[var(--theme-ring)] ring-offset-0 outline-none";
+const hoverStateClassName =
+  "text-foreground bg-[--hover] shadow-[var(--tab-shadow-hover,var(--tab-shadow))]";
 
 const filterItems: TabItem<string>[] = [
   { key: "all", label: "All", icon: <Circle aria-hidden="true" /> },
@@ -33,6 +35,140 @@ const navigationItems: TabItem<string>[] = [
   { key: "goals", label: "Goals" },
   { key: "focus", label: "Focus-visible", className: focusVisibleClassName },
 ];
+
+type TabBarStateSpec = {
+  id: string;
+  name: string;
+  value: string;
+  items: TabItem<string>[];
+  code: string;
+};
+
+function createStateItems(stateItem: TabItem<string>): TabItem<string>[] {
+  return [
+    { key: "today", label: "Today" },
+    stateItem,
+    { key: "backlog", label: "Backlog" },
+  ];
+}
+
+const TAB_BAR_STATES: readonly TabBarStateSpec[] = [
+  {
+    id: "default",
+    name: "Default",
+    value: "today",
+    items: createStateItems({ key: "upcoming", label: "Upcoming" }),
+    code: `<TabBar
+  items={[
+    { key: "today", label: "Today" },
+    { key: "upcoming", label: "Upcoming" },
+    { key: "backlog", label: "Backlog" },
+  ]}
+  value="today"
+  onValueChange={() => {}}
+  ariaLabel="Tab state preview"
+/>`,
+  },
+  {
+    id: "hover",
+    name: "Hover",
+    value: "today",
+    items: createStateItems({
+      key: "hover",
+      label: "Hover",
+      className: hoverStateClassName,
+    }),
+    code: `<TabBar
+  items={[
+    { key: "today", label: "Today" },
+    { key: "hover", label: "Hover", className: "${hoverStateClassName}" },
+    { key: "backlog", label: "Backlog" },
+  ]}
+  value="today"
+  onValueChange={() => {}}
+  ariaLabel="Tab state preview"
+/>`,
+  },
+  {
+    id: "active",
+    name: "Active",
+    value: "active",
+    items: createStateItems({ key: "active", label: "Active" }),
+    code: `<TabBar
+  items={[
+    { key: "today", label: "Today" },
+    { key: "active", label: "Active" },
+    { key: "backlog", label: "Backlog" },
+  ]}
+  value="active"
+  onValueChange={() => {}}
+  ariaLabel="Tab state preview"
+/>`,
+  },
+  {
+    id: "focus-visible",
+    name: "Focus-visible",
+    value: "today",
+    items: createStateItems({
+      key: "focus",
+      label: "Focus-visible",
+      className: focusVisibleClassName,
+    }),
+    code: `<TabBar
+  items={[
+    { key: "today", label: "Today" },
+    { key: "focus", label: "Focus-visible", className: "${focusVisibleClassName}" },
+    { key: "backlog", label: "Backlog" },
+  ]}
+  value="today"
+  onValueChange={() => {}}
+  ariaLabel="Tab state preview"
+/>`,
+  },
+  {
+    id: "disabled",
+    name: "Disabled",
+    value: "today",
+    items: createStateItems({ key: "disabled", label: "Disabled", disabled: true }),
+    code: `<TabBar
+  items={[
+    { key: "today", label: "Today" },
+    { key: "disabled", label: "Disabled", disabled: true },
+    { key: "backlog", label: "Backlog" },
+  ]}
+  value="today"
+  onValueChange={() => {}}
+  ariaLabel="Tab state preview"
+/>`,
+  },
+  {
+    id: "loading",
+    name: "Loading",
+    value: "today",
+    items: createStateItems({ key: "loading", label: "Loading", loading: true }),
+    code: `<TabBar
+  items={[
+    { key: "today", label: "Today" },
+    { key: "loading", label: "Loading", loading: true },
+    { key: "backlog", label: "Backlog" },
+  ]}
+  value="today"
+  onValueChange={() => {}}
+  ariaLabel="Tab state preview"
+/>`,
+  },
+];
+
+function TabBarStatePreview({ state }: { state: TabBarStateSpec }) {
+  return (
+    <TabBar
+      items={state.items}
+      value={state.value}
+      onValueChange={() => {}}
+      ariaLabel={`${state.name} tab state`}
+    />
+  );
+}
 
 function TabBarGalleryPreview() {
   const [filterTab, setFilterTab] = React.useState<string>(filterItems[1]?.key ?? "all");
@@ -89,18 +225,22 @@ export default defineGallerySection({
           id: "state",
           label: "State",
           type: "state",
-          values: [
-            { value: "Active" },
-            { value: "Focus-visible" },
-            { value: "Disabled" },
-            { value: "Loading" },
-          ],
+          values: TAB_BAR_STATES.map(({ name }) => ({ value: name })),
         },
       ],
       preview: createGalleryPreview({
         id: "ui:tab-bar:variants",
         render: () => <TabBarGalleryPreview />,
       }),
+      states: TAB_BAR_STATES.map((state) => ({
+        id: state.id,
+        name: state.name,
+        code: state.code,
+        preview: createGalleryPreview({
+          id: `ui:tab-bar:state:${state.id}`,
+          render: () => <TabBarStatePreview state={state} />,
+        }),
+      })),
       code: `<TabBar
   items={[
     { key: "all", label: "All", icon: <Circle aria-hidden="true" /> },


### PR DESCRIPTION
## Summary
- add TabBar gallery state specs with previews for default, hover, active, focus-visible, disabled, and loading cases
- regenerate the gallery manifest so the new state previews are registered

## Testing
- npm test -- --run --update
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1281e4e44832cb3e9880639f48615