### PR TITLE
Use theme success tokens for CheckCircle

### DIFF
--- a/src/components/ui/toggles/CheckCircle.tsx
+++ b/src/components/ui/toggles/CheckCircle.tsx
@@ -5,7 +5,7 @@
  * CheckCircle — Lavender-Glitch concentric checkbox
  * - Accessible (role="checkbox"), Space/Enter toggles
  * - Ignite / powerdown animation to match NeonIcon / Button
- * - --success / --success-glow tokens with fallbacks
+ * - --success / --success-glow tokens from theme variables
  * - Deselect experience:
  *    • Any uncheck triggers a brief "justCleared" window that suppresses hover/focus glow,
  *      ensuring a visible power-down to the neutral state.
@@ -100,8 +100,8 @@ export default function CheckCircle({
   }, [checked, markJustCleared, justCleared]);
 
   // Theme-driven tones
-  const pink = "hsl(var(--success,150 70% 45%))";
-  const glow = "hsl(var(--success-glow,150 70% 35% / 0.6))";
+  const pink = "hsl(var(--success))";
+  const glow = "hsl(var(--success-glow))";
 
   // Neon phase: ignite / steady-on / powerdown / off
   const effectiveHoverOrFocus = (hovered || focused) && !justCleared;


### PR DESCRIPTION
## Summary
- replace the CheckCircle toggle's success tones with direct theme variable usage
- update the component documentation to match the new theme-driven colors

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1576f6cd8832cb83f9c81b867f4d5