### PR TITLE
Refine home hero actions for sNuemorphism

### DIFF
--- a/src/components/home/home-landing/HomeHeroSection.tsx
+++ b/src/components/home/home-landing/HomeHeroSection.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { Home } from "lucide-react";
-import { PageHeader } from "@/components/ui";
+import { PageHeader, type HeroSlots } from "@/components/ui";
 import WelcomeHeroFigure from "../WelcomeHeroFigure";
 import type { HomeHeroSectionProps } from "./types";
 
@@ -18,6 +18,31 @@ export default function HomeHeroSection({ variant, actions }: HomeHeroSectionPro
     [variant],
   );
 
+  const hasActionContent = React.useMemo(
+    () => React.Children.count(actions ?? null) > 0,
+    [actions],
+  );
+
+  const heroFrameSlots = React.useMemo<HeroSlots | undefined>(() => {
+    if (!hasActionContent) {
+      return undefined;
+    }
+
+    return {
+      actions: {
+        node: (
+          <div className="flex w-full flex-wrap items-center justify-center gap-[var(--space-2)] sm:flex-nowrap sm:justify-end sm:gap-[var(--space-3)]">
+            {actions}
+          </div>
+        ),
+        className:
+          "w-full rounded-card r-card-lg border border-border/50 bg-card/80 px-[var(--space-3)] py-[var(--space-2)] shadow-neoSoft transition-[box-shadow] duration-[var(--dur-chill)] ease-[var(--ease-out)] hover:shadow-neo focus-within:ring-1 focus-within:ring-ring/60",
+        label: "Home hero quick actions",
+        unstyled: true,
+      },
+    } satisfies HeroSlots;
+  }, [actions, hasActionContent]);
+
   return (
     <section
       id="landing-hero"
@@ -28,11 +53,12 @@ export default function HomeHeroSection({ variant, actions }: HomeHeroSectionPro
     >
       <div className="col-span-12">
         <PageHeader
+          frameProps={heroFrameSlots ? { slots: heroFrameSlots } : undefined}
           header={{
             id: "home-header",
             heading: "Welcome to Planner",
             subtitle: "Plan your day, track goals, and review games.",
-            icon: <Home className="text-muted-foreground" />,
+            icon: <Home className="text-foreground" />,
             sticky: false,
             barClassName: "flex-wrap gap-y-[var(--space-3)] md:flex-nowrap",
             right: (
@@ -49,14 +75,9 @@ export default function HomeHeroSection({ variant, actions }: HomeHeroSectionPro
           hero={{
             heading: "Your day at a glance",
             sticky: false,
-            barVariant: "raised",
+            barVariant: "flat",
             glitch: "subtle",
             topClassName: "top-[var(--header-stack)]",
-            actions: (
-              <div className="flex w-full flex-wrap items-center justify-center gap-[var(--space-2)] sm:flex-nowrap sm:justify-end">
-                {actions}
-              </div>
-            ),
           }}
         />
       </div>


### PR DESCRIPTION
## Summary
- reshape the home hero actions into a single sNuemorphism plate via NeomorphicHeroFrame slots
- default the hero label cluster to a flat bar and upgrade the header icon tone for contrast
- guard slot setup when no actions are provided to avoid empty wells

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1a2465764832cb99a09feb8a1d8fe