### PR TITLE
feat(ui): add tone support to spinner

### DIFF
--- a/src/components/prompts/SpinnerShowcase.tsx
+++ b/src/components/prompts/SpinnerShowcase.tsx
@@ -2,10 +2,18 @@ import { Spinner } from "@/components/ui";
 
 export default function SpinnerShowcase() {
   return (
-    <div className="flex items-center gap-[var(--space-4)]">
-      <Spinner size={16} />
-      <Spinner size={24} />
-      <Spinner size={32} />
+    <div className="flex flex-col gap-[var(--space-4)]">
+      <div className="flex items-center gap-[var(--space-4)]">
+        <Spinner size={16} />
+        <Spinner size={24} />
+        <Spinner size={32} />
+      </div>
+      <div className="flex items-center gap-[var(--space-4)]">
+        <Spinner tone="primary" />
+        <Spinner tone="accent" />
+        <Spinner tone="info" />
+        <Spinner tone="danger" />
+      </div>
     </div>
   );
 }

--- a/src/components/ui/feedback/Spinner.tsx
+++ b/src/components/ui/feedback/Spinner.tsx
@@ -4,14 +4,25 @@ import * as React from "react";
 import type { CSSProperties } from "react";
 import { cn } from "@/lib/utils";
 
+const toneToBorderClass = {
+  primary: "border-primary",
+  accent: "border-accent",
+  info: "border-accent-2",
+  danger: "border-danger",
+} as const;
+
+export type SpinnerTone = keyof typeof toneToBorderClass;
+
 type SpinnerProps = {
   className?: string;
   size?: CSSProperties["width"];
+  tone?: SpinnerTone;
 };
 
 export default function Spinner({
   className,
   size = "var(--space-6)",
+  tone = "accent",
 }: SpinnerProps) {
   return (
     <div
@@ -19,7 +30,8 @@ export default function Spinner({
       aria-label="Loading"
       aria-live="polite"
       className={cn(
-        "inline-block animate-spin rounded-full border border-accent border-t-transparent",
+        "inline-block animate-spin rounded-full border border-t-transparent",
+        toneToBorderClass[tone],
         className,
       )}
       style={{ width: size, height: size }}

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -6,7 +6,7 @@ import { Slot } from "@radix-ui/react-slot";
 import { motion, useReducedMotion } from "framer-motion";
 import type { HTMLMotionProps } from "framer-motion";
 import { cn, withBasePath } from "@/lib/utils";
-import Spinner from "../feedback/Spinner";
+import Spinner, { type SpinnerTone } from "../feedback/Spinner";
 import { neuRaised, neuInset } from "./Neu";
 import designTokens from "../../../../tokens/tokens.js";
 
@@ -43,7 +43,7 @@ export const buttonSizes = {
 
 export type ButtonSize = keyof typeof buttonSizes;
 
-type Tone = "primary" | "accent" | "info" | "danger";
+type Tone = SpinnerTone;
 
 type ControlHeightToken =
   | "controlHSm"
@@ -413,7 +413,7 @@ export const Button = React.forwardRef<
       )}
       {loading ? (
         <span className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center">
-          <Spinner size={spinnerSize} />
+          <Spinner size={spinnerSize} tone={tone} />
         </span>
       ) : null}
       <span className={contentClasses}>{contentChildren}</span>


### PR DESCRIPTION
## Summary
- add semantic tone support to the Spinner component with theme-driven border tokens
- forward each button tone to its loading spinner and reuse the shared tone type
- expand the spinner showcase to demonstrate tone variants alongside size examples

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d16d82a8a4832c9464797a01679a70