### PR TITLE
feat: add neutral underline tone to header

### DIFF
--- a/src/components/ui/layout/Header.gallery.tsx
+++ b/src/components/ui/layout/Header.gallery.tsx
@@ -39,20 +39,23 @@ const headerTabs: HeaderTabsProps<string>["items"] = [
   },
 ];
 
-const headerRailToneExamples: ReadonlyArray<{
-  tone: "subtle" | "loud";
+const headerUnderlineToneExamples: ReadonlyArray<{
+  railTone: "subtle" | "loud";
+  underlineTone: "brand" | "neutral";
   label: string;
   ariaLabel: string;
 }> = [
   {
-    tone: "subtle",
-    label: "Subtle rail tone (default)",
-    ariaLabel: "Header demo tabs (subtle tone)",
+    railTone: "subtle",
+    underlineTone: "neutral",
+    label: "Neutral underline (default)",
+    ariaLabel: "Header demo tabs (neutral underline)",
   },
   {
-    tone: "loud",
-    label: "Loud rail tone",
-    ariaLabel: "Header demo tabs (loud tone)",
+    railTone: "loud",
+    underlineTone: "brand",
+    label: "Brand underline",
+    ariaLabel: "Header demo tabs (brand underline)",
   },
 ];
 
@@ -67,9 +70,9 @@ function HeaderGalleryPreview() {
 
   return (
     <div className="grid gap-[var(--space-4)] lg:grid-cols-2">
-      {headerRailToneExamples.map((example) => (
+      {headerUnderlineToneExamples.map((example) => (
         <div
-          key={example.tone}
+          key={example.underlineTone}
           className="rounded-card border border-card-hairline/60 bg-panel/80 p-[var(--space-5)] shadow-[var(--shadow-outline-subtle)]"
         >
           <p className="mb-[var(--space-3)] text-label font-medium text-muted-foreground">
@@ -85,7 +88,8 @@ function HeaderGalleryPreview() {
                 className="h-[var(--space-5)] w-[var(--space-5)] text-primary"
               />
             }
-            railTone={example.tone}
+            railTone={example.railTone}
+            underlineTone={example.underlineTone}
             tabs={{
               items: headerTabs,
               value,
@@ -152,6 +156,15 @@ export default defineGallerySection({
             { value: "Loud" },
           ],
         },
+        {
+          id: "underline-tone",
+          label: "Underline tone",
+          type: "variant",
+          values: [
+            { value: "Neutral" },
+            { value: "Brand" },
+          ],
+        },
       ],
       preview: createGalleryPreview({
         id: "ui:header:tabs",
@@ -159,14 +172,15 @@ export default defineGallerySection({
       }),
       code: `<div className="grid gap-[var(--space-4)] lg:grid-cols-2">
   <div className="rounded-card border border-card-hairline/60 bg-panel/80 p-[var(--space-5)] shadow-[var(--shadow-outline-subtle)]">
-    <p className="mb-[var(--space-3)] text-label text-muted-foreground">
-      Subtle rail tone (default)
+    <p className="mb-[var(--space-3)] text-label font-medium text-muted-foreground">
+      Neutral underline (default)
     </p>
     <Header
       eyebrow="Workspace"
       heading="Header"
       subtitle="Segmented navigation anchored to the header"
       railTone="subtle"
+      underlineTone="neutral"
       icon={
         <Circle
           aria-hidden="true"
@@ -209,7 +223,7 @@ export default defineGallerySection({
         ],
         value: "summary",
         onChange: () => {},
-        ariaLabel: "Header demo tabs (subtle tone)",
+        ariaLabel: "Header demo tabs (neutral underline)",
         size: "md",
       }}
       sticky={false}
@@ -238,14 +252,15 @@ export default defineGallerySection({
     </div>
   </div>
   <div className="rounded-card border border-card-hairline/60 bg-panel/80 p-[var(--space-5)] shadow-[var(--shadow-outline-subtle)]">
-    <p className="mb-[var(--space-3)] text-label text-muted-foreground">
-      Loud rail tone
+    <p className="mb-[var(--space-3)] text-label font-medium text-muted-foreground">
+      Brand underline
     </p>
     <Header
       eyebrow="Workspace"
       heading="Header"
       subtitle="Segmented navigation anchored to the header"
       railTone="loud"
+      underlineTone="brand"
       icon={
         <Circle
           aria-hidden="true"
@@ -288,7 +303,7 @@ export default defineGallerySection({
         ],
         value: "summary",
         onChange: () => {},
-        ariaLabel: "Header demo tabs (loud tone)",
+        ariaLabel: "Header demo tabs (brand underline)",
         size: "md",
       }}
       sticky={false}

--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -70,6 +70,8 @@ export interface HeaderProps<Key extends string = string>
   variant?: "plain" | "neo" | "minimal";
   /** Show neon underline */
   underline?: boolean;
+  /** Controls the underline gradient tone. Defaults to a neutral treatment. */
+  underlineTone?: "brand" | "neutral";
 }
 
 export default function Header<Key extends string = string>({
@@ -94,6 +96,7 @@ export default function Header<Key extends string = string>({
   tabs,
   variant = "plain",
   underline = true,
+  underlineTone = "neutral",
   ...rest
 }: HeaderProps<Key>) {
   const isNeo = variant === "neo";
@@ -226,9 +229,14 @@ export default function Header<Key extends string = string>({
           isNeo && "overflow-hidden",
           translucentSurfaceClasses,
 
-          // Neon underline
+          // Underline accent
           underline &&
-            "after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent after:z-[2]",
+            cx(
+              "after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:z-[2]",
+              underlineTone === "brand"
+                ? "after:from-primary after:via-accent after:to-transparent"
+                : "after:from-card-hairline after:via-card-hairline/70 after:to-transparent",
+            ),
 
           className,
         )}

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`ReviewsPage > renders default state 1`] = `
             class="relative z-[2] md:space-y-[var(--space-6)] space-y-[var(--space-2)]"
           >
             <header
-              class="z-[999] relative isolate border-b border-card-hairline/60 bg-surface/80 backdrop-blur after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:from-primary after:via-accent after:to-transparent after:z-[2]"
+              class="z-[999] relative isolate border-b border-card-hairline/60 bg-surface/80 backdrop-blur after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:z-[2] after:from-card-hairline after:via-card-hairline/70 after:to-transparent"
               id="reviews-header"
             >
               <div


### PR DESCRIPTION
## Summary
- add an `underlineTone` prop to `Header`, defaulting to a neutral card hairline gradient while keeping a brand option
- surface the underline tone choices in the header gallery entry with updated preview metadata and copy
- refresh the reviews page snapshot so tests align with the new neutral underline treatment

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d18e31a980832cbf530a1fbe4fde4b