### PR TITLE
Ensure project selection resets when project removed

### DIFF
--- a/src/components/planner/DayCard.tsx
+++ b/src/components/planner/DayCard.tsx
@@ -41,15 +41,6 @@ export default function DayCard({ iso, isToday }: Props) {
   const [selectedProjectId, setSelectedProjectId] = useSelectedProject(iso);
   const [, setSelectedTaskId] = useSelectedTask(iso);
 
-  React.useEffect(() => {
-    if (
-      selectedProjectId &&
-      !projects.some((p) => p.id === selectedProjectId)
-    ) {
-      setSelectedProjectId("");
-    }
-  }, [projects, selectedProjectId, setSelectedProjectId]);
-
   return (
     <section
       className={cn(
@@ -85,7 +76,7 @@ export default function DayCard({ iso, isToday }: Props) {
         />
       </div>
       {selectedProjectId && (
-        <>
+        <React.Fragment>
           <div
             className="hidden lg:block lg:col-span-1 w-px mx-auto bg-card-hairline/90 rounded-full self-stretch"
             aria-hidden
@@ -107,7 +98,7 @@ export default function DayCard({ iso, isToday }: Props) {
               setSelectedTaskId={setSelectedTaskId}
             />
           </div>
-        </>
+        </React.Fragment>
       )}
     </section>
   );

--- a/src/components/planner/TodayHero.tsx
+++ b/src/components/planner/TodayHero.tsx
@@ -52,12 +52,6 @@ export default function TodayHero({ iso }: Props) {
     return project?.name ?? "";
   }, [projects, selProjectId]);
 
-  useEffect(() => {
-    if (selProjectId && !projects.some((p) => p.id === selProjectId)) {
-      setSelProjectId("");
-    }
-  }, [projects, selProjectId, setSelProjectId]);
-
   const scopedTasks = useMemo(
     () => (selProjectId ? tasks.filter((t) => t.projectId === selProjectId) : []),
     [tasks, selProjectId],

--- a/src/components/planner/useSelection.ts
+++ b/src/components/planner/useSelection.ts
@@ -63,10 +63,23 @@ const produceProjectSelection: SelectionProducer = (projectId) =>
  * @returns Tuple of current project ID and setter.
  */
 export function useSelectedProject(iso: ISODate) {
-  return useSelectionState(iso, {
+  const { days } = useDays();
+  const selection = useSelectionState(iso, {
     getCurrentId: getProjectId,
     produceSelection: produceProjectSelection,
   });
+
+  const [selectedProjectId, setSelectedProjectId] = selection;
+  const dayProjects = days[iso]?.projects;
+
+  React.useEffect(() => {
+    if (!selectedProjectId) return;
+    if (!dayProjects?.some((project) => project.id === selectedProjectId)) {
+      setSelectedProjectId("");
+    }
+  }, [dayProjects, selectedProjectId, setSelectedProjectId]);
+
+  return selection;
 }
 
 const getTaskId: SelectionGetter = (selection) => selection?.taskId ?? "";


### PR DESCRIPTION
## Summary
- update `useSelectedProject` to read the day map and clear the current id when its project disappears
- drop the redundant project-reset effects from `DayCard` and `TodayHero` so they rely on the shared hook

## Testing
- npm run test -- --run tests/planner/UseSelection.test.tsx
- npm run test -- --run tests/planner/DayCard.test.tsx tests/planner/DayRow.test.tsx
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1293d1d40832c9bbd605c83394972