### PR TITLE
Ensure color swatches react to theme changes

### DIFF
--- a/src/components/prompts/ColorsView.tsx
+++ b/src/components/prompts/ColorsView.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui";
 import type { DesignTokenGroup } from "@/components/gallery/types";
 import { copyText } from "@/lib/clipboard";
+import { useTheme } from "@/lib/theme-context";
 
 const CHECKERBOARD_STYLE: React.CSSProperties = {
   backgroundImage:
@@ -259,6 +260,8 @@ function TokenPreview({ token }: { token: TokenMeta }) {
 }
 
 function ColorPreview({ name }: { name: string }) {
+  const [theme] = useTheme();
+  const { variant, bg } = theme;
   const swatchRef = React.useRef<HTMLDivElement | null>(null);
   const [resolvedColor, setResolvedColor] = React.useState<string | null>(null);
   const [isTranslucent, setIsTranslucent] = React.useState(false);
@@ -305,7 +308,7 @@ function ColorPreview({ name }: { name: string }) {
 
     setResolvedColor(color);
     setIsTranslucent(translucent);
-  }, [name]);
+  }, [bg, name, variant]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- subscribe the color swatch preview to theme context updates so resolved tokens refresh when themes change

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1cf8eacbc832c9eb4ebd81472e0c3