### PR TITLE
Align PageHeader life divider tint with accent token

### DIFF
--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -261,7 +261,7 @@ const PageHeaderInner = <
 
   const frameStyleWithDivider = React.useMemo<React.CSSProperties>(() => {
     const heroSlotDividerColor =
-      heroDividerTint === "life" ? "var(--accent)" : "var(--ring)";
+      heroDividerTint === "life" ? "var(--accent-3)" : "var(--ring)";
     return {
       ...(frameStyle ?? {}),
       "--hero-slot-divider": heroSlotDividerColor,

--- a/tests/components/PageHeader.test.tsx
+++ b/tests/components/PageHeader.test.tsx
@@ -162,7 +162,7 @@ describe("PageHeader", () => {
     expect(frame).not.toBeNull();
     expect(
       (frame as HTMLElement).style.getPropertyValue("--hero-slot-divider"),
-    ).toBe("var(--accent)");
+    ).toBe("var(--accent-3)");
   });
 
   it("balances header text when titles span multiple lines", () => {


### PR DESCRIPTION
## Summary
- update the PageHeader hero frame to use the life accent-3 token for divider styling
- adjust the PageHeader test to expect the accent-3 variable when the life palette is active

## Testing
- npm run check
- Manual: Viewed the Goals Reminders life header in the dev server to confirm the hero divider and slots share the teal tone

------
https://chatgpt.com/codex/tasks/task_e_68d1b55f0bfc832caad652281ddbee47