### PR TITLE
Fix components gallery tab ids

### DIFF
--- a/src/components/components/ComponentsGalleryPanels.tsx
+++ b/src/components/components/ComponentsGalleryPanels.tsx
@@ -9,7 +9,11 @@ import type { DesignTokenGroup } from "@/components/gallery/types";
 import { Card, CardContent } from "@/components/ui";
 import Badge from "@/components/ui/primitives/Badge";
 
-import type { ComponentsView } from "./useComponentsGalleryState";
+import {
+  COMPONENTS_PANEL_ID,
+  COMPONENTS_VIEW_TAB_ID_BASE,
+  type ComponentsView,
+} from "./useComponentsGalleryState";
 
 interface ComponentsGalleryPanelsProps {
   readonly view: ComponentsView;
@@ -35,12 +39,12 @@ export default function ComponentsGalleryPanels({
   tokenGroups,
 }: ComponentsGalleryPanelsProps) {
   const isTokensView = view === "tokens";
-  const tokensTabId = "components-tokens-tab";
+  const tokensTabId = `${COMPONENTS_VIEW_TAB_ID_BASE}-tokens-tab`;
 
   return (
     <section className="col-span-full grid gap-[var(--space-6)] md:gap-[var(--space-7)] lg:gap-[var(--space-8)]">
       <div
-        id="components-components-panel"
+        id={COMPONENTS_PANEL_ID}
         role="tabpanel"
         aria-labelledby={componentsPanelLabelledBy}
         tabIndex={isTokensView ? -1 : 0}
@@ -82,7 +86,7 @@ export default function ComponentsGalleryPanels({
         </div>
       </div>
       <div
-        id="components-tokens-panel"
+        id={`${COMPONENTS_VIEW_TAB_ID_BASE}-tokens-panel`}
         role="tabpanel"
         aria-labelledby={tokensTabId}
         tabIndex={isTokensView ? 0 : -1}

--- a/src/components/components/ComponentsPageClient.tsx
+++ b/src/components/components/ComponentsPageClient.tsx
@@ -8,7 +8,12 @@ import { PageHeader, PageShell } from "@/components/ui";
 import { cn } from "@/lib/utils";
 
 import ComponentsGalleryPanels from "./ComponentsGalleryPanels";
-import { useComponentsGalleryState } from "./useComponentsGalleryState";
+import {
+  COMPONENTS_PANEL_ID,
+  COMPONENTS_SECTION_TAB_ID_BASE,
+  COMPONENTS_VIEW_TAB_ID_BASE,
+  useComponentsGalleryState,
+} from "./useComponentsGalleryState";
 
 const NEO_TABLIST_SHARED_CLASSES = [
   "data-[variant=neo]:rounded-card",
@@ -94,7 +99,7 @@ export default function ComponentsPageClient({
             value: view,
             onChange: handleViewChange,
             ariaLabel: "Component gallery view",
-            idBase: "components",
+            idBase: COMPONENTS_VIEW_TAB_ID_BASE,
             linkPanels: true,
             variant: "neo",
             tablistClassName: cn(NEO_TABLIST_SHARED_CLASSES, "w-full md:w-auto"),
@@ -122,7 +127,7 @@ export default function ComponentsPageClient({
                 items: heroTabs,
                 value: section,
                 onChange: handleSectionChange,
-                idBase: "components",
+                idBase: COMPONENTS_SECTION_TAB_ID_BASE,
                 linkPanels: true,
                 size: "sm",
                 variant: "default",
@@ -138,6 +143,7 @@ export default function ComponentsPageClient({
                     onClick,
                     "aria-label": ariaLabelProp,
                     "aria-labelledby": ariaLabelledByProp,
+                    "aria-controls": ariaControlsProp,
                     title: titleProp,
                     ...restProps
                   } = props;
@@ -153,6 +159,9 @@ export default function ComponentsPageClient({
                   const computedAriaLabel =
                     ariaLabelProp ??
                     (labelText && !ariaLabelledByProp ? labelText : undefined);
+                  const computedAriaControls =
+                    ariaControlsProp != null ? COMPONENTS_PANEL_ID : undefined;
+
                   return (
                     <button
                       type="button"
@@ -174,6 +183,7 @@ export default function ComponentsPageClient({
                       }}
                       disabled={disabled}
                       aria-labelledby={ariaLabelledByProp}
+                      aria-controls={computedAriaControls}
                       aria-label={computedAriaLabel}
                       title={computedTitle}
                     >

--- a/src/components/components/useComponentsGalleryState.ts
+++ b/src/components/components/useComponentsGalleryState.ts
@@ -18,6 +18,10 @@ import { usePersistentState } from "@/lib/db";
 export type Section = GalleryNavigationSection["id"];
 export type ComponentsView = GallerySectionGroupKey;
 
+export const COMPONENTS_VIEW_TAB_ID_BASE = "components";
+export const COMPONENTS_SECTION_TAB_ID_BASE = "components-section";
+export const COMPONENTS_PANEL_ID = "components-components-panel";
+
 interface TabItem {
   readonly key: string;
   readonly label: string;
@@ -360,11 +364,12 @@ export function useComponentsGalleryState({
   );
 
   const componentsPanelLabelledBy = React.useMemo(() => {
-    const base = `components-${view}-tab`;
+    const viewTabId = `${COMPONENTS_VIEW_TAB_ID_BASE}-${view}-tab`;
     if (heroTabs.length > 0) {
-      return `${base} components-${section}-tab`;
+      const sectionTabId = `${COMPONENTS_SECTION_TAB_ID_BASE}-${section}-tab`;
+      return `${viewTabId} ${sectionTabId}`;
     }
-    return base;
+    return viewTabId;
   }, [heroTabs.length, section, view]);
 
   const handleViewChange = React.useCallback(


### PR DESCRIPTION
## Summary
- add shared constants for the components gallery view tabs, section tabs, and panel ids
- update the components gallery hero tabs to use a distinct id base and keep aria-controls wired to the panel
- compose the gallery panel aria-labelledby string with the new hero tab id prefix and reuse the constants in the panels

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d12eb7e740832c8e0fa5182d39e7d4