### PR TITLE
Apply neo variant to prompts tab list

### DIFF
--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -152,6 +152,7 @@ export default function PromptsPage() {
         <TabList
           items={tabItems}
           ariaLabel="Prompt workspaces"
+          variant="neo"
           showBaseline
         />
 


### PR DESCRIPTION
## Summary
- update the prompts tab list to use the neo variant while retaining its accessibility props
- rely on the existing TabBar neo styles so the tabs inherit the neumorphic hero frame appearance

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68d15d38b88c832cb898f46ef2449e39