### PR TITLE
Align planner week picker with component gallery

### DIFF
--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -403,7 +403,7 @@ export default function WeekPicker() {
           <div
             role="listbox"
             aria-label={`Select a focus day between ${rangeLabel}`}
-            className="flex flex-nowrap gap-[var(--space-3)] overflow-x-auto snap-x snap-mandatory lg:flex-wrap lg:gap-y-[var(--space-3)] lg:overflow-visible lg:[scroll-snap-type:none]"
+            className="flex gap-[var(--space-3)] overflow-x-auto snap-x snap-mandatory lg:overflow-visible"
           >
             {days.map((d, i) => (
               <DayChip

--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -417,7 +417,7 @@
     calc(18ch + var(--space-3)),
     calc(22ch + var(--space-4))
   );
-  flex: 1 1 var(--chip-min);
+  flex: none;
   min-inline-size: var(--chip-min);
   max-inline-size: var(--chip-max);
   position: relative;

--- a/src/components/prompts/component-gallery/PlannerPanel.tsx
+++ b/src/components/prompts/component-gallery/PlannerPanel.tsx
@@ -124,7 +124,7 @@ function WeekPickerShellPreview() {
         <div
           role="listbox"
           aria-label="Select a focus day for the shell preview"
-          className="flex flex-nowrap gap-[var(--space-3)] overflow-x-auto snap-x snap-mandatory lg:flex-wrap lg:gap-y-[var(--space-3)] lg:overflow-visible lg:[scroll-snap-type:none]"
+          className="flex gap-[var(--space-3)] overflow-x-auto snap-x snap-mandatory lg:overflow-visible"
         >
           {weekPickerShellDemoDays.map((day) => {
             const { tint, text } = getWeekPickerShellDemoAppearance(

--- a/types/react-jsx.d.ts
+++ b/types/react-jsx.d.ts
@@ -2,7 +2,6 @@ import type * as ReactJSXRuntime from "react/jsx-runtime";
 
 declare global {
   namespace JSX {
-    type Element = ReactJSXRuntime.JSX.Element;
     interface ElementClass
       extends ReactJSXRuntime.JSX.ElementClass {}
     interface ElementAttributesProperty


### PR DESCRIPTION
## Summary
- align the planner week picker chip layout with the component gallery treatment while keeping the shell totals intact
- keep the planner component gallery preview in sync with the new chip list markup and sizing rules
- drop the redundant JSX.Element alias so the stricter type checker no longer reports duplicate identifiers

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1b003b0b8832c92c0f2149d718d7f