### PR TITLE
Fix components gallery query builder and extend tests

### DIFF
--- a/src/components/components/useComponentsGalleryState.ts
+++ b/src/components/components/useComponentsGalleryState.ts
@@ -529,16 +529,10 @@ export function useComponentsGalleryState({
 
   const buildQueryWithHash = React.useCallback((next: URLSearchParams) => {
     const queryString = next.toString();
+    const hash = typeof window === "undefined" ? undefined : window.location.hash;
     if (queryString.length === 0) {
-      if (typeof window === "undefined") {
-        return "";
-      }
-      return formatQueryWithHash("", window.location.hash);
+      return hash ?? "";
     }
-    if (typeof window === "undefined") {
-      return formatQueryWithHash(queryString, undefined);
-    }
-    const hash = window.location.hash;
     return formatQueryWithHash(queryString, hash);
   }, []);
 

--- a/tests/components/ComponentsGalleryState.test.tsx
+++ b/tests/components/ComponentsGalleryState.test.tsx
@@ -204,6 +204,74 @@ describe("useComponentsGalleryState", () => {
     });
 
     expect(replaceSpy.mock.calls.some(([url]) => url === "?")).toBe(false);
+
+    replaceSpy.mockClear();
+    window.location.hash = "";
+
+    act(() => {
+      result.current.handleViewChange("complex");
+    });
+
+    await waitFor(() => {
+      expect(result.current.view).toBe("complex");
+    });
+
+    replaceSpy.mockClear();
+
+    act(() => {
+      result.current.setQuery("chips");
+    });
+
+    await waitFor(() => {
+      expect(result.current.query).toBe("chips");
+    });
+
+    replaceSpy.mockClear();
+
+    act(() => {
+      result.current.handleViewChange("primitives");
+    });
+
+    await waitFor(() => {
+      expect(replaceSpy).toHaveBeenCalled();
+    });
+
+    replaceSpy.mockClear();
+
+    act(() => {
+      result.current.setQuery("");
+    });
+
+    await waitFor(() => {
+      expect(replaceSpy).toHaveBeenLastCalledWith("", { scroll: false });
+    });
+
+    expect(replaceSpy.mock.calls.some(([url]) => url === "?")).toBe(false);
+
+    replaceSpy.mockClear();
+    window.location.hash = "#gallery";
+
+    act(() => {
+      result.current.setQuery("modal");
+    });
+
+    await waitFor(() => {
+      expect(replaceSpy).toHaveBeenLastCalledWith("?q=modal#gallery", {
+        scroll: false,
+      });
+    });
+
+    replaceSpy.mockClear();
+
+    act(() => {
+      result.current.setQuery("");
+    });
+
+    await waitFor(() => {
+      expect(replaceSpy).toHaveBeenLastCalledWith("#gallery", { scroll: false });
+    });
+
+    expect(replaceSpy.mock.calls.some(([url]) => url === "?")).toBe(false);
   });
 
   it("defaults to the complex homepage section when section param is missing", () => {


### PR DESCRIPTION
## Summary
- ensure buildQueryWithHash returns an empty string or existing hash fragment when no search params remain
- expand the components gallery state test to cover clearing view/query params while preserving hash fragments

## Testing
- npm test -- --run
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d2709d53b8832c83e30a7e9da5b72c