### PR TITLE
Add JSX namespace augmentation for framer-motion

### DIFF
--- a/types/jsx-namespace.d.ts
+++ b/types/jsx-namespace.d.ts
@@ -1,0 +1,9 @@
+import type * as React from "react";
+
+declare global {
+  namespace JSX {
+    interface Element extends React.ReactElement<any, any> {}
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add a global JSX namespace augmentation so framer-motion types compile under React 19

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d19f302044832c9759702388188558