### PR TITLE
Sync review editors with external metadata

### DIFF
--- a/src/components/reviews/PillarsSelector.tsx
+++ b/src/components/reviews/PillarsSelector.tsx
@@ -88,6 +88,10 @@ function PillarsSelector(
 ) {
   const [pillars, setPillars] = React.useState<Pillar[]>(pillars0);
 
+  React.useEffect(() => {
+    setPillars(Array.isArray(pillars0) ? [...pillars0] : []);
+  }, [pillars0]);
+
   const togglePillar = React.useCallback(
     (p: Pillar) => {
       setPillars((prev) => {

--- a/src/components/reviews/ResultScoreSection.tsx
+++ b/src/components/reviews/ResultScoreSection.tsx
@@ -38,6 +38,14 @@ function ResultScoreSection(
   const scoreRangeRef = React.useRef<HTMLInputElement>(null);
   const resultLabelId = React.useId();
 
+  React.useEffect(() => {
+    setResult(result0);
+  }, [result0]);
+
+  React.useEffect(() => {
+    setScore(score0);
+  }, [score0]);
+
   const save = React.useCallback(() => {
     commitMeta({ result, score });
   }, [result, score, commitMeta]);

--- a/src/components/reviews/TimestampMarkers.tsx
+++ b/src/components/reviews/TimestampMarkers.tsx
@@ -60,6 +60,10 @@ function TimestampMarkers(
   const [tTime, setTTime] = React.useState(lastMarkerTime);
   const [tNote, setTNote] = React.useState("");
 
+  React.useEffect(() => {
+    setMarkers(Array.isArray(markers0) ? markers0.map(normalizeMarker) : []);
+  }, [markers0]);
+
   const timeRef = React.useRef<HTMLInputElement>(null);
   const noteRef = React.useRef<HTMLInputElement>(null);
 


### PR DESCRIPTION
## Summary
- keep the result switch and score slider in sync with external review metadata updates
- mirror incoming review pillar selections in the neon chip selector
- recompute timestamp marker state whenever the upstream markers prop changes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d2c6ff6264832ca29f757043b7eafb