### PR TITLE
Remove OS preference notice from animation toggle

### DIFF
--- a/src/components/ui/AnimationToggle.tsx
+++ b/src/components/ui/AnimationToggle.tsx
@@ -15,7 +15,6 @@ export default function AnimationToggle({
   loading?: boolean;
 }) {
   const [enabled, setEnabled] = usePersistentState<boolean>(KEY, true);
-  const [showNotice, setShowNotice] = React.useState(false);
   const reduceMotion = usePrefersReducedMotion();
   const appliedByToggleRef = React.useRef(false);
   const latestEnabledRef = React.useRef(enabled);
@@ -25,7 +24,6 @@ export default function AnimationToggle({
     if (readLocal<boolean>(KEY) === null && reduceMotion) {
       setEnabled(false);
       writeLocal(KEY, false);
-      setShowNotice(true);
     }
   }, [reduceMotion, setEnabled]);
 
@@ -50,7 +48,6 @@ export default function AnimationToggle({
   function toggle() {
     const next = !enabled;
     setEnabled(next);
-    setShowNotice(false);
   }
 
   return (
@@ -79,11 +76,6 @@ export default function AnimationToggle({
           <ZapOff className="h-[var(--space-4)] w-[var(--space-4)]" />
         )}
       </button>
-      {showNotice && (
-        <span className="text-label text-muted-foreground">
-          Animations disabled per OS preference
-        </span>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove the local notice state from `AnimationToggle` while keeping the reduced motion persistence
- delete the notice span so the control renders only the button

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1552e2d48832cac81a60e475c4c6e