### PR TITLE
Fix Field numeric heights to resolve pixel values

### DIFF
--- a/src/components/ui/primitives/Field.tsx
+++ b/src/components/ui/primitives/Field.tsx
@@ -37,7 +37,7 @@ function resolveHeight(height?: FieldHeight | number) {
   }
 
   if (typeof height === "number") {
-    return `${height / 4}rem`;
+    return `${height}px`;
   }
 
   return HEIGHT_MAP.md;

--- a/tests/primitives/Field.test.tsx
+++ b/tests/primitives/Field.test.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { render, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import { FieldRoot, FieldInput } from "../../src/components/ui/primitives/Field";
+
+afterEach(cleanup);
+
+describe("Field", () => {
+  it("resolves numeric height to pixel value", () => {
+    const { getByTestId } = render(
+      <FieldRoot data-testid="field" height={48}>
+        <FieldInput aria-label="Pixel height" />
+      </FieldRoot>,
+    );
+
+    expect(getByTestId("field")).toHaveStyle("--field-h: 48px");
+  });
+});

--- a/tests/primitives/Input.test.tsx
+++ b/tests/primitives/Input.test.tsx
@@ -26,6 +26,14 @@ describe("Input", () => {
     expect(field).toHaveStyle(`--field-h: ${value}`);
   });
 
+  it("applies numeric height as pixels", () => {
+    const { getByRole } = render(
+      <Input aria-label="numeric" height={48} />,
+    );
+    const field = getByRole("textbox").parentElement as HTMLElement;
+    expect(field).toHaveStyle("--field-h: 48px");
+  });
+
   it("applies indent padding", () => {
     const { getByRole } = render(
       <Input aria-label="indent" indent />,

--- a/tests/primitives/SearchBar.test.tsx
+++ b/tests/primitives/SearchBar.test.tsx
@@ -67,6 +67,14 @@ describe('SearchBar', () => {
     expect(input).toBeDisabled();
   });
 
+  it("applies numeric height as pixels", () => {
+    const { getByRole } = render(
+      <SearchBar value="" onValueChange={() => {}} height={52} />,
+    );
+    const field = getByRole("searchbox").parentElement as HTMLElement;
+    expect(field).toHaveStyle("--field-h: 52px");
+  });
+
   it('renders an associated label when provided', () => {
     const { getByLabelText } = render(
       <SearchBar value="" onValueChange={() => {}} label="Search tasks" />

--- a/types/react-jsx.d.ts
+++ b/types/react-jsx.d.ts
@@ -2,7 +2,7 @@ import type * as ReactJSXRuntime from "react/jsx-runtime";
 
 declare global {
   namespace JSX {
-    type Element = ReactJSXRuntime.JSX.Element;
+    interface Element extends ReactJSXRuntime.JSX.Element {}
     interface ElementClass
       extends ReactJSXRuntime.JSX.ElementClass {}
     interface ElementAttributesProperty


### PR DESCRIPTION
## Summary
- interpret numeric Field heights as pixel strings so primitives honor design token dimensions
- add regression coverage in Field, Input, and SearchBar tests to verify numeric heights resolve to px
- align the JSX Element type declaration to avoid conflicts during type checking

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1b2382a80832c9c09c4542e31cf7b