### PR TITLE
Extend CSP inline fallback to style-src-elem

### DIFF
--- a/security-headers.mjs
+++ b/security-headers.mjs
@@ -28,7 +28,7 @@ export const createContentSecurityPolicy = (nonce) =>
     `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
     // 'unsafe-inline' is a temporary compatibility fallback until inline styles are refactored.
     `style-src 'self' 'nonce-${nonce}' 'unsafe-inline'`,
-    `style-src-elem 'self' 'nonce-${nonce}'`,
+    `style-src-elem 'self' 'nonce-${nonce}' 'unsafe-inline'`,
     "style-src-attr 'unsafe-inline'",
     "img-src 'self' data:",
     "font-src 'self' data:",


### PR DESCRIPTION
## Summary
- add `'unsafe-inline'` to the `style-src-elem` directive so the temporary inline fallback works in browsers that honor it

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d288c9cb50832c8ef83394c53a70a1