### PR TITLE
Default hero glitch effect to subtle mode

### DIFF
--- a/src/components/ui/layout/hero/Hero.tsx
+++ b/src/components/ui/layout/hero/Hero.tsx
@@ -40,7 +40,7 @@ export interface HeroProps<Key extends string = string>
   /** Whether to include glitchy frame and background layers. */
   frame?: boolean;
 
-  /** Level of glitch treatment for frame overlays. */
+  /** Level of glitch treatment for frame overlays (defaults to subtle). */
   glitch?: "default" | "subtle" | "off";
 
   /** Divider tint for neon line. */

--- a/src/components/ui/layout/hero/useHeroStyles.ts
+++ b/src/components/ui/layout/hero/useHeroStyles.ts
@@ -57,7 +57,7 @@ export function useHeroStyles(options: HeroStyleOptions): HeroStyleResult {
   } = options;
 
   return React.useMemo(() => {
-    const glitchMode = glitch ?? "subtle";
+    const glitchMode: NonNullable<HeroStyleOptions["glitch"]> = glitch ?? "subtle";
     const isGlitchDefault = glitchMode === "default";
     const isGlitchSubtle = glitchMode === "subtle";
     const isGlitchOff = glitchMode === "off";


### PR DESCRIPTION
## Summary
- document the hero glitch prop default so new instances emphasize the subtle treatment
- tighten the hero style hook typing around the subtle glitch fallback to keep loud glitch styles opt-in

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d153810584832c8f5f7e75522a339e