### PR TITLE
Allow theme-splits slug to resolve

### DIFF
--- a/src/components/gallery/generated-manifest.ts
+++ b/src/components/gallery/generated-manifest.ts
@@ -1716,7 +1716,8 @@ export const galleryPayload = {
           "name": "Split",
           "tags": [
             "split",
-            "layout"
+            "layout",
+            "theme"
           ],
           "kind": "component",
           "code": "<Split left={<div>Left</div>} right={<div>Right</div>} />",
@@ -5293,7 +5294,8 @@ export const galleryPayload = {
         "name": "Split",
         "tags": [
           "split",
-          "layout"
+          "layout",
+          "theme"
         ],
         "kind": "component",
         "code": "<Split left={<div>Left</div>} right={<div>Right</div>} />",

--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -3160,7 +3160,7 @@ React.useEffect(() => {
           right={<div className="p-[var(--space-4)]">Right</div>}
         />
       ),
-      tags: ["split", "layout"],
+      tags: ["split", "layout", "theme"],
       code: `<Split left={<div>Left</div>} right={<div>Right</div>} />`,
     },
     {

--- a/tests/components/ComponentsSlug.test.ts
+++ b/tests/components/ComponentsSlug.test.ts
@@ -24,6 +24,15 @@ describe("ComponentsSlug", () => {
     expect(result?.query).toBe("Button");
   });
 
+  it("resolves legacy theme split alias", () => {
+    const result = resolveComponentsSlug("theme-splits");
+    expect(result).toMatchObject({
+      section: "layout",
+      view: "components",
+    });
+    expect(result?.query).toBe("Split");
+  });
+
   it("maps view aliases", () => {
     const result = resolveComponentsSlug("colors");
     expect(result).toMatchObject({ view: "tokens" });


### PR DESCRIPTION
## Summary
- add the theme tag to the Split gallery entry so the theme-splits slug resolves
- update the generated gallery manifest with the new tag metadata
- add a regression test proving resolveComponentsSlug accepts theme-splits

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1c49e4020832cbb16b9f98538f43c