### PR TITLE
Fix CSP style nonce handling

### DIFF
--- a/public/scripts/theme-bootstrap.js
+++ b/public/scripts/theme-bootstrap.js
@@ -64,6 +64,33 @@
     const cl = document.documentElement.classList;
     const dataset = document.documentElement.dataset;
     const style = document.documentElement.style;
+
+    function resolveAssetPath(relativePath) {
+      try {
+        const current = document.currentScript;
+        if (current && current.src) {
+          return new URL(relativePath, current.src).pathname;
+        }
+      } catch {
+        // ignore and fall through
+      }
+      try {
+        return new URL(relativePath, window.location.href).pathname;
+      } catch {
+        return relativePath.startsWith("/")
+          ? relativePath
+          : "/" + relativePath.replace(/^\.\/+/u, "");
+      }
+    }
+
+    style.setProperty(
+      "--asset-noise-url",
+      "url('" + resolveAssetPath("../noise.svg") + "')",
+    );
+    style.setProperty(
+      "--asset-glitch-gif-url",
+      "url('" + resolveAssetPath("../glitch-gif.gif") + "')",
+    );
     resetThemeClasses(cl);
     cl.add("theme-" + data.variant);
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,6 @@ import "./globals.css";
 // Load tokens + per-theme backdrops AFTER globals so overrides win.
 import "./themes.css";
 
-import type { CSSProperties } from "react";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import SiteChrome from "@/components/chrome/SiteChrome";
@@ -12,6 +11,7 @@ import { withBasePath } from "@/lib/utils";
 import Script from "next/script";
 import ThemeProvider from "@/lib/theme-context";
 import { THEME_BOOTSTRAP_SCRIPT_PATH } from "@/lib/theme";
+import StyledJsxRegistry from "@/lib/styled-jsx-registry";
 
 export const metadata: Metadata = {
   title: {
@@ -27,11 +27,6 @@ export const metadata: Metadata = {
  * - Falls back to system preference
  * - Applies appropriate theme classes
  */
-const htmlStyle = {
-  "--asset-noise-url": `url('${withBasePath("/noise.svg")}')`,
-  "--asset-glitch-gif-url": `url('${withBasePath("/glitch-gif.gif")}')`,
-} as CSSProperties;
-
 export default async function RootLayout({
   children,
 }: {
@@ -54,7 +49,6 @@ export default async function RootLayout({
       lang="en"
       className="theme-lg"
       suppressHydrationWarning
-      style={htmlStyle}
     >
       <head>
         <Script
@@ -71,7 +65,8 @@ export default async function RootLayout({
         >
           Skip to main content
         </a>
-        <ThemeProvider>
+        <StyledJsxRegistry nonce={nonce}>
+          <ThemeProvider>
           <div aria-hidden className="page-backdrop">
             <div className="page-shell">
               <div className="page-backdrop__layer" />
@@ -93,7 +88,8 @@ export default async function RootLayout({
               </PageShell>
             </footer>
           </div>
-        </ThemeProvider>
+          </ThemeProvider>
+        </StyledJsxRegistry>
       </body>
     </html>
   );

--- a/src/lib/styled-jsx-registry.tsx
+++ b/src/lib/styled-jsx-registry.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import type { PropsWithChildren } from "react";
+import { useMemo } from "react";
+import { useServerInsertedHTML } from "next/navigation";
+import type { StyledJsxStyleRegistry } from "styled-jsx/dist/index/index";
+import { StyleRegistry, createStyleRegistry } from "styled-jsx/dist/index/index";
+
+interface StyledJsxRegistryProps extends PropsWithChildren {
+  readonly nonce?: string;
+}
+
+export default function StyledJsxRegistry({
+  children,
+  nonce,
+}: StyledJsxRegistryProps) {
+  const registry: StyledJsxStyleRegistry = useMemo(
+    () => createStyleRegistry(),
+    [],
+  );
+
+  useServerInsertedHTML(() => {
+    const styles = registry.styles({ nonce });
+    registry.flush();
+
+    return <>{styles}</>;
+  });
+
+  return <StyleRegistry registry={registry}>{children}</StyleRegistry>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,6 @@
     },
     "types": [
       "vitest/globals",
-      "styled-jsx",
       "react",
       "node"
     ],

--- a/types/styled-jsx.d.ts
+++ b/types/styled-jsx.d.ts
@@ -1,0 +1,20 @@
+declare module "styled-jsx/dist/index/index" {
+  import type { ReactElement, ReactNode } from "react";
+
+  export type StyledJsxStyleRegistry = {
+    styles(options?: { nonce?: string }): ReactElement[];
+    flush(): void;
+    add(props: unknown): void;
+    remove(props: unknown): void;
+  };
+
+  export const StyleRegistry: ({
+    children,
+    registry,
+  }: {
+    children: ReactNode;
+    registry?: StyledJsxStyleRegistry;
+  }) => ReactElement;
+
+  export function createStyleRegistry(): StyledJsxStyleRegistry;
+}


### PR DESCRIPTION
## Summary
- remove the inline html custom property injection and wrap the app shell with a styled-jsx registry that forwards the CSP nonce
- move asset custom property setup into the theme bootstrap script with base-path aware URL resolution
- add a typed styled-jsx registry helper and module declaration while trimming redundant global type loading

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1db2de1b4832c81dee6c84247f127