### PR TITLE
Refine header plain variant styling

### DIFF
--- a/src/components/ui/layout/Header.gallery.tsx
+++ b/src/components/ui/layout/Header.gallery.tsx
@@ -59,6 +59,8 @@ function HeaderGalleryPreview() {
         ariaLabel: "Header demo tabs",
         size: "md",
       }}
+      variant="plain"
+      railVariant="subtle"
       sticky={false}
       topClassName="top-0"
     >
@@ -139,6 +141,8 @@ export default defineGallerySection({
     ariaLabel: "Header demo tabs",
     size: "md",
   }}
+  variant="plain"
+  railVariant="subtle"
   sticky={false}
   topClassName="top-0"
 >

--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -56,6 +56,8 @@ export interface HeaderProps<Key extends string = string>
   barClassName?: string;
   bodyClassName?: string;
   rail?: boolean;
+  /** Decorative rail emphasis; defaults to the subtler glow. */
+  railVariant?: "subtle" | "loud";
   /** Reduce vertical padding and height, ideal for denser layouts. */
   compact?: boolean;
   /** Built-in top-right segmented tabs (preferred). */
@@ -81,6 +83,7 @@ export default function Header<Key extends string = string>({
   barClassName,
   bodyClassName,
   rail = true,
+  railVariant = "subtle",
   compact = false,
   tabs,
   variant = "plain",
@@ -89,6 +92,8 @@ export default function Header<Key extends string = string>({
 }: HeaderProps<Key>) {
   const isNeo = variant === "neo";
   const isMinimal = variant === "minimal";
+  const isPlain = variant === "plain";
+  const hasNeomorphicFrame = isNeo || isPlain;
 
   let tabControl: React.ReactNode = null;
   if (tabs) {
@@ -201,13 +206,16 @@ export default function Header<Key extends string = string>({
 
   return (
     <>
-      {isNeo ? <NeomorphicFrameStyles /> : null}
+      {hasNeomorphicFrame ? <NeomorphicFrameStyles /> : null}
       <header
         className={cx(
           "z-[999] relative isolate",
           isNeo &&
             "rounded-card r-card-lg bg-card/70 backdrop-blur-md hero2-neomorph",
           isNeo && "overflow-hidden",
+          isPlain &&
+            "rounded-card r-card-lg border border-[hsl(var(--border))/0.45] bg-card/70 shadow-neoSoft backdrop-blur-md hero2-frame hero2-neomorph",
+          isPlain && "overflow-hidden",
 
           // Neon underline
           underline &&
@@ -224,14 +232,17 @@ export default function Header<Key extends string = string>({
             "relative flex items-center gap-[var(--space-3)] sm:gap-[var(--space-4)]",
             barPadding,
             minHeightClass,
-            isNeo && "z-[2]",
+            hasNeomorphicFrame && "z-[2]",
             hasNav && "flex-wrap gap-y-[var(--space-2)] sm:flex-nowrap",
             barClassName,
           )}
         >
           {rail ? (
             <div
-              className="header-rail pointer-events-none absolute left-0 top-[var(--space-1)] bottom-[var(--space-1)] w-[var(--space-2)] rounded-l-2xl"
+              className={cx(
+                "header-rail pointer-events-none absolute left-0 top-[var(--space-1)] bottom-[var(--space-1)] w-[var(--space-2)] rounded-l-2xl",
+                railVariant === "subtle" && "header-rail--subtle",
+              )}
               aria-hidden
             />
           ) : null}
@@ -308,7 +319,7 @@ export default function Header<Key extends string = string>({
           <div
             className={cx(
               "relative",
-              isNeo && "z-[2]",
+              hasNeomorphicFrame && "z-[2]",
               bodyPadding,
               bodyClassName,
             )}

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -146,16 +146,142 @@ exports[`ReviewsPage > renders default state 1`] = `
           <div
             class="relative z-[2] md:space-y-[var(--space-6)] space-y-[var(--space-2)]"
           >
+            <style
+              global="true"
+              jsx="true"
+            >
+              
+      .hero2-neomorph {
+        background: linear-gradient(
+          145deg,
+          hsl(var(--card)),
+          hsl(var(--panel))
+        );
+        --hero2-shadow-key: var(--shadow);
+        --hero2-shadow-ambient: inset 0 0 0 calc(var(--hairline-w) * 1.5)
+          hsl(var(--shadow-color) / 0.18);
+        box-shadow: var(--hero2-shadow-ambient), var(--hero2-shadow-key);
+        position: relative;
+        z-index: 0;
+        --hero2-focus-ring-rest: 0 0 0 0 hsl(var(--ring) / 0),
+          0 0 0 0 hsl(var(--ring) / 0);
+        --hero2-focus-ring-active: 0 0 0 calc(var(--hairline-w) * 1)
+          hsl(var(--ring)),
+          var(--shadow-glow-lg);
+        --hero2-focus-ring: var(--hero2-focus-ring-rest);
+        --hero2-glow-top-left-color: hsl(var(--highlight) / 0.55);
+        --hero2-glow-top-left-soft: hsl(var(--highlight) / 0.08);
+        --hero2-glow-bottom-right-color: hsl(var(--shadow-color) / 0.42);
+        --hero2-glow-bottom-right-soft: hsl(var(--shadow-color) / 0.14);
+        --hero2-glow-top-left: radial-gradient(
+          140% 140% at 0% 0%,
+          var(--hero2-glow-top-left-color) 0%,
+          var(--hero2-glow-top-left-soft) 45%,
+          transparent 75%
+        );
+        --hero2-glow-bottom-right: radial-gradient(
+          160% 160% at 100% 100%,
+          var(--hero2-glow-bottom-right-color) 0%,
+          var(--hero2-glow-bottom-right-soft) 55%,
+          transparent 82%
+        );
+      }
+      .hero2-neomorph::before,
+      .hero2-neomorph::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        pointer-events: none;
+        z-index: -1;
+        opacity: 1;
+      }
+      .hero2-neomorph::before {
+        background: var(--hero2-glow-top-left);
+        box-shadow: var(--hero2-focus-ring);
+        transition: box-shadow var(--dur-quick, 160ms) ease-out;
+      }
+      .hero2-neomorph::after {
+        background: var(--hero2-glow-bottom-right);
+      }
+      @supports (color: color-mix(in oklab, white, black)) {
+        .hero2-neomorph {
+          --hero2-shadow-ambient: inset 0 0 0 calc(var(--hairline-w) * 1.5)
+            color-mix(
+              in oklab,
+              hsl(var(--shadow-color)) 28%,
+              hsl(var(--highlight))
+            );
+          --hero2-glow-top-left-color: color-mix(
+            in oklab,
+            hsl(var(--highlight)) 72%,
+            hsl(var(--shadow-color))
+          );
+          --hero2-glow-top-left-soft: color-mix(
+            in oklab,
+            hsl(var(--highlight)) 22%,
+            transparent
+          );
+          --hero2-glow-bottom-right-color: color-mix(
+            in oklab,
+            hsl(var(--shadow-color)) 82%,
+            hsl(var(--highlight))
+          );
+          --hero2-glow-bottom-right-soft: color-mix(
+            in oklab,
+            hsl(var(--shadow-color)) 28%,
+            transparent
+          );
+        }
+      }
+      @media (prefers-contrast: more) {
+        .hero2-frame {
+          border-color: hsl(var(--foreground) / 0.7) !important;
+        }
+        .hero2-neomorph {
+          --hero2-shadow-key: 0 0 var(--space-4)
+            hsl(var(--foreground) / 0.75);
+          --hero2-shadow-ambient: inset 0 0 0 calc(var(--hairline-w) * 2)
+            hsl(var(--foreground) / 0.7);
+          box-shadow: var(--hero2-shadow-ambient), var(--hero2-shadow-key);
+          --hero2-glow-top-left: none;
+          --hero2-glow-bottom-right: none;
+          --hero2-focus-ring-rest: 0 0 0 0 hsl(var(--foreground) / 0),
+            0 0 0 0 hsl(var(--foreground) / 0);
+          --hero2-focus-ring-active: 0 0 0 calc(var(--hairline-w) * 2)
+            hsl(var(--foreground) / 0.9),
+            0 0 0 0 hsl(var(--foreground) / 0.6);
+        }
+      }
+      @media (forced-colors: active) {
+        .hero2-frame {
+          border-color: CanvasText !important;
+          background: Canvas !important;
+        }
+        .hero2-neomorph {
+          background: Canvas !important;
+          box-shadow: none !important;
+          --hero2-glow-top-left: none;
+          --hero2-glow-bottom-right: none;
+          --hero2-focus-ring-rest: 0 0 0 0 Canvas,
+            0 0 0 0 Canvas;
+          --hero2-focus-ring-active: 0 0 0 calc(var(--hairline-w) * 2)
+            CanvasText,
+            0 0 0 0 CanvasText;
+        }
+      }
+    
+            </style>
             <header
-              class="z-[999] relative isolate after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent after:z-[2]"
+              class="z-[999] relative isolate rounded-card r-card-lg border border-[hsl(var(--border))/0.45] bg-card/70 shadow-neoSoft backdrop-blur-md hero2-frame hero2-neomorph overflow-hidden after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent after:z-[2]"
               id="reviews-header"
             >
               <div
-                class="relative flex items-center gap-[var(--space-3)] sm:gap-[var(--space-4)] px-[var(--header-bar-px,var(--space-3))] sm:px-[var(--header-bar-sm-px,var(--space-4))] py-[var(--space-3)] sm:py-[var(--space-4)] min-h-[var(--space-7)] [--header-bar-px:var(--space-0)] sm:[--header-bar-sm-px:var(--space-0)]"
+                class="relative flex items-center gap-[var(--space-3)] sm:gap-[var(--space-4)] px-[var(--header-bar-px,var(--space-3))] sm:px-[var(--header-bar-sm-px,var(--space-4))] py-[var(--space-3)] sm:py-[var(--space-4)] min-h-[var(--space-7)] z-[2] [--header-bar-px:var(--space-0)] sm:[--header-bar-sm-px:var(--space-0)]"
               >
                 <div
                   aria-hidden="true"
-                  class="header-rail pointer-events-none absolute left-0 top-[var(--space-1)] bottom-[var(--space-1)] w-[var(--space-2)] rounded-l-2xl"
+                  class="header-rail pointer-events-none absolute left-0 top-[var(--space-1)] bottom-[var(--space-1)] w-[var(--space-2)] rounded-l-2xl header-rail--subtle"
                 />
                 <div
                   class="flex min-w-0 flex-1 items-center gap-[var(--space-3)] sm:gap-[var(--space-4)]"


### PR DESCRIPTION
## Summary
- add a subtle neomorphic treatment to the Header plain variant, including border, shadow, and shared frame styles
- introduce a railVariant prop so the decorative rail defaults to the subdued style and update the gallery preview to highlight the new default
- refresh the Reviews page snapshot to capture the updated surface and rail treatment

## Testing
- npm run lint
- npm run typecheck
- npm test -- --run --maxWorkers=2 *(hangs on tests/components/ComponentsGalleryState.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d139638910832cad12d5f250b50ebe