### PR TITLE
Fix not-found button styles

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -33,9 +33,9 @@ export default function NotFound() {
           heading: "This page does not exist",
           padding: "none",
           actions: (
-            <Link href="/">
-              <Button>Go home</Button>
-            </Link>
+            <Button asChild>
+              <Link href="/">Go home</Link>
+            </Button>
           ),
           children: (
             <p className="text-ui text-muted-foreground">


### PR DESCRIPTION
## Summary
- render the not-found page link with `Button asChild` so the anchor inherits button styling and focus states

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d2ed3e96cc832c930573b78589b05f