### PR TITLE
Refactor feature headers into PageShell headers

### DIFF
--- a/src/components/components/ComponentsPageClient.tsx
+++ b/src/components/components/ComponentsPageClient.tsx
@@ -80,155 +80,163 @@ export default function ComponentsPageClient({
   } = useComponentsGalleryState({ navigation });
 
   return (
-    <PageShell
-      as="main"
-      grid
-      aria-labelledby="components-header"
-      className="py-[var(--space-6)] md:py-[var(--space-7)] lg:py-[var(--space-8)]"
-      contentClassName="gap-y-[var(--space-6)] md:gap-y-[var(--space-7)] lg:gap-y-[var(--space-8)]"
-    >
-      <PageHeader
-        containerClassName="relative isolate col-span-full"
-        header={{
-          id: "components-header",
-          heading: "Component Gallery",
-          subtitle: "Browse Planner UI building blocks by category.",
-          sticky: false,
-          tabs: {
-            items: viewTabs,
-            value: view,
-            onChange: handleViewChange,
-            ariaLabel: "Component gallery view",
-            idBase: COMPONENTS_VIEW_TAB_ID_BASE,
-            linkPanels: true,
-            variant: "neo",
-            tablistClassName: cn(NEO_TABLIST_SHARED_CLASSES, "w-full md:w-auto"),
-          },
-        }}
-        frameProps={{
-          className: HEADER_FRAME_CLASSNAME,
-        }}
-        hero={{
-          frame: true,
-          sticky: false,
-          eyebrow: heroCopy.eyebrow,
-          heading: heroCopy.heading,
-          subtitle: heroCopy.subtitle,
-          icon: (
-            <span className="[&_svg]:size-[var(--space-6)]">
-              <PanelsTopLeft aria-hidden />
-            </span>
-          ),
-          barClassName:
-            "isolate overflow-hidden rounded-card r-card-lg before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:bg-[radial-gradient(118%_82%_at_15%_-18%,hsl(var(--accent)/0.34),transparent_65%),radial-gradient(112%_78%_at_85%_-12%,hsl(var(--ring)/0.3),transparent_70%)] before:opacity-80 before:mix-blend-screen after:pointer-events-none after:absolute after:inset-0 after:-z-20 after:bg-[linear-gradient(135deg,hsl(var(--card)/0.9),hsl(var(--panel)/0.78)),repeating-linear-gradient(0deg,hsl(var(--ring)/0.12)_0_hsl(var(--ring)/0.12)_var(--hairline-w),transparent_var(--hairline-w),transparent_var(--space-2))] after:opacity-70 after:mix-blend-soft-light motion-reduce:after:opacity-50",
-          subTabs: showSectionTabs
-            ? {
-                ariaLabel: "Component section",
-                items: heroTabs,
-                value: section,
-                onChange: handleSectionChange,
-                idBase: COMPONENTS_SECTION_TAB_ID_BASE,
-                linkPanels: true,
-                size: "sm",
-                variant: "default",
-                showBaseline: true,
-                tablistClassName: cn(
-                  "max-w-full shadow-neo-inset rounded-card r-card-lg",
-                  "w-full md:w-auto",
-                ),
-                className: "max-w-full w-full md:w-auto",
-                renderItem: ({ item, props, ref, disabled }) => {
-                  const {
-                    className: baseClassName,
-                    onClick,
-                    "aria-label": ariaLabelProp,
-                    "aria-labelledby": ariaLabelledByProp,
-                    "aria-controls": ariaControlsProp,
-                    title: titleProp,
-                    ...restProps
-                  } = props;
-                  const handleClick: React.MouseEventHandler<HTMLElement> = (
-                    event,
-                  ) => {
-                    onClick?.(event);
-                    handleSectionChange(item.key);
-                  };
-                  const labelText =
-                    typeof item.label === "string" ? item.label : undefined;
-                  const computedTitle = titleProp ?? labelText;
-                  const computedAriaLabel =
-                    ariaLabelProp ??
-                    (labelText && !ariaLabelledByProp ? labelText : undefined);
-                  const computedAriaControls =
-                    ariaControlsProp != null ? COMPONENTS_PANEL_ID : undefined;
-
-                  return (
-                    <button
-                      type="button"
-                      {...restProps}
-                      ref={ref as React.Ref<HTMLButtonElement>}
-                      className={cn(
-                        baseClassName,
-                        "text-label font-normal text-muted-foreground transition-colors",
-                        "data-[active=true]:text-foreground data-[active=true]:font-medium",
-                        disabled && "pointer-events-none",
-                      )}
-                      onClick={(event) => {
-                        if (disabled) {
-                          event.preventDefault();
-                          event.stopPropagation();
-                          return;
-                        }
-                        handleClick(event);
-                      }}
-                      disabled={disabled}
-                      aria-labelledby={ariaLabelledByProp}
-                      aria-controls={computedAriaControls}
-                      aria-label={computedAriaLabel}
-                      title={computedTitle}
-                    >
-                      <span className="truncate">{item.label}</span>
-                    </button>
-                  );
-                },
-              }
-            : undefined,
-          search:
-            showSectionTabs
+    <>
+      <PageShell
+        as="header"
+        className="py-[var(--space-6)] md:py-[var(--space-7)] lg:py-[var(--space-8)]"
+      >
+        <PageHeader
+          containerClassName="relative isolate col-span-full"
+          header={{
+            id: "components-header",
+            heading: "Component Gallery",
+            subtitle: "Browse Planner UI building blocks by category.",
+            sticky: false,
+            tabs: {
+              items: viewTabs,
+              value: view,
+              onChange: handleViewChange,
+              ariaLabel: "Component gallery view",
+              idBase: COMPONENTS_VIEW_TAB_ID_BASE,
+              linkPanels: true,
+              variant: "neo",
+              tablistClassName: cn(NEO_TABLIST_SHARED_CLASSES, "w-full md:w-auto"),
+            },
+          }}
+          frameProps={{
+            className: HEADER_FRAME_CLASSNAME,
+          }}
+          hero={{
+            frame: true,
+            sticky: false,
+            eyebrow: heroCopy.eyebrow,
+            heading: heroCopy.heading,
+            subtitle: heroCopy.subtitle,
+            icon: (
+              <span className="[&_svg]:size-[var(--space-6)]">
+                <PanelsTopLeft aria-hidden />
+              </span>
+            ),
+            barClassName:
+              "isolate overflow-hidden rounded-card r-card-lg before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:bg-[radial-gradient(118%_82%_at_15%_-18%,hsl(var(--accent)/0.34),transparent_65%),radial-gradient(112%_78%_at_85%_-12%,hsl(var(--ring)/0.3),transparent_70%)] before:opacity-80 before:mix-blend-screen after:pointer-events-none after:absolute after:inset-0 after:-z-20 after:bg-[linear-gradient(135deg,hsl(var(--card)/0.9),hsl(var(--panel)/0.78)),repeating-linear-gradient(0deg,hsl(var(--ring)/0.12)_0_hsl(var(--ring)/0.12)_var(--hairline-w),transparent_var(--hairline-w),transparent_var(--space-2))] after:opacity-70 after:mix-blend-soft-light motion-reduce:after:opacity-50",
+            subTabs: showSectionTabs
               ? {
-                  id: "components-search",
-                  value: query,
-                  onValueChange: setQuery,
-                  debounceMs: 250,
-                  round: true,
-                  variant: "neo",
-                  label: searchLabel,
-                  placeholder: searchPlaceholder,
-                  fieldClassName: cn(
-                    "bg-[linear-gradient(135deg,hsl(var(--card)/0.95),hsl(var(--panel)/0.82))]",
-                    "!shadow-neo-soft",
-                    "hover:!shadow-neo-soft",
-                    "active:!shadow-neo-soft",
-                    "focus-within:!shadow-neo-soft",
-                    "focus-within:[--tw-ring-offset-width:var(--space-1)]",
-                    "focus-within:[--tw-ring-offset-color:hsl(var(--panel)/0.82)]",
-                    "motion-reduce:transition-none motion-reduce:hover:!shadow-neo-soft motion-reduce:active:!shadow-neo-soft motion-reduce:focus-within:!shadow-neo-soft",
+                  ariaLabel: "Component section",
+                  items: heroTabs,
+                  value: section,
+                  onChange: handleSectionChange,
+                  idBase: COMPONENTS_SECTION_TAB_ID_BASE,
+                  linkPanels: true,
+                  size: "sm",
+                  variant: "default",
+                  showBaseline: true,
+                  tablistClassName: cn(
+                    "max-w-full shadow-neo-inset rounded-card r-card-lg",
+                    "w-full md:w-auto",
                   ),
+                  className: "max-w-full w-full md:w-auto",
+                  renderItem: ({ item, props, ref, disabled }) => {
+                    const {
+                      className: baseClassName,
+                      onClick,
+                      "aria-label": ariaLabelProp,
+                      "aria-labelledby": ariaLabelledByProp,
+                      "aria-controls": ariaControlsProp,
+                      title: titleProp,
+                      ...restProps
+                    } = props;
+                    const handleClick: React.MouseEventHandler<HTMLElement> = (
+                      event,
+                    ) => {
+                      onClick?.(event);
+                      handleSectionChange(item.key);
+                    };
+                    const labelText =
+                      typeof item.label === "string" ? item.label : undefined;
+                    const computedTitle = titleProp ?? labelText;
+                    const computedAriaLabel =
+                      ariaLabelProp ??
+                      (labelText && !ariaLabelledByProp ? labelText : undefined);
+                    const computedAriaControls =
+                      ariaControlsProp != null ? COMPONENTS_PANEL_ID : undefined;
+
+                    return (
+                      <button
+                        type="button"
+                        {...restProps}
+                        ref={ref as React.Ref<HTMLButtonElement>}
+                        className={cn(
+                          baseClassName,
+                          "text-label font-normal text-muted-foreground transition-colors",
+                          "data-[active=true]:text-foreground data-[active=true]:font-medium",
+                          disabled && "pointer-events-none",
+                        )}
+                        onClick={(event) => {
+                          if (disabled) {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            return;
+                          }
+                          handleClick(event);
+                        }}
+                        disabled={disabled}
+                        aria-labelledby={ariaLabelledByProp}
+                        aria-controls={computedAriaControls}
+                        aria-label={computedAriaLabel}
+                        title={computedTitle}
+                      >
+                        <span className="truncate">{item.label}</span>
+                      </button>
+                    );
+                  },
                 }
               : undefined,
-        }}
-      />
-      <ComponentsGalleryPanels
-        view={view}
-        filteredSpecs={filteredSpecs}
-        sectionLabel={sectionLabel}
-        countLabel={countLabel}
-        countDescriptionId={countDescriptionId}
-        componentsPanelLabelledBy={componentsPanelLabelledBy}
-        componentsPanelRef={componentsPanelRef}
-        tokensPanelRef={tokensPanelRef}
-        tokenGroups={tokenGroups}
-      />
-    </PageShell>
+            search:
+              showSectionTabs
+                ? {
+                    id: "components-search",
+                    value: query,
+                    onValueChange: setQuery,
+                    debounceMs: 250,
+                    round: true,
+                    variant: "neo",
+                    label: searchLabel,
+                    placeholder: searchPlaceholder,
+                    fieldClassName: cn(
+                      "bg-[linear-gradient(135deg,hsl(var(--card)/0.95),hsl(var(--panel)/0.82))]",
+                      "!shadow-neo-soft",
+                      "hover:!shadow-neo-soft",
+                      "active:!shadow-neo-soft",
+                      "focus-within:!shadow-neo-soft",
+                      "focus-within:[--tw-ring-offset-width:var(--space-1)]",
+                      "focus-within:[--tw-ring-offset-color:hsl(var(--panel)/0.82)]",
+                      "motion-reduce:transition-none motion-reduce:hover:!shadow-neo-soft motion-reduce:active:!shadow-neo-soft motion-reduce:focus-within:!shadow-neo-soft",
+                    ),
+                  }
+                : undefined,
+          }}
+        />
+      </PageShell>
+
+      <PageShell
+        as="main"
+        grid
+        aria-labelledby="components-header"
+        className="py-[var(--space-6)] md:py-[var(--space-7)] lg:py-[var(--space-8)]"
+        contentClassName="gap-y-[var(--space-6)] md:gap-y-[var(--space-7)] lg:gap-y-[var(--space-8)]"
+      >
+        <ComponentsGalleryPanels
+          view={view}
+          filteredSpecs={filteredSpecs}
+          sectionLabel={sectionLabel}
+          countLabel={countLabel}
+          countDescriptionId={countDescriptionId}
+          componentsPanelLabelledBy={componentsPanelLabelledBy}
+          componentsPanelRef={componentsPanelRef}
+          tokensPanelRef={tokensPanelRef}
+          tokenGroups={tokenGroups}
+        />
+      </PageShell>
+    </>
   );
 }

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -415,13 +415,8 @@ function GoalsPageContent() {
   }, [tab, handleAddReminder]);
 
   return (
-    <PageShell
-      as="main"
-      aria-labelledby="goals-header"
-      className="py-[var(--space-6)]"
-    >
-      <div className="grid gap-[var(--space-6)]">
-        {/* ======= HEADER ======= */}
+    <>
+      <PageShell as="header" className="py-[var(--space-6)]">
         <PageHeader
           header={{
             id: "goals-header",
@@ -455,18 +450,25 @@ function GoalsPageContent() {
           search={reminderHeroSearch}
           actions={reminderHeroActions}
         />
+      </PageShell>
 
-        {/* ======= PANELS ======= */}
-        <div
-          role="region"
-          id="goals-panel"
-          aria-labelledby="goals-tab"
-          hidden={tab !== "goals"}
-          tabIndex={tab === "goals" ? 0 : -1}
-          ref={goalsRef}
-        >
-          {tab === "goals" && (
-            <div className="grid gap-[var(--space-4)]">
+      <PageShell
+        as="main"
+        aria-labelledby="goals-header"
+        className="py-[var(--space-6)]"
+      >
+        <div className="grid gap-[var(--space-6)]">
+          {/* ======= PANELS ======= */}
+          <div
+            role="region"
+            id="goals-panel"
+            aria-labelledby="goals-tab"
+            hidden={tab !== "goals"}
+            tabIndex={tab === "goals" ? 0 : -1}
+            ref={goalsRef}
+          >
+            {tab === "goals" && (
+              <div className="grid gap-[var(--space-4)]">
               <div className="space-y-[var(--space-2)]">
                 <SectionCard className="card-neo-soft">
                   <SectionCard.Header
@@ -554,89 +556,90 @@ function GoalsPageContent() {
               )}
             </div>
           )}
-        </div>
-
-        <div
-          role="region"
-          id="reminders-panel"
-          aria-labelledby="reminders-tab"
-          hidden={tab !== "reminders"}
-          tabIndex={tab === "reminders" ? 0 : -1}
-          ref={remindersRef}
-          className="grid gap-[var(--space-4)]"
-        >
-          {tab === "reminders" && <RemindersTab />}
-        </div>
-
-        <div
-          role="region"
-          id="timer-panel"
-          aria-labelledby="timer-tab"
-          hidden={tab !== "timer"}
-          tabIndex={tab === "timer" ? 0 : -1}
-          ref={timerRef}
-          className="grid gap-[var(--space-4)]"
-        >
-          {tab === "timer" && <TimerTab />}
-        </div>
-      </div>
-
-      <Modal
-        id={nukeDialogId}
-        open={confirmClearOpen}
-        onClose={handleCloseNuke}
-        aria-labelledby={nukeHeadingId}
-        aria-describedby={nukeDescriptionId}
-        className="shadow-[var(--shadow-neo-soft)]"
-      >
-        <CardHeader className="space-y-[var(--space-2)]">
-          <CardTitle id={nukeHeadingId}>Delete all goals?</CardTitle>
-          <CardDescription id={nukeDescriptionId}>
-            This action permanently removes every goal, including completed history.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-[var(--space-3)]">
-          <div className="rounded-card border border-danger/40 bg-danger/10 px-[var(--space-4)] py-[var(--space-3)] text-left shadow-[var(--shadow-outline-subtle)]">
-            <p className="text-ui font-medium text-danger">
-              You are about to nuke {totalCount} {totalCount === 1 ? "goal" : "goals"}.
-            </p>
-            <p className="text-label text-muted-foreground">
-              There is no automatic undo. Export anything important before continuing.
-            </p>
           </div>
-        </CardContent>
-        <CardFooter className="flex justify-end gap-[var(--space-2)]">
-          <Button
-            ref={confirmButtonRef}
-            type="button"
-            size="sm"
-            variant="primary"
-            tone="danger"
-            tactile
-            onClick={handleConfirmNuke}
-            className="shrink-0"
-          >
-            <Bomb aria-hidden="true" className="size-[var(--space-4)]" />
-            <span className="font-semibold tracking-[0.01em]">Delete all goals</span>
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            variant="ghost"
-            onClick={handleCloseNuke}
-            className="shrink-0"
-          >
-            Cancel
-          </Button>
-        </CardFooter>
-      </Modal>
 
-      {/* Use boolean styled-jsx attribute to satisfy typings */}
-      <style jsx>{`
-        .tabular-nums {
-          font-variant-numeric: tabular-nums;
-        }
-      `}</style>
-    </PageShell>
+          <div
+            role="region"
+            id="reminders-panel"
+            aria-labelledby="reminders-tab"
+            hidden={tab !== "reminders"}
+            tabIndex={tab === "reminders" ? 0 : -1}
+            ref={remindersRef}
+            className="grid gap-[var(--space-4)]"
+          >
+            {tab === "reminders" && <RemindersTab />}
+          </div>
+
+          <div
+            role="region"
+            id="timer-panel"
+            aria-labelledby="timer-tab"
+            hidden={tab !== "timer"}
+            tabIndex={tab === "timer" ? 0 : -1}
+            ref={timerRef}
+            className="grid gap-[var(--space-4)]"
+          >
+            {tab === "timer" && <TimerTab />}
+          </div>
+        </div>
+
+        <Modal
+          id={nukeDialogId}
+          open={confirmClearOpen}
+          onClose={handleCloseNuke}
+          aria-labelledby={nukeHeadingId}
+          aria-describedby={nukeDescriptionId}
+          className="shadow-[var(--shadow-neo-soft)]"
+        >
+          <CardHeader className="space-y-[var(--space-2)]">
+            <CardTitle id={nukeHeadingId}>Delete all goals?</CardTitle>
+            <CardDescription id={nukeDescriptionId}>
+              This action permanently removes every goal, including completed history.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-[var(--space-3)]">
+            <div className="rounded-card border border-danger/40 bg-danger/10 px-[var(--space-4)] py-[var(--space-3)] text-left shadow-[var(--shadow-outline-subtle)]">
+              <p className="text-ui font-medium text-danger">
+                You are about to nuke {totalCount} {totalCount === 1 ? "goal" : "goals"}.
+              </p>
+              <p className="text-label text-muted-foreground">
+                There is no automatic undo. Export anything important before continuing.
+              </p>
+            </div>
+          </CardContent>
+          <CardFooter className="flex justify-end gap-[var(--space-2)]">
+            <Button
+              ref={confirmButtonRef}
+              type="button"
+              size="sm"
+              variant="primary"
+              tone="danger"
+              tactile
+              onClick={handleConfirmNuke}
+              className="shrink-0"
+            >
+              <Bomb aria-hidden="true" className="size-[var(--space-4)]" />
+              <span className="font-semibold tracking-[0.01em]">Delete all goals</span>
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={handleCloseNuke}
+              className="shrink-0"
+            >
+              Cancel
+            </Button>
+          </CardFooter>
+        </Modal>
+
+        {/* Use boolean styled-jsx attribute to satisfy typings */}
+        <style jsx>{`
+          .tabular-nums {
+            font-variant-numeric: tabular-nums;
+          }
+        `}</style>
+      </PageShell>
+    </>
   );
 }

--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -81,11 +81,7 @@ function Inner() {
 
   return (
     <>
-      <PageShell
-        as="main"
-        className="py-[var(--space-6)] space-y-[var(--space-6)]"
-        aria-labelledby="planner-header"
-      >
+      <PageShell as="header" className="py-[var(--space-6)]">
         {/* Week header (range, nav, totals, day chips) */}
         <PageHeader
           contentClassName="space-y-[var(--space-2)]"
@@ -116,7 +112,13 @@ function Inner() {
             ),
           }}
         />
+      </PageShell>
 
+      <PageShell
+        as="main"
+        className="py-[var(--space-6)] space-y-[var(--space-6)]"
+        aria-labelledby="planner-header"
+      >
         {/* Today + Side column */}
         <section
           aria-label="Today and weekly panels"

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -134,12 +134,8 @@ export default function PromptsPage() {
   }, [activeTab, chatPrompts.length, codexPrompts.length, notes]);
 
   return (
-    <PageShell
-      as="main"
-      className="space-y-[var(--space-6)] py-[var(--space-6)]"
-      aria-labelledby="prompts-header"
-    >
-      <Tabs value={activeTab} onValueChange={setActiveTab} idBase="prompts-tabs">
+    <>
+      <PageShell as="header" className="py-[var(--space-6)]">
         <PromptsHeader
           id="prompts-header"
           count={activeCount}
@@ -148,42 +144,50 @@ export default function PromptsPage() {
           onSave={handleSave}
           disabled={saveDisabled}
         />
+      </PageShell>
 
-        <TabList
-          items={tabItems}
-          ariaLabel="Prompt workspaces"
-          variant="neo"
-          showBaseline
-        />
-
-        <TabPanel value="chat" className="pb-[var(--space-8)]">
-          <ChatPromptsTab
-            title={chatTitleDraft}
-            text={chatTextDraft}
-            onTitleChange={setChatTitleDraft}
-            onTextChange={setChatTextDraft}
-            prompts={chatFiltered}
-            query={chatQuery}
-            personas={personas}
+      <PageShell
+        as="main"
+        className="space-y-[var(--space-6)] py-[var(--space-6)]"
+        aria-labelledby="prompts-header"
+      >
+        <Tabs value={activeTab} onValueChange={setActiveTab} idBase="prompts-tabs">
+          <TabList
+            items={tabItems}
+            ariaLabel="Prompt workspaces"
+            variant="neo"
+            showBaseline
           />
-        </TabPanel>
 
-        <TabPanel value="codex" className="pb-[var(--space-8)]">
-          <CodexPromptsTab
-            title={codexTitleDraft}
-            text={codexTextDraft}
-            onTitleChange={setCodexTitleDraft}
-            onTextChange={setCodexTextDraft}
-            prompts={codexFiltered}
-            query={codexQuery}
-          />
-        </TabPanel>
+          <TabPanel value="chat" className="pb-[var(--space-8)]">
+            <ChatPromptsTab
+              title={chatTitleDraft}
+              text={chatTextDraft}
+              onTitleChange={setChatTitleDraft}
+              onTextChange={setChatTextDraft}
+              prompts={chatFiltered}
+              query={chatQuery}
+              personas={personas}
+            />
+          </TabPanel>
 
-        <TabPanel value="notes" className="pb-[var(--space-8)]">
-          <NotesTab value={notes} onChange={setNotes} />
-        </TabPanel>
-      </Tabs>
-    </PageShell>
+          <TabPanel value="codex" className="pb-[var(--space-8)]">
+            <CodexPromptsTab
+              title={codexTitleDraft}
+              text={codexTextDraft}
+              onTitleChange={setCodexTitleDraft}
+              onTextChange={setCodexTextDraft}
+              prompts={codexFiltered}
+              query={codexQuery}
+            />
+          </TabPanel>
+
+          <TabPanel value="notes" className="pb-[var(--space-8)]">
+            <NotesTab value={notes} onChange={setNotes} />
+          </TabPanel>
+        </Tabs>
+      </PageShell>
+    </>
   );
 }
 

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -64,76 +64,79 @@ export default function ReviewsPage({
   const detailBaseId = active ? `review-${active.id}` : "review-detail";
 
   return (
-    <PageShell
-      as="main"
-      className="py-[var(--space-6)] space-y-[var(--space-6)]"
-      aria-labelledby="reviews-header"
-    >
-      <PageHeader
-        className="rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-4)]"
-        contentClassName="space-y-[var(--space-2)]"
-        header={{
-          id: "reviews-header",
-          heading: "Reviews",
-          icon: <BookOpen className="opacity-80" />,
-          topClassName: "top-[var(--header-stack)]",
-          underline: true,
-          sticky: false,
-        }}
-        hero={{
-          frame: false,
-          sticky: false,
-          topClassName: "top-[var(--header-stack)]",
-          heading: "Browse Reviews",
-          subtitle: <span className="pill">Total {base.length}</span>,
-          search: {
-            round: true,
-            value: q,
-            onValueChange: setQ,
-            placeholder: "Search title, tags, opponent, patch…",
-            "aria-label": "Search reviews",
-            className: "flex-1",
-          },
-          actions: (
-            <div className="flex flex-col gap-[var(--space-2)] sm:flex-row sm:items-center sm:gap-[var(--space-3)]">
-              <label className="flex w-full flex-col gap-[var(--space-1)] sm:w-auto sm:flex-row sm:items-center sm:gap-[var(--space-2)]">
-                <span className="text-ui font-medium text-muted-foreground">
-                  Sort
-                </span>
-                <Select
-                  variant="animated"
-                  ariaLabel="Sort reviews"
-                  value={sort}
-                  onChange={(v) => setSort(v as SortKey)}
-                  items={[
-                    { value: "newest", label: "Newest" },
-                    { value: "oldest", label: "Oldest" },
-                    { value: "title", label: "Title" },
-                  ]}
-                  className="w-full sm:w-auto"
-                  size="lg"
-                />
-              </label>
-              <Button
-                type="button"
-                variant="primary"
-                size="md"
-                className="w-full whitespace-nowrap sm:w-auto"
-                onClick={handleCreateReview}
-              >
-                <Plus />
-                <span>New Review</span>
-              </Button>
-            </div>
-          ),
-        }}
-      />
+    <>
+      <PageShell as="header" className="py-[var(--space-6)]">
+        <PageHeader
+          className="rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-4)]"
+          contentClassName="space-y-[var(--space-2)]"
+          header={{
+            id: "reviews-header",
+            heading: "Reviews",
+            icon: <BookOpen className="opacity-80" />,
+            topClassName: "top-[var(--header-stack)]",
+            underline: true,
+            sticky: false,
+          }}
+          hero={{
+            frame: false,
+            sticky: false,
+            topClassName: "top-[var(--header-stack)]",
+            heading: "Browse Reviews",
+            subtitle: <span className="pill">Total {base.length}</span>,
+            search: {
+              round: true,
+              value: q,
+              onValueChange: setQ,
+              placeholder: "Search title, tags, opponent, patch…",
+              "aria-label": "Search reviews",
+              className: "flex-1",
+            },
+            actions: (
+              <div className="flex flex-col gap-[var(--space-2)] sm:flex-row sm:items-center sm:gap-[var(--space-3)]">
+                <label className="flex w-full flex-col gap-[var(--space-1)] sm:w-auto sm:flex-row sm:items-center sm:gap-[var(--space-2)]">
+                  <span className="text-ui font-medium text-muted-foreground">
+                    Sort
+                  </span>
+                  <Select
+                    variant="animated"
+                    ariaLabel="Sort reviews"
+                    value={sort}
+                    onChange={(v) => setSort(v as SortKey)}
+                    items={[
+                      { value: "newest", label: "Newest" },
+                      { value: "oldest", label: "Oldest" },
+                      { value: "title", label: "Title" },
+                    ]}
+                    className="w-full sm:w-auto"
+                    size="lg"
+                  />
+                </label>
+                <Button
+                  type="button"
+                  variant="primary"
+                  size="md"
+                  className="w-full whitespace-nowrap sm:w-auto"
+                  onClick={handleCreateReview}
+                >
+                  <Plus />
+                  <span>New Review</span>
+                </Button>
+              </div>
+            ),
+          }}
+        />
+      </PageShell>
 
-      <div
-        className={cn(
-          "grid grid-cols-1 items-start gap-[var(--space-4)] sm:gap-[var(--space-6)] lg:gap-[var(--space-8)] md:grid-cols-6 lg:grid-cols-12",
-        )}
+      <PageShell
+        as="main"
+        className="py-[var(--space-6)] space-y-[var(--space-6)]"
+        aria-labelledby="reviews-header"
       >
+        <div
+          className={cn(
+            "grid grid-cols-1 items-start gap-[var(--space-4)] sm:gap-[var(--space-6)] lg:gap-[var(--space-8)] md:grid-cols-6 lg:grid-cols-12",
+          )}
+        >
         <nav
           aria-label="Review list"
           className="md:col-span-2 lg:col-span-4"
@@ -228,6 +231,7 @@ export default function ReviewsPage({
           )}
         </div>
       </div>
-    </PageShell>
+      </PageShell>
+    </>
   );
 }

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -2,11 +2,8 @@
 
 exports[`ReviewsPage > renders default state 1`] = `
 <div>
-  <main
-    aria-labelledby="reviews-header"
-    class="page-shell py-[var(--space-6)] space-y-[var(--space-6)]"
-    id="main-content"
-    tabindex="-1"
+  <header
+    class="page-shell py-[var(--space-6)]"
   >
     <section>
       <style
@@ -469,6 +466,13 @@ exports[`ReviewsPage > renders default state 1`] = `
         </div>
       </div>
     </section>
+  </header>
+  <main
+    aria-labelledby="reviews-header"
+    class="page-shell py-[var(--space-6)] space-y-[var(--space-6)]"
+    id="main-content"
+    tabindex="-1"
+  >
     <div
       class="grid grid-cols-1 items-start gap-[var(--space-4)] sm:gap-[var(--space-6)] lg:gap-[var(--space-8)] md:grid-cols-6 lg:grid-cols-12"
     >

--- a/types/react-jsx.d.ts
+++ b/types/react-jsx.d.ts
@@ -2,7 +2,7 @@ import type * as ReactJSXRuntime from "react/jsx-runtime";
 
 declare global {
   namespace JSX {
-    type Element = ReactJSXRuntime.JSX.Element;
+    interface Element extends ReactJSXRuntime.JSX.Element {}
     interface ElementClass
       extends ReactJSXRuntime.JSX.ElementClass {}
     interface ElementAttributesProperty


### PR DESCRIPTION
## Summary
- wrap major feature headers (reviews, planner, goals, components gallery, prompts) in dedicated `<PageShell as="header">` containers and keep main shells focused on body content
- update the reviews snapshot to reflect the new header/main separation
- align the JSX element typing with the shared React JSX runtime definition to keep type checking green

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1ae86334c832cbeb23409ccd6e2d7