### PR TITLE
Fix hero life divider tint

### DIFF
--- a/src/components/ui/layout/hero/useHeroStyles.ts
+++ b/src/components/ui/layout/hero/useHeroStyles.ts
@@ -67,7 +67,7 @@ export function useHeroStyles(options: HeroStyleOptions): HeroStyleResult {
     const showRail = rail && !isGlitchOff;
     const showDividerGlow = frame && !isGlitchOff;
     const dividerStyle = {
-      "--divider": dividerTint === "life" ? "var(--accent)" : "var(--ring)",
+      "--divider": dividerTint === "life" ? "var(--accent-3)" : "var(--ring)",
     } as React.CSSProperties;
 
     const stickyClasses = sticky ? cn("sticky sticky-blur", topClassName) : "";

--- a/tests/components/PageHeader.test.tsx
+++ b/tests/components/PageHeader.test.tsx
@@ -105,6 +105,30 @@ describe("PageHeader", () => {
     expect(subtitle).not.toHaveClass("font-normal");
   });
 
+  it("uses the life divider tint token when requested", () => {
+    render(
+      <PageHeader
+        header={baseHeader}
+        hero={{
+          ...baseHero,
+          dividerTint: "life",
+          actions: <button type="button">Primary action</button>,
+        }}
+        frameProps={{ slots: null }}
+      />,
+    );
+
+    const actionButton = screen.getByRole("button", {
+      name: "Primary action",
+    });
+    const dividerContainer = actionButton.closest("div[style]");
+
+    expect(dividerContainer).not.toBeNull();
+    expect(
+      (dividerContainer as HTMLElement).style.getPropertyValue("--divider"),
+    ).toBe("var(--accent-3)");
+  });
+
   it("balances header text when titles span multiple lines", () => {
     const wrappingHeading =
       "Expanded overview with multi-line planning guidance";


### PR DESCRIPTION
## Summary
- map the hero life divider tint to the teal accent token in the hero style hook
- add a PageHeader test covering the life divider tint styling when the hero renders its own action area

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d179158194832ca574d1dc75bdab1d