### PR TITLE
Nest routed content inside site chrome

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -67,27 +67,28 @@ export default async function RootLayout({
         </a>
         <StyledJsxRegistry nonce={nonce}>
           <ThemeProvider>
-          <div aria-hidden className="page-backdrop">
-            <div className="page-shell">
-              <div className="page-backdrop__layer" />
+            <div aria-hidden className="page-backdrop">
+              <div className="page-shell">
+                <div className="page-backdrop__layer" />
+              </div>
             </div>
-          </div>
-          <SiteChrome />
-          <CatCompanion />
-          <div className="relative z-10">
-            {children}
-            <footer
-              role="contentinfo"
-              className="mt-[var(--space-8)] border-t border-border bg-surface"
-            >
-              <PageShell className="flex flex-col gap-[var(--space-1)] py-[var(--space-5)] text-label text-muted-foreground md:flex-row md:items-center md:justify-between">
-                <p className="text-ui font-medium text-foreground">
-                  Planner keeps local-first goals organized so every ritual stays actionable.
-                </p>
-                <p>© {year} Planner Labs. All rights reserved.</p>
-              </PageShell>
-            </footer>
-          </div>
+            <SiteChrome>
+              <CatCompanion />
+              <div className="relative z-10">
+                {children}
+                <footer
+                  role="contentinfo"
+                  className="mt-[var(--space-8)] border-t border-border bg-surface"
+                >
+                  <PageShell className="flex flex-col gap-[var(--space-1)] py-[var(--space-5)] text-label text-muted-foreground md:flex-row md:items-center md:justify-between">
+                    <p className="text-ui font-medium text-foreground">
+                      Planner keeps local-first goals organized so every ritual stays actionable.
+                    </p>
+                    <p>© {year} Planner Labs. All rights reserved.</p>
+                  </PageShell>
+                </footer>
+              </div>
+            </SiteChrome>
           </ThemeProvider>
         </StyledJsxRegistry>
       </body>

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -16,46 +16,49 @@ import Link from "next/link";
  * - Full-width container; content constrained by .page-shell
  * - Z-index > heroes, so it stays above scrolling headers
  */
-export default function SiteChrome() {
+export default function SiteChrome({ children }: React.PropsWithChildren) {
   return (
-    <header role="banner" className="sticky top-0 z-50 sticky-blur">
-      {/* Bar content */}
-      <PageShell
-        grid
-        className="pt-[var(--space-3)] pb-0 md:pb-[var(--space-3)]"
-        contentClassName="items-center"
-      >
-        <Link
-          href="/"
-          aria-label="Home"
-          className="col-span-full flex items-center gap-[var(--space-3)] md:col-span-3 lg:col-span-3"
+    <React.Fragment>
+      <header role="banner" className="sticky top-0 z-50 sticky-blur">
+        {/* Bar content */}
+        <PageShell
+          grid
+          className="pt-[var(--space-3)] pb-0 md:pb-[var(--space-3)]"
+          contentClassName="items-center"
         >
-          <span
-            className="h-[var(--space-2)] w-[var(--space-2)] rounded-full animate-pulse bg-[hsl(var(--accent-overlay))] shadow-[var(--shadow-glow-sm)]"
-            aria-hidden
-          />
-          <BrandWordmark />
-        </Link>
+          <Link
+            href="/"
+            aria-label="Home"
+            className="col-span-full flex items-center gap-[var(--space-3)] md:col-span-3 lg:col-span-3"
+          >
+            <span
+              className="h-[var(--space-2)] w-[var(--space-2)] rounded-full animate-pulse bg-[hsl(var(--accent-overlay))] shadow-[var(--shadow-glow-sm)]"
+              aria-hidden
+            />
+            <BrandWordmark />
+          </Link>
 
-        <div className="col-span-full hidden min-w-0 items-center md:col-span-6 md:flex lg:col-span-7">
-          <NavBar />
-        </div>
+          <div className="col-span-full hidden min-w-0 items-center md:col-span-6 md:flex lg:col-span-7">
+            <NavBar />
+          </div>
 
-        <div className="col-span-full flex items-center justify-end gap-[var(--space-3)] md:col-span-3 md:justify-self-end lg:col-span-2">
-          <ThemeToggle />
-          <AnimationToggle />
-        </div>
+          <div className="col-span-full flex items-center justify-end gap-[var(--space-3)] md:col-span-3 md:justify-self-end lg:col-span-2">
+            <ThemeToggle />
+            <AnimationToggle />
+          </div>
 
-        <div className="col-span-full md:hidden">
-          <BottomNav />
-        </div>
-      </PageShell>
+          <div className="col-span-full md:hidden">
+            <BottomNav />
+          </div>
+        </PageShell>
 
-      {/* Hairline (neon-friendly, non-interactive) */}
-      <div
-        aria-hidden
-        className="pointer-events-none h-[var(--hairline-w)] w-full bg-[linear-gradient(90deg,transparent,hsl(var(--border)),transparent)]"
-      />
-    </header>
+        {/* Hairline (neon-friendly, non-interactive) */}
+        <div
+          aria-hidden
+          className="pointer-events-none h-[var(--hairline-w)] w-full bg-[linear-gradient(90deg,transparent,hsl(var(--border)),transparent)]"
+        />
+      </header>
+      {children}
+    </React.Fragment>
   );
 }

--- a/tests/chrome/SiteChrome.test.tsx
+++ b/tests/chrome/SiteChrome.test.tsx
@@ -19,14 +19,31 @@ import SiteChrome from "@/components/chrome/SiteChrome";
 
 describe("SiteChrome", () => {
   it("links the brand to home", async () => {
-    render(<SiteChrome />);
+    render(
+      <SiteChrome>
+        <div />
+      </SiteChrome>,
+    );
     const link = screen.getByRole("link", { name: "Home" });
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute("href", "/");
   });
 
   it("renders the mobile navigation", () => {
-    render(<SiteChrome />);
+    render(
+      <SiteChrome>
+        <div />
+      </SiteChrome>,
+    );
     expect(screen.getAllByTestId("mobile-nav")).not.toHaveLength(0);
+  });
+
+  it("renders provided children", () => {
+    render(
+      <SiteChrome>
+        <div data-testid="inner" />
+      </SiteChrome>,
+    );
+    expect(screen.getByTestId("inner")).toBeInTheDocument();
   });
 });

--- a/tests/home/HomePage.test.tsx
+++ b/tests/home/HomePage.test.tsx
@@ -20,12 +20,11 @@ describe("Home page", () => {
     () => {
       render(
         <ThemeProvider>
-          <React.Fragment>
-            <SiteChrome />
+          <SiteChrome>
             <Suspense fallback="loading">
               <Page />
             </Suspense>
-          </React.Fragment>
+          </SiteChrome>
         </ThemeProvider>,
       );
       const expectLink = (label: string, href: string) => {

--- a/tests/ui/SiteChrome.test.tsx
+++ b/tests/ui/SiteChrome.test.tsx
@@ -11,7 +11,9 @@ describe("SiteChrome", () => {
   it("links to the home page via the noxi brand", () => {
     render(
       <ThemeProvider>
-        <SiteChrome />
+        <SiteChrome>
+          <div />
+        </SiteChrome>
       </ThemeProvider>,
     );
     const homeLink = screen.getByRole("link", { name: "Home" });


### PR DESCRIPTION
## Summary
- move the CatCompanion and routed content into SiteChrome so the chrome encloses each page while leaving the backdrop layer untouched
- allow SiteChrome to accept optional children and render them beneath the sticky header
- update layout-centric tests for the new SiteChrome shape and confirm children render inside the chrome

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1e8d8ae4c832c8462f581c9ebb71c