### PR TITLE
Align planner WeekPicker chip widths with component design

### DIFF
--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -174,7 +174,7 @@ const DayChip = React.forwardRef<HTMLButtonElement, DayChipProps>(function DayCh
           : "Click or press Enter to focus"
       }
       className={cn(
-        "chip relative rounded-card r-card-lg border text-left px-[var(--space-3)] py-[var(--space-2)] transition snap-start",
+        "chip relative flex-none w-[--chip-width] rounded-card r-card-lg border text-left px-[var(--space-3)] py-[var(--space-2)] transition snap-start",
         // default border is NOT white; use card hairline tint
         "border-card-hairline",
         completionTint,

--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -417,6 +417,7 @@
     calc(18ch + var(--space-3)),
     calc(22ch + var(--space-4))
   );
+  --chip-width: var(--chip-min);
   flex: 1 1 var(--chip-min);
   min-inline-size: var(--chip-min);
   max-inline-size: var(--chip-max);
@@ -432,6 +433,10 @@
       hsl(var(--shadow-color) / 0.3);
   --chip-shadow: var(--neo-shadow);
   box-shadow: var(--chip-shadow);
+}
+
+.chip.flex-none {
+  flex: none;
 }
 
 .chip:hover {

--- a/src/components/prompts/component-gallery/PlannerPanel.tsx
+++ b/src/components/prompts/component-gallery/PlannerPanel.tsx
@@ -141,7 +141,7 @@ function WeekPickerShellPreview() {
                 aria-selected={day.selected ?? false}
                 aria-label={`Select ${day.accessible}`}
                 className={cn(
-                  "chip relative rounded-card r-card-lg border text-left px-[var(--space-3)] py-[var(--space-2)] transition snap-start",
+                  "chip relative flex-none w-[--chip-width] rounded-card r-card-lg border text-left px-[var(--space-3)] py-[var(--space-2)] transition snap-start",
                   "border-card-hairline",
                   tint,
                   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",


### PR DESCRIPTION
## Summary
- update the planner WeekPicker chip layout to use the same fixed-width styling as the component gallery
- define a reusable chip width variable and ensure flex-none overrides the default flex sizing
- sync the WeekPickerShell preview chips with the planner styling so the gallery reflects the live component

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1b53f4d9c832ca521e1b1a9448d3b