### PR TITLE
Refactor spinner and progress styles to use tokens

### DIFF
--- a/src/components/gallery/generated-manifest.ts
+++ b/src/components/gallery/generated-manifest.ts
@@ -209,11 +209,20 @@ export const galleryPayload = {
                 },
                 {
                   "value": "Loading"
+                },
+                {
+                  "value": "Primary"
+                },
+                {
+                  "value": "Primary Hover"
+                },
+                {
+                  "value": "Primary Active"
                 }
               ]
             }
           ],
-          "code": "<div className=\"flex flex-col gap-[var(--space-4)]\">\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <IconButton size=\"sm\" variant=\"ghost\" aria-label=\"Add item sm\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"md\" variant=\"ghost\" aria-label=\"Add item md\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"lg\" variant=\"ghost\" aria-label=\"Add item lg\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"xl\" variant=\"ghost\" aria-label=\"Add item xl\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"md\" variant=\"secondary\" aria-label=\"Add item secondary\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"md\" variant=\"primary\" aria-label=\"Add item primary\">\n      <Plus />\n    </IconButton>\n  </div>\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <IconButton aria-label=\"Default\">\n      <Plus />\n    </IconButton>\n    <IconButton className=\"bg-[--hover]\" aria-label=\"Hover\">\n      <Plus />\n    </IconButton>\n    <IconButton className=\"ring-2 ring-[var(--focus)]\" aria-label=\"Focus\">\n      <Plus />\n    </IconButton>\n    <IconButton\n      className=\"bg-[--active]\"\n      aria-pressed\n      aria-label=\"Active\"\n    >\n      <Plus />\n    </IconButton>\n    <IconButton disabled aria-label=\"Disabled\">\n      <Plus />\n    </IconButton>\n    <IconButton loading aria-label=\"Loading\">\n      <Plus />\n    </IconButton>\n  </div>\n</div>",
+          "code": "<div className=\"flex flex-col gap-[var(--space-4)]\">\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <IconButton size=\"sm\" variant=\"ghost\" aria-label=\"Add item sm\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"md\" variant=\"ghost\" aria-label=\"Add item md\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"lg\" variant=\"ghost\" aria-label=\"Add item lg\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"xl\" variant=\"ghost\" aria-label=\"Add item xl\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"md\" variant=\"secondary\" aria-label=\"Add item secondary\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"md\" variant=\"primary\" aria-label=\"Add item primary\">\n      <Plus />\n    </IconButton>\n  </div>\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <IconButton aria-label=\"Default\">\n      <Plus />\n    </IconButton>\n    <IconButton className=\"bg-[--hover]\" aria-label=\"Hover\">\n      <Plus />\n    </IconButton>\n    <IconButton className=\"ring-2 ring-[var(--focus)]\" aria-label=\"Focus\">\n      <Plus />\n    </IconButton>\n    <IconButton\n      className=\"bg-[--active]\"\n      aria-pressed\n      aria-label=\"Active\"\n    >\n      <Plus />\n    </IconButton>\n    <IconButton disabled aria-label=\"Disabled\">\n      <Plus />\n    </IconButton>\n    <IconButton loading aria-label=\"Loading\">\n      <Plus />\n    </IconButton>\n  </div>\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <IconButton variant=\"primary\" aria-label=\"Primary\">\n      <Plus />\n    </IconButton>\n    <IconButton\n      className=\"bg-[--hover] shadow-[var(--shadow-neon-strong)]\"\n      variant=\"primary\"\n      aria-label=\"Primary hover\"\n    >\n      <Plus />\n    </IconButton>\n    <IconButton\n      className=\"bg-[--active] shadow-[var(--shadow-inset-contrast),var(--shadow-neon-soft)]\"\n      variant=\"primary\"\n      aria-label=\"Primary active\"\n      aria-pressed\n    >\n      <Plus />\n    </IconButton>\n  </div>\n</div>",
           "preview": {
             "id": "ui:icon-button:matrix"
           },
@@ -264,6 +273,30 @@ export const galleryPayload = {
               "code": "<IconButton loading aria-label=\"Loading\">\n  <Plus />\n</IconButton>",
               "preview": {
                 "id": "ui:icon-button:state:loading"
+              }
+            },
+            {
+              "id": "primary",
+              "name": "Primary",
+              "code": "<IconButton variant=\"primary\" aria-label=\"Primary\">\n  <Plus />\n</IconButton>",
+              "preview": {
+                "id": "ui:icon-button:state:primary"
+              }
+            },
+            {
+              "id": "primary-hover",
+              "name": "Primary Hover",
+              "code": "<IconButton\n  className=\"bg-[--hover] shadow-[var(--shadow-neon-strong)]\"\n  variant=\"primary\"\n  aria-label=\"Primary hover\"\n>\n  <Plus />\n</IconButton>",
+              "preview": {
+                "id": "ui:icon-button:state:primary-hover"
+              }
+            },
+            {
+              "id": "primary-active",
+              "name": "Primary Active",
+              "code": "<IconButton\n  className=\"bg-[--active] shadow-[var(--shadow-inset-contrast),var(--shadow-neon-soft)]\"\n  variant=\"primary\"\n  aria-label=\"Primary active\"\n  aria-pressed\n>\n  <Plus />\n</IconButton>",
+              "preview": {
+                "id": "ui:icon-button:state:primary-active"
               }
             }
           ]
@@ -324,12 +357,15 @@ export const galleryPayload = {
                   "value": "Disabled"
                 },
                 {
+                  "value": "Disabled link"
+                },
+                {
                   "value": "Loading"
                 }
               ]
             }
           ],
-          "code": "<div className=\"flex flex-wrap gap-[var(--space-2)]\">\n  <SegmentedButton>Default</SegmentedButton>\n  <SegmentedButton className=\"[--hover:var(--seg-hover-base)] bg-[--hover] text-[hsl(var(--foreground))] [text-shadow:0_0_calc(var(--space-2)-var(--spacing-0-5))_hsl(var(--accent)/0.25)]\">Hover</SegmentedButton>\n  <SegmentedButton selected>Active</SegmentedButton>\n  <SegmentedButton className=\"ring-2 ring-[--theme-ring] ring-offset-0 outline-none\">Focus-visible</SegmentedButton>\n  <SegmentedButton disabled>Disabled</SegmentedButton>\n  <SegmentedButton loading>Loading</SegmentedButton>\n</div>",
+          "code": "<div className=\"flex flex-wrap gap-[var(--space-2)]\">\n  <SegmentedButton>Default</SegmentedButton>\n  <SegmentedButton className=\"[--hover:var(--seg-hover-base)] bg-[--hover] text-[hsl(var(--foreground))] [text-shadow:0_0_calc(var(--space-2)-var(--spacing-0-5))_hsl(var(--accent)/0.25)]\">Hover</SegmentedButton>\n  <SegmentedButton selected>Active</SegmentedButton>\n  <SegmentedButton className=\"ring-2 ring-[--theme-ring] ring-offset-0 outline-none\">Focus-visible</SegmentedButton>\n  <SegmentedButton disabled>Disabled</SegmentedButton>\n  <SegmentedButton as=\"a\" href=\"#\" disabled>Disabled link</SegmentedButton>\n  <SegmentedButton loading>Loading</SegmentedButton>\n</div>",
           "preview": {
             "id": "ui:segmented-button:states"
           },
@@ -372,6 +408,14 @@ export const galleryPayload = {
               "code": "<SegmentedButton disabled>Disabled</SegmentedButton>",
               "preview": {
                 "id": "ui:segmented-button:state:disabled"
+              }
+            },
+            {
+              "id": "disabled-link",
+              "name": "Disabled link",
+              "code": "<SegmentedButton as=\"a\" href=\"#\" disabled>Disabled link</SegmentedButton>",
+              "preview": {
+                "id": "ui:segmented-button:state:disabled-link"
               }
             },
             {
@@ -1218,7 +1262,7 @@ export const galleryPayload = {
               "id": "chip-loading",
               "name": "Chip loading",
               "description": "While sync runs the badge disables interaction and shows an accent spinner anchored by the spacing scale.",
-              "code": "<div className=\"flex flex-wrap items-center gap-[var(--space-2)]\">\n  <Badge interactive>Default</Badge>\n  <Badge\n    interactive\n    disabled\n    className=\"pointer-events-none\"\n  >\n    Loading\n    <Spinner\n      size={16}\n      className=\"ml-[var(--space-2)] border-[hsl(var(--ring))] border-t-transparent\"\n    />\n  </Badge>\n</div>",
+              "code": "<div className=\"flex flex-wrap items-center gap-[var(--space-2)]\">\n  <Badge interactive>Default</Badge>\n  <Badge\n    interactive\n    disabled\n    className=\"pointer-events-none\"\n  >\n    Loading\n    <Spinner\n      size=\"sm\"\n      className=\"ml-[var(--space-2)] border-[hsl(var(--ring))] border-t-transparent\"\n    />\n  </Badge>\n</div>",
               "preview": {
                 "id": "prompts:prompts:prompts-header:state:chip-loading"
               }
@@ -1635,7 +1679,7 @@ export const galleryPayload = {
               "id": "opening",
               "name": "Opening / loading",
               "description": "Soft elevation token and spinner communicate progress while the sheet animates in.",
-              "code": "<Sheet\n  open\n  onClose={() => {}}\n  className=\"shadow-[var(--shadow-neo-soft)]\"\n>\n  <CardHeader>\n    <CardTitle>Syncing tasks</CardTitle>\n    <CardDescription>\n      Keep content visible while the sheet animates into place.\n    </CardDescription>\n  </CardHeader>\n  <CardContent className=\"flex items-center gap-[var(--space-3)] rounded-card border border-border/40 bg-surface-2 p-[var(--space-3)] shadow-[var(--shadow-outline-subtle)]\">\n    <Spinner size={20} />\n    <span className=\"text-ui text-muted-foreground\">Loading dashboard</span>\n  </CardContent>\n</Sheet>",
+              "code": "<Sheet\n  open\n  onClose={() => {}}\n  className=\"shadow-[var(--shadow-neo-soft)]\"\n>\n  <CardHeader>\n    <CardTitle>Syncing tasks</CardTitle>\n    <CardDescription>\n      Keep content visible while the sheet animates into place.\n    </CardDescription>\n  </CardHeader>\n  <CardContent className=\"flex items-center gap-[var(--space-3)] rounded-card border border-border/40 bg-surface-2 p-[var(--space-3)] shadow-[var(--shadow-outline-subtle)]\">\n    <Spinner size=\"md\" />\n    <span className=\"text-ui text-muted-foreground\">Loading dashboard</span>\n  </CardContent>\n</Sheet>",
               "preview": {
                 "id": "prompts:layout:sheet-demo:state:opening"
               }
@@ -1686,7 +1730,7 @@ export const galleryPayload = {
               "id": "loading",
               "name": "Opening / loading",
               "description": "Soft elevation token pairs with a spinner while the dialog content hydrates.",
-              "code": "<Modal\n  open\n  onClose={() => {}}\n  className=\"shadow-[var(--shadow-neo-soft)]\"\n>\n  <CardHeader>\n    <CardTitle>Confirm selection</CardTitle>\n    <CardDescription>\n      Surface a loader while the dialog hydrates.\n    </CardDescription>\n  </CardHeader>\n  <CardContent className=\"flex items-center gap-[var(--space-3)] rounded-card border border-border/40 bg-surface-2 p-[var(--space-3)] shadow-[var(--shadow-outline-subtle)]\">\n    <Spinner size={20} />\n    <span className=\"text-ui text-muted-foreground\">Syncing choices...</span>\n  </CardContent>\n</Modal>",
+              "code": "<Modal\n  open\n  onClose={() => {}}\n  className=\"shadow-[var(--shadow-neo-soft)]\"\n>\n  <CardHeader>\n    <CardTitle>Confirm selection</CardTitle>\n    <CardDescription>\n      Surface a loader while the dialog hydrates.\n    </CardDescription>\n  </CardHeader>\n  <CardContent className=\"flex items-center gap-[var(--space-3)] rounded-card border border-border/40 bg-surface-2 p-[var(--space-3)] shadow-[var(--shadow-outline-subtle)]\">\n    <Spinner size=\"md\" />\n    <span className=\"text-ui text-muted-foreground\">Syncing choices...</span>\n  </CardContent>\n</Modal>",
               "preview": {
                 "id": "prompts:layout:modal-demo:state:loading"
               }
@@ -1798,9 +1842,35 @@ export const galleryPayload = {
                   "value": "Disabled"
                 }
               ]
+            },
+            {
+              "id": "rail-tone",
+              "label": "Rail tone",
+              "type": "variant",
+              "values": [
+                {
+                  "value": "Subtle"
+                },
+                {
+                  "value": "Loud"
+                }
+              ]
+            },
+            {
+              "id": "underline-tone",
+              "label": "Underline tone",
+              "type": "variant",
+              "values": [
+                {
+                  "value": "Neutral"
+                },
+                {
+                  "value": "Brand"
+                }
+              ]
             }
           ],
-          "code": "<Header\n  heading=\"Header\"\n  subtitle=\"Segmented navigation anchored to the header\"\n  tabs={{\n    items: [\n      {\n        key: \"summary\",\n        label: \"Summary\",\n        icon: (\n          <Circle\n            aria-hidden=\"true\"\n            className=\"h-[var(--space-4)] w-[var(--space-4)]\"\n          />\n        ),\n      },\n      {\n        key: \"timeline\",\n        label: \"Timeline\",\n        icon: (\n          <CircleDot\n            aria-hidden=\"true\"\n            className=\"h-[var(--space-4)] w-[var(--space-4)]\"\n          />\n        ),\n      },\n      {\n        key: \"insights\",\n        label: \"Insights\",\n        icon: (\n          <CircleCheck\n            aria-hidden=\"true\"\n            className=\"h-[var(--space-4)] w-[var(--space-4)]\"\n          />\n        ),\n        disabled: true,\n      },\n    ],\n    value: \"summary\",\n    onChange: () => {},\n    ariaLabel: \"Header demo tabs\",\n    size: \"md\",\n  }}\n  sticky={false}\n  topClassName=\"top-0\"\n>\n  <p className=\"text-ui text-muted-foreground\">\n    Viewing\n    <span className=\"ml-[var(--space-1)] font-medium text-foreground\">\n      Summary\n    </span>\n  </p>\n</Header>",
+          "code": "<div className=\"grid gap-[var(--space-4)] lg:grid-cols-2\">\n  <div className=\"rounded-card border border-card-hairline/60 bg-panel/80 p-[var(--space-5)] shadow-[var(--shadow-outline-subtle)]\">\n    <p className=\"mb-[var(--space-3)] text-label font-medium text-muted-foreground\">\n      Neutral underline (default)\n    </p>\n    <Header\n      eyebrow=\"Workspace\"\n      heading=\"Header\"\n      subtitle=\"Segmented navigation anchored to the header\"\n      railTone=\"subtle\"\n      underlineTone=\"neutral\"\n      icon={\n        <Circle\n          aria-hidden=\"true\"\n          className=\"h-[var(--space-5)] w-[var(--space-5)] text-primary\"\n        />\n      }\n      tabs={{\n        items: [\n          {\n            key: \"summary\",\n            label: \"Summary\",\n            icon: (\n              <Circle\n                aria-hidden=\"true\"\n                className=\"h-[var(--space-4)] w-[var(--space-4)]\"\n              />\n            ),\n          },\n          {\n            key: \"timeline\",\n            label: \"Timeline\",\n            icon: (\n              <CircleDot\n                aria-hidden=\"true\"\n                className=\"h-[var(--space-4)] w-[var(--space-4)]\"\n              />\n            ),\n          },\n          {\n            key: \"insights\",\n            label: \"Insights\",\n            icon: (\n              <CircleCheck\n                aria-hidden=\"true\"\n                className=\"h-[var(--space-4)] w-[var(--space-4)]\"\n              />\n            ),\n            disabled: true,\n          },\n        ],\n        value: \"summary\",\n        onChange: () => {},\n        ariaLabel: \"Header demo tabs (neutral underline)\",\n        size: \"md\",\n      }}\n      sticky={false}\n      topClassName=\"top-0\"\n    >\n      <p className=\"text-ui text-muted-foreground\">\n        Viewing\n        <span className=\"ml-[var(--space-1)] font-medium text-foreground\">\n          Summary\n        </span>\n      </p>\n    </Header>\n    <div className=\"mt-[var(--space-4)] grid gap-[var(--space-3)] sm:grid-cols-2\">\n      <div className=\"rounded-card border border-card-hairline/60 bg-surface px-[var(--space-4)] py-[var(--space-3)]\">\n        <p className=\"text-label text-muted-foreground\">Next milestone</p>\n        <p className=\"mt-[var(--space-1)] text-ui font-medium text-foreground\">\n          Launch sprint\n        </p>\n      </div>\n      <div className=\"rounded-card border border-card-hairline/60 bg-surface px-[var(--space-4)] py-[var(--space-3)]\">\n        <p className=\"text-label text-muted-foreground\">Team focus</p>\n        <p className=\"mt-[var(--space-1)] text-ui font-medium text-foreground\">\n          Deep work block\n        </p>\n      </div>\n    </div>\n  </div>\n  <div className=\"rounded-card border border-card-hairline/60 bg-panel/80 p-[var(--space-5)] shadow-[var(--shadow-outline-subtle)]\">\n    <p className=\"mb-[var(--space-3)] text-label font-medium text-muted-foreground\">\n      Brand underline\n    </p>\n    <Header\n      eyebrow=\"Workspace\"\n      heading=\"Header\"\n      subtitle=\"Segmented navigation anchored to the header\"\n      railTone=\"loud\"\n      underlineTone=\"brand\"\n      icon={\n        <Circle\n          aria-hidden=\"true\"\n          className=\"h-[var(--space-5)] w-[var(--space-5)] text-primary\"\n        />\n      }\n      tabs={{\n        items: [\n          {\n            key: \"summary\",\n            label: \"Summary\",\n            icon: (\n              <Circle\n                aria-hidden=\"true\"\n                className=\"h-[var(--space-4)] w-[var(--space-4)]\"\n              />\n            ),\n          },\n          {\n            key: \"timeline\",\n            label: \"Timeline\",\n            icon: (\n              <CircleDot\n                aria-hidden=\"true\"\n                className=\"h-[var(--space-4)] w-[var(--space-4)]\"\n              />\n            ),\n          },\n          {\n            key: \"insights\",\n            label: \"Insights\",\n            icon: (\n              <CircleCheck\n                aria-hidden=\"true\"\n                className=\"h-[var(--space-4)] w-[var(--space-4)]\"\n              />\n            ),\n            disabled: true,\n          },\n        ],\n        value: \"summary\",\n        onChange: () => {},\n        ariaLabel: \"Header demo tabs (brand underline)\",\n        size: \"md\",\n      }}\n      sticky={false}\n      topClassName=\"top-0\"\n    >\n      <p className=\"text-ui text-muted-foreground\">\n        Viewing\n        <span className=\"ml-[var(--space-1)] font-medium text-foreground\">\n          Summary\n        </span>\n      </p>\n    </Header>\n    <div className=\"mt-[var(--space-4)] grid gap-[var(--space-3)] sm:grid-cols-2\">\n      <div className=\"rounded-card border border-card-hairline/60 bg-surface px-[var(--space-4)] py-[var(--space-3)]\">\n        <p className=\"text-label text-muted-foreground\">Next milestone</p>\n        <p className=\"mt-[var(--space-1)] text-ui font-medium text-foreground\">\n          Launch sprint\n        </p>\n      </div>\n      <div className=\"rounded-card border border-card-hairline/60 bg-surface px-[var(--space-4)] py-[var(--space-3)]\">\n        <p className=\"text-label text-muted-foreground\">Team focus</p>\n        <p className=\"mt-[var(--space-1)] text-ui font-medium text-foreground\">\n          Deep work block\n        </p>\n      </div>\n    </div>\n  </div>\n</div>",
           "preview": {
             "id": "ui:header:tabs"
           }
@@ -2065,7 +2135,7 @@ export const galleryPayload = {
             "loading"
           ],
           "kind": "primitive",
-          "code": "<Spinner size=\"var(--space-6)\" />",
+          "code": "<Spinner size=\"xl\" />",
           "preview": {
             "id": "prompts:feedback:spinner"
           }
@@ -3158,7 +3228,7 @@ export const galleryPayload = {
         {
           "id": "badge",
           "name": "Badge",
-          "description": "Compact pill with tone-driven styles",
+          "description": "Compact pill with tone-driven styles. Accent tones now meet ≥4.5:1 contrast for white content",
           "kind": "primitive",
           "tags": [
             "badge",
@@ -3466,11 +3536,20 @@ export const galleryPayload = {
               },
               {
                 "value": "Loading"
+              },
+              {
+                "value": "Primary"
+              },
+              {
+                "value": "Primary Hover"
+              },
+              {
+                "value": "Primary Active"
               }
             ]
           }
         ],
-        "code": "<div className=\"flex flex-col gap-[var(--space-4)]\">\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <IconButton size=\"sm\" variant=\"ghost\" aria-label=\"Add item sm\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"md\" variant=\"ghost\" aria-label=\"Add item md\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"lg\" variant=\"ghost\" aria-label=\"Add item lg\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"xl\" variant=\"ghost\" aria-label=\"Add item xl\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"md\" variant=\"secondary\" aria-label=\"Add item secondary\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"md\" variant=\"primary\" aria-label=\"Add item primary\">\n      <Plus />\n    </IconButton>\n  </div>\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <IconButton aria-label=\"Default\">\n      <Plus />\n    </IconButton>\n    <IconButton className=\"bg-[--hover]\" aria-label=\"Hover\">\n      <Plus />\n    </IconButton>\n    <IconButton className=\"ring-2 ring-[var(--focus)]\" aria-label=\"Focus\">\n      <Plus />\n    </IconButton>\n    <IconButton\n      className=\"bg-[--active]\"\n      aria-pressed\n      aria-label=\"Active\"\n    >\n      <Plus />\n    </IconButton>\n    <IconButton disabled aria-label=\"Disabled\">\n      <Plus />\n    </IconButton>\n    <IconButton loading aria-label=\"Loading\">\n      <Plus />\n    </IconButton>\n  </div>\n</div>",
+        "code": "<div className=\"flex flex-col gap-[var(--space-4)]\">\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <IconButton size=\"sm\" variant=\"ghost\" aria-label=\"Add item sm\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"md\" variant=\"ghost\" aria-label=\"Add item md\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"lg\" variant=\"ghost\" aria-label=\"Add item lg\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"xl\" variant=\"ghost\" aria-label=\"Add item xl\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"md\" variant=\"secondary\" aria-label=\"Add item secondary\">\n      <Plus />\n    </IconButton>\n    <IconButton size=\"md\" variant=\"primary\" aria-label=\"Add item primary\">\n      <Plus />\n    </IconButton>\n  </div>\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <IconButton aria-label=\"Default\">\n      <Plus />\n    </IconButton>\n    <IconButton className=\"bg-[--hover]\" aria-label=\"Hover\">\n      <Plus />\n    </IconButton>\n    <IconButton className=\"ring-2 ring-[var(--focus)]\" aria-label=\"Focus\">\n      <Plus />\n    </IconButton>\n    <IconButton\n      className=\"bg-[--active]\"\n      aria-pressed\n      aria-label=\"Active\"\n    >\n      <Plus />\n    </IconButton>\n    <IconButton disabled aria-label=\"Disabled\">\n      <Plus />\n    </IconButton>\n    <IconButton loading aria-label=\"Loading\">\n      <Plus />\n    </IconButton>\n  </div>\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <IconButton variant=\"primary\" aria-label=\"Primary\">\n      <Plus />\n    </IconButton>\n    <IconButton\n      className=\"bg-[--hover] shadow-[var(--shadow-neon-strong)]\"\n      variant=\"primary\"\n      aria-label=\"Primary hover\"\n    >\n      <Plus />\n    </IconButton>\n    <IconButton\n      className=\"bg-[--active] shadow-[var(--shadow-inset-contrast),var(--shadow-neon-soft)]\"\n      variant=\"primary\"\n      aria-label=\"Primary active\"\n      aria-pressed\n    >\n      <Plus />\n    </IconButton>\n  </div>\n</div>",
         "preview": {
           "id": "ui:icon-button:matrix"
         },
@@ -3521,6 +3600,30 @@ export const galleryPayload = {
             "code": "<IconButton loading aria-label=\"Loading\">\n  <Plus />\n</IconButton>",
             "preview": {
               "id": "ui:icon-button:state:loading"
+            }
+          },
+          {
+            "id": "primary",
+            "name": "Primary",
+            "code": "<IconButton variant=\"primary\" aria-label=\"Primary\">\n  <Plus />\n</IconButton>",
+            "preview": {
+              "id": "ui:icon-button:state:primary"
+            }
+          },
+          {
+            "id": "primary-hover",
+            "name": "Primary Hover",
+            "code": "<IconButton\n  className=\"bg-[--hover] shadow-[var(--shadow-neon-strong)]\"\n  variant=\"primary\"\n  aria-label=\"Primary hover\"\n>\n  <Plus />\n</IconButton>",
+            "preview": {
+              "id": "ui:icon-button:state:primary-hover"
+            }
+          },
+          {
+            "id": "primary-active",
+            "name": "Primary Active",
+            "code": "<IconButton\n  className=\"bg-[--active] shadow-[var(--shadow-inset-contrast),var(--shadow-neon-soft)]\"\n  variant=\"primary\"\n  aria-label=\"Primary active\"\n  aria-pressed\n>\n  <Plus />\n</IconButton>",
+            "preview": {
+              "id": "ui:icon-button:state:primary-active"
             }
           }
         ]
@@ -3581,12 +3684,15 @@ export const galleryPayload = {
                 "value": "Disabled"
               },
               {
+                "value": "Disabled link"
+              },
+              {
                 "value": "Loading"
               }
             ]
           }
         ],
-        "code": "<div className=\"flex flex-wrap gap-[var(--space-2)]\">\n  <SegmentedButton>Default</SegmentedButton>\n  <SegmentedButton className=\"[--hover:var(--seg-hover-base)] bg-[--hover] text-[hsl(var(--foreground))] [text-shadow:0_0_calc(var(--space-2)-var(--spacing-0-5))_hsl(var(--accent)/0.25)]\">Hover</SegmentedButton>\n  <SegmentedButton selected>Active</SegmentedButton>\n  <SegmentedButton className=\"ring-2 ring-[--theme-ring] ring-offset-0 outline-none\">Focus-visible</SegmentedButton>\n  <SegmentedButton disabled>Disabled</SegmentedButton>\n  <SegmentedButton loading>Loading</SegmentedButton>\n</div>",
+        "code": "<div className=\"flex flex-wrap gap-[var(--space-2)]\">\n  <SegmentedButton>Default</SegmentedButton>\n  <SegmentedButton className=\"[--hover:var(--seg-hover-base)] bg-[--hover] text-[hsl(var(--foreground))] [text-shadow:0_0_calc(var(--space-2)-var(--spacing-0-5))_hsl(var(--accent)/0.25)]\">Hover</SegmentedButton>\n  <SegmentedButton selected>Active</SegmentedButton>\n  <SegmentedButton className=\"ring-2 ring-[--theme-ring] ring-offset-0 outline-none\">Focus-visible</SegmentedButton>\n  <SegmentedButton disabled>Disabled</SegmentedButton>\n  <SegmentedButton as=\"a\" href=\"#\" disabled>Disabled link</SegmentedButton>\n  <SegmentedButton loading>Loading</SegmentedButton>\n</div>",
         "preview": {
           "id": "ui:segmented-button:states"
         },
@@ -3629,6 +3735,14 @@ export const galleryPayload = {
             "code": "<SegmentedButton disabled>Disabled</SegmentedButton>",
             "preview": {
               "id": "ui:segmented-button:state:disabled"
+            }
+          },
+          {
+            "id": "disabled-link",
+            "name": "Disabled link",
+            "code": "<SegmentedButton as=\"a\" href=\"#\" disabled>Disabled link</SegmentedButton>",
+            "preview": {
+              "id": "ui:segmented-button:state:disabled-link"
             }
           },
           {
@@ -4435,7 +4549,7 @@ export const galleryPayload = {
           "loading"
         ],
         "kind": "primitive",
-        "code": "<Spinner size=\"var(--space-6)\" />",
+        "code": "<Spinner size=\"xl\" />",
         "preview": {
           "id": "prompts:feedback:spinner"
         }
@@ -4681,7 +4795,7 @@ export const galleryPayload = {
       {
         "id": "badge",
         "name": "Badge",
-        "description": "Compact pill with tone-driven styles",
+        "description": "Compact pill with tone-driven styles. Accent tones now meet ≥4.5:1 contrast for white content",
         "kind": "primitive",
         "tags": [
           "badge",
@@ -4899,7 +5013,7 @@ export const galleryPayload = {
             "id": "chip-loading",
             "name": "Chip loading",
             "description": "While sync runs the badge disables interaction and shows an accent spinner anchored by the spacing scale.",
-            "code": "<div className=\"flex flex-wrap items-center gap-[var(--space-2)]\">\n  <Badge interactive>Default</Badge>\n  <Badge\n    interactive\n    disabled\n    className=\"pointer-events-none\"\n  >\n    Loading\n    <Spinner\n      size={16}\n      className=\"ml-[var(--space-2)] border-[hsl(var(--ring))] border-t-transparent\"\n    />\n  </Badge>\n</div>",
+            "code": "<div className=\"flex flex-wrap items-center gap-[var(--space-2)]\">\n  <Badge interactive>Default</Badge>\n  <Badge\n    interactive\n    disabled\n    className=\"pointer-events-none\"\n  >\n    Loading\n    <Spinner\n      size=\"sm\"\n      className=\"ml-[var(--space-2)] border-[hsl(var(--ring))] border-t-transparent\"\n    />\n  </Badge>\n</div>",
             "preview": {
               "id": "prompts:prompts:prompts-header:state:chip-loading"
             }
@@ -5213,7 +5327,7 @@ export const galleryPayload = {
             "id": "opening",
             "name": "Opening / loading",
             "description": "Soft elevation token and spinner communicate progress while the sheet animates in.",
-            "code": "<Sheet\n  open\n  onClose={() => {}}\n  className=\"shadow-[var(--shadow-neo-soft)]\"\n>\n  <CardHeader>\n    <CardTitle>Syncing tasks</CardTitle>\n    <CardDescription>\n      Keep content visible while the sheet animates into place.\n    </CardDescription>\n  </CardHeader>\n  <CardContent className=\"flex items-center gap-[var(--space-3)] rounded-card border border-border/40 bg-surface-2 p-[var(--space-3)] shadow-[var(--shadow-outline-subtle)]\">\n    <Spinner size={20} />\n    <span className=\"text-ui text-muted-foreground\">Loading dashboard</span>\n  </CardContent>\n</Sheet>",
+            "code": "<Sheet\n  open\n  onClose={() => {}}\n  className=\"shadow-[var(--shadow-neo-soft)]\"\n>\n  <CardHeader>\n    <CardTitle>Syncing tasks</CardTitle>\n    <CardDescription>\n      Keep content visible while the sheet animates into place.\n    </CardDescription>\n  </CardHeader>\n  <CardContent className=\"flex items-center gap-[var(--space-3)] rounded-card border border-border/40 bg-surface-2 p-[var(--space-3)] shadow-[var(--shadow-outline-subtle)]\">\n    <Spinner size=\"md\" />\n    <span className=\"text-ui text-muted-foreground\">Loading dashboard</span>\n  </CardContent>\n</Sheet>",
             "preview": {
               "id": "prompts:layout:sheet-demo:state:opening"
             }
@@ -5264,7 +5378,7 @@ export const galleryPayload = {
             "id": "loading",
             "name": "Opening / loading",
             "description": "Soft elevation token pairs with a spinner while the dialog content hydrates.",
-            "code": "<Modal\n  open\n  onClose={() => {}}\n  className=\"shadow-[var(--shadow-neo-soft)]\"\n>\n  <CardHeader>\n    <CardTitle>Confirm selection</CardTitle>\n    <CardDescription>\n      Surface a loader while the dialog hydrates.\n    </CardDescription>\n  </CardHeader>\n  <CardContent className=\"flex items-center gap-[var(--space-3)] rounded-card border border-border/40 bg-surface-2 p-[var(--space-3)] shadow-[var(--shadow-outline-subtle)]\">\n    <Spinner size={20} />\n    <span className=\"text-ui text-muted-foreground\">Syncing choices...</span>\n  </CardContent>\n</Modal>",
+            "code": "<Modal\n  open\n  onClose={() => {}}\n  className=\"shadow-[var(--shadow-neo-soft)]\"\n>\n  <CardHeader>\n    <CardTitle>Confirm selection</CardTitle>\n    <CardDescription>\n      Surface a loader while the dialog hydrates.\n    </CardDescription>\n  </CardHeader>\n  <CardContent className=\"flex items-center gap-[var(--space-3)] rounded-card border border-border/40 bg-surface-2 p-[var(--space-3)] shadow-[var(--shadow-outline-subtle)]\">\n    <Spinner size=\"md\" />\n    <span className=\"text-ui text-muted-foreground\">Syncing choices...</span>\n  </CardContent>\n</Modal>",
             "preview": {
               "id": "prompts:layout:modal-demo:state:loading"
             }
@@ -5376,9 +5490,35 @@ export const galleryPayload = {
                 "value": "Disabled"
               }
             ]
+          },
+          {
+            "id": "rail-tone",
+            "label": "Rail tone",
+            "type": "variant",
+            "values": [
+              {
+                "value": "Subtle"
+              },
+              {
+                "value": "Loud"
+              }
+            ]
+          },
+          {
+            "id": "underline-tone",
+            "label": "Underline tone",
+            "type": "variant",
+            "values": [
+              {
+                "value": "Neutral"
+              },
+              {
+                "value": "Brand"
+              }
+            ]
           }
         ],
-        "code": "<Header\n  heading=\"Header\"\n  subtitle=\"Segmented navigation anchored to the header\"\n  tabs={{\n    items: [\n      {\n        key: \"summary\",\n        label: \"Summary\",\n        icon: (\n          <Circle\n            aria-hidden=\"true\"\n            className=\"h-[var(--space-4)] w-[var(--space-4)]\"\n          />\n        ),\n      },\n      {\n        key: \"timeline\",\n        label: \"Timeline\",\n        icon: (\n          <CircleDot\n            aria-hidden=\"true\"\n            className=\"h-[var(--space-4)] w-[var(--space-4)]\"\n          />\n        ),\n      },\n      {\n        key: \"insights\",\n        label: \"Insights\",\n        icon: (\n          <CircleCheck\n            aria-hidden=\"true\"\n            className=\"h-[var(--space-4)] w-[var(--space-4)]\"\n          />\n        ),\n        disabled: true,\n      },\n    ],\n    value: \"summary\",\n    onChange: () => {},\n    ariaLabel: \"Header demo tabs\",\n    size: \"md\",\n  }}\n  sticky={false}\n  topClassName=\"top-0\"\n>\n  <p className=\"text-ui text-muted-foreground\">\n    Viewing\n    <span className=\"ml-[var(--space-1)] font-medium text-foreground\">\n      Summary\n    </span>\n  </p>\n</Header>",
+        "code": "<div className=\"grid gap-[var(--space-4)] lg:grid-cols-2\">\n  <div className=\"rounded-card border border-card-hairline/60 bg-panel/80 p-[var(--space-5)] shadow-[var(--shadow-outline-subtle)]\">\n    <p className=\"mb-[var(--space-3)] text-label font-medium text-muted-foreground\">\n      Neutral underline (default)\n    </p>\n    <Header\n      eyebrow=\"Workspace\"\n      heading=\"Header\"\n      subtitle=\"Segmented navigation anchored to the header\"\n      railTone=\"subtle\"\n      underlineTone=\"neutral\"\n      icon={\n        <Circle\n          aria-hidden=\"true\"\n          className=\"h-[var(--space-5)] w-[var(--space-5)] text-primary\"\n        />\n      }\n      tabs={{\n        items: [\n          {\n            key: \"summary\",\n            label: \"Summary\",\n            icon: (\n              <Circle\n                aria-hidden=\"true\"\n                className=\"h-[var(--space-4)] w-[var(--space-4)]\"\n              />\n            ),\n          },\n          {\n            key: \"timeline\",\n            label: \"Timeline\",\n            icon: (\n              <CircleDot\n                aria-hidden=\"true\"\n                className=\"h-[var(--space-4)] w-[var(--space-4)]\"\n              />\n            ),\n          },\n          {\n            key: \"insights\",\n            label: \"Insights\",\n            icon: (\n              <CircleCheck\n                aria-hidden=\"true\"\n                className=\"h-[var(--space-4)] w-[var(--space-4)]\"\n              />\n            ),\n            disabled: true,\n          },\n        ],\n        value: \"summary\",\n        onChange: () => {},\n        ariaLabel: \"Header demo tabs (neutral underline)\",\n        size: \"md\",\n      }}\n      sticky={false}\n      topClassName=\"top-0\"\n    >\n      <p className=\"text-ui text-muted-foreground\">\n        Viewing\n        <span className=\"ml-[var(--space-1)] font-medium text-foreground\">\n          Summary\n        </span>\n      </p>\n    </Header>\n    <div className=\"mt-[var(--space-4)] grid gap-[var(--space-3)] sm:grid-cols-2\">\n      <div className=\"rounded-card border border-card-hairline/60 bg-surface px-[var(--space-4)] py-[var(--space-3)]\">\n        <p className=\"text-label text-muted-foreground\">Next milestone</p>\n        <p className=\"mt-[var(--space-1)] text-ui font-medium text-foreground\">\n          Launch sprint\n        </p>\n      </div>\n      <div className=\"rounded-card border border-card-hairline/60 bg-surface px-[var(--space-4)] py-[var(--space-3)]\">\n        <p className=\"text-label text-muted-foreground\">Team focus</p>\n        <p className=\"mt-[var(--space-1)] text-ui font-medium text-foreground\">\n          Deep work block\n        </p>\n      </div>\n    </div>\n  </div>\n  <div className=\"rounded-card border border-card-hairline/60 bg-panel/80 p-[var(--space-5)] shadow-[var(--shadow-outline-subtle)]\">\n    <p className=\"mb-[var(--space-3)] text-label font-medium text-muted-foreground\">\n      Brand underline\n    </p>\n    <Header\n      eyebrow=\"Workspace\"\n      heading=\"Header\"\n      subtitle=\"Segmented navigation anchored to the header\"\n      railTone=\"loud\"\n      underlineTone=\"brand\"\n      icon={\n        <Circle\n          aria-hidden=\"true\"\n          className=\"h-[var(--space-5)] w-[var(--space-5)] text-primary\"\n        />\n      }\n      tabs={{\n        items: [\n          {\n            key: \"summary\",\n            label: \"Summary\",\n            icon: (\n              <Circle\n                aria-hidden=\"true\"\n                className=\"h-[var(--space-4)] w-[var(--space-4)]\"\n              />\n            ),\n          },\n          {\n            key: \"timeline\",\n            label: \"Timeline\",\n            icon: (\n              <CircleDot\n                aria-hidden=\"true\"\n                className=\"h-[var(--space-4)] w-[var(--space-4)]\"\n              />\n            ),\n          },\n          {\n            key: \"insights\",\n            label: \"Insights\",\n            icon: (\n              <CircleCheck\n                aria-hidden=\"true\"\n                className=\"h-[var(--space-4)] w-[var(--space-4)]\"\n              />\n            ),\n            disabled: true,\n          },\n        ],\n        value: \"summary\",\n        onChange: () => {},\n        ariaLabel: \"Header demo tabs (brand underline)\",\n        size: \"md\",\n      }}\n      sticky={false}\n      topClassName=\"top-0\"\n    >\n      <p className=\"text-ui text-muted-foreground\">\n        Viewing\n        <span className=\"ml-[var(--space-1)] font-medium text-foreground\">\n          Summary\n        </span>\n      </p>\n    </Header>\n    <div className=\"mt-[var(--space-4)] grid gap-[var(--space-3)] sm:grid-cols-2\">\n      <div className=\"rounded-card border border-card-hairline/60 bg-surface px-[var(--space-4)] py-[var(--space-3)]\">\n        <p className=\"text-label text-muted-foreground\">Next milestone</p>\n        <p className=\"mt-[var(--space-1)] text-ui font-medium text-foreground\">\n          Launch sprint\n        </p>\n      </div>\n      <div className=\"rounded-card border border-card-hairline/60 bg-surface px-[var(--space-4)] py-[var(--space-3)]\">\n        <p className=\"text-label text-muted-foreground\">Team focus</p>\n        <p className=\"mt-[var(--space-1)] text-ui font-medium text-foreground\">\n          Deep work block\n        </p>\n      </div>\n    </div>\n  </div>\n</div>",
         "preview": {
           "id": "ui:header:tabs"
         }
@@ -6704,6 +6844,9 @@ export const galleryPreviewModules = [
       "ui:icon-button:state:active",
       "ui:icon-button:state:disabled",
       "ui:icon-button:state:loading",
+      "ui:icon-button:state:primary",
+      "ui:icon-button:state:primary-hover",
+      "ui:icon-button:state:primary-active",
     ],
   },
   {
@@ -6740,6 +6883,7 @@ export const galleryPreviewModules = [
       "ui:segmented-button:state:active",
       "ui:segmented-button:state:focus-visible",
       "ui:segmented-button:state:disabled",
+      "ui:segmented-button:state:disabled-link",
       "ui:segmented-button:state:loading",
     ],
   },

--- a/src/components/prompts/SpinnerShowcase.tsx
+++ b/src/components/prompts/SpinnerShowcase.tsx
@@ -4,9 +4,9 @@ export default function SpinnerShowcase() {
   return (
     <div className="flex flex-col gap-[var(--space-4)]">
       <div className="flex items-center gap-[var(--space-4)]">
-        <Spinner size={16} />
-        <Spinner size={24} />
-        <Spinner size={32} />
+        <Spinner size="sm" />
+        <Spinner size="lg" />
+        <Spinner size="xl" />
       </div>
       <div className="flex items-center gap-[var(--space-4)]">
         <Spinner tone="primary" />

--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -372,7 +372,7 @@ function PromptsHeaderChipStatePreview({ state }: { state: ChipState }) {
         <span>{labelMap[state]}</span>
         {state === "loading" ? (
           <Spinner
-            size={16}
+            size="sm"
             className="ml-[var(--space-2)] border-[hsl(var(--ring))] border-t-transparent"
           />
         ) : null}
@@ -1351,7 +1351,7 @@ function BottomNavStatesDemo({ mode = "combined" }: { mode?: BottomNavDemoMode }
                   <span className="flex items-center gap-[var(--space-1)]">
                     {label}
                     {state === "syncing" ? (
-                      <Spinner size="var(--space-3)" />
+                      <Spinner size="xs" />
                     ) : null}
                   </span>
                 </button>
@@ -1604,7 +1604,7 @@ function SheetOpeningState() {
         </CardDescription>
       </CardHeader>
       <CardContent className="flex items-center gap-[var(--space-3)] rounded-card border border-border/40 bg-surface-2 p-[var(--space-3)] shadow-[var(--shadow-outline-subtle)]">
-        <Spinner size={20} />
+        <Spinner size="md" />
         <span className="text-ui text-muted-foreground">Loading dashboard</span>
       </CardContent>
     </Sheet>
@@ -1751,7 +1751,7 @@ function ModalOpeningState() {
         </CardDescription>
       </CardHeader>
       <CardContent className="flex items-center gap-[var(--space-3)] rounded-card border border-border/40 bg-surface-2 p-[var(--space-3)] shadow-[var(--shadow-outline-subtle)]">
-        <Spinner size={20} />
+        <Spinner size="md" />
         <span className="text-ui text-muted-foreground">Syncing choices...</span>
       </CardContent>
     </Modal>
@@ -2112,7 +2112,7 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
   >
     Loading
     <Spinner
-      size={16}
+      size="sm"
       className="ml-[var(--space-2)] border-[hsl(var(--ring))] border-t-transparent"
     />
   </Badge>
@@ -2915,7 +2915,7 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
     </CardDescription>
   </CardHeader>
   <CardContent className="flex items-center gap-[var(--space-3)] rounded-card border border-border/40 bg-surface-2 p-[var(--space-3)] shadow-[var(--shadow-outline-subtle)]">
-    <Spinner size={20} />
+    <Spinner size="md" />
     <span className="text-ui text-muted-foreground">Loading dashboard</span>
   </CardContent>
 </Sheet>`,
@@ -3065,7 +3065,7 @@ React.useEffect(() => {
     </CardDescription>
   </CardHeader>
   <CardContent className="flex items-center gap-[var(--space-3)] rounded-card border border-border/40 bg-surface-2 p-[var(--space-3)] shadow-[var(--shadow-outline-subtle)]">
-    <Spinner size={20} />
+    <Spinner size="md" />
     <span className="text-ui text-muted-foreground">Syncing choices...</span>
   </CardContent>
 </Modal>`,
@@ -3782,7 +3782,7 @@ React.useEffect(() => {
       name: "Spinner",
       element: <SpinnerShowcase />,
       tags: ["spinner", "loading"],
-      code: `<Spinner size="var(--space-6)" />`,
+      code: `<Spinner size="xl" />`,
     },
   ],
   toggles: [

--- a/src/components/ui/AnimationToggle.tsx
+++ b/src/components/ui/AnimationToggle.tsx
@@ -69,7 +69,7 @@ export default function AnimationToggle({
         )}
       >
         {loading ? (
-          <Spinner size="var(--space-4)" />
+          <Spinner size="sm" />
         ) : enabled ? (
           <Zap className="h-[var(--space-4)] w-[var(--space-4)]" />
         ) : (

--- a/src/components/ui/feedback/Progress.tsx
+++ b/src/components/ui/feedback/Progress.tsx
@@ -6,6 +6,8 @@ import * as React from "react";
 /** Simple progress bar (0..100), with SR label */
 export default function Progress({ value, label }: { value: number; label?: string }) {
   const v = Math.max(0, Math.min(100, Math.round(value)));
+  const widthClass = `w-[${v}%]`;
+
   return (
     <div
       className="h-[var(--space-2)] w-full rounded-full bg-muted shadow-neo-inset"
@@ -14,8 +16,7 @@ export default function Progress({ value, label }: { value: number; label?: stri
         className="h-full w-full overflow-hidden rounded-full bg-panel/90 shadow-neo-inset"
       >
         <span
-          className="block h-full rounded-full bg-[linear-gradient(90deg,hsl(var(--accent)),hsl(var(--accent-2)))] transition-[width] shadow-neo-sm"
-          style={{ width: `${v}%` }}
+          className={`block h-full rounded-full bg-[linear-gradient(90deg,hsl(var(--accent)),hsl(var(--accent-2)))] transition-[width] shadow-neo-sm ${widthClass}`}
           aria-valuemin={0}
           aria-valuemax={100}
           aria-valuenow={v}

--- a/src/components/ui/feedback/Spinner.tsx
+++ b/src/components/ui/feedback/Spinner.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import * as React from "react";
-import type { CSSProperties } from "react";
 import { cn } from "@/lib/utils";
 
 const toneToBorderClass = {
@@ -13,15 +12,31 @@ const toneToBorderClass = {
 
 export type SpinnerTone = keyof typeof toneToBorderClass;
 
+const sizeToVariableClass = {
+  xs: "[--spinner-size:var(--space-3)]",
+  sm: "[--spinner-size:var(--space-4)]",
+  md: "[--spinner-size:calc(var(--space-5)-var(--space-1))]",
+  lg: "[--spinner-size:var(--space-5)]",
+  xl: "[--spinner-size:var(--space-6)]",
+  "2xl": "[--spinner-size:var(--space-7)]",
+  "control-xs": "[--spinner-size:calc(var(--control-h-xs)/2)]",
+  "control-sm": "[--spinner-size:calc(var(--control-h-sm)/2)]",
+  "control-md": "[--spinner-size:calc(var(--control-h-md)/2)]",
+  "control-lg": "[--spinner-size:calc(var(--control-h-lg)/2)]",
+  "control-xl": "[--spinner-size:calc(var(--control-h-xl)/2)]",
+} as const;
+
+export type SpinnerSize = keyof typeof sizeToVariableClass;
+
 type SpinnerProps = {
   className?: string;
-  size?: CSSProperties["width"];
+  size?: SpinnerSize;
   tone?: SpinnerTone;
 };
 
 export default function Spinner({
   className,
-  size = "var(--space-6)",
+  size = "xl",
   tone = "accent",
 }: SpinnerProps) {
   return (
@@ -30,11 +45,11 @@ export default function Spinner({
       aria-label="Loading"
       aria-live="polite"
       className={cn(
-        "inline-block animate-spin rounded-full border border-t-transparent",
+        "inline-block h-[var(--spinner-size)] w-[var(--spinner-size)] animate-spin rounded-full border border-t-transparent",
         toneToBorderClass[tone],
+        sizeToVariableClass[size],
         className,
       )}
-      style={{ width: size, height: size }}
     >
       <span className="sr-only">Loading...</span>
     </div>

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -6,9 +6,8 @@ import { Slot } from "@radix-ui/react-slot";
 import { motion, useReducedMotion } from "framer-motion";
 import type { HTMLMotionProps } from "framer-motion";
 import { cn, withBasePath } from "@/lib/utils";
-import Spinner, { type SpinnerTone } from "../feedback/Spinner";
+import Spinner, { type SpinnerTone, type SpinnerSize } from "../feedback/Spinner";
 import { neuRaised, neuInset } from "./Neu";
-import designTokens from "../../../../tokens/tokens.js";
 
 export const buttonSizes = {
   sm: {
@@ -45,64 +44,11 @@ export type ButtonSize = keyof typeof buttonSizes;
 
 type Tone = SpinnerTone;
 
-type ControlHeightToken =
-  | "controlHSm"
-  | "controlHMd"
-  | "controlHLg"
-  | "controlHXl";
-
-const FALLBACK_CONTROL_HEIGHTS: Record<ButtonSize, number> = {
-  sm: 32,
-  md: 40,
-  lg: 48,
-  xl: 56,
-};
-
-const CONTROL_HEIGHT_TOKENS: Record<ButtonSize, ControlHeightToken> = {
-  sm: "controlHSm",
-  md: "controlHMd",
-  lg: "controlHLg",
-  xl: "controlHXl",
-};
-
-const parsePxTokenValue = (value: unknown): number | null => {
-  if (typeof value !== "string") {
-    return null;
-  }
-
-  const numericValue = Number.parseFloat(value);
-
-  return Number.isNaN(numericValue) ? null : numericValue;
-};
-
-const halfControlHeight = (
-  tokenKey: ControlHeightToken,
-  fallback: number,
-): string => {
-  const rawValue = (designTokens as Record<string, unknown>)[tokenKey];
-  const parsedValue = parsePxTokenValue(rawValue);
-  const resolvedValue = (parsedValue ?? fallback) / 2;
-
-  return `${resolvedValue}px`;
-};
-
-const spinnerSizes: Record<ButtonSize, string> = {
-  sm: halfControlHeight(
-    CONTROL_HEIGHT_TOKENS.sm,
-    FALLBACK_CONTROL_HEIGHTS.sm,
-  ),
-  md: halfControlHeight(
-    CONTROL_HEIGHT_TOKENS.md,
-    FALLBACK_CONTROL_HEIGHTS.md,
-  ),
-  lg: halfControlHeight(
-    CONTROL_HEIGHT_TOKENS.lg,
-    FALLBACK_CONTROL_HEIGHTS.lg,
-  ),
-  xl: halfControlHeight(
-    CONTROL_HEIGHT_TOKENS.xl,
-    FALLBACK_CONTROL_HEIGHTS.xl,
-  ),
+const buttonSpinnerSizes: Record<ButtonSize, SpinnerSize> = {
+  sm: "control-sm",
+  md: "control-md",
+  lg: "control-lg",
+  xl: "control-xl",
 };
 
 const MotionSlot = motion.create(Slot);
@@ -286,7 +232,7 @@ export const Button = React.forwardRef<
     !asChild && "href" in props && typeof props.href !== "undefined";
   const toneColorVar = colorVar[tone];
   const s = buttonSizes[size];
-  const spinnerSize = spinnerSizes[size];
+  const spinnerSize = buttonSpinnerSizes[size];
   const base = cn(
     "relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)]",
     "data-[disabled=true]:opacity-[var(--disabled)] data-[disabled=true]:pointer-events-none",

--- a/src/components/ui/primitives/Field.tsx
+++ b/src/components/ui/primitives/Field.tsx
@@ -112,7 +112,7 @@ export const FieldRoot = React.forwardRef<HTMLDivElement, FieldRootProps>(
               data-slot="spinner"
               className="pointer-events-none absolute right-[var(--space-4)] top-1/2 -translate-y-1/2 text-muted-foreground"
             >
-              {spinner ?? <Spinner size={16} />}
+              {spinner ?? <Spinner size="sm" />}
             </span>
           ) : null}
         </div>

--- a/src/components/ui/select/AnimatedSelectList.tsx
+++ b/src/components/ui/select/AnimatedSelectList.tsx
@@ -131,7 +131,7 @@ export function AnimatedSelectList({
                         className="flex size-[var(--space-4)] shrink-0 items-center justify-center"
                       >
                         <Spinner
-                          size="var(--space-4)"
+                          size="sm"
                           className="border-border border-t-transparent opacity-80"
                         />
                       </span>

--- a/src/components/ui/toggles/Toggle.tsx
+++ b/src/components/ui/toggles/Toggle.tsx
@@ -94,7 +94,7 @@ export default function Toggle({
     >
       {loading ? (
         <span className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center">
-          <Spinner size={16} className="border-border border-t-transparent opacity-80" />
+          <Spinner size="sm" className="border-border border-t-transparent opacity-80" />
         </span>
       ) : null}
       {/* Sliding indicator */}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -4,6 +4,8 @@
 import type { Config } from "tailwindcss";
 import { spacingTokens, radiusScale } from "./src/lib/tokens";
 
+const progressWidthSafelist = Array.from({ length: 101 }, (_, index) => `w-[${index}%]`);
+
 const borderRadiusTokens = Object.entries(radiusScale).reduce(
   (acc, [token, value]) => {
     acc[token] = `${value}px`;
@@ -15,6 +17,7 @@ const borderRadiusTokens = Object.entries(radiusScale).reduce(
 const config: Config = {
   darkMode: "class",
   content: ["./src/**/*.{ts,tsx}"],
+  safelist: progressWidthSafelist,
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- map `Spinner` sizing tokens to CSS variables and remove inline size styles
- drive the `Progress` fill width via tokenised classes and safelist the dynamic widths in Tailwind
- update button, toggle, field, select, and gallery demos to consume the new spinner sizing API

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1cf306b8c832cbddea7de599c3119