### PR TITLE
fix: adjust review panel card layout

### DIFF
--- a/src/components/reviews/ReviewPanel.tsx
+++ b/src/components/reviews/ReviewPanel.tsx
@@ -8,7 +8,7 @@ export default function ReviewPanel({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <Card
-      className={cn("w-full container", className)}
+      className={cn("w-full max-w-full", className)}
       {...props}
     />
   );

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -632,7 +632,7 @@ exports[`ReviewsPage > renders default state 1`] = `
       >
         <div
           aria-live="polite"
-          class="rounded-card r-card-lg p-[var(--space-4)] border border-border/25 bg-card/60 shadow-outline-subtle w-full container mx-auto flex flex-col items-center justify-center gap-[var(--space-2)] py-[var(--space-8)] text-ui text-muted-foreground"
+          class="rounded-card r-card-lg p-[var(--space-4)] border border-border/25 bg-card/60 shadow-outline-subtle w-full max-w-full mx-auto flex flex-col items-center justify-center gap-[var(--space-2)] py-[var(--space-8)] text-ui text-muted-foreground"
         >
           <svg
             aria-hidden="true"


### PR DESCRIPTION
## Summary
- replace the Tailwind `container` class on the review panel card with a full-width helper so the layout respects page gutters
- update the reviews page snapshot to match the revised class list

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1ed0fe8b8832ca8939e27f2b82647