### PR TITLE
Preserve scroll position when switching page tabs

### DIFF
--- a/src/components/chrome/PageTabs.tsx
+++ b/src/components/chrome/PageTabs.tsx
@@ -132,6 +132,7 @@ export default function PageTabs({
             {...restProps}
             ref={ref as React.Ref<HTMLAnchorElement>}
             href={item.href}
+            scroll={false}
             className={mergedClassName}
             onClick={(event) => {
               if (disabled) {


### PR DESCRIPTION
## Summary
- prevent tab navigation links from resetting the page scroll by passing `scroll={false}` to Next.js Link

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d15bc67d24832c90e5d1fc83934511