### PR TITLE
Restore main landmark in root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -83,7 +83,9 @@ export default async function RootLayout({
             <SiteChrome>
               <CatCompanion />
               <div className="relative z-10">
-                {children}
+                <main id="main-content" tabIndex={-1}>
+                  {children}
+                </main>
                 <footer
                   role="contentinfo"
                   className="mt-[var(--space-8)] border-t border-border bg-surface"


### PR DESCRIPTION
## Summary
- add the missing `<main>` landmark to the root layout so the global skip link targets an element that exists
- keep the existing layout stacking context while ensuring all page content is rendered inside the landmark

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3250e75c8832c9e8123ca9a864765