### PR TITLE
Add rail tone toggle for Header rail

### DIFF
--- a/src/components/ui/layout/Header.gallery.tsx
+++ b/src/components/ui/layout/Header.gallery.tsx
@@ -39,6 +39,23 @@ const headerTabs: HeaderTabsProps<string>["items"] = [
   },
 ];
 
+const headerRailToneExamples: ReadonlyArray<{
+  tone: "subtle" | "loud";
+  label: string;
+  ariaLabel: string;
+}> = [
+  {
+    tone: "subtle",
+    label: "Subtle rail tone (default)",
+    ariaLabel: "Header demo tabs (subtle tone)",
+  },
+  {
+    tone: "loud",
+    label: "Loud rail tone",
+    ariaLabel: "Header demo tabs (loud tone)",
+  },
+];
+
 function HeaderGalleryPreview() {
   const [value, setValue] = React.useState<string>(
     () => headerTabs.find((tab) => !tab.disabled)?.key ?? headerTabs[0]?.key ?? "",
@@ -49,48 +66,59 @@ function HeaderGalleryPreview() {
   );
 
   return (
-    <div className="rounded-card border border-card-hairline/60 bg-panel/80 p-[var(--space-5)] shadow-[var(--shadow-outline-subtle)]">
-      <Header
-        eyebrow="Workspace"
-        heading="Header"
-        subtitle="Segmented navigation anchored to the header"
-        icon={
-          <Circle
-            aria-hidden="true"
-            className="h-[var(--space-5)] w-[var(--space-5)] text-primary"
-          />
-        }
-        tabs={{
-          items: headerTabs,
-          value,
-          onChange: setValue,
-          ariaLabel: "Header demo tabs",
-          size: "md",
-        }}
-        sticky={false}
-        topClassName="top-0"
-      >
-        <p className="text-ui text-muted-foreground">
-          Viewing
-          <span className="ml-[var(--space-1)] font-medium text-foreground">
-            {activeLabel}
-          </span>
-        </p>
-      </Header>
-      <div className="mt-[var(--space-4)] grid gap-[var(--space-3)] sm:grid-cols-2">
-        <div className="rounded-card border border-card-hairline/60 bg-surface px-[var(--space-4)] py-[var(--space-3)]">
-          <p className="text-label text-muted-foreground">Next milestone</p>
-          <p className="mt-[var(--space-1)] text-ui font-medium text-foreground">
-            Launch sprint
+    <div className="grid gap-[var(--space-4)] lg:grid-cols-2">
+      {headerRailToneExamples.map((example) => (
+        <div
+          key={example.tone}
+          className="rounded-card border border-card-hairline/60 bg-panel/80 p-[var(--space-5)] shadow-[var(--shadow-outline-subtle)]"
+        >
+          <p className="mb-[var(--space-3)] text-label font-medium text-muted-foreground">
+            {example.label}
           </p>
+          <Header
+            eyebrow="Workspace"
+            heading="Header"
+            subtitle="Segmented navigation anchored to the header"
+            icon={
+              <Circle
+                aria-hidden="true"
+                className="h-[var(--space-5)] w-[var(--space-5)] text-primary"
+              />
+            }
+            railTone={example.tone}
+            tabs={{
+              items: headerTabs,
+              value,
+              onChange: setValue,
+              ariaLabel: example.ariaLabel,
+              size: "md",
+            }}
+            sticky={false}
+            topClassName="top-0"
+          >
+            <p className="text-ui text-muted-foreground">
+              Viewing
+              <span className="ml-[var(--space-1)] font-medium text-foreground">
+                {activeLabel}
+              </span>
+            </p>
+          </Header>
+          <div className="mt-[var(--space-4)] grid gap-[var(--space-3)] sm:grid-cols-2">
+            <div className="rounded-card border border-card-hairline/60 bg-surface px-[var(--space-4)] py-[var(--space-3)]">
+              <p className="text-label text-muted-foreground">Next milestone</p>
+              <p className="mt-[var(--space-1)] text-ui font-medium text-foreground">
+                Launch sprint
+              </p>
+            </div>
+            <div className="rounded-card border border-card-hairline/60 bg-surface px-[var(--space-4)] py-[var(--space-3)]">
+              <p className="text-label text-muted-foreground">Team focus</p>
+              <p className="mt-[var(--space-1)] text-ui font-medium text-foreground">
+                Deep work block
+              </p>
+            </div>
+          </div>
         </div>
-        <div className="rounded-card border border-card-hairline/60 bg-surface px-[var(--space-4)] py-[var(--space-3)]">
-          <p className="text-label text-muted-foreground">Team focus</p>
-          <p className="mt-[var(--space-1)] text-ui font-medium text-foreground">
-            Deep work block
-          </p>
-        </div>
-      </div>
+      ))}
     </div>
   );
 }
@@ -115,83 +143,177 @@ export default defineGallerySection({
             { value: "Disabled" },
           ],
         },
+        {
+          id: "rail-tone",
+          label: "Rail tone",
+          type: "variant",
+          values: [
+            { value: "Subtle" },
+            { value: "Loud" },
+          ],
+        },
       ],
       preview: createGalleryPreview({
         id: "ui:header:tabs",
         render: () => <HeaderGalleryPreview />,
       }),
