### PR TITLE
Allow hero search slot to opt out of neo wrapper

### DIFF
--- a/src/components/ui/layout/NeomorphicHeroFrame.tsx
+++ b/src/components/ui/layout/NeomorphicHeroFrame.tsx
@@ -23,6 +23,7 @@ export interface HeroSlot {
   className?: string;
   label?: string;
   labelledById?: string;
+  unstyled?: boolean;
 }
 
 export type HeroSlotInput = React.ReactNode | HeroSlot;
@@ -224,6 +225,9 @@ function normalizeSlot(value: HeroSlotInput | undefined): HeroSlot | null {
 
 const slotWellBaseClass =
   "hero-slot-well group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md bg-card/75 px-[var(--space-3)] py-[var(--space-2)] [--neo-inset-shadow:var(--shadow-neo-inset)] neo-inset hero-focus transition-[box-shadow,transform] duration-[var(--dur-chill)] ease-[var(--ease-out)] motion-reduce:transform-none motion-reduce:transition-none focus-within:ring-1 focus-within:ring-ring/60 before:pointer-events-none before:absolute before:inset-0 before:z-0 before:content-[''] before:rounded-[inherit] before:bg-[radial-gradient(circle_at_top_left,hsl(var(--highlight)/0.35)_0%,transparent_62%)] before:opacity-70 before:mix-blend-screen after:pointer-events-none after:absolute after:inset-0 after:z-0 after:content-[''] after:rounded-[inherit] after:translate-x-[calc(var(--space-1)/2)] after:translate-y-[calc(var(--space-1)/2)] after:bg-[radial-gradient(circle_at_bottom_right,hsl(var(--shadow-color)/0.28)_0%,transparent_65%)] after:shadow-[var(--shadow-neo-soft)] after:opacity-65 hover:[--neo-inset-shadow:var(--shadow-neo-soft)] focus-visible:[--neo-inset-shadow:var(--shadow-neo-soft)] focus-within:[--neo-inset-shadow:var(--shadow-neo-soft)] hover:-translate-y-[var(--hairline-w)] focus-visible:-translate-y-[var(--hairline-w)] focus-within:-translate-y-[var(--hairline-w)]";
+
+const slotUnstyledBaseClass =
+  "group/hero-slot flex w-full min-w-0 flex-col gap-[var(--space-2)]";
 
 const slotContentClass = "relative z-[1] flex w-full min-w-0 flex-col";
 
@@ -445,12 +449,13 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
             slot.labelledById.trim().length > 0
               ? slot.labelledById.trim()
               : undefined;
+          const isUnstyled = slot.unstyled ?? false;
           return (
             <div
               key={key}
               data-slot={key}
               className={cn(
-                slotWellBaseClass,
+                isUnstyled ? slotUnstyledBaseClass : slotWellBaseClass,
                 layout[key as keyof LayoutState],
                 aligns[key],
                 slot.className,
@@ -459,7 +464,11 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
               aria-label={slotLabel}
               aria-labelledby={slotLabelledById}
             >
-              <div className={slotContentClass}>{slot.node}</div>
+              {isUnstyled ? (
+                slot.node
+              ) : (
+                <div className={slotContentClass}>{slot.node}</div>
+              )}
             </div>
           );
         })}

--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -377,6 +377,12 @@ const PageHeaderInner = <
         ? visibleLabel.trim()
         : undefined;
 
+    const searchVariant = resolvedSearch.variant;
+    const searchRound = resolvedSearch.round;
+    const usesNeoPill =
+      searchVariant === "neo" ||
+      (searchVariant === undefined && searchRound !== false);
+
     const slotLabel = sanitizedAriaLabelledBy
       ? sanitizedAriaLabel ?? sanitizedVisibleLabel
       : sanitizedAriaLabel ?? sanitizedVisibleLabel ?? "Hero search";
@@ -387,6 +393,7 @@ const PageHeaderInner = <
       ...(sanitizedAriaLabelledBy
         ? { labelledById: sanitizedAriaLabelledBy }
         : {}),
