### PR TITLE
Fix Tailwind apply errors by using token-driven styles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@reference "tailwindcss/utilities";
 @layer base {
   :root {
     --shell-max: var(--shell-width);
@@ -56,7 +57,19 @@
     width: 100%;
     max-width: var(--shell-max, var(--shell-width));
     margin-inline: auto;
-    @apply px-[var(--space-6)] md:px-[var(--space-7)] lg:px-[var(--space-8)];
+    padding-inline: var(--space-6);
+  }
+
+  @media (min-width: 48rem) {
+    .page-shell {
+      padding-inline: var(--space-7);
+    }
+  }
+
+  @media (min-width: 64rem) {
+    .page-shell {
+      padding-inline: var(--space-8);
+    }
   }
 
   .page-backdrop {
@@ -202,16 +215,25 @@ html.bg-intense body::after {
 
 @layer base {
   * {
-    @apply border-border;
+    border-color: hsl(var(--border));
   }
   h1 {
-    @apply text-title-lg font-semibold tracking-[-0.01em];
+    font-size: var(--font-title-lg);
+    line-height: 1.2;
+    font-weight: 600;
+    letter-spacing: -0.01em;
   }
   h2 {
-    @apply text-title font-semibold tracking-[-0.01em];
+    font-size: var(--font-title);
+    line-height: 1.25;
+    font-weight: 600;
+    letter-spacing: -0.01em;
   }
   h3 {
-    @apply text-body font-semibold tracking-[-0.01em];
+    font-size: var(--font-body);
+    line-height: 1.6;
+    font-weight: 600;
+    letter-spacing: -0.01em;
   }
 }
 
@@ -654,7 +676,20 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
   }
 
   .btn-like-segmented {
-    @apply inline-flex items-center rounded-[var(--control-radius)] border px-[var(--space-4)] py-[var(--space-2)] text-ui font-medium tracking-[0.02em] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] focus-visible:ring-offset-0 disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[loading=true]:pointer-events-none;
+    display: inline-flex;
+    align-items: center;
+    border-radius: var(--control-radius);
+    border-width: var(--hairline-w);
+    border-style: solid;
+    padding-inline: var(--space-4);
+    padding-block: var(--space-2);
+    transition-property: color, background-color, border-color, box-shadow;
+    transition-duration: var(--dur-quick);
+    transition-timing-function: var(--ease-out);
+    font-size: var(--font-ui);
+    line-height: 1.35;
+    font-weight: 500;
+    letter-spacing: 0.02em;
     position: relative;
     overflow: hidden;
     border-color: hsl(var(--card-hairline));
@@ -675,6 +710,24 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
   .btn-like-segmented:active {
     background: var(--active, var(--seg-active-base));
     color: hsl(var(--foreground));
+  }
+  .btn-like-segmented:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 calc(var(--hairline-w) * 2) hsl(var(--focus));
+  }
+  .btn-like-segmented:disabled,
+  .btn-like-segmented[disabled] {
+    opacity: var(--disabled);
+    pointer-events: none;
+  }
+  .btn-like-segmented[data-loading="true"] {
+    opacity: var(--loading);
+    pointer-events: none;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .btn-like-segmented {
+      transition: none;
+    }
   }
   .btn-like-segmented::after {
     content: "";
@@ -750,7 +803,10 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
 
   /* Inputs */
   .input-base {
-    @apply rounded-[var(--control-radius)] border text-ui font-medium;
+    @apply rounded-[var(--control-radius)] border;
+    font-size: var(--font-ui);
+    line-height: 1.35;
+    font-weight: 500;
     height: var(--control-h);
     padding: 0 var(--control-px);
     font-size: var(--control-fs);
@@ -881,7 +937,11 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
   /* Base chip & variants */
   .pill {
     --pill-height: calc(var(--space-6) - var(--space-1));
-    @apply inline-flex items-center rounded-full border text-label font-medium tracking-[0.02em];
+    @apply inline-flex items-center rounded-full border;
+    font-size: var(--font-label);
+    line-height: 1.2;
+    font-weight: 500;
+    letter-spacing: 0.02em;
     height: var(--pill-height);
     padding: 0 var(--space-3);
     gap: var(--space-2);
@@ -1015,7 +1075,10 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
 .meta-strip .pill {
   --b: hsl(var(--card-hairline));
   --bg: hsl(var(--background));
-  @apply text-label font-medium tracking-[0.02em];
+  font-size: var(--font-label);
+  line-height: 1.2;
+  font-weight: 500;
+  letter-spacing: 0.02em;
   line-height: 1;
   padding: 0.45rem 0.55rem;
   border-radius: var(--radius-full);
@@ -1063,7 +1126,9 @@ html.fx-overdrive :where(h1, h2, h3, .card-title) {
   letter-spacing: -0.01em;
 }
 .card-subtitle {
-  @apply text-ui text-muted-foreground;
+  font-size: var(--font-ui);
+  line-height: 1.35;
+  color: hsl(var(--muted-foreground));
 }
 .tile-row {
   @apply h-12 flex items-center;
@@ -1205,7 +1270,11 @@ textarea:-webkit-autofill {
 
 /* Compact pill */
 .pill-compact {
-  @apply inline-flex items-center rounded-full border border-card-hairline px-[var(--space-2)] py-[var(--space-1)] text-label font-medium tracking-[0.02em] leading-tight;
+  @apply inline-flex items-center rounded-full border border-card-hairline px-[var(--space-2)] py-[var(--space-1)] leading-tight;
+  font-size: var(--font-label);
+  line-height: 1.2;
+  font-weight: 500;
+  letter-spacing: 0.02em;
   background-color: hsl(var(--muted) / 0.18);
 }
 .pill-compact:hover {
@@ -1222,11 +1291,23 @@ textarea:-webkit-autofill {
 
 /* Card padding rhythm */
 .card-pad {
-  @apply p-4 md:p-5;
+  padding: var(--space-4);
 }
 
 .card-pad-lg {
-  @apply p-6 sm:p-8;
+  padding: var(--space-6);
+}
+
+@media (min-width: 48rem) {
+  .card-pad {
+    padding: var(--space-5);
+  }
+}
+
+@media (min-width: 40rem) {
+  .card-pad-lg {
+    padding: var(--space-8);
+  }
 }
 
 /* === Pretty Badges (Lavender-Glitch hairline + glow) === */
@@ -1253,12 +1334,18 @@ textarea:-webkit-autofill {
 }
 .badge--xs {
   padding: calc(var(--space-1) - var(--space-1) / 4) var(--space-2);
-  @apply text-label font-medium tracking-[0.02em];
+  font-size: var(--font-label);
+  line-height: 1.2;
+  font-weight: 500;
+  letter-spacing: 0.02em;
   line-height: 1;
 }
 .badge--sm {
   padding: calc(var(--space-3) / 2 - var(--space-1) / 4) calc(var(--space-3) - var(--space-1) / 2);
-  @apply text-label font-medium tracking-[0.02em];
+  font-size: var(--font-label);
+  line-height: 1.2;
+  font-weight: 500;
+  letter-spacing: 0.02em;
   line-height: 1;
 }
 .badge__icon {
@@ -1469,26 +1556,46 @@ textarea:-webkit-autofill {
 
 @layer components {
   .type-eyebrow {
-    @apply text-label font-medium tracking-[0.02em] uppercase;
+    font-size: var(--font-label);
+    line-height: 1.2;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
   }
   .type-title {
-    @apply text-title-lg font-semibold tracking-[-0.01em];
+    font-size: var(--font-title-lg);
+    line-height: 1.2;
+    font-weight: 600;
+    letter-spacing: -0.01em;
   }
   .type-subtitle {
-    @apply text-title font-semibold tracking-[-0.01em];
+    font-size: var(--font-title);
+    line-height: 1.25;
+    font-weight: 600;
+    letter-spacing: -0.01em;
   }
   .type-body {
-    @apply text-body;
+    font-size: var(--font-body);
+    line-height: 1.6;
   }
   .type-caption {
-    @apply text-label font-medium tracking-[0.02em] text-muted-foreground;
+    font-size: var(--font-label);
+    line-height: 1.2;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    color: hsl(var(--muted-foreground));
   }
   .title-ghost {
-    @apply text-title-lg font-semibold opacity-60;
+    font-size: var(--font-title-lg);
+    line-height: 1.2;
+    font-weight: 600;
+    opacity: 0.6;
     filter: blur(1px);
   }
   .title-glow {
-    @apply text-2xl font-semibold;
+    font-size: 1.5rem;
+    line-height: 2rem;
+    font-weight: 600;
   }
 }
 .ds-grid-gap {
@@ -1540,7 +1647,8 @@ textarea:-webkit-autofill {
   }
 }
 .ds-list {
-  @apply list-none pl-5 space-y-2 text-foreground;
+  @apply list-none pl-5 space-y-2;
+  color: hsl(var(--foreground));
 }
 
 .ds-list li {
@@ -1567,7 +1675,10 @@ textarea:-webkit-autofill {
   border: 1px solid hsl(var(--card-hairline));
   background: hsl(var(--card));
   color: hsl(var(--foreground));
-  @apply text-label font-medium tracking-[0.02em];
+  font-size: var(--font-label);
+  line-height: 1.2;
+  font-weight: 500;
+  letter-spacing: 0.02em;
   line-height: 1;
   white-space: nowrap;
   transition:
@@ -1820,7 +1931,10 @@ textarea:-webkit-autofill {
   position: relative;
   z-index: 1;
   padding: calc(var(--space-1) + var(--spacing-0-5)) var(--space-3);
-  @apply text-label font-medium tracking-[0.02em];
+  font-size: var(--font-label);
+  line-height: 1.2;
+  font-weight: 500;
+  letter-spacing: 0.02em;
   color: hsl(var(--muted-foreground));
   border-radius: var(--radius-full);
   transition:
@@ -2192,7 +2306,10 @@ a:active .lucide {
 
 @layer components {
   .goal-card {
-    @apply relative overflow-hidden rounded-[var(--radius-2xl)] border border-border;
+    @apply relative overflow-hidden rounded-[var(--radius-2xl)];
+    border-width: var(--hairline-w);
+    border-style: solid;
+    border-color: hsl(var(--border));
     background: linear-gradient(
       135deg,
       hsl(var(--surface-2)),
@@ -2246,7 +2363,10 @@ a:active .lucide {
   }
 
   .page-tabs-surface {
-    @apply border-b border-border bg-background/60;
+    border-bottom-width: var(--hairline-w);
+    border-bottom-style: solid;
+    border-bottom-color: hsl(var(--border));
+    background-color: hsl(var(--background) / 0.6);
   }
 
   @supports (color: color-mix(in oklab, white, black)) {

--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -3,6 +3,7 @@
    Depends on tokens/utilities in src/app/globals.css.
    Avoids redefining global shells/rails/pills.
 */
+@reference "tailwindcss/utilities";
 
 /* ============ Page header tweaks ============ */
 .planner-header__hero {
@@ -110,7 +111,10 @@
 }
 
 .proj-card__title {
-  @apply text-ui font-medium tracking-[-0.01em];
+  font-size: var(--font-ui);
+  line-height: 1.35;
+  font-weight: 500;
+  letter-spacing: -0.01em;
   color: hsl(var(--foreground));
 }
 .proj-card:hover .proj-card__title {
@@ -323,7 +327,10 @@
 }
 
 .ws-tile__date {
-  @apply text-label font-medium tracking-[0.02em];
+  font-size: var(--font-label);
+  line-height: 1.2;
+  font-weight: 500;
+  letter-spacing: 0.02em;
   color: hsl(var(--muted-foreground));
   text-transform: uppercase;
 }
@@ -333,7 +340,10 @@
   align-items: baseline;
   gap: var(--spacing-0-5);
   color: hsl(var(--foreground));
-  @apply text-title font-semibold tracking-[-0.01em];
+  font-size: var(--font-title);
+  line-height: 1.25;
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
 .ws-bleed {
@@ -559,12 +569,18 @@
 
 /* compact internals */
 .chip__date {
-  @apply text-label font-medium tracking-[0.02em];
+  font-size: var(--font-label);
+  line-height: 1.2;
+  font-weight: 500;
+  letter-spacing: 0.02em;
   color: inherit;
 }
 .chip__counts {
   margin-top: var(--space-1);
-  @apply text-ui font-semibold tracking-[-0.01em];
+  font-size: var(--font-ui);
+  line-height: 1.35;
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/src/components/ui/layout/TitleBar.tsx
+++ b/src/components/ui/layout/TitleBar.tsx
@@ -37,7 +37,10 @@ export default function TitleBar({ label, idText = "ID:0x13LG" }: Props) {
           font-family:
             ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
             "Liberation Mono", "Courier New", monospace;
-          @apply text-ui font-medium tracking-[0.02em];
+          font-size: var(--font-ui);
+          line-height: 1.35;
+          font-weight: 500;
+          letter-spacing: 0.02em;
         }
       `}</style>
     </>


### PR DESCRIPTION
## Summary
- add `@reference "tailwindcss/utilities"` to shared styles and replace the page shell padding helpers with explicit token-based spacing to avoid missing variant errors.【F:src/app/globals.css†L1-L71】
- swap heading, button, pill, and badge helpers to direct token-driven typography and border styles so Tailwind no longer rejects custom utilities.【F:src/app/globals.css†L216-L238】【F:src/app/globals.css†L678-L749】【F:src/app/globals.css†L1075-L1131】【F:src/app/globals.css†L1255-L1282】
- update planner CSS and the TitleBar monospace label to use tokens instead of `@apply`, ensuring consistent font metrics without Tailwind errors.【F:src/components/planner/style.css†L1-L347】【F:src/components/planner/style.css†L571-L583】【F:src/components/ui/layout/TitleBar.tsx†L1-L43】

## Testing
- npm run check【ccef22†L1-L9】

------
https://chatgpt.com/codex/tasks/task_e_68d1b99fd46c832cb6b5ff0c9de42a9d