### PR TITLE
Fix GlitchSegmented child filtering and add multiline navigation test

### DIFF
--- a/src/components/ui/primitives/GlitchSegmented.tsx
+++ b/src/components/ui/primitives/GlitchSegmented.tsx
@@ -34,11 +34,14 @@ export const GlitchSegmentedGroup = ({
     btnRefs.current[index] = el;
   };
 
-  const values = React.Children.toArray(children).map((child) =>
-    React.isValidElement(child)
-      ? (child.props as GlitchSegmentedButtonProps).value
-      : "",
+  const childArray = React.Children.toArray(children);
+  const buttonChildren = childArray.filter(
+    (child): child is React.ReactElement<GlitchSegmentedButtonProps> =>
+      React.isValidElement<GlitchSegmentedButtonProps>(child) &&
+      child.type === GlitchSegmentedButton,
   );
+  const values = buttonChildren.map((child) => child.props.value);
+  btnRefs.current.length = buttonChildren.length;
 
   const onKeyDown = (e: React.KeyboardEvent) => {
     const idx = values.findIndex((v) => v === value);
@@ -65,6 +68,8 @@ export const GlitchSegmentedGroup = ({
     }
   };
 
+  let buttonIndex = 0;
+
   return (
     <div
       role="tablist"
@@ -77,16 +82,21 @@ export const GlitchSegmentedGroup = ({
       )}
       onKeyDown={onKeyDown}
     >
-      {React.Children.map(children, (child, i) => {
-        if (!React.isValidElement<GlitchSegmentedButtonProps>(child))
+      {React.Children.map(children, (child) => {
+        if (
+          !(
+            React.isValidElement<GlitchSegmentedButtonProps>(child) &&
+            child.type === GlitchSegmentedButton
+          )
+        ) {
           return child;
+        }
+        const currentIndex = buttonIndex++;
         const selected = child.props.value === value;
-        const buttonChild =
-          child as React.ReactElement<GlitchSegmentedButtonProps>;
         const normalizedValue = normalizeValueForId(child.props.value);
 
-        return React.cloneElement(buttonChild, {
-          ref: setBtnRef(i),
+        return React.cloneElement(child, {
+          ref: setBtnRef(currentIndex),
           tabIndex: selected ? 0 : -1,
           selected,
           onSelect: () => onChange(child.props.value),

--- a/tests/primitives/GlitchSegmented.test.tsx
+++ b/tests/primitives/GlitchSegmented.test.tsx
@@ -1,32 +1,88 @@
-import React from 'react';
-import { render, cleanup } from '@testing-library/react';
-import { describe, it, expect, afterEach } from 'vitest';
-import { GlitchSegmentedGroup, GlitchSegmentedButton } from '../../src/components/ui/primitives/GlitchSegmented';
+import React from "react";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  GlitchSegmentedGroup,
+  GlitchSegmentedButton,
+} from "../../src/components/ui/primitives/GlitchSegmented";
 
 afterEach(cleanup);
 
-describe('GlitchSegmented', () => {
-  it('renders buttons', () => {
+describe("GlitchSegmented", () => {
+  it("renders buttons", () => {
     const { getByRole } = render(
       <GlitchSegmentedGroup value="a" onChange={() => {}}>
         <GlitchSegmentedButton value="a">A</GlitchSegmentedButton>
         <GlitchSegmentedButton value="b">B</GlitchSegmentedButton>
-      </GlitchSegmentedGroup>
+      </GlitchSegmentedGroup>,
     );
-    expect(getByRole('tab', { name: 'A' })).toBeInTheDocument();
-    expect(getByRole('tab', { name: 'B' })).toBeInTheDocument();
+    expect(getByRole("tab", { name: "A" })).toBeInTheDocument();
+    expect(getByRole("tab", { name: "B" })).toBeInTheDocument();
   });
 
-  it('has no outline when focused', () => {
+  it("has no outline when focused", () => {
     const { getByRole } = render(
       <GlitchSegmentedGroup value="a" onChange={() => {}}>
         <GlitchSegmentedButton value="a">A</GlitchSegmentedButton>
-      </GlitchSegmentedGroup>
+      </GlitchSegmentedGroup>,
     );
-    const btn = getByRole('tab');
+    const btn = getByRole("tab");
     btn.focus();
     const style = getComputedStyle(btn);
-    expect(style.outlineStyle === 'none' || style.outlineStyle === '').toBe(true);
-    expect(style.outlineWidth === '0px' || style.outlineWidth === '').toBe(true);
+    expect(style.outlineStyle === "none" || style.outlineStyle === "").toBe(
+      true,
+    );
+    expect(style.outlineWidth === "0px" || style.outlineWidth === "").toBe(
+      true,
+    );
+  });
+
+  it("navigates with arrow keys when formatted across multiple lines", () => {
+    const onChange = vi.fn();
+    const GroupWithState = () => {
+      const [current, setCurrent] = React.useState("one");
+      return (
+        <GlitchSegmentedGroup
+          value={current}
+          onChange={(next) => {
+            setCurrent(next);
+            onChange(next);
+          }}
+        >
+          <GlitchSegmentedButton value="one">
+            One
+          </GlitchSegmentedButton>
+          {"\n"}
+          <GlitchSegmentedButton value="two">
+            Two
+          </GlitchSegmentedButton>
+          {"\n"}
+          <GlitchSegmentedButton value="three">
+            Three
+          </GlitchSegmentedButton>
+        </GlitchSegmentedGroup>
+      );
+    };
+
+    const { getByRole } = render(<GroupWithState />);
+    const first = getByRole("tab", { name: "One" });
+    first.focus();
+
+    fireEvent.keyDown(first, { key: "ArrowRight" });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenNthCalledWith(1, "two");
+    const second = getByRole("tab", { name: "Two" });
+    expect(second).toHaveFocus();
+
+    fireEvent.keyDown(second, { key: "ArrowRight" });
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange).toHaveBeenNthCalledWith(2, "three");
+    const third = getByRole("tab", { name: "Three" });
+    expect(third).toHaveFocus();
+
+    fireEvent.keyDown(third, { key: "ArrowLeft" });
+    expect(onChange).toHaveBeenCalledTimes(3);
+    expect(onChange).toHaveBeenNthCalledWith(3, "two");
+    expect(second).toHaveFocus();
   });
 });

--- a/types/jsx-namespace.d.ts
+++ b/types/jsx-namespace.d.ts
@@ -1,9 +1,1 @@
-import type * as React from "react";
-
-declare global {
-  namespace JSX {
-    interface Element extends React.ReactElement<any, any> {}
-  }
-}
-
 export {};


### PR DESCRIPTION
## Summary
- filter `GlitchSegmented` children down to button elements before computing values and wiring refs so keyboard navigation ignores whitespace/text nodes
- add a regression test that exercises arrow navigation with multiline JSX formatting
- drop the redundant JSX namespace augmentation to avoid conflicting `JSX.Element` declarations during typechecking

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1b291bb50832c8b89b762abd4bc8d