### PR TITLE
Add ring contrast token support

### DIFF
--- a/src/components/ui/primitives/Badge.tsx
+++ b/src/components/ui/primitives/Badge.tsx
@@ -143,7 +143,7 @@ export default function Badge<T extends React.ElementType = "span">(
             !isButtonElement && "data-[disabled=true]:pointer-events-none",
           ),
         isSelected &&
-          "bg-primary-soft/36 border-[var(--ring-contrast)] shadow-glow-xl text-[var(--text-on-accent)]",
+          "bg-primary-soft/36 border-ring-contrast shadow-glow-xl text-[var(--text-on-accent)]",
         glitch &&
           "shadow-inset-hairline hover:shadow-inset-contrast hover:shadow-glow-lg focus-visible:shadow-inset-contrast focus-visible:shadow-glow-lg",
         className,

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -2,6 +2,7 @@ export const colorTokens = [
   "bg-border",
   "bg-input",
   "bg-ring",
+  "bg-ring-contrast",
   "bg-background",
   "bg-foreground",
   "bg-card",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -23,7 +23,10 @@ const config: Config = {
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
-        ring: "hsl(var(--ring))",
+        ring: {
+          DEFAULT: "hsl(var(--ring))",
+          contrast: "hsl(var(--ring-contrast))",
+        },
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
         card: {


### PR DESCRIPTION
## Summary
- convert the Tailwind ring color entry into a map that exposes the contrast variant
- append the bg-ring-contrast token so DemoTokens recognizes the new background helper
- update the badge primitive to use the semantic border-ring-contrast utility when selected

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d320d996bc832c93d71660ce7c390c