### PR TITLE
Add nuke all goals control

### DIFF
--- a/src/components/goals/useGoals.ts
+++ b/src/components/goals/useGoals.ts
@@ -140,6 +140,16 @@ export function useGoals() {
     [goals, setGoals],
   );
 
+  const clearGoals = React.useCallback(() => {
+    setErr(null);
+    setGoals(() => []);
+    setLastDeleted(null);
+    if (undoTimer.current) {
+      clearTimeout(undoTimer.current);
+      undoTimer.current = null;
+    }
+  }, [setGoals]);
+
   const updateGoal = React.useCallback(
     (id: string, updates: Pick<Goal, "title" | "metric" | "notes">) => {
       setGoals((prev) =>
@@ -171,6 +181,7 @@ export function useGoals() {
     removeGoal,
     updateGoal,
     undoRemove,
+    clearGoals,
   } as const;
 }
 


### PR DESCRIPTION
## Summary
- add a destructive "Nuke all" control on the Goals page with modal confirmation and feedback messaging
- expose a `clearGoals` helper from the goals hook to wipe persisted goals and reset undo state

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d178f63e0c832cb692cbcddcc4f838