### PR TITLE
Adjust hero glitch defaults

### DIFF
--- a/src/components/ui/layout/hero/Hero.tsx
+++ b/src/components/ui/layout/hero/Hero.tsx
@@ -88,7 +88,7 @@ function Hero<Key extends string = string>({
   actions,
   tone = "heroic",
   frame = true,
-  glitch = "default",
+  glitch = "subtle",
   sticky = true,
   topClassName = "top-[var(--space-8)]",
   barClassName,

--- a/src/components/ui/layout/hero/useHeroStyles.ts
+++ b/src/components/ui/layout/hero/useHeroStyles.ts
@@ -57,12 +57,12 @@ export function useHeroStyles(options: HeroStyleOptions): HeroStyleResult {
   } = options;
 
   return React.useMemo(() => {
-    const glitchMode = glitch ?? "default";
+    const glitchMode = glitch ?? "subtle";
+    const isGlitchDefault = glitchMode === "default";
     const isGlitchSubtle = glitchMode === "subtle";
     const isGlitchOff = glitchMode === "off";
-    const isGlitchCalm = isGlitchSubtle || isGlitchOff;
     const heroVariant: HeroTabVariant | undefined = frame ? "neo" : undefined;
-    const shouldRenderGlitchStyles = frame && !isGlitchCalm;
+    const shouldRenderGlitchStyles = frame && isGlitchDefault;
     const isRaisedBar = barVariant === "raised";
     const showRail = rail && !isGlitchOff;
     const showDividerGlow = frame && !isGlitchOff;

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -216,7 +216,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                   >
                     <span
                       aria-hidden="true"
-                      class="header-rail pointer-events-none absolute left-0 top-[var(--space-1)] bottom-[var(--space-1)] w-[var(--space-2)] rounded-l-2xl"
+                      class="header-rail pointer-events-none absolute left-0 top-[var(--space-1)] bottom-[var(--space-1)] w-[var(--space-2)] rounded-l-2xl header-rail--subtle"
                     />
                     <div
                       class="min-w-0"


### PR DESCRIPTION
## Summary
- default the hero component glitch mode to subtle
- update hero style hook to treat subtle as calm and only animate on explicit default
- refresh the reviews page snapshot for the new subtle rail styling

## Testing
- npm run lint
- npm run typecheck
- npm test -- --run *(hangs on existing tests/components/ComponentsGalleryState.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d13979b360832ca6c0a83f05b51fcc