### PR TITLE
Align button tone demos with primary variant

### DIFF
--- a/src/components/prompts/ButtonShowcase.tsx
+++ b/src/components/prompts/ButtonShowcase.tsx
@@ -6,8 +6,12 @@ export default function ButtonShowcase() {
   return (
     <div className="mb-[var(--space-8)] space-y-[var(--space-4)]">
       <div className="flex flex-wrap gap-[var(--space-2)]">
-        <Button tone="primary">Primary tone</Button>
-        <Button tone="accent">Accent tone</Button>
+        <Button tone="primary" variant="primary">
+          Primary tone
+        </Button>
+        <Button tone="accent" variant="primary">
+          Accent tone
+        </Button>
         <Button tone="info" variant="ghost">
           Info ghost
         </Button>

--- a/src/components/ui/primitives/Button.gallery.tsx
+++ b/src/components/ui/primitives/Button.gallery.tsx
@@ -64,8 +64,12 @@ function ButtonGalleryPreview() {
   return (
     <div className="flex flex-col gap-[var(--space-4)]">
       <div className="flex flex-wrap gap-[var(--space-2)]">
-        <Button tone="primary">Primary tone</Button>
-        <Button tone="accent">Accent tone</Button>
+        <Button tone="primary" variant="primary">
+          Primary tone
+        </Button>
+        <Button tone="accent" variant="primary">
+          Accent tone
+        </Button>
         <Button tone="info" variant="ghost">
           Info ghost
         </Button>
@@ -163,8 +167,12 @@ export default defineGallerySection({
       })),
       code: `<div className="flex flex-col gap-[var(--space-4)]">
   <div className="flex flex-wrap gap-[var(--space-2)]">
-    <Button tone="primary">Primary tone</Button>
-    <Button tone="accent">Accent tone</Button>
+    <Button tone="primary" variant="primary">
+      Primary tone
+    </Button>
+    <Button tone="accent" variant="primary">
+      Accent tone
+    </Button>
     <Button tone="info" variant="ghost">
       Info ghost
     </Button>


### PR DESCRIPTION
## Summary
- update the prompts button showcase to render primary and accent tone examples with the primary variant
- mirror the primary variant usage in the button gallery preview and its code sample so the gallery matches the prompts demo

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d2d952969c832c9d728575d5add538