-      code: `<div className="rounded-card border border-card-hairline/60 bg-panel/80 p-[var(--space-5)] shadow-[var(--shadow-outline-subtle)]">
-  <Header
-    eyebrow="Workspace"
-    heading="Header"
-    subtitle="Segmented navigation anchored to the header"
-    icon={
-      <Circle
-        aria-hidden="true"
-        className="h-[var(--space-5)] w-[var(--space-5)] text-primary"
-      />
-    }
-    tabs={{
-      items: [
-        {
-          key: "summary",
-          label: "Summary",
-          icon: (
-            <Circle
-              aria-hidden="true"
-              className="h-[var(--space-4)] w-[var(--space-4)]"
-            />
-          ),
-        },
-        {
-          key: "timeline",
-          label: "Timeline",
-          icon: (
-            <CircleDot
-              aria-hidden="true"
-              className="h-[var(--space-4)] w-[var(--space-4)]"
-            />
-          ),
-        },
-        {
-          key: "insights",
-          label: "Insights",
-          icon: (
-            <CircleCheck
-              aria-hidden="true"
-              className="h-[var(--space-4)] w-[var(--space-4)]"
-            />
-          ),
-          disabled: true,
-        },
-      ],
-      value: "summary",
-      onChange: () => {},
-      ariaLabel: "Header demo tabs",
-      size: "md",
-    }}
-    sticky={false}
-    topClassName="top-0"
-  >
-    <p className="text-ui text-muted-foreground">
-      Viewing
-      <span className="ml-[var(--space-1)] font-medium text-foreground">
-        Summary
-      </span>
+      code: `<div className="grid gap-[var(--space-4)] lg:grid-cols-2">
+  <div className="rounded-card border border-card-hairline/60 bg-panel/80 p-[var(--space-5)] shadow-[var(--shadow-outline-subtle)]">
+    <p className="mb-[var(--space-3)] text-label text-muted-foreground">
+      Subtle rail tone (default)
     </p>
-  </Header>
-  <div className="mt-[var(--space-4)] grid gap-[var(--space-3)] sm:grid-cols-2">
-    <div className="rounded-card border border-card-hairline/60 bg-surface px-[var(--space-4)] py-[var(--space-3)]">
-      <p className="text-label text-muted-foreground">Next milestone</p>
-      <p className="mt-[var(--space-1)] text-ui font-medium text-foreground">
-        Launch sprint
+    <Header
+      eyebrow="Workspace"
+      heading="Header"
+      subtitle="Segmented navigation anchored to the header"
+      railTone="subtle"
+      icon={
+        <Circle
+          aria-hidden="true"
+          className="h-[var(--space-5)] w-[var(--space-5)] text-primary"
+        />
+      }
+      tabs={{
+        items: [
+          {
+            key: "summary",
+            label: "Summary",
+            icon: (
+              <Circle
+                aria-hidden="true"
+                className="h-[var(--space-4)] w-[var(--space-4)]"
+              />
+            ),
+          },
+          {
+            key: "timeline",
+            label: "Timeline",
+            icon: (
+              <CircleDot
+                aria-hidden="true"
+                className="h-[var(--space-4)] w-[var(--space-4)]"
+              />
+            ),
+          },
+          {
+            key: "insights",
+            label: "Insights",
+            icon: (
+              <CircleCheck
+                aria-hidden="true"
+                className="h-[var(--space-4)] w-[var(--space-4)]"
+              />
+            ),
+            disabled: true,
+          },
+        ],
+        value: "summary",
+        onChange: () => {},
+        ariaLabel: "Header demo tabs (subtle tone)",
+        size: "md",
+      }}
+      sticky={false}
+      topClassName="top-0"
+    >
+      <p className="text-ui text-muted-foreground">
+        Viewing
+        <span className="ml-[var(--space-1)] font-medium text-foreground">
+          Summary
+        </span>
       </p>
+    </Header>
+    <div className="mt-[var(--space-4)] grid gap-[var(--space-3)] sm:grid-cols-2">
+      <div className="rounded-card border border-card-hairline/60 bg-surface px-[var(--space-4)] py-[var(--space-3)]">
+        <p className="text-label text-muted-foreground">Next milestone</p>
+        <p className="mt-[var(--space-1)] text-ui font-medium text-foreground">
+          Launch sprint
+        </p>
+      </div>
+      <div className="rounded-card border border-card-hairline/60 bg-surface px-[var(--space-4)] py-[var(--space-3)]">
+        <p className="text-label text-muted-foreground">Team focus</p>
+        <p className="mt-[var(--space-1)] text-ui font-medium text-foreground">
+          Deep work block
+        </p>
+      </div>
     </div>
