### PR TITLE
Ensure TaskRow labels fall back for untitled tasks

### DIFF
--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -46,9 +46,8 @@ export default function TaskRow({
   const trimmedImageUrl = imageUrl.trim();
   const canAttachImage = trimmedImageUrl.length > 0;
   const trimmedTaskTitle = task.title.trim();
-  const renameTaskLabel = trimmedTaskTitle
-    ? `Rename task ${trimmedTaskTitle}`
-    : "Rename task";
+  const accessibleTaskTitle = trimmedTaskTitle || "Untitled task";
+  const renameTaskLabel = `Rename task ${accessibleTaskTitle}`;
 
   const validateImageUrl = React.useCallback((value: string) => {
     if (!value) {
@@ -159,7 +158,7 @@ export default function TaskRow({
       >
         <button
           type="button"
-          aria-label={`Select task ${task.title}`}
+          aria-label={`Select task ${accessibleTaskTitle}`}
           onClick={handleRowClick}
           onKeyDown={handleRowKeyDown}
           onKeyUp={handleRowKeyUp}
@@ -171,7 +170,7 @@ export default function TaskRow({
           )}
           data-focus-within={hasFocusWithin ? "true" : undefined}
         >
-          <span className="sr-only">{`Select task ${task.title}`}</span>
+          <span className="sr-only">{`Select task ${accessibleTaskTitle}`}</span>
         </button>
 
         <div
@@ -190,7 +189,7 @@ export default function TaskRow({
               onChange={() => {
                 if (!editing) toggleTask();
               }}
-              aria-label={`Toggle ${task.title} done`}
+              aria-label={`Toggle ${accessibleTaskTitle} done`}
               size="sm"
             />
           </div>
@@ -285,7 +284,7 @@ export default function TaskRow({
             >
               <Image
                 src={url}
-                alt={`Task image for ${task.title}`}
+                alt={`Task image for ${accessibleTaskTitle}`}
                 width={taskImageSize}
                 height={taskImageSize}
                 className="rounded-card r-card-md object-cover"

--- a/tests/planner/TaskRow.test.tsx
+++ b/tests/planner/TaskRow.test.tsx
@@ -193,7 +193,7 @@ describe("TaskRow", () => {
     expect(input).toHaveAttribute("aria-invalid", "true");
   });
 
-  it("falls back to a generic rename label when the task title is empty", () => {
+  it("provides accessible fallbacks when the task title is empty", () => {
     render(
       <TaskRow
         task={{
@@ -212,9 +212,18 @@ describe("TaskRow", () => {
       />,
     );
 
+    expect(
+      screen.getByLabelText("Select task Untitled task"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByLabelText("Toggle Untitled task done")[0],
+    ).toBeInTheDocument();
+
     const editButton = screen.getAllByLabelText("Edit task")[0];
     fireEvent.click(editButton);
 
-    expect(screen.getByLabelText("Rename task")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Rename task Untitled task"),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- ensure TaskRow uses a shared accessible fallback label when task titles are blank
- update the TaskRow test suite to assert the new fallback behaviour

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d15a2e96a4832cbabe507a9f7b0da8