### PR TITLE
Add hero2 neomorphic glow overlays

### DIFF
--- a/src/components/ui/layout/NeomorphicFrameStyles.tsx
+++ b/src/components/ui/layout/NeomorphicFrameStyles.tsx
@@ -16,6 +16,48 @@ export function NeomorphicFrameStyles() {
         --hero2-shadow-ambient: inset 0 0 0 calc(var(--hairline-w) * 1.5)
           hsl(var(--shadow-color) / 0.18);
         box-shadow: var(--hero2-shadow-ambient), var(--hero2-shadow-key);
+        position: relative;
+        z-index: 0;
+        --hero2-focus-ring-rest: 0 0 0 0 hsl(var(--ring) / 0),
+          0 0 0 0 hsl(var(--ring) / 0);
+        --hero2-focus-ring-active: 0 0 0 calc(var(--hairline-w) * 1)
+          hsl(var(--ring)),
+          var(--shadow-glow-lg);
+        --hero2-focus-ring: var(--hero2-focus-ring-rest);
+        --hero2-glow-top-left-color: hsl(var(--highlight) / 0.55);
+        --hero2-glow-top-left-soft: hsl(var(--highlight) / 0.08);
+        --hero2-glow-bottom-right-color: hsl(var(--shadow-color) / 0.42);
+        --hero2-glow-bottom-right-soft: hsl(var(--shadow-color) / 0.14);
+        --hero2-glow-top-left: radial-gradient(
+          140% 140% at 0% 0%,
+          var(--hero2-glow-top-left-color) 0%,
+          var(--hero2-glow-top-left-soft) 45%,
+          transparent 75%
+        );
+        --hero2-glow-bottom-right: radial-gradient(
+          160% 160% at 100% 100%,
+          var(--hero2-glow-bottom-right-color) 0%,
+          var(--hero2-glow-bottom-right-soft) 55%,
+          transparent 82%
+        );
+      }
+      .hero2-neomorph::before,
+      .hero2-neomorph::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        pointer-events: none;
+        z-index: -1;
+        opacity: 1;
+      }
+      .hero2-neomorph::before {
+        background: var(--hero2-glow-top-left);
+        box-shadow: var(--hero2-focus-ring);
+        transition: box-shadow var(--dur-quick, 160ms) ease-out;
+      }
+      .hero2-neomorph::after {
+        background: var(--hero2-glow-bottom-right);
       }
       @supports (color: color-mix(in oklab, white, black)) {
         .hero2-neomorph {
@@ -25,6 +67,26 @@ export function NeomorphicFrameStyles() {
               hsl(var(--shadow-color)) 28%,
               hsl(var(--highlight))
             );
+          --hero2-glow-top-left-color: color-mix(
+            in oklab,
+            hsl(var(--highlight)) 72%,
+            hsl(var(--shadow-color))
+          );
+          --hero2-glow-top-left-soft: color-mix(
+            in oklab,
+            hsl(var(--highlight)) 22%,
+            transparent
+          );
+          --hero2-glow-bottom-right-color: color-mix(
+            in oklab,
+            hsl(var(--shadow-color)) 82%,
+            hsl(var(--highlight))
+          );
+          --hero2-glow-bottom-right-soft: color-mix(
+            in oklab,
+            hsl(var(--shadow-color)) 28%,
+            transparent
+          );
         }
       }
       @media (prefers-contrast: more) {
@@ -37,6 +99,13 @@ export function NeomorphicFrameStyles() {
           --hero2-shadow-ambient: inset 0 0 0 calc(var(--hairline-w) * 2)
             hsl(var(--foreground) / 0.7);
           box-shadow: var(--hero2-shadow-ambient), var(--hero2-shadow-key);
+          --hero2-glow-top-left: none;
+          --hero2-glow-bottom-right: none;
+          --hero2-focus-ring-rest: 0 0 0 0 hsl(var(--foreground) / 0),
+            0 0 0 0 hsl(var(--foreground) / 0);
+          --hero2-focus-ring-active: 0 0 0 calc(var(--hairline-w) * 2)
+            hsl(var(--foreground) / 0.9),
+            0 0 0 0 hsl(var(--foreground) / 0.6);
         }
       }
       @media (forced-colors: active) {
@@ -47,6 +116,13 @@ export function NeomorphicFrameStyles() {
         .hero2-neomorph {
           background: Canvas !important;
           box-shadow: none !important;
+          --hero2-glow-top-left: none;
+          --hero2-glow-bottom-right: none;
+          --hero2-focus-ring-rest: 0 0 0 0 Canvas,
+            0 0 0 0 Canvas;
+          --hero2-focus-ring-active: 0 0 0 calc(var(--hairline-w) * 2)
+            CanvasText,
+            0 0 0 0 CanvasText;
         }
       }
     `}</style>

--- a/src/components/ui/layout/NeomorphicHeroFrame.tsx
+++ b/src/components/ui/layout/NeomorphicHeroFrame.tsx
@@ -467,7 +467,7 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
     ) : null;
 
     const haloClasses =
-      "before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:rounded-[inherit] before:opacity-0 before:transition before:duration-300 before:ease-out before:content-[''] before:[box-shadow:0_0_0_var(--hairline-w)_hsl(var(--ring)),var(--shadow-glow-lg)] motion-reduce:before:transition-none";
+      "before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:rounded-[inherit] before:transition before:duration-300 before:ease-out before:content-[''] motion-reduce:before:transition-none";
 
     return (
       <>
@@ -481,8 +481,8 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
               ? cn(
                   "border border-border/55 bg-card/70 text-foreground shadow-outline-subtle hero2-frame hero2-neomorph",
                   haloClasses,
-                  "has-[:focus-visible]:before:opacity-100",
-                  "data-[has-focus=true]:before:opacity-100",
+                  "has-[:focus-visible]:before:[--hero2-focus-ring:var(--hero2-focus-ring-active)]",
+                  "data-[has-focus=true]:before:[--hero2-focus-ring:var(--hero2-focus-ring-active)]",
                   variantStyles.radius,
                   variantStyles.padding,
                 )

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -24,6 +24,48 @@ exports[`ReviewsPage > renders default state 1`] = `
         --hero2-shadow-ambient: inset 0 0 0 calc(var(--hairline-w) * 1.5)
           hsl(var(--shadow-color) / 0.18);
         box-shadow: var(--hero2-shadow-ambient), var(--hero2-shadow-key);
+        position: relative;
+        z-index: 0;
+        --hero2-focus-ring-rest: 0 0 0 0 hsl(var(--ring) / 0),
+          0 0 0 0 hsl(var(--ring) / 0);
+        --hero2-focus-ring-active: 0 0 0 calc(var(--hairline-w) * 1)
+          hsl(var(--ring)),
+          var(--shadow-glow-lg);
+        --hero2-focus-ring: var(--hero2-focus-ring-rest);
+        --hero2-glow-top-left-color: hsl(var(--highlight) / 0.55);
+        --hero2-glow-top-left-soft: hsl(var(--highlight) / 0.08);
+        --hero2-glow-bottom-right-color: hsl(var(--shadow-color) / 0.42);
+        --hero2-glow-bottom-right-soft: hsl(var(--shadow-color) / 0.14);
+        --hero2-glow-top-left: radial-gradient(
+          140% 140% at 0% 0%,
+          var(--hero2-glow-top-left-color) 0%,
+          var(--hero2-glow-top-left-soft) 45%,
+          transparent 75%
+        );
+        --hero2-glow-bottom-right: radial-gradient(
+          160% 160% at 100% 100%,
+          var(--hero2-glow-bottom-right-color) 0%,
+          var(--hero2-glow-bottom-right-soft) 55%,
+          transparent 82%
+        );
+      }
+      .hero2-neomorph::before,
+      .hero2-neomorph::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        pointer-events: none;
+        z-index: -1;
+        opacity: 1;
+      }
+      .hero2-neomorph::before {
+        background: var(--hero2-glow-top-left);
+        box-shadow: var(--hero2-focus-ring);
+        transition: box-shadow var(--dur-quick, 160ms) ease-out;
+      }
+      .hero2-neomorph::after {
+        background: var(--hero2-glow-bottom-right);
       }
       @supports (color: color-mix(in oklab, white, black)) {
         .hero2-neomorph {
@@ -33,6 +75,26 @@ exports[`ReviewsPage > renders default state 1`] = `
               hsl(var(--shadow-color)) 28%,
               hsl(var(--highlight))
             );
+          --hero2-glow-top-left-color: color-mix(
+            in oklab,
+            hsl(var(--highlight)) 72%,
+            hsl(var(--shadow-color))
+          );
+          --hero2-glow-top-left-soft: color-mix(
+            in oklab,
+            hsl(var(--highlight)) 22%,
+            transparent
+          );
+          --hero2-glow-bottom-right-color: color-mix(
+            in oklab,
+            hsl(var(--shadow-color)) 82%,
+            hsl(var(--highlight))
+          );
+          --hero2-glow-bottom-right-soft: color-mix(
+            in oklab,
+            hsl(var(--shadow-color)) 28%,
+            transparent
+          );
         }
       }
       @media (prefers-contrast: more) {
@@ -45,6 +107,13 @@ exports[`ReviewsPage > renders default state 1`] = `
           --hero2-shadow-ambient: inset 0 0 0 calc(var(--hairline-w) * 2)
             hsl(var(--foreground) / 0.7);
           box-shadow: var(--hero2-shadow-ambient), var(--hero2-shadow-key);
+          --hero2-glow-top-left: none;
+          --hero2-glow-bottom-right: none;
+          --hero2-focus-ring-rest: 0 0 0 0 hsl(var(--foreground) / 0),
+            0 0 0 0 hsl(var(--foreground) / 0);
+          --hero2-focus-ring-active: 0 0 0 calc(var(--hairline-w) * 2)
+            hsl(var(--foreground) / 0.9),
+            0 0 0 0 hsl(var(--foreground) / 0.6);
         }
       }
       @media (forced-colors: active) {
@@ -55,12 +124,19 @@ exports[`ReviewsPage > renders default state 1`] = `
         .hero2-neomorph {
           background: Canvas !important;
           box-shadow: none !important;
+          --hero2-glow-top-left: none;
+          --hero2-glow-bottom-right: none;
+          --hero2-focus-ring-rest: 0 0 0 0 Canvas,
+            0 0 0 0 Canvas;
+          --hero2-focus-ring-active: 0 0 0 calc(var(--hairline-w) * 2)
+            CanvasText,
+            0 0 0 0 CanvasText;
         }
       }
     
       </style>
       <div
-        class="group/hero-frame relative isolate flex flex-col overflow-visible hero-focus border border-border/55 bg-card/70 text-foreground shadow-outline-subtle hero2-frame hero2-neomorph before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:rounded-[inherit] before:opacity-0 before:transition before:duration-300 before:ease-out before:content-[''] before:[box-shadow:0_0_0_var(--hairline-w)_hsl(var(--ring)),var(--shadow-glow-lg)] motion-reduce:before:transition-none has-[:focus-visible]:before:opacity-100 data-[has-focus=true]:before:opacity-100 rounded-card r-card-lg md:px-[var(--space-7)] md:py-[var(--space-7)] lg:px-[var(--space-8)] lg:py-[var(--space-8)] rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-4)]"
+        class="group/hero-frame relative isolate flex flex-col overflow-visible hero-focus border border-border/55 bg-card/70 text-foreground shadow-outline-subtle hero2-frame hero2-neomorph before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:rounded-[inherit] before:transition before:duration-300 before:ease-out before:content-[''] motion-reduce:before:transition-none has-[:focus-visible]:before:[--hero2-focus-ring:var(--hero2-focus-ring-active)] data-[has-focus=true]:before:[--hero2-focus-ring:var(--hero2-focus-ring-active)] rounded-card r-card-lg md:px-[var(--space-7)] md:py-[var(--space-7)] lg:px-[var(--space-8)] lg:py-[var(--space-8)] rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-4)]"
         data-variant="default"
         tabindex="-1"
       >


### PR DESCRIPTION
## Summary
- add shared pseudo-element overlays for hero2 neomorph frames with token-driven color-mix blends
- gate the new glow behind contrast and forced-color media queries and switch focus ring handling to CSS variables
- refresh the ReviewsPage snapshot for the updated class list

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d130177f44832cac88d8638ef47783