### PR TITLE
Add CSP nonce meta tag for styled-jsx whitelist

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -51,6 +51,7 @@ export default async function RootLayout({
       suppressHydrationWarning
     >
       <head>
+        {nonce ? <meta property="csp-nonce" content={nonce} /> : null}
         <Script
           id="theme-bootstrap"
           strategy="beforeInteractive"


### PR DESCRIPTION
## Summary
- add a conditional `csp-nonce` meta tag in the document head so styled-jsx can read the nonce when provided
- keep passing the nonce to the theme bootstrap script and `StyledJsxRegistry`

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d27e5c7a80832c8ff3d55a7162be19