### PR TITLE
Preserve gallery hash when syncing URL

### DIFF
--- a/src/components/components/useComponentsGalleryState.ts
+++ b/src/components/components/useComponentsGalleryState.ts
@@ -450,15 +450,25 @@ export function useComponentsGalleryState({
     };
   }, [lastInteractionRef]);
 
+  const buildQueryWithHash = React.useCallback((next: URLSearchParams) => {
+    const queryString = next.toString();
+    const queryPrefix = `?${queryString}`;
+    if (typeof window === "undefined") {
+      return queryPrefix;
+    }
+    const hash = window.location.hash;
+    return hash ? `${queryPrefix}${hash}` : queryPrefix;
+  }, []);
+
   React.useEffect(() => {
     const current = sectionParam ?? "";
     if (current === section) return;
     const next = new URLSearchParams(paramsString);
     next.set("section", section);
     startTransition(() => {
-      router.replace(`?${next.toString()}`, { scroll: false });
+      router.replace(buildQueryWithHash(next), { scroll: false });
     });
-  }, [paramsString, router, section, sectionParam, startTransition]);
+  }, [buildQueryWithHash, paramsString, router, section, sectionParam, startTransition]);
 
   React.useEffect(() => {
     const current = normalizeView(viewParam);
@@ -470,9 +480,18 @@ export function useComponentsGalleryState({
       next.set("view", view);
     }
     startTransition(() => {
-      router.replace(`?${next.toString()}`, { scroll: false });
+      router.replace(buildQueryWithHash(next), { scroll: false });
     });
-  }, [defaultView, normalizeView, paramsString, router, startTransition, view, viewParam]);
+  }, [
+    buildQueryWithHash,
+    defaultView,
+    normalizeView,
+    paramsString,
+    router,
+    startTransition,
+    view,
+    viewParam,
+  ]);
 
   React.useEffect(() => {
     const current = queryParam ?? "";
@@ -484,9 +503,9 @@ export function useComponentsGalleryState({
       next.delete("q");
     }
     startTransition(() => {
-      router.replace(`?${next.toString()}`, { scroll: false });
+      router.replace(buildQueryWithHash(next), { scroll: false });
     });
-  }, [paramsString, query, queryParam, router, startTransition]);
+  }, [buildQueryWithHash, paramsString, query, queryParam, router, startTransition]);
 
   React.useEffect(() => {
     if (view === "tokens") {

--- a/tests/components/ComponentsGalleryState.test.tsx
+++ b/tests/components/ComponentsGalleryState.test.tsx
@@ -1,0 +1,95 @@
+import * as React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useComponentsGalleryState } from "@/components/components/useComponentsGalleryState";
+import type { GalleryNavigationData } from "@/components/gallery/types";
+
+const replaceSpy = vi.fn<(url: string, options?: { scroll: boolean }) => void>();
+let searchParamsString = "";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: replaceSpy,
+  }),
+  useSearchParams: () => new URLSearchParams(searchParamsString),
+}));
+
+vi.mock("@/components/prompts/constants", () => ({
+  getGallerySectionEntries: vi.fn(() => []),
+}));
+
+function mockUsePersistentState<T>(
+  _key: string,
+  initial: T,
+): [T, React.Dispatch<React.SetStateAction<T>>] {
+  return React.useState<T>(initial);
+}
+
+vi.mock("@/lib/db", () => ({
+  usePersistentState: mockUsePersistentState,
+}));
+
+const navigation: GalleryNavigationData = {
+  groups: [
+    {
+      id: "primitives",
+      label: "Primitives",
+      copy: {
+        eyebrow: "Primitives",
+        heading: "Primitives",
+        subtitle: "Primitive components",
+      },
+      sections: [
+        {
+          id: "buttons",
+          label: "Buttons",
+          copy: {
+            eyebrow: "Buttons",
+            heading: "Buttons",
+            subtitle: "Button components",
+          },
+          groupId: "primitives",
+        },
+        {
+          id: "inputs",
+          label: "Inputs",
+          copy: {
+            eyebrow: "Inputs",
+            heading: "Inputs",
+            subtitle: "Input components",
+          },
+          groupId: "primitives",
+        },
+      ],
+    },
+  ],
+};
+
+describe("useComponentsGalleryState", () => {
+  beforeEach(() => {
+    searchParamsString = new URLSearchParams({ section: "buttons" }).toString();
+    replaceSpy.mockClear();
+    window.location.hash = "";
+  });
+
+  it("preserves the hash fragment when updating the section", async () => {
+    window.location.hash = "#main-content";
+
+    const { result } = renderHook(() =>
+      useComponentsGalleryState({
+        navigation,
+      }),
+    );
+
+    act(() => {
+      result.current.handleSectionChange("inputs");
+    });
+
+    await waitFor(() => {
+      expect(replaceSpy).toHaveBeenCalledWith("?section=inputs#main-content", {
+        scroll: false,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- capture the current location hash when building replacement URLs in useComponentsGalleryState
- reuse a helper so section/view/query effects append the fragment consistently
- add a gallery state test that keeps the hash when switching sections

## Testing
- npm run check *(fails: Home page > renders navigation links timed out; suite aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68d12cdb125c832c9ce88fb1dcf4580e