+      ...(usesNeoPill ? { unstyled: true } : {}),
     };
   }, [resolvedSearch]);
 

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -260,30 +260,67 @@ exports[`ReviewsPage > renders default state 1`] = `
         >
           <div
             aria-label="Search reviews"
-            class="hero-slot-well group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md bg-card/75 px-[var(--space-3)] py-[var(--space-2)] [--neo-inset-shadow:var(--shadow-neo-inset)] neo-inset hero-focus transition-[box-shadow,transform] duration-[var(--dur-chill)] ease-[var(--ease-out)] motion-reduce:transform-none motion-reduce:transition-none focus-within:ring-1 focus-within:ring-ring/60 before:pointer-events-none before:absolute before:inset-0 before:z-0 before:content-[''] before:rounded-[inherit] before:bg-[radial-gradient(circle_at_top_left,hsl(var(--highlight)/0.35)_0%,transparent_62%)] before:opacity-70 before:mix-blend-screen after:pointer-events-none after:absolute after:inset-0 after:z-0 after:content-[''] after:rounded-[inherit] after:translate-x-[calc(var(--space-1)/2)] after:translate-y-[calc(var(--space-1)/2)] after:bg-[radial-gradient(circle_at_bottom_right,hsl(var(--shadow-color)/0.28)_0%,transparent_65%)] after:shadow-[var(--shadow-neo-soft)] after:opacity-65 hover:[--neo-inset-shadow:var(--shadow-neo-soft)] focus-visible:[--neo-inset-shadow:var(--shadow-neo-soft)] focus-within:[--neo-inset-shadow:var(--shadow-neo-soft)] hover:-translate-y-[var(--hairline-w)] focus-visible:-translate-y-[var(--hairline-w)] focus-within:-translate-y-[var(--hairline-w)] md:col-span-7 md:justify-self-center"
+            class="group/hero-slot flex w-full min-w-0 flex-col gap-[var(--space-2)] md:col-span-7 md:justify-self-center"
             data-slot="search"
             role="group"
           >
-            <div
-              class="relative z-[1] flex w-full min-w-0 flex-col"
+            <form
+              class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-[var(--space-2)] data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full min-w-0 rounded-full flex-1"
+              role="search"
             >
-              <form
-                class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-[var(--space-2)] data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none w-full min-w-0 rounded-full flex-1"
-                role="search"
+              <div
+                class="min-w-0"
               >
                 <div
-                  class="min-w-0"
+                  class="flex w-full flex-col gap-[var(--space-1)] min-w-0"
                 >
                   <div
-                    class="flex w-full flex-col gap-[var(--space-1)] min-w-0"
+                    class="group/field relative inline-flex min-h-[var(--field-h,var(--control-h-md))] items-center border bg-[hsl(var(--bg))] text-foreground shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.08),inset_0_calc(var(--hairline-w)*-1)_0_hsl(var(--border)/0.32)] transition-[background,box-shadow,filter] duration-[var(--dur-quick)] ease-out focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] focus-within:ring-offset-0 focus-within:ring-offset-[hsl(var(--bg))] hover:shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.12),inset_0_calc(var(--hairline-w)*-1)_0_hsl(var(--border)/0.45)] active:brightness-[0.96] data-[disabled=true]:pointer-events-none data-[disabled=true]:border-[hsl(var(--card-hairline)/0.4)] data-[disabled=true]:bg-[hsl(var(--card))] data-[disabled=true]:shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.04)] data-[disabled=true]:text-muted-foreground/70 data-[loading=true]:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[invalid=true]:border-[hsl(var(--danger)/0.6)] data-[invalid=true]:focus-within:ring-[hsl(var(--danger))] w-full hero2-neomorph z-0 !border border-[hsl(var(--border)/0.4)] !shadow-neo-soft hover:!shadow-neo-soft active:!shadow-neo-soft focus-within:!shadow-neo-soft [--hover:transparent] [--active:transparent] rounded-full [&>input]:rounded-full overflow-hidden hero2-frame"
+                    style="--field-h: var(--control-h-md);"
                   >
-                    <div
-                      class="group/field relative inline-flex min-h-[var(--field-h,var(--control-h-md))] items-center border bg-[hsl(var(--bg))] text-foreground shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.08),inset_0_calc(var(--hairline-w)*-1)_0_hsl(var(--border)/0.32)] transition-[background,box-shadow,filter] duration-[var(--dur-quick)] ease-out focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] focus-within:ring-offset-0 focus-within:ring-offset-[hsl(var(--bg))] hover:shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.12),inset_0_calc(var(--hairline-w)*-1)_0_hsl(var(--border)/0.45)] active:brightness-[0.96] data-[disabled=true]:pointer-events-none data-[disabled=true]:border-[hsl(var(--card-hairline)/0.4)] data-[disabled=true]:bg-[hsl(var(--card))] data-[disabled=true]:shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.04)] data-[disabled=true]:text-muted-foreground/70 data-[loading=true]:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[invalid=true]:border-[hsl(var(--danger)/0.6)] data-[invalid=true]:focus-within:ring-[hsl(var(--danger))] w-full hero2-neomorph z-0 !border border-[hsl(var(--border)/0.4)] !shadow-neo-soft hover:!shadow-neo-soft active:!shadow-neo-soft focus-within:!shadow-neo-soft [--hover:transparent] [--active:transparent] rounded-full [&>input]:rounded-full overflow-hidden hero2-frame"
-                      style="--field-h: var(--control-h-md);"
+                    <svg
+                      aria-hidden="true"
+                      class="lucide lucide-search pointer-events-none absolute left-[var(--space-4)] top-1/2 size-[var(--space-4)] -translate-y-1/2 text-muted-foreground transition-colors duration-[var(--dur-quick)] ease-out opacity-60 group-focus-within:opacity-100 group-focus-within:text-accent-3 group-data-[disabled=true]/field:opacity-[var(--disabled)] group-data-[loading=true]/field:opacity-[var(--loading)] group-data-[invalid=true]/field:text-danger"
+                      fill="none"
+                      height="24"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="m21 21-4.34-4.34"
+                      />
+                      <circle
+                        cx="11"
+                        cy="11"
+                        r="8"
+                      />
+                    </svg>
+                    <input
+                      aria-label="Search reviews"
+                      autocapitalize="none"
+                      autocomplete="off"
+                      autocorrect="off"
+                      class="peer block h-[var(--field-h,var(--control-h-md))] w-full rounded-[inherit] border-none bg-transparent px-[var(--space-3)] text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent focus:outline-none focus-visible:outline-none disabled:cursor-not-allowed read-only:cursor-default transition-[color,opacity] group-data-[disabled=true]/field:text-muted-foreground/70 group-data-[disabled=true]/field:placeholder:text-muted-foreground/50 group-data-[loading=true]/field:opacity-[var(--loading)] appearance-none [&::-webkit-search-cancel-button]:hidden [&::-webkit-search-cancel-button]:appearance-none pl-[var(--space-7)]"
+                      placeholder="Search title, tags, opponent, patch…"
+                      spellcheck="false"
+                      type="search"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear"
+                      class="inline-flex items-center justify-center select-none rounded-[var(--radius-full)] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] border bg-card/35 hover:bg-[--hover] [--hover:theme('colors.interaction.foreground.tintHover')] [--active:theme('colors.interaction.foreground.tintActive')] border-line/35 text-foreground h-[var(--control-h-sm)] w-[var(--control-h-sm)] [&_svg]:size-[calc(var(--control-h-sm)/2)] absolute right-[var(--space-3)] top-1/2 -translate-y-1/2 transition-opacity pointer-events-none opacity-0"
+                      tabindex="0"
+                      title="Clear"
+                      type="button"
                     >
                       <svg
                         aria-hidden="true"
-                        class="lucide lucide-search pointer-events-none absolute left-[var(--space-4)] top-1/2 size-[var(--space-4)] -translate-y-1/2 text-muted-foreground transition-colors duration-[var(--dur-quick)] ease-out opacity-60 group-focus-within:opacity-100 group-focus-within:text-accent-3 group-data-[disabled=true]/field:opacity-[var(--disabled)] group-data-[loading=true]/field:opacity-[var(--loading)] group-data-[invalid=true]/field:text-danger"
+                        class="lucide lucide-x"
                         fill="none"
                         height="24"
                         stroke="currentColor"
@@ -295,58 +332,17 @@ exports[`ReviewsPage > renders default state 1`] = `
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="m21 21-4.34-4.34"
+                          d="M18 6 6 18"
                         />
