### PR TITLE
Normalize review motion to use design tokens

### DIFF
--- a/src/components/reviews/PillarsSelector.tsx
+++ b/src/components/reviews/PillarsSelector.tsx
@@ -58,7 +58,7 @@ function NeonPillarChip({
           filter: `blur(${auraBlurRadius})`,
           background:
             "radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%)",
-          transition: "opacity 220ms var(--ease-out)",
+          transition: "opacity var(--dur-chill) var(--ease-out)",
         }}
         aria-hidden
       />
@@ -73,7 +73,7 @@ function NeonPillarChip({
           background:
             "radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%)",
           filter: `blur(${neonBlurRadius})`,
-          transition: "opacity 220ms var(--ease-out)",
+          transition: "opacity var(--dur-chill) var(--ease-out)",
         }}
         aria-hidden
       />

--- a/src/components/reviews/ResultScoreSection.tsx
+++ b/src/components/reviews/ResultScoreSection.tsx
@@ -58,7 +58,7 @@ function ResultScoreSection(
   const resultIndicatorStyle: ResultIndicatorStyle = {
     width: "calc(50% - var(--space-1))",
     transform: `translate3d(${result === "Win" ? "0" : "100%"},0,0)`,
-    transitionTimingFunction: "cubic-bezier(.22,1,.36,1)",
+    transitionTimingFunction: "var(--ease-out)",
     "--result-indicator-gradient":
       result === "Win"
         ? "linear-gradient(90deg, hsl(var(--success)/0.22), hsl(var(--accent)/0.18))"
@@ -98,7 +98,7 @@ function ResultScoreSection(
         >
           <span
             aria-hidden
-            className="absolute top-[var(--space-1)] bottom-[var(--space-1)] left-[var(--space-1)] rounded-[inherit] transition-transform duration-300 [background:var(--result-indicator-gradient)] shadow-[var(--shadow-neo-soft)]"
+            className="absolute top-[var(--space-1)] bottom-[var(--space-1)] left-[var(--space-1)] rounded-[inherit] transition-transform duration-[var(--dur-chill)] [background:var(--result-indicator-gradient)] shadow-[var(--shadow-neo-soft)]"
             style={resultIndicatorStyle}
           />
           <div className="relative z-10 grid w-full grid-cols-2 text-ui font-mono">

--- a/src/components/reviews/ReviewCard.tsx
+++ b/src/components/reviews/ReviewCard.tsx
@@ -34,7 +34,7 @@ export default function ReviewCard({
       aria-busy={isLoading ? true : undefined}
       className={cn(
         "group rounded-card r-card-lg border border-border bg-card/85 p-[var(--space-3)]",
-        "transition-colors transition-shadow duration-200 focus-visible:outline-none",
+        "transition-colors transition-shadow duration-[var(--dur-chill)] focus-visible:outline-none",
         "shadow-neoSoft",
         "hover:border-ring/60 hover:bg-card hover:shadow-ring",
         "focus-visible:border-ring focus-visible:bg-card focus-visible:ring-2 focus-visible:ring-ring focus-visible:shadow-ring",

--- a/src/components/reviews/ReviewList.tsx
+++ b/src/components/reviews/ReviewList.tsx
@@ -31,7 +31,7 @@ export default function ReviewList({
 
   const containerClass = cn(
     "w-full mx-auto rounded-card r-card-lg border border-border/35 bg-card/60 text-card-foreground shadow-outline-subtle",
-    "ds-card-pad backdrop-blur-sm transition-colors transition-shadow duration-200",
+    "ds-card-pad backdrop-blur-sm transition-colors transition-shadow duration-[var(--dur-chill)]",
     hoverRing &&
       "hover:ring-2 hover:ring-[var(--focus)] focus-within:ring-2 focus-within:ring-[var(--focus)]",
     className,

--- a/src/components/reviews/ReviewListItem.tsx
+++ b/src/components/reviews/ReviewListItem.tsx
@@ -7,7 +7,7 @@ import type { Review } from "@/lib/types";
 import Badge from "@/components/ui/primitives/Badge";
 
 const shellBase = cn(
-  "relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20",
+  "relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-[var(--dur-chill)] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20",
   "hover:bg-[theme('colors.interaction.accent.tintHover')] hover:ring-2 hover:ring-[var(--focus)]",
   "focus-visible:bg-[theme('colors.interaction.accent.tintHover')] focus-visible:ring-2 focus-visible:ring-[var(--focus)]",
   "active:bg-[theme('colors.interaction.accent.tintActive')] active:ring-2 active:ring-[var(--focus)]",

--- a/src/components/reviews/ReviewSliderTrack.tsx
+++ b/src/components/reviews/ReviewSliderTrack.tsx
@@ -92,7 +92,7 @@ const ReviewSliderTrack = ({
             variant === "display" ? "w-[var(--progress)]" : undefined,
             isInteractive &&
               cn(
-                "ring-1 ring-transparent transition-[box-shadow] duration-140 ease-out",
+                "ring-1 ring-transparent transition-[box-shadow] duration-[var(--dur-quick)] ease-out",
                 fillInteractionClassNames[tone],
               ),
             fillClassName,
@@ -105,7 +105,7 @@ const ReviewSliderTrack = ({
             knobSizeByVariant[variant],
             isInteractive &&
               cn(
-                "transition-[background-color,border-color,box-shadow] duration-140 ease-out",
+                "transition-[background-color,border-color,box-shadow] duration-[var(--dur-quick)] ease-out",
                 knobInteractionClassNames[tone],
               ),
             knobClassName,

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`ReviewEditor > renders default state 1`] = `
             class="mb-[var(--space-2)]"
           >
             <div
-              class="mb-2 flex items-center gap-2"
+              class="mb-[var(--space-2)] flex items-center gap-[var(--space-2)]"
             >
               <h3
                 class="text-ui tracking-wide text-muted-foreground"
@@ -27,7 +27,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                 Lane
               </h3>
               <div
-                class="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent"
+                class="h-[var(--hairline-w)] flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent"
               />
             </div>
             <div
@@ -283,17 +283,17 @@ exports[`ReviewEditor > renders default state 1`] = `
             </div>
           </div>
           <div
-            class="flex flex-col gap-2"
+            class="flex flex-col gap-[var(--space-2)]"
           >
             <div
-              class="mb-2"
+              class="mb-[var(--space-2)]"
             >
               <div
                 class="relative"
               >
                 <svg
                   aria-hidden="true"
-                  class="lucide lucide-target pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+                  class="lucide lucide-target pointer-events-none absolute left-[var(--space-4)] top-1/2 size-[var(--icon-size-sm)] -translate-y-1/2 text-muted-foreground"
                   fill="none"
                   height="24"
                   stroke="currentColor"
@@ -324,7 +324,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                   class="flex w-full flex-col gap-[var(--space-1)]"
                 >
                   <div
-                    class="group/field relative inline-flex min-h-[var(--field-h,var(--control-h-md))] w-full items-center rounded-[var(--control-radius)] border border-[hsl(var(--card-hairline)/0.65)] bg-[hsl(var(--bg))] text-foreground shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.08),inset_0_calc(var(--hairline-w)*-1)_0_hsl(var(--border)/0.32)] transition-[background,box-shadow,filter] duration-[var(--dur-quick)] ease-out focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] focus-within:ring-offset-0 focus-within:ring-offset-[hsl(var(--bg))] hover:shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.12),inset_0_calc(var(--hairline-w)*-1)_0_hsl(var(--border)/0.45)] active:brightness-[0.96] data-[disabled=true]:pointer-events-none data-[disabled=true]:border-[hsl(var(--card-hairline)/0.4)] data-[disabled=true]:bg-[hsl(var(--card))] data-[disabled=true]:shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.04)] data-[disabled=true]:text-muted-foreground/70 data-[loading=true]:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[invalid=true]:border-[hsl(var(--danger)/0.6)] data-[invalid=true]:focus-within:ring-[hsl(var(--danger))] overflow-hidden pl-6"
+                    class="group/field relative inline-flex min-h-[var(--field-h,var(--control-h-md))] w-full items-center rounded-[var(--control-radius)] border border-[hsl(var(--card-hairline)/0.65)] bg-[hsl(var(--bg))] text-foreground shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.08),inset_0_calc(var(--hairline-w)*-1)_0_hsl(var(--border)/0.32)] transition-[background,box-shadow,filter] duration-[var(--dur-quick)] ease-out focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] focus-within:ring-offset-0 focus-within:ring-offset-[hsl(var(--bg))] hover:shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.12),inset_0_calc(var(--hairline-w)*-1)_0_hsl(var(--border)/0.45)] active:brightness-[0.96] data-[disabled=true]:pointer-events-none data-[disabled=true]:border-[hsl(var(--card-hairline)/0.4)] data-[disabled=true]:bg-[hsl(var(--card))] data-[disabled=true]:shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.04)] data-[disabled=true]:text-muted-foreground/70 data-[loading=true]:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[invalid=true]:border-[hsl(var(--danger)/0.6)] data-[invalid=true]:focus-within:ring-[hsl(var(--danger))] overflow-hidden pl-[var(--space-6)]"
                     style="--field-h: var(--control-h-md);"
                   >
                     <input
@@ -342,7 +342,7 @@ exports[`ReviewEditor > renders default state 1`] = `
             </div>
             <div>
               <div
-                class="mb-2 flex items-center gap-2"
+                class="mb-[var(--space-2)] flex items-center gap-[var(--space-2)]"
               >
                 <h3
                   class="text-ui tracking-wide text-muted-foreground"
@@ -351,7 +351,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                   Opponent
                 </h3>
                 <div
-                  class="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent"
+                  class="h-[var(--hairline-w)] flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent"
                 />
               </div>
               <div
@@ -359,7 +359,7 @@ exports[`ReviewEditor > renders default state 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="lucide lucide-shield pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+                  class="lucide lucide-shield pointer-events-none absolute left-[var(--space-4)] top-1/2 size-[var(--icon-size-sm)] -translate-y-1/2 text-muted-foreground"
                   fill="none"
                   height="24"
                   stroke="currentColor"
@@ -378,7 +378,7 @@ exports[`ReviewEditor > renders default state 1`] = `
                   class="flex w-full flex-col gap-[var(--space-1)]"
                 >
                   <div
-                    class="group/field relative inline-flex min-h-[var(--field-h,var(--control-h-md))] w-full items-center rounded-[var(--control-radius)] border border-[hsl(var(--card-hairline)/0.65)] bg-[hsl(var(--bg))] text-foreground shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.08),inset_0_calc(var(--hairline-w)*-1)_0_hsl(var(--border)/0.32)] transition-[background,box-shadow,filter] duration-[var(--dur-quick)] ease-out focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] focus-within:ring-offset-0 focus-within:ring-offset-[hsl(var(--bg))] hover:shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.12),inset_0_calc(var(--hairline-w)*-1)_0_hsl(var(--border)/0.45)] active:brightness-[0.96] data-[disabled=true]:pointer-events-none data-[disabled=true]:border-[hsl(var(--card-hairline)/0.4)] data-[disabled=true]:bg-[hsl(var(--card))] data-[disabled=true]:shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.04)] data-[disabled=true]:text-muted-foreground/70 data-[loading=true]:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[invalid=true]:border-[hsl(var(--danger)/0.6)] data-[invalid=true]:focus-within:ring-[hsl(var(--danger))] overflow-hidden pl-6"
+                    class="group/field relative inline-flex min-h-[var(--field-h,var(--control-h-md))] w-full items-center rounded-[var(--control-radius)] border border-[hsl(var(--card-hairline)/0.65)] bg-[hsl(var(--bg))] text-foreground shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.08),inset_0_calc(var(--hairline-w)*-1)_0_hsl(var(--border)/0.32)] transition-[background,box-shadow,filter] duration-[var(--dur-quick)] ease-out focus-within:outline-none focus-within:ring-2 focus-within:ring-[hsl(var(--ring))] focus-within:ring-offset-0 focus-within:ring-offset-[hsl(var(--bg))] hover:shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.12),inset_0_calc(var(--hairline-w)*-1)_0_hsl(var(--border)/0.45)] active:brightness-[0.96] data-[disabled=true]:pointer-events-none data-[disabled=true]:border-[hsl(var(--card-hairline)/0.4)] data-[disabled=true]:bg-[hsl(var(--card))] data-[disabled=true]:shadow-[inset_0_var(--hairline-w)_0_hsl(var(--highlight)/0.04)] data-[disabled=true]:text-muted-foreground/70 data-[loading=true]:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[invalid=true]:border-[hsl(var(--danger)/0.6)] data-[invalid=true]:focus-within:ring-[hsl(var(--danger))] overflow-hidden pl-[var(--space-6)]"
                     style="--field-h: var(--control-h-md);"
                   >
                     <input
@@ -406,7 +406,7 @@ exports[`ReviewEditor > renders default state 1`] = `
     >
       <div>
         <div
-          class="mb-2 flex items-center gap-2"
+          class="mb-[var(--space-2)] flex items-center gap-[var(--space-2)]"
         >
           <h3
             class="text-ui tracking-wide text-muted-foreground"
@@ -415,7 +415,7 @@ exports[`ReviewEditor > renders default state 1`] = `
             Result
           </h3>
           <div
-            class="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent"
+            class="h-[var(--hairline-w)] flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent"
           />
         </div>
         <button
@@ -428,8 +428,8 @@ exports[`ReviewEditor > renders default state 1`] = `
         >
           <span
             aria-hidden="true"
-            class="absolute top-[var(--space-1)] bottom-[var(--space-1)] left-[var(--space-1)] rounded-[inherit] transition-transform duration-300 [background:var(--result-indicator-gradient)] shadow-[var(--shadow-neo-soft)]"
-            style="width: calc(50% - var(--space-1)); transform: translate3d(0,0,0); transition-timing-function: cubic-bezier(.22,1,.36,1); --result-indicator-gradient: linear-gradient(90deg, hsl(var(--success)/0.22), hsl(var(--accent)/0.18));"
+            class="absolute top-[var(--space-1)] bottom-[var(--space-1)] left-[var(--space-1)] rounded-[inherit] transition-transform duration-[var(--dur-chill)] [background:var(--result-indicator-gradient)] shadow-[var(--shadow-neo-soft)]"
+            style="width: calc(50% - var(--space-1)); transform: translate3d(0,0,0); transition-timing-function: var(--ease-out); --result-indicator-gradient: linear-gradient(90deg, hsl(var(--success)/0.22), hsl(var(--accent)/0.18));"
           />
           <div
             class="relative z-10 grid w-full grid-cols-2 text-ui font-mono"
@@ -449,7 +449,7 @@ exports[`ReviewEditor > renders default state 1`] = `
       </div>
       <div>
         <div
-          class="mb-2 flex items-center gap-2"
+          class="mb-[var(--space-2)] flex items-center gap-[var(--space-2)]"
         >
           <h3
             class="text-ui tracking-wide text-muted-foreground"
@@ -458,7 +458,7 @@ exports[`ReviewEditor > renders default state 1`] = `
             Score
           </h3>
           <div
-            class="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent"
+            class="h-[var(--hairline-w)] flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent"
           />
         </div>
         <div
@@ -481,11 +481,11 @@ exports[`ReviewEditor > renders default state 1`] = `
               class="relative h-2 w-full rounded-full bg-muted shadow-neo-inset"
             >
               <div
-                class="absolute left-0 top-0 h-2 rounded-full shadow-ring bg-gradient-to-r from-primary to-accent [--ring:var(--primary)] ring-1 ring-transparent transition-[box-shadow] duration-140 ease-out group-hover:ring-[theme('colors.interaction.accent.tintHover')] group-active:ring-[theme('colors.interaction.accent.tintActive')]"
+                class="absolute left-0 top-0 h-2 rounded-full shadow-ring bg-gradient-to-r from-primary to-accent [--ring:var(--primary)] ring-1 ring-transparent transition-[box-shadow] duration-[var(--dur-quick)] ease-out group-hover:ring-[theme('colors.interaction.accent.tintHover')] group-active:ring-[theme('colors.interaction.accent.tintActive')]"
                 style="width: calc(50% + var(--space-2) + var(--space-1) / 2);"
               />
               <div
-                class="absolute top-1/2 -translate-y-1/2 rounded-full border border-border bg-card shadow-neoSoft h-5 w-5 transition-[background-color,border-color,box-shadow] duration-140 ease-out group-hover:bg-[theme('colors.interaction.accent.surfaceHover')] group-active:bg-[theme('colors.interaction.accent.surfaceActive')] group-hover:border-transparent group-active:border-transparent group-hover:shadow-control-hover group-active:shadow-control"
+                class="absolute top-1/2 -translate-y-1/2 rounded-full border border-border bg-card shadow-neoSoft h-5 w-5 transition-[background-color,border-color,box-shadow] duration-[var(--dur-quick)] ease-out group-hover:bg-[theme('colors.interaction.accent.surfaceHover')] group-active:bg-[theme('colors.interaction.accent.surfaceActive')] group-hover:border-transparent group-active:border-transparent group-hover:shadow-control-hover group-active:shadow-control"
                 style="left: calc(50% - (var(--space-2) + var(--space-1) / 2));"
               />
             </div>
@@ -768,7 +768,7 @@ exports[`ReviewEditor > renders default state 1`] = `
       </div>
       <div>
         <div
-          class="mb-2 flex items-center gap-2"
+          class="mb-[var(--space-2)] flex items-center gap-[var(--space-2)]"
         >
           <h3
             class="text-ui tracking-wide text-muted-foreground"
@@ -776,11 +776,11 @@ exports[`ReviewEditor > renders default state 1`] = `
             Pillars
           </h3>
           <div
-            class="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent"
+            class="h-[var(--hairline-w)] flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent"
           />
         </div>
         <div
-          class="flex flex-wrap gap-2"
+          class="flex flex-wrap gap-[var(--space-2)]"
         >
           <button
             aria-pressed="false"
@@ -794,12 +794,12 @@ exports[`ReviewEditor > renders default state 1`] = `
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="filter: blur(calc(var(--space-3) - var(--spacing-0-5))); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity 220ms var(--ease-out);"
+                style="filter: blur(calc(var(--space-3) - var(--spacing-0-5))); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity var(--dur-chill) var(--ease-out);"
               />
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(var(--spacing-0-5)); transition: opacity 220ms var(--ease-out);"
+                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(var(--spacing-0-5)); transition: opacity var(--dur-chill) var(--ease-out);"
               />
               <span
                 class="lg-pillar-badge rounded-full h-[var(--control-h-sm)] px-[var(--space-4)] text-ui gap-[var(--space-2)]"
@@ -921,12 +921,12 @@ exports[`ReviewEditor > renders default state 1`] = `
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="filter: blur(calc(var(--space-3) - var(--spacing-0-5))); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity 220ms var(--ease-out);"
+                style="filter: blur(calc(var(--space-3) - var(--spacing-0-5))); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity var(--dur-chill) var(--ease-out);"
               />
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(var(--spacing-0-5)); transition: opacity 220ms var(--ease-out);"
+                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(var(--spacing-0-5)); transition: opacity var(--dur-chill) var(--ease-out);"
               />
               <span
                 class="lg-pillar-badge rounded-full h-[var(--control-h-sm)] px-[var(--space-4)] text-ui gap-[var(--space-2)]"
@@ -1058,12 +1058,12 @@ exports[`ReviewEditor > renders default state 1`] = `
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="filter: blur(calc(var(--space-3) - var(--spacing-0-5))); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity 220ms var(--ease-out);"
+                style="filter: blur(calc(var(--space-3) - var(--spacing-0-5))); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity var(--dur-chill) var(--ease-out);"
               />
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(var(--spacing-0-5)); transition: opacity 220ms var(--ease-out);"
+                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(var(--spacing-0-5)); transition: opacity var(--dur-chill) var(--ease-out);"
               />
               <span
                 class="lg-pillar-badge rounded-full h-[var(--control-h-sm)] px-[var(--space-4)] text-ui gap-[var(--space-2)]"
@@ -1184,12 +1184,12 @@ exports[`ReviewEditor > renders default state 1`] = `
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="filter: blur(calc(var(--space-3) - var(--spacing-0-5))); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity 220ms var(--ease-out);"
+                style="filter: blur(calc(var(--space-3) - var(--spacing-0-5))); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity var(--dur-chill) var(--ease-out);"
               />
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(var(--spacing-0-5)); transition: opacity 220ms var(--ease-out);"
+                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(var(--spacing-0-5)); transition: opacity var(--dur-chill) var(--ease-out);"
               />
               <span
                 class="lg-pillar-badge rounded-full h-[var(--control-h-sm)] px-[var(--space-4)] text-ui gap-[var(--space-2)]"
@@ -1319,12 +1319,12 @@ exports[`ReviewEditor > renders default state 1`] = `
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="filter: blur(calc(var(--space-3) - var(--spacing-0-5))); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity 220ms var(--ease-out);"
+                style="filter: blur(calc(var(--space-3) - var(--spacing-0-5))); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity var(--dur-chill) var(--ease-out);"
               />
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(var(--spacing-0-5)); transition: opacity 220ms var(--ease-out);"
+                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(var(--spacing-0-5)); transition: opacity var(--dur-chill) var(--ease-out);"
               />
               <span
                 class="lg-pillar-badge rounded-full h-[var(--control-h-sm)] px-[var(--space-4)] text-ui gap-[var(--space-2)]"
@@ -1466,12 +1466,12 @@ exports[`ReviewEditor > renders default state 1`] = `
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="filter: blur(calc(var(--space-3) - var(--spacing-0-5))); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity 220ms var(--ease-out);"
+                style="filter: blur(calc(var(--space-3) - var(--spacing-0-5))); background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)/.45), transparent 70%); transition: opacity var(--dur-chill) var(--ease-out);"
               />
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute inset-0 rounded-card r-card-lg opacity-0"
-                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(var(--spacing-0-5)); transition: opacity 220ms var(--ease-out);"
+                style="background: radial-gradient(60% 60% at 50% 50%, hsl(var(--accent)), transparent 70%); filter: blur(var(--spacing-0-5)); transition: opacity var(--dur-chill) var(--ease-out);"
               />
               <span
                 class="lg-pillar-badge rounded-full h-[var(--control-h-sm)] px-[var(--space-4)] text-ui gap-[var(--space-2)]"
@@ -1582,7 +1582,7 @@ exports[`ReviewEditor > renders default state 1`] = `
       </div>
       <div>
         <div
-          class="mb-2 flex items-center gap-2"
+          class="mb-[var(--space-2)] flex items-center gap-[var(--space-2)]"
         >
           <h3
             class="text-ui tracking-wide text-muted-foreground"
@@ -1590,7 +1590,7 @@ exports[`ReviewEditor > renders default state 1`] = `
             Timestamps
           </h3>
           <div
-            class="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent"
+            class="h-[var(--hairline-w)] flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent"
           />
         </div>
         <div
@@ -2052,7 +2052,7 @@ exports[`ReviewEditor > renders default state 1`] = `
       </div>
       <div>
         <div
-          class="mb-2 flex items-center gap-2"
+          class="mb-[var(--space-2)] flex items-center gap-[var(--space-2)]"
         >
           <h3
             class="text-ui tracking-wide text-muted-foreground"
@@ -2061,7 +2061,7 @@ exports[`ReviewEditor > renders default state 1`] = `
             Tags
           </h3>
           <div
-            class="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent"
+            class="h-[var(--hairline-w)] flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent"
           />
         </div>
         <div
@@ -2149,7 +2149,7 @@ exports[`ReviewEditor > renders default state 1`] = `
       </div>
       <div>
         <div
-          class="mb-2 flex items-center gap-2"
+          class="mb-[var(--space-2)] flex items-center gap-[var(--space-2)]"
         >
           <h3
             class="text-ui tracking-wide text-muted-foreground"
@@ -2158,7 +2158,7 @@ exports[`ReviewEditor > renders default state 1`] = `
             Notes
           </h3>
           <div
-            class="h-px flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent"
+            class="h-[var(--hairline-w)] flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent"
           />
         </div>
         <div

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`ReviewListItem > renders default state 1`] = `
 <div>
   <button
     aria-label="Open review: Sample Review"
-    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-[theme('colors.interaction.accent.tintHover')] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[theme('colors.interaction.accent.tintHover')] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[theme('colors.interaction.accent.tintActive')] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-[theme('colors.interaction.accent.tintActive')] data-[selected=true]:ring-2 data-[selected=true]:ring-[theme('colors.interaction.accent.surfaceActive')]"
+    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-[var(--dur-chill)] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-[theme('colors.interaction.accent.tintHover')] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[theme('colors.interaction.accent.tintHover')] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[theme('colors.interaction.accent.tintActive')] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-[theme('colors.interaction.accent.tintActive')] data-[selected=true]:ring-2 data-[selected=true]:ring-[theme('colors.interaction.accent.surfaceActive')]"
     data-scope="reviews"
     type="button"
   >
@@ -58,7 +58,7 @@ exports[`ReviewListItem > renders disabled state 1`] = `
 <div>
   <button
     aria-label="Open review: Sample Review"
-    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-[theme('colors.interaction.accent.tintHover')] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[theme('colors.interaction.accent.tintHover')] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[theme('colors.interaction.accent.tintActive')] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-[theme('colors.interaction.accent.tintActive')] data-[selected=true]:ring-2 data-[selected=true]:ring-[theme('colors.interaction.accent.surfaceActive')]"
+    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-[var(--dur-chill)] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-[theme('colors.interaction.accent.tintHover')] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[theme('colors.interaction.accent.tintHover')] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[theme('colors.interaction.accent.tintActive')] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-[theme('colors.interaction.accent.tintActive')] data-[selected=true]:ring-2 data-[selected=true]:ring-[theme('colors.interaction.accent.surfaceActive')]"
     data-scope="reviews"
     disabled=""
     type="button"
@@ -112,7 +112,7 @@ exports[`ReviewListItem > renders disabled state 1`] = `
 exports[`ReviewListItem > renders loading state 1`] = `
 <div>
   <div
-    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-[theme('colors.interaction.accent.tintHover')] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[theme('colors.interaction.accent.tintHover')] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[theme('colors.interaction.accent.tintActive')] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-[theme('colors.interaction.accent.tintActive')] data-[selected=true]:ring-2 data-[selected=true]:ring-[theme('colors.interaction.accent.surfaceActive')] motion-safe:animate-pulse motion-reduce:animate-none"
+    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-[var(--dur-chill)] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-[theme('colors.interaction.accent.tintHover')] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[theme('colors.interaction.accent.tintHover')] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[theme('colors.interaction.accent.tintActive')] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-[theme('colors.interaction.accent.tintActive')] data-[selected=true]:ring-2 data-[selected=true]:ring-[theme('colors.interaction.accent.surfaceActive')] motion-safe:animate-pulse motion-reduce:animate-none"
     data-scope="reviews"
   >
     <div
@@ -130,7 +130,7 @@ exports[`ReviewListItem > renders selected state 1`] = `
   <button
     aria-current="true"
     aria-label="Open review: Sample Review"
-    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-[theme('colors.interaction.accent.tintHover')] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[theme('colors.interaction.accent.tintHover')] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[theme('colors.interaction.accent.tintActive')] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-[theme('colors.interaction.accent.tintActive')] data-[selected=true]:ring-2 data-[selected=true]:ring-[theme('colors.interaction.accent.surfaceActive')]"
+    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-[var(--dur-chill)] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-[theme('colors.interaction.accent.tintHover')] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[theme('colors.interaction.accent.tintHover')] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[theme('colors.interaction.accent.tintActive')] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-[theme('colors.interaction.accent.tintActive')] data-[selected=true]:ring-2 data-[selected=true]:ring-[theme('colors.interaction.accent.surfaceActive')]"
     data-scope="reviews"
     data-selected="true"
     type="button"
@@ -185,7 +185,7 @@ exports[`ReviewListItem > renders untitled state 1`] = `
 <div>
   <button
     aria-label="Open review: Untitled Review"
-    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-[theme('colors.interaction.accent.tintHover')] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[theme('colors.interaction.accent.tintHover')] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[theme('colors.interaction.accent.tintActive')] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-[theme('colors.interaction.accent.tintActive')] data-[selected=true]:ring-2 data-[selected=true]:ring-[theme('colors.interaction.accent.surfaceActive')]"
+    class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-[var(--dur-chill)] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-[theme('colors.interaction.accent.tintHover')] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[theme('colors.interaction.accent.tintHover')] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[theme('colors.interaction.accent.tintActive')] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-[theme('colors.interaction.accent.tintActive')] data-[selected=true]:ring-2 data-[selected=true]:ring-[theme('colors.interaction.accent.surfaceActive')]"
     data-scope="reviews"
     type="button"
   >

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -481,7 +481,7 @@ exports[`ReviewsPage > renders default state 1`] = `
         class="md:col-span-2 lg:col-span-4"
       >
         <section
-          class="w-full mx-auto rounded-card r-card-lg border border-border/35 bg-card/60 text-card-foreground shadow-outline-subtle ds-card-pad backdrop-blur-sm transition-shadow duration-200 hover:ring-2 hover:ring-[var(--focus)] focus-within:ring-2 focus-within:ring-[var(--focus)] h-auto overflow-auto p-[var(--space-2)] md:h-[var(--content-viewport-height)]"
+          class="w-full mx-auto rounded-card r-card-lg border border-border/35 bg-card/60 text-card-foreground shadow-outline-subtle ds-card-pad backdrop-blur-sm transition-shadow duration-[var(--dur-chill)] hover:ring-2 hover:ring-[var(--focus)] focus-within:ring-2 focus-within:ring-[var(--focus)] h-auto overflow-auto p-[var(--space-2)] md:h-[var(--content-viewport-height)]"
           data-scope="reviews"
         >
           <header
@@ -495,7 +495,7 @@ exports[`ReviewsPage > renders default state 1`] = `
             <li>
               <button
                 aria-label="Open review: Alpha"
-                class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-[theme('colors.interaction.accent.tintHover')] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[theme('colors.interaction.accent.tintHover')] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[theme('colors.interaction.accent.tintActive')] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-[theme('colors.interaction.accent.tintActive')] data-[selected=true]:ring-2 data-[selected=true]:ring-[theme('colors.interaction.accent.surfaceActive')]"
+                class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-[var(--dur-chill)] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-[theme('colors.interaction.accent.tintHover')] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[theme('colors.interaction.accent.tintHover')] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[theme('colors.interaction.accent.tintActive')] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-[theme('colors.interaction.accent.tintActive')] data-[selected=true]:ring-2 data-[selected=true]:ring-[theme('colors.interaction.accent.surfaceActive')]"
                 data-scope="reviews"
                 type="button"
               >
@@ -539,7 +539,7 @@ exports[`ReviewsPage > renders default state 1`] = `
             <li>
               <button
                 aria-label="Open review: Gamma"
-                class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-[theme('colors.interaction.accent.tintHover')] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[theme('colors.interaction.accent.tintHover')] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[theme('colors.interaction.accent.tintActive')] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-[theme('colors.interaction.accent.tintActive')] data-[selected=true]:ring-2 data-[selected=true]:ring-[theme('colors.interaction.accent.surfaceActive')]"
+                class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-[var(--dur-chill)] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-[theme('colors.interaction.accent.tintHover')] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[theme('colors.interaction.accent.tintHover')] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[theme('colors.interaction.accent.tintActive')] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-[theme('colors.interaction.accent.tintActive')] data-[selected=true]:ring-2 data-[selected=true]:ring-[theme('colors.interaction.accent.surfaceActive')]"
                 data-scope="reviews"
                 type="button"
               >
@@ -583,7 +583,7 @@ exports[`ReviewsPage > renders default state 1`] = `
             <li>
               <button
                 aria-label="Open review: Beta"
-                class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-200 focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-[theme('colors.interaction.accent.tintHover')] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[theme('colors.interaction.accent.tintHover')] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[theme('colors.interaction.accent.tintActive')] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-[theme('colors.interaction.accent.tintActive')] data-[selected=true]:ring-2 data-[selected=true]:ring-[theme('colors.interaction.accent.surfaceActive')]"
+                class="relative w-full text-left rounded-card r-card-lg p-[var(--space-3)] bg-card/90 border border-border/35 transition-all duration-[var(--dur-chill)] focus-visible:outline-none disabled:opacity-60 disabled:pointer-events-none disabled:bg-muted/20 hover:bg-[theme('colors.interaction.accent.tintHover')] hover:ring-2 hover:ring-[var(--focus)] focus-visible:bg-[theme('colors.interaction.accent.tintHover')] focus-visible:ring-2 focus-visible:ring-[var(--focus)] active:bg-[theme('colors.interaction.accent.tintActive')] active:ring-2 active:ring-[var(--focus)] data-[selected=true]:bg-[theme('colors.interaction.accent.tintActive')] data-[selected=true]:ring-2 data-[selected=true]:ring-[theme('colors.interaction.accent.surfaceActive')]"
                 data-scope="reviews"
                 type="button"
               >

--- a/types/geist-font.d.ts
+++ b/types/geist-font.d.ts
@@ -1,5 +1,5 @@
 declare module "geist/font" {
-  interface GeistFontOptions {
+  export interface GeistFontOptions {
     subsets: string[];
     weight?: string | string[];
     style?: string | string[];
@@ -11,7 +11,7 @@ declare module "geist/font" {
     axes?: string[];
   }
 
-  interface GeistFont {
+  export interface GeistFont {
     className: string;
     variable: string;
     style: {
@@ -21,4 +21,16 @@ declare module "geist/font" {
 
   export function Geist(options: GeistFontOptions): GeistFont;
   export function Geist_Mono(options: GeistFontOptions): GeistFont;
+}
+
+declare module "geist/font/mono" {
+  import type { GeistFont } from "geist/font";
+
+  export const GeistMono: GeistFont;
+}
+
+declare module "geist/font/sans" {
+  import type { GeistFont } from "geist/font";
+
+  export const GeistSans: GeistFont;
 }


### PR DESCRIPTION
## Summary
- replace hard-coded neon aura transitions in the reviews pillars selector with the shared chill duration token
- align review score indicator, slider, cards, and list shells on tokenized durations and refresh the affected snapshots
- add geist font module typings so typechecking succeeds with the new imports

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d299edbba4832cad124cf5ddf508cd