-    <div className="rounded-card border border-card-hairline/60 bg-surface px-[var(--space-4)] py-[var(--space-3)]">
-      <p className="text-label text-muted-foreground">Team focus</p>
-      <p className="mt-[var(--space-1)] text-ui font-medium text-foreground">
-        Deep work block
+  </div>
+  <div className="rounded-card border border-card-hairline/60 bg-panel/80 p-[var(--space-5)] shadow-[var(--shadow-outline-subtle)]">
+    <p className="mb-[var(--space-3)] text-label text-muted-foreground">
+      Loud rail tone
+    </p>
+    <Header
+      eyebrow="Workspace"
+      heading="Header"
+      subtitle="Segmented navigation anchored to the header"
+      railTone="loud"
+      icon={
+        <Circle
+          aria-hidden="true"
+          className="h-[var(--space-5)] w-[var(--space-5)] text-primary"
+        />
+      }
+      tabs={{
+        items: [
+          {
+            key: "summary",
+            label: "Summary",
+            icon: (
+              <Circle
+                aria-hidden="true"
+                className="h-[var(--space-4)] w-[var(--space-4)]"
+              />
+            ),
+          },
+          {
+            key: "timeline",
+            label: "Timeline",
+            icon: (
+              <CircleDot
+                aria-hidden="true"
+                className="h-[var(--space-4)] w-[var(--space-4)]"
+              />
+            ),
+          },
+          {
+            key: "insights",
+            label: "Insights",
+            icon: (
+              <CircleCheck
+                aria-hidden="true"
+                className="h-[var(--space-4)] w-[var(--space-4)]"
+              />
+            ),
+            disabled: true,
+          },
+        ],
+        value: "summary",
+        onChange: () => {},
+        ariaLabel: "Header demo tabs (loud tone)",
+        size: "md",
+      }}
+      sticky={false}
+      topClassName="top-0"
+    >
+      <p className="text-ui text-muted-foreground">
+        Viewing
+        <span className="ml-[var(--space-1)] font-medium text-foreground">
+          Summary
+        </span>
       </p>
+    </Header>
+    <div className="mt-[var(--space-4)] grid gap-[var(--space-3)] sm:grid-cols-2">
+      <div className="rounded-card border border-card-hairline/60 bg-surface px-[var(--space-4)] py-[var(--space-3)]">
+        <p className="text-label text-muted-foreground">Next milestone</p>
+        <p className="mt-[var(--space-1)] text-ui font-medium text-foreground">
+          Launch sprint
+        </p>
+      </div>
+      <div className="rounded-card border border-card-hairline/60 bg-surface px-[var(--space-4)] py-[var(--space-3)]">
+        <p className="text-label text-muted-foreground">Team focus</p>
+        <p className="mt-[var(--space-1)] text-ui font-medium text-foreground">
+          Deep work block
+        </p>
+      </div>
     </div>
   </div>
 </div>`,

--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -57,8 +57,10 @@ export interface HeaderProps<Key extends string = string>
   bodyClassName?: string;
   rail?: boolean;
   /** Decorative rail emphasis; defaults to the subtler glow. */
+  railTone?: "subtle" | "loud";
+  /** @deprecated Use railTone instead. */
   railVariant?: "subtle" | "loud";
-  /** Custom rail classes to opt into alternate treatments (e.g., loud rail). */
+  /** Custom rail classes to opt into alternate treatments. */
   railClassName?: string;
   /** Reduce vertical padding and height, ideal for denser layouts. */
   compact?: boolean;
@@ -85,7 +87,8 @@ export default function Header<Key extends string = string>({
   barClassName,
   bodyClassName,
   rail = true,
-  railVariant = "subtle",
+  railTone,
+  railVariant,
   railClassName,
   compact = false,
   tabs,
@@ -210,6 +213,8 @@ export default function Header<Key extends string = string>({
       : "py-[var(--space-3)] sm:py-[var(--space-4)]",
   );
 
+  const resolvedRailTone = railTone ?? railVariant ?? "subtle";
+
   return (
     <>
       {shouldRenderNeomorphicFrameStyles ? <NeomorphicFrameStyles /> : null}
@@ -245,8 +250,7 @@ export default function Header<Key extends string = string>({
             <div
               className={cx(
                 "header-rail pointer-events-none absolute left-0 top-[var(--space-1)] bottom-[var(--space-1)] w-[var(--space-2)] rounded-l-2xl",
-                railVariant !== "loud" && "header-rail--subtle",
-                railVariant === "loud" && "header-rail--loud",
+                resolvedRailTone !== "loud" && "header-rail--subtle",
                 railClassName,
               )}
               aria-hidden


### PR DESCRIPTION
## Summary
- introduce a `railTone` prop on `Header` with a subtle default and map the old `railVariant` to it for compatibility
- apply the selected tone modifier when rendering the decorative rail
- expand the header gallery to showcase both rail tones and document the prop in the code snippet

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d177df8344832ca7d64c073f4bdcf5