-                        <circle
-                          cx="11"
-                          cy="11"
-                          r="8"
+                        <path
+                          d="m6 6 12 12"
                         />
                       </svg>
-                      <input
-                        aria-label="Search reviews"
-                        autocapitalize="none"
-                        autocomplete="off"
-                        autocorrect="off"
-                        class="peer block h-[var(--field-h,var(--control-h-md))] w-full rounded-[inherit] border-none bg-transparent px-[var(--space-3)] text-ui text-foreground placeholder:text-muted-foreground/70 caret-accent focus:outline-none focus-visible:outline-none disabled:cursor-not-allowed read-only:cursor-default transition-[color,opacity] group-data-[disabled=true]/field:text-muted-foreground/70 group-data-[disabled=true]/field:placeholder:text-muted-foreground/50 group-data-[loading=true]/field:opacity-[var(--loading)] appearance-none [&::-webkit-search-cancel-button]:hidden [&::-webkit-search-cancel-button]:appearance-none pl-[var(--space-7)]"
-                        placeholder="Search title, tags, opponent, patch…"
-                        spellcheck="false"
-                        type="search"
-                        value=""
-                      />
-                      <button
-                        aria-label="Clear"
-                        class="inline-flex items-center justify-center select-none rounded-[var(--radius-full)] duration-[var(--dur-quick)] ease-out motion-reduce:transition-none active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] border bg-card/35 hover:bg-[--hover] [--hover:theme('colors.interaction.foreground.tintHover')] [--active:theme('colors.interaction.foreground.tintActive')] border-line/35 text-foreground h-[var(--control-h-sm)] w-[var(--control-h-sm)] [&_svg]:size-[calc(var(--control-h-sm)/2)] absolute right-[var(--space-3)] top-1/2 -translate-y-1/2 transition-opacity pointer-events-none opacity-0"
-                        tabindex="0"
-                        title="Clear"
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="lucide lucide-x"
-                          fill="none"
-                          height="24"
-                          stroke="currentColor"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M18 6 6 18"
-                          />
-                          <path
-                            d="m6 6 12 12"
-                          />
-                        </svg>
-                      </button>
-                    </div>
+                    </button>
                   </div>
                 </div>
-              </form>
-            </div>
+              </div>
+            </form>
           </div>
           <div
             class="hero-slot-well group/hero-slot relative isolate flex min-w-0 flex-col gap-[var(--space-2)] overflow-hidden rounded-card r-card-md bg-card/75 px-[var(--space-3)] py-[var(--space-2)] [--neo-inset-shadow:var(--shadow-neo-inset)] neo-inset hero-focus transition-[box-shadow,transform] duration-[var(--dur-chill)] ease-[var(--ease-out)] motion-reduce:transform-none motion-reduce:transition-none focus-within:ring-1 focus-within:ring-ring/60 before:pointer-events-none before:absolute before:inset-0 before:z-0 before:content-[''] before:rounded-[inherit] before:bg-[radial-gradient(circle_at_top_left,hsl(var(--highlight)/0.35)_0%,transparent_62%)] before:opacity-70 before:mix-blend-screen after:pointer-events-none after:absolute after:inset-0 after:z-0 after:content-[''] after:rounded-[inherit] after:translate-x-[calc(var(--space-1)/2)] after:translate-y-[calc(var(--space-1)/2)] after:bg-[radial-gradient(circle_at_bottom_right,hsl(var(--shadow-color)/0.28)_0%,transparent_65%)] after:shadow-[var(--shadow-neo-soft)] after:opacity-65 hover:[--neo-inset-shadow:var(--shadow-neo-soft)] focus-visible:[--neo-inset-shadow:var(--shadow-neo-soft)] focus-within:[--neo-inset-shadow:var(--shadow-neo-soft)] hover:-translate-y-[var(--hairline-w)] focus-visible:-translate-y-[var(--hairline-w)] focus-within:-translate-y-[var(--hairline-w)] md:col-span-5 md:justify-self-center"


### PR DESCRIPTION
## Summary
- add an `unstyled` escape hatch to hero slots so they can render without the neomorphic well
- mark the page header search slot as unstyled whenever the neo pill search variant is active
- refresh the reviews page snapshot to capture the simplified search slot markup

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d18e590af4832cafc0aa33fe6eb4f8