### PR TITLE
Fix Geist font imports for Next 15

### DIFF
--- a/src/app/fonts.ts
+++ b/src/app/fonts.ts
@@ -1,16 +1,7 @@
-import { Geist, Geist_Mono } from "geist/font";
+import { GeistSans } from "geist/font/sans";
+import { GeistMono } from "geist/font/mono";
 
-const geistSans = Geist({
-  subsets: ["latin"],
-  variable: "--font-sans",
-});
-
-const geistMono = Geist_Mono({
-  subsets: ["latin"],
-  variable: "--font-mono",
-});
-
-export const geistSansClassName = geistSans.className;
-export const geistSansVariable = geistSans.variable;
-export const geistMonoClassName = geistMono.className;
-export const geistMonoVariable = geistMono.variable;
+export const geistSansClassName = GeistSans.className;
+export const geistSansVariable = GeistSans.variable;
+export const geistMonoClassName = GeistMono.className;
+export const geistMonoVariable = GeistMono.variable;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -30,8 +30,8 @@
       "Segoe UI", sans-serif;
     --font-mono-fallback: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
       "Liberation Mono", "Courier New", monospace;
-    --font-sans: var(--font-sans-fallback);
-    --font-mono: var(--font-mono-fallback);
+    --font-sans: var(--font-geist-sans, var(--font-sans-fallback));
+    --font-mono: var(--font-geist-mono, var(--font-mono-fallback));
     --icon-size-xs: calc(var(--space-4) - var(--spacing-0-5));
     --icon-size-sm: var(--space-4);
     --icon-size-md: calc(var(--space-5) - var(--space-1) - var(--spacing-0-5));


### PR DESCRIPTION
## Summary
- switch Geist font imports to the new `geist/font/sans` and `geist/font/mono` exports
- map global font CSS variables to the Geist-provided custom properties

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d28ac2be1c832ca62b3597ee987bc1