### PR TITLE
Fix GitHub Pages workflows for work branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - work
 
 jobs:
   checks:

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -12,6 +12,7 @@ on:
       - completed
     branches:
       - main
+      - work
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/types/geist-font.d.ts
+++ b/types/geist-font.d.ts
@@ -1,36 +1,8 @@
-declare module "geist/font" {
-  export interface GeistFontOptions {
-    subsets: string[];
-    weight?: string | string[];
-    style?: string | string[];
-    display?: string;
-    variable?: string;
-    preload?: boolean;
-    fallback?: string[];
-    adjustFontFallback?: boolean;
-    axes?: string[];
-  }
-
-  export interface GeistFont {
-    className: string;
-    variable: string;
-    style: {
-      fontFamily: string;
-    };
-  }
-
-  export function Geist(options: GeistFontOptions): GeistFont;
-  export function Geist_Mono(options: GeistFontOptions): GeistFont;
-}
-
-declare module "geist/font/mono" {
-  import type { GeistFont } from "geist/font";
-
-  export const GeistMono: GeistFont;
-}
-
-declare module "geist/font/sans" {
-  import type { GeistFont } from "geist/font";
-
-  export const GeistSans: GeistFont;
-}
+/**
+ * Legacy placeholder for Geist font module typing.
+ *
+ * The `geist` package now ships its own TypeScript declarations, so we no longer
+ * need to redeclare the modules here. Keeping this stub preserves the ambient
+ * module resolution path without duplicating upstream exports.
+ */
+export {};


### PR DESCRIPTION
## Summary
- trigger the CI workflow for both the main and work branches so primary development pushes run checks
- allow the Pages deployment workflow to listen to the work branch and keep GitHub Pages deployments current
- replace the obsolete Geist font type shim with a placeholder so type definitions rely on the upstream package

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d2c1682070832cb513efb720bd5b73