### PR TITLE
Add accent overlay utilities

### DIFF
--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -36,7 +36,7 @@ export default function SiteChrome({ children }: SiteChromeProps) {
             className="col-span-full flex items-center gap-[var(--space-3)] md:col-span-3 lg:col-span-3"
           >
             <span
-              className="h-[var(--space-2)] w-[var(--space-2)] rounded-full animate-pulse bg-[hsl(var(--accent-overlay))] shadow-[var(--shadow-glow-sm)]"
+              className="h-[var(--space-2)] w-[var(--space-2)] rounded-full animate-pulse bg-accent-overlay shadow-[var(--shadow-glow-sm)]"
               aria-hidden
             />
             <BrandWordmark />

--- a/src/components/goals/reminders/ReminderList.tsx
+++ b/src/components/goals/reminders/ReminderList.tsx
@@ -279,7 +279,7 @@ function RemTile({
               <div className="flex items-center gap-[var(--space-2)]">
                 <span
                   aria-hidden="true"
-                  className="inline-block size-[var(--space-2)] rounded-full bg-[hsl(var(--accent-overlay))]"
+                  className="inline-block size-[var(--space-2)] rounded-full bg-accent-overlay"
                 />
                 <span className="text-label font-medium tracking-[0.02em]">{fmtDate(value.createdAt)}</span>
               </div>

--- a/src/components/prompts/component-gallery/MiscPanel.tsx
+++ b/src/components/prompts/component-gallery/MiscPanel.tsx
@@ -53,7 +53,7 @@ export default function MiscPanel({ data }: MiscPanelProps) {
         {
           label: "Accent Overlay Box",
           element: (
-            <div className="w-56 h-6 flex items-center justify-center rounded-[var(--radius-md)] bg-[var(--accent-overlay)] text-accent-foreground">
+            <div className="w-56 h-6 flex items-center justify-center rounded-[var(--radius-md)] bg-accent-overlay text-accent-foreground">
               Overlay
             </div>
           ),

--- a/src/components/ui/primitives/Badge.tsx
+++ b/src/components/ui/primitives/Badge.tsx
@@ -44,7 +44,7 @@ const sizeMap: Record<Size, string> = {
 const toneBorder: Record<Tone, string> = {
   neutral: "border-card-hairline",
   primary: "border-ring",
-  accent: "border-[var(--accent-overlay)]",
+  accent: "border-accent-overlay",
   top: "border-tone-top",
   jungle: "border-tone-jg",
   mid: "border-tone-mid",

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -17,6 +17,7 @@ export const colorTokens = [
   "bg-accent",
   "bg-accent-foreground",
   "bg-accent-soft",
+  "bg-accent-overlay",
   "bg-accent-3",
   "bg-accent-2",
   "bg-accent-2-foreground",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -49,6 +49,7 @@ const config: Config = {
           DEFAULT: "hsl(var(--accent))",
           foreground: "hsl(var(--accent-foreground))",
           soft: "hsl(var(--accent-soft))",
+          overlay: "hsl(var(--accent-overlay))",
         },
         "accent-3": {
           DEFAULT: "hsl(var(--accent-3))",

--- a/tests/ui/Badge.test.tsx
+++ b/tests/ui/Badge.test.tsx
@@ -21,7 +21,7 @@ describe('Badge', () => {
   it('applies accent tone styles', () => {
     const { getByText } = render(<Badge tone="accent">Accent</Badge>);
     const badge = getByText('Accent');
-    expect(badge).toHaveClass('border-[var(--accent-overlay)]');
+    expect(badge).toHaveClass('border-accent-overlay');
   });
 
   it('supports the size tokens', () => {


### PR DESCRIPTION
## Summary
- add an `accent.overlay` entry to the Tailwind theme and expose the background token for demos
- replace bracket-based accent overlay classes with semantic utilities and update badge styling/tests

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d2ce81efb8832c87ecb650fb943416