### PR TITLE
Align review form spacing with design tokens

### DIFF
--- a/src/components/reviews/LaneOpponentForm.tsx
+++ b/src/components/reviews/LaneOpponentForm.tsx
@@ -66,10 +66,10 @@ function LaneOpponentForm(
   );
 
   return (
-    <div className="flex flex-col gap-2">
-      <div className="mb-2">
+    <div className="flex flex-col gap-[var(--space-2)]">
+      <div className="mb-[var(--space-2)]">
         <div className="relative">
-          <Target className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Target className="pointer-events-none absolute left-[var(--space-4)] top-1/2 size-[var(--icon-size-sm)] -translate-y-1/2 text-muted-foreground" />
           <Input
             ref={laneRef}
             name="lane"
@@ -83,7 +83,7 @@ function LaneOpponentForm(
                 go(opponentRef);
               }
             }}
-            className="pl-6"
+            className="pl-[var(--space-6)]"
             placeholder="Ashe/Lulu"
             aria-label="Lane (used as Title)"
           />
@@ -93,7 +93,7 @@ function LaneOpponentForm(
       <div>
         <SectionLabel id={opponentLabelId}>Opponent</SectionLabel>
         <div className="relative">
-          <Shield className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Shield className="pointer-events-none absolute left-[var(--space-4)] top-1/2 size-[var(--icon-size-sm)] -translate-y-1/2 text-muted-foreground" />
           <Input
             ref={opponentRef}
             name="opponent"
@@ -107,7 +107,7 @@ function LaneOpponentForm(
               }
             }}
             placeholder="Draven/Thresh"
-            className="pl-6"
+            className="pl-[var(--space-6)]"
             aria-labelledby={opponentLabelId}
           />
         </div>

--- a/src/components/reviews/PillarsSelector.tsx
+++ b/src/components/reviews/PillarsSelector.tsx
@@ -116,7 +116,7 @@ function PillarsSelector(
   return (
     <div>
       <SectionLabel>Pillars</SectionLabel>
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap gap-[var(--space-2)]">
         {ALL_PILLARS.map((p) => {
           const active = pillars.includes(p);
           return (

--- a/src/components/reviews/ReviewSummaryHeader.tsx
+++ b/src/components/reviews/ReviewSummaryHeader.tsx
@@ -45,10 +45,10 @@ export default function ReviewSummaryHeader({
 
   return (
     <div className="section-h sticky">
-      <div className="grid w-full grid-cols-[1fr_auto] items-center gap-4">
+      <div className="grid w-full grid-cols-[1fr_auto] items-center gap-[var(--space-4)]">
         <div className="min-w-0">
-          <div className="mb-1 text-ui font-medium tracking-[0.02em] text-foreground/60">Title</div>
-          <div className="truncate text-title font-semibold tracking-[-0.01em] leading-7 text-foreground/70">
+          <div className="mb-[var(--space-1)] text-ui font-medium tracking-[0.02em] text-foreground/60">Title</div>
+          <div className="truncate text-title font-semibold tracking-[-0.01em] text-foreground/70">
             {title || "Untitled review"}
           </div>
         </div>
@@ -61,7 +61,9 @@ export default function ReviewSummaryHeader({
               )}
               title={roleLabel}
             >
-              {RoleIcon ? <RoleIcon className="h-5 w-5" /> : null}
+              {RoleIcon ? (
+                <RoleIcon className="h-[var(--icon-size-sm)] w-[var(--icon-size-sm)]" />
+              ) : null}
               {roleLabel}
             </span>
           ) : null}
@@ -74,7 +76,7 @@ export default function ReviewSummaryHeader({
               title="Edit review"
               onClick={onEdit}
             >
-              <Pencil className="h-5 w-5" />
+              <Pencil className="h-[var(--icon-size-sm)] w-[var(--icon-size-sm)]" />
             </IconButton>
           ) : null}
         </div>

--- a/src/components/reviews/SectionLabel.tsx
+++ b/src/components/reviews/SectionLabel.tsx
@@ -16,14 +16,14 @@ export default function SectionLabel<T extends React.ElementType = "h3">({
   const Component = as ?? "h3";
 
   return (
-    <div className="mb-2 flex items-center gap-2">
+    <div className="mb-[var(--space-2)] flex items-center gap-[var(--space-2)]">
       <Component
         className={cn("text-ui tracking-wide text-muted-foreground", className)}
         {...props}
       >
         {children}
       </Component>
-      <div className="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
+      <div className="h-[var(--hairline-w)] flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- swap review section label spacing utilities for token-based margins, gaps, and hairline thickness
- move lane/opponent form icons and padding to shared spacing and icon-size tokens
- align review summary and pillar selector layouts with design tokens instead of raw Tailwind numbers

## Testing
- npm run check *(fails: npm not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d296728540832cbc4fb015080e6784