### PR TITLE
Allow SiteChrome to render optional children

### DIFF
--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -10,52 +10,59 @@ import AnimationToggle from "@/components/ui/AnimationToggle";
 import { PageShell } from "@/components/ui";
 import Link from "next/link";
 
+type SiteChromeProps = {
+  children?: React.ReactNode;
+};
+
 /**
  * SiteChrome — sticky top bar with Lavender-Glitch hairline
  * - Uses .sticky-blur (backdrop + border) from globals.css
  * - Full-width container; content constrained by .page-shell
  * - Z-index > heroes, so it stays above scrolling headers
  */
-export default function SiteChrome() {
+export default function SiteChrome({ children }: SiteChromeProps) {
   return (
-    <header role="banner" className="sticky top-0 z-50 sticky-blur">
-      {/* Bar content */}
-      <PageShell
-        grid
-        className="pt-[var(--space-3)] pb-0 md:pb-[var(--space-3)]"
-        contentClassName="items-center"
-      >
-        <Link
-          href="/"
-          aria-label="Home"
-          className="col-span-full flex items-center gap-[var(--space-3)] md:col-span-3 lg:col-span-3"
+    <>
+      <header role="banner" className="sticky top-0 z-50 sticky-blur">
+        {/* Bar content */}
+        <PageShell
+          grid
+          className="pt-[var(--space-3)] pb-0 md:pb-[var(--space-3)]"
+          contentClassName="items-center"
         >
-          <span
-            className="h-[var(--space-2)] w-[var(--space-2)] rounded-full animate-pulse bg-[hsl(var(--accent-overlay))] shadow-[var(--shadow-glow-sm)]"
-            aria-hidden
-          />
-          <BrandWordmark />
-        </Link>
+          <Link
+            href="/"
+            aria-label="Home"
+            className="col-span-full flex items-center gap-[var(--space-3)] md:col-span-3 lg:col-span-3"
+          >
+            <span
+              className="h-[var(--space-2)] w-[var(--space-2)] rounded-full animate-pulse bg-[hsl(var(--accent-overlay))] shadow-[var(--shadow-glow-sm)]"
+              aria-hidden
+            />
+            <BrandWordmark />
+          </Link>
 
-        <div className="col-span-full hidden min-w-0 items-center md:col-span-6 md:flex lg:col-span-7">
-          <NavBar />
-        </div>
+          <div className="col-span-full hidden min-w-0 items-center md:col-span-6 md:flex lg:col-span-7">
+            <NavBar />
+          </div>
 
-        <div className="col-span-full flex items-center justify-end gap-[var(--space-3)] md:col-span-3 md:justify-self-end lg:col-span-2">
-          <ThemeToggle />
-          <AnimationToggle />
-        </div>
+          <div className="col-span-full flex items-center justify-end gap-[var(--space-3)] md:col-span-3 md:justify-self-end lg:col-span-2">
+            <ThemeToggle />
+            <AnimationToggle />
+          </div>
 
-        <div className="col-span-full md:hidden">
-          <BottomNav />
-        </div>
-      </PageShell>
+          <div className="col-span-full md:hidden">
+            <BottomNav />
+          </div>
+        </PageShell>
 
-      {/* Hairline (neon-friendly, non-interactive) */}
-      <div
-        aria-hidden
-        className="pointer-events-none h-[var(--hairline-w)] w-full bg-[linear-gradient(90deg,transparent,hsl(var(--border)),transparent)]"
-      />
-    </header>
+        {/* Hairline (neon-friendly, non-interactive) */}
+        <div
+          aria-hidden
+          className="pointer-events-none h-[var(--hairline-w)] w-full bg-[linear-gradient(90deg,transparent,hsl(var(--border)),transparent)]"
+        />
+      </header>
+      {children}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- define a SiteChromeProps type so the component can accept optional children
- wrap the chrome markup in a fragment and render children beneath the header

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1e8e37d20832ca69ada5e6f6d904b