### PR TITLE
Use spacing tokens for goal status dots

### DIFF
--- a/src/components/goals/GoalList.tsx
+++ b/src/components/goals/GoalList.tsx
@@ -197,7 +197,7 @@ export default function GoalList({
                       <span
                         aria-hidden
                         className={[
-                          "h-2 w-2 rounded-full transition-all",
+                          "h-[var(--space-2)] w-[var(--space-2)] rounded-full transition-all",
                           g.done
                             ? "bg-muted-foreground/40"
                             : "bg-accent shadow-ring motion-safe:animate-pulse",

--- a/src/components/goals/GoalQueue.tsx
+++ b/src/components/goals/GoalQueue.tsx
@@ -61,7 +61,10 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
 
                 return (
                   <li key={it.id} className="group flex items-center gap-[var(--space-2)] py-[var(--space-3)]">
-                    <span className="h-2 w-2 rounded-full bg-foreground/40" aria-hidden />
+                    <span
+                      className="h-[var(--space-2)] w-[var(--space-2)] rounded-full bg-foreground/40"
+                      aria-hidden
+                    />
                     <p className="flex-1 truncate text-ui font-medium">{it.text}</p>
                     <time
                       className="text-label font-medium tracking-[0.02em] text-muted-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
@@ -89,7 +92,10 @@ export default function GoalQueue({ items, onAdd, onRemove }: GoalQueueProps) {
           </ul>
 
           <form onSubmit={submit} className="flex items-center gap-[var(--space-2)] pt-[var(--space-3)]">
-            <span className="h-2 w-2 rounded-full bg-foreground/40" aria-hidden />
+            <span
+              className="h-[var(--space-2)] w-[var(--space-2)] rounded-full bg-foreground/40"
+              aria-hidden
+            />
             <label className="sr-only" htmlFor={inputId}>
               Add to queue and press Enter
             </label>


### PR DESCRIPTION
## Summary
- replace the goal list status indicator to size via shared spacing tokens instead of fixed h/w utilities
- align the goal queue list and add-form dots on the same tokenized sizing for consistent presentation

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d320c661c4832cbff4f50dc6c43f4a