### PR TITLE
Refine focus ring tokens and className composition

### DIFF
--- a/src/components/home/IsometricRoom.tsx
+++ b/src/components/home/IsometricRoom.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import Card from "@/components/ui/primitives/Card";
+import { cn } from "@/lib/utils";
 import { VARIANT_LABELS, type Variant } from "@/lib/theme";
 
 interface IsometricRoomProps {
@@ -29,7 +30,10 @@ export default function IsometricRoom({ variant }: IsometricRoomProps) {
     <Card
       role="img"
       aria-label={`Isometric room with ${label}`}
-      className={`relative h-[var(--room-size)] overflow-hidden bg-background border shadow-neo transition-[transform,box-shadow] duration-[var(--dur-quick)] ease-[var(--ease-out)] motion-reduce:transition-none hover:-translate-y-[var(--space-1)] hover:shadow-neo-soft focus-visible:shadow-neo-soft active:translate-y-0 active:shadow-neo-soft focus-visible:ring-2 focus-visible:ring-[var(--focus)] focus-visible:ring-offset-0 motion-reduce:hover:translate-y-0 [--room-size:calc(var(--space-8)*3)] [--room-depth:calc(var(--room-size)/2)] ${VARIANT_STYLES[variant]}`}
+      className={cn(
+        "relative h-[var(--room-size)] overflow-hidden bg-background border shadow-neo transition-[transform,box-shadow] duration-[var(--dur-quick)] ease-[var(--ease-out)] motion-reduce:transition-none hover:-translate-y-[var(--space-1)] hover:shadow-neo-soft focus-visible:shadow-neo-soft active:translate-y-0 active:shadow-neo-soft focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] focus-visible:ring-offset-0 motion-reduce:hover:translate-y-0 [--room-size:calc(var(--space-8)*3)] [--room-depth:calc(var(--room-size)/2)]",
+        VARIANT_STYLES[variant],
+      )}
     >
       <div className="absolute inset-0 [transform-style:preserve-3d]">
         <div className="absolute inset-x-0 bottom-0 h-[var(--room-depth)] bg-[hsl(var(--room-floor))] origin-bottom [transform:rotateX(90deg)]" />

--- a/src/components/ui/Select.gallery.tsx
+++ b/src/components/ui/Select.gallery.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { createGalleryPreview, defineGallerySection } from "@/components/gallery/registry";
+import { cn } from "@/lib/utils";
 
 import Select from "./Select";
 import type { AnimatedSelectProps } from "./select/shared";
@@ -34,8 +35,8 @@ const SELECT_STATES: readonly SelectStateSpec[] = [
     id: "focus-visible",
     name: "Focus-visible",
     className:
-      "rounded-[var(--control-radius)] ring-2 ring-[var(--theme-ring)] ring-offset-0",
-    code: "<Select className=\"rounded-[var(--control-radius)] ring-2 ring-[var(--theme-ring)] ring-offset-0\" placeholder=\"Focus-visible\" items={items} />",
+      "rounded-[var(--control-radius)] ring-2 ring-[hsl(var(--ring))] ring-offset-0",
+    code: "<Select className=\"rounded-[var(--control-radius)] ring-2 ring-[hsl(var(--ring))] ring-offset-0\" placeholder=\"Focus-visible\" items={items} />",
   },
   {
     id: "active",
@@ -70,7 +71,7 @@ function SelectStatePreview({ state }: { state: SelectStateSpec }) {
   const { items: stateItems, placeholder, ariaLabel, ...restProps } = props ?? {};
   const sampleItems = stateItems ?? ITEMS;
   const baseClassName = "w-full sm:w-auto";
-  const finalClassName = className ? `${baseClassName} ${className}` : baseClassName;
+  const finalClassName = cn(baseClassName, className);
 
   return (
     <Select
@@ -169,26 +170,28 @@ export default defineGallerySection({
           render: () => <SelectStatePreview state={state} />,
         }),
       })),
-      code: `const items = [
+        code: `import { cn } from "@/lib/utils";
+
+const items = [
   { value: "one", label: "One" },
   { value: "two", label: "Two" },
   { value: "three", label: "Three" },
 ];
 
-const SELECT_STATES = [
-  { label: "Default" },
-  { label: "Hover", buttonClassName: "bg-[--hover]" },
-  {
-    label: "Focus-visible",
-    className: "rounded-[var(--control-radius)] ring-2 ring-[var(--theme-ring)] ring-offset-0",
-  },
-  { label: "Active", buttonClassName: "bg-[--active]" },
-  { label: "Disabled", props: { disabled: true } },
-  {
-    label: "Loading",
-    buttonClassName: "pointer-events-none opacity-[var(--loading)]",
-  },
-];
+  const SELECT_STATES = [
+    { label: "Default" },
+    { label: "Hover", buttonClassName: "bg-[--hover]" },
+    {
+      label: "Focus-visible",
+      className: "rounded-[var(--control-radius)] ring-2 ring-[hsl(var(--ring))] ring-offset-0",
+    },
+    { label: "Active", buttonClassName: "bg-[--active]" },
+    { label: "Disabled", props: { disabled: true } },
+    {
+      label: "Loading",
+      buttonClassName: "pointer-events-none opacity-[var(--loading)]",
+    },
+  ];
 
 const [value, setValue] = React.useState(items[0]?.value ?? "");
 
@@ -213,26 +216,24 @@ const [value, setValue] = React.useState(items[0]?.value ?? "");
   <div className="flex flex-col gap-[var(--space-2)]">
     <p className="text-caption text-muted-foreground">States</p>
     <div className="flex flex-wrap gap-[var(--space-2)]">
-      {SELECT_STATES.map(({ label, buttonClassName, className, props }) => {
-        const { items: stateItems, ...restProps } = props ?? {};
-        const sampleItems = stateItems ?? items;
-        const baseClassName = "w-full sm:w-auto";
-        const finalClassName = className
-          ? baseClassName + " " + className
-          : baseClassName;
+        {SELECT_STATES.map(({ label, buttonClassName, className, props }) => {
+          const { items: stateItems, ...restProps } = props ?? {};
+          const sampleItems = stateItems ?? items;
+          const baseClassName = "w-full sm:w-auto";
+          const finalClassName = cn(baseClassName, className);
 
-        return (
-          <Select
-            key={label}
-            items={[...sampleItems]}
-            placeholder={label}
-            ariaLabel={label}
-            buttonClassName={buttonClassName}
-            className={finalClassName}
-            {...restProps}
-          />
-        );
-      })}
+          return (
+            <Select
+              key={label}
+              items={[...sampleItems]}
+              placeholder={label}
+              ariaLabel={label}
+              buttonClassName={buttonClassName}
+              className={finalClassName}
+              {...restProps}
+            />
+          );
+        })}
     </div>
   </div>
 </div>`,


### PR DESCRIPTION
## Summary
- update the select gallery preview to compose classes with `cn` and use the `--ring` token for focus-visible styling
- align the isometric room card with the `cn` helper and `hsl(var(--ring))` focus outline

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68d32553d3e8832cb5cefcfcce786605