### PR TITLE
Handle elements/styles aliases in component gallery

### DIFF
--- a/src/components/components/slug.ts
+++ b/src/components/components/slug.ts
@@ -55,6 +55,8 @@ for (const group of GALLERY_SECTION_GROUPS) {
 
 const VIEW_ALIAS = new Map<string, GallerySectionGroupKey>([
   ["colors", "tokens"],
+  ["styles", "tokens"],
+  ["elements", "primitives"],
 ]);
 
 interface EntryMetadata {

--- a/src/components/components/useComponentsGalleryState.ts
+++ b/src/components/components/useComponentsGalleryState.ts
@@ -116,6 +116,29 @@ export function useComponentsGalleryState({
     [viewOrder],
   );
 
+  const mapView = React.useCallback(
+    (raw: string | null): ComponentsView | null => {
+      if (!raw) {
+        return null;
+      }
+      const normalized = raw.trim().toLowerCase();
+      if (!normalized) {
+        return null;
+      }
+      if (normalized === "elements") {
+        return "primitives";
+      }
+      if (normalized === "styles" || normalized === "colors") {
+        return "tokens";
+      }
+      if ((viewOrder as readonly string[]).includes(normalized as ComponentsView)) {
+        return normalized as ComponentsView;
+      }
+      return null;
+    },
+    [viewOrder],
+  );
+
   const navSectionEntries = React.useMemo(
     () => groups.flatMap((group) => group.sections),
     [groups],
@@ -173,12 +196,9 @@ export function useComponentsGalleryState({
       if (rawView === null) {
         return true;
       }
-      if (rawView === "colors") {
-        return false;
-      }
-      return !(viewOrder as readonly string[]).includes(rawView);
+      return mapView(rawView) === null;
     },
-    [viewOrder],
+    [mapView],
   );
 
   const fallbackCopy = React.useMemo<GalleryHeroCopy>(() => {
@@ -195,15 +215,13 @@ export function useComponentsGalleryState({
 
   const normalizeView = React.useCallback(
     (value: string | null): ComponentsView => {
-      if (value === "colors") {
-        return "tokens";
-      }
-      if (value && (viewOrder as readonly string[]).includes(value)) {
-        return value as ComponentsView;
+      const mapped = mapView(value);
+      if (mapped) {
+        return mapped;
       }
       return defaultView;
     },
-    [defaultView, viewOrder],
+    [defaultView, mapView],
   );
 
   const normalizeSection = React.useCallback(

--- a/tests/components/ComponentsGalleryState.test.tsx
+++ b/tests/components/ComponentsGalleryState.test.tsx
@@ -118,6 +118,32 @@ describe("useComponentsGalleryState", () => {
     });
   });
 
+  it("normalizes elements and styles view aliases", () => {
+    searchParamsString = new URLSearchParams({
+      section: "buttons",
+      view: "elements",
+    }).toString();
+    const elementsHook = renderHook(() =>
+      useComponentsGalleryState({
+        navigation,
+      }),
+    );
+    expect(elementsHook.result.current.view).toBe("primitives");
+    elementsHook.unmount();
+
+    searchParamsString = new URLSearchParams({
+      section: "buttons",
+      view: "styles",
+    }).toString();
+    const stylesHook = renderHook(() =>
+      useComponentsGalleryState({
+        navigation,
+      }),
+    );
+    expect(stylesHook.result.current.view).toBe("tokens");
+    stylesHook.unmount();
+  });
+
   it("omits the question mark when all query params are cleared", () => {
     expect(formatQueryWithHash("", undefined)).toBe("");
     expect(formatQueryWithHash("", "")).toBe("");

--- a/tests/components/ComponentsSlug.test.ts
+++ b/tests/components/ComponentsSlug.test.ts
@@ -34,9 +34,17 @@ describe("ComponentsSlug", () => {
   });
 
   it("maps view aliases", () => {
-    const result = resolveComponentsSlug("colors");
-    expect(result).toMatchObject({ view: "tokens" });
-    expect(result?.section).toBeUndefined();
+    const colorsResult = resolveComponentsSlug("colors");
+    expect(colorsResult).toMatchObject({ view: "tokens", viewExplicit: true });
+    expect(colorsResult?.section).toBeUndefined();
+
+    const stylesResult = resolveComponentsSlug("styles");
+    expect(stylesResult).toMatchObject({ view: "tokens", viewExplicit: true });
+    expect(stylesResult?.section).toBeUndefined();
+
+    const elementsResult = resolveComponentsSlug("elements");
+    expect(elementsResult).toMatchObject({ view: "primitives", viewExplicit: true });
+    expect(elementsResult?.section).toBeUndefined();
   });
 
   it("maps prompts to the components view", () => {
@@ -63,5 +71,7 @@ describe("ComponentsSlug", () => {
     expect(slugs).toContain("button");
     expect(slugs).toContain("action-buttons");
     expect(slugs).toContain("colors");
+    expect(slugs).toContain("styles");
+    expect(slugs).toContain("elements");
   });
 });


### PR DESCRIPTION
## Summary
- map the `elements` and `styles` slugs to existing gallery views so they resolve correctly
- normalize view parameters through a shared helper so aliases behave the same as canonical views
- add regression coverage for the new aliases in slug resolution and gallery state tests

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d2f156346c832cb3df5483e21dbae6