### PR TITLE
Adjust CSP to tolerate Vercel feedback styles

### DIFF
--- a/security-headers.mjs
+++ b/security-headers.mjs
@@ -36,12 +36,15 @@ const VERCEL_FEEDBACK_WS_ORIGINS = Object.freeze(["wss://vercel.live"]);
 export const createContentSecurityPolicy = (nonce, options) => {
   const allowVercelFeedback = options?.allowVercelFeedback === true;
 
-  const styleSrc = [
-    "'self'",
-    `'nonce-${nonce}'`,
-    "'unsafe-inline'",
-  ];
-  const styleSrcElem = [...styleSrc];
+  const nonceSource = `'nonce-${nonce}'`;
+  const styleSrcBase = ["'self'", "'unsafe-inline'"];
+  const styleSrc = [...styleSrcBase];
+  const styleSrcElem = [...styleSrcBase];
+
+  if (!allowVercelFeedback) {
+    styleSrc.push(nonceSource);
+    styleSrcElem.push(nonceSource);
+  }
   const imgSrc = ["'self'", "data:"];
   const connectSrc = ["'self'"];
 


### PR DESCRIPTION
## Summary
- allow inline styles without a nonce when Vercel feedback is enabled so the widget stops tripping the CSP

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d2e6624218832c900c2664bb5e8891