### PR TITLE
Respect hero default frame in PageHeader

### DIFF
--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -244,7 +244,7 @@ const PageHeaderInner = <
     [heroActions, actions],
   );
 
-  const resolvedHeroFrame = heroFrame ?? false;
+  const resolvedHeroFrame = heroFrame ?? true;
 
   const heroDividerTint = heroDividerTintProp ?? "primary";
 


### PR DESCRIPTION
## Summary
- default the PageHeader hero frame prop to true so the Hero component keeps its framed styling when unspecified

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1e720691c832cabc0920a18c42290