### PR TITLE
Normalize hero offsets across pages

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -446,7 +446,6 @@ function GoalsPageContent() {
             heading: heroHeading,
             subtitle: heroSubtitle,
             sticky: false,
-            topClassName: GOALS_STICKY_TOP_CLASS,
             dividerTint: heroDividerTint,
             "aria-labelledby": heroHeadingId,
             "aria-describedby": heroAriaDescribedby,

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -407,7 +407,6 @@ export default function TimerTab() {
     <>
       <Hero
         frame={false}
-        topClassName="top-[var(--header-stack)]"
         eyebrow="Focus"
         heading="Timer"
         subtitle="Pick a duration and focus."

--- a/src/components/home/home-landing/HomeHeroSection.tsx
+++ b/src/components/home/home-landing/HomeHeroSection.tsx
@@ -51,7 +51,6 @@ export default function HomeHeroSection({ variant, actions }: HomeHeroSectionPro
             sticky: false,
             barVariant: "raised",
             glitch: "subtle",
-            topClassName: "top-[var(--header-stack)]",
             actions: (
               <div className="flex w-full flex-wrap items-center justify-center gap-[var(--space-2)] sm:flex-nowrap sm:justify-end">
                 {actions}

--- a/src/components/prompts/PromptsHeader.tsx
+++ b/src/components/prompts/PromptsHeader.tsx
@@ -50,7 +50,6 @@ export default function PromptsHeader({
         frame: false,
         sticky: false,
         tone: "supportive",
-        topClassName: "top-[var(--header-stack)]",
         heading: (
           <span className="sr-only" id={`${id}-hero`}>
             Prompt workspace controls

--- a/src/components/prompts/component-gallery/MiscPanel.tsx
+++ b/src/components/prompts/component-gallery/MiscPanel.tsx
@@ -441,7 +441,7 @@ export default function MiscPanel({ data }: MiscPanelProps) {
           element: (
             <div className="w-56 h-56 overflow-auto space-y-[var(--space-6)]">
               <Header heading="Stacked" icon={<Star className="opacity-80" />} />
-              <Hero heading="Stacked" topClassName="top-[var(--header-stack)]" />
+              <Hero heading="Stacked" />
               <div className="h-96" />
             </div>
           ),

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -76,14 +76,12 @@ export default function ReviewsPage({
           id: "reviews-header",
           heading: "Reviews",
           icon: <BookOpen className="opacity-80" />,
-          topClassName: "top-[var(--header-stack)]",
           underline: true,
           sticky: false,
         }}
         hero={{
           frame: false,
           sticky: false,
-          topClassName: "top-[var(--header-stack)]",
           heading: "Browse Reviews",
           subtitle: <span className="pill">Total {base.length}</span>,
           search: {

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -270,7 +270,6 @@ export default function TeamCompPage() {
         as: "section",
         frame: false,
         sticky: true,
-        topClassName: "top-[var(--header-stack)]",
         eyebrow: active?.label,
         heading: "Comps",
         subtitle:
@@ -348,7 +347,6 @@ export default function TeamCompPage() {
         as: "section",
         frame: true,
         sticky: true,
-        topClassName: "top-[var(--header-stack)]",
         eyebrow: active?.label ?? "Comps",
         heading: "Builder",
         subtitle,
@@ -420,7 +418,6 @@ export default function TeamCompPage() {
       as: "section",
       frame: false,
       sticky: false,
-      topClassName: "top-[var(--header-stack)]",
       rail: true,
       heading: "Clear Speed Buckets",
       dividerTint: "primary",

--- a/src/components/ui/layout/hero/Hero.tsx
+++ b/src/components/ui/layout/hero/Hero.tsx
@@ -90,7 +90,7 @@ function Hero<Key extends string = string>({
   frame = true,
   glitch = "subtle",
   sticky = true,
-  topClassName = "top-[var(--space-8)]",
+  topClassName = "top-[var(--header-stack)]",
   barClassName,
   bodyClassName,
   barVariant = "flat",

--- a/types/jsx-namespace.d.ts
+++ b/types/jsx-namespace.d.ts
@@ -1,0 +1,16 @@
+import type * as React from "react";
+
+declare global {
+  namespace JSX {
+    type Element = React.JSX.Element;
+    interface ElementClass extends React.JSX.ElementClass {}
+    interface ElementAttributesProperty
+      extends React.JSX.ElementAttributesProperty {}
+    interface ElementChildrenAttribute
+      extends React.JSX.ElementChildrenAttribute {}
+    interface IntrinsicElements extends React.JSX.IntrinsicElements {}
+    interface IntrinsicAttributes extends React.JSX.IntrinsicAttributes {}
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- default Hero sticky offset now aligns with the global header stack token
- remove redundant hero offset overrides across planner, reviews, prompts, and home experiences
- add a JSX namespace shim so type checking recognizes JSX.Element exports

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1a090e398832cbfd91c9fe86ca1e5