### PR TITLE
Fix a11y labels and guard interactive regions

### DIFF
--- a/src/components/goals/reminders/ReminderList.tsx
+++ b/src/components/goals/reminders/ReminderList.tsx
@@ -62,6 +62,8 @@ function RemTile({
   const [body, setBody] = React.useState(value.body ?? "");
   const [tagsText, setTagsText] = React.useState(value.tags.join(", "));
   const titleRef = React.useRef<HTMLInputElement | null>(null);
+  const noteFieldId = `reminder-${value.id}-note`;
+  const tagsFieldId = `reminder-${value.id}-tags`;
 
   useAutoFocus({ ref: titleRef, when: editing });
 
@@ -173,8 +175,14 @@ function RemTile({
       <div className="mt-[var(--space-2)] space-y-[var(--space-3)]">
         {editing ? (
           <>
-            <label className="text-label font-medium tracking-[0.02em] opacity-70">Note</label>
+            <label
+              className="text-label font-medium tracking-[0.02em] opacity-70"
+              htmlFor={noteFieldId}
+            >
+              Note
+            </label>
             <Textarea
+              id={noteFieldId}
               aria-label="Body"
               placeholder="Short, skimmable sentence."
               value={body}
@@ -185,9 +193,14 @@ function RemTile({
               resize="resize-y"
               textareaClassName="min-h-[calc(var(--space-8)*2_+_var(--space-3))] leading-relaxed"
             />
-
-            <label className="text-label font-medium tracking-[0.02em] opacity-70">Tags</label>
+            <label
+              className="text-label font-medium tracking-[0.02em] opacity-70"
+              htmlFor={tagsFieldId}
+            >
+              Tags
+            </label>
             <Input
+              id={tagsFieldId}
               aria-label="Tags (comma separated)"
               placeholder="tags, comma, separated"
               value={tagsText}

--- a/src/components/planner/ProjectList.tsx
+++ b/src/components/planner/ProjectList.tsx
@@ -11,6 +11,8 @@ import EmptyRow from "./EmptyRow";
 import PlannerListPanel from "./PlannerListPanel";
 import type { Project } from "./plannerTypes";
 
+const PROJECT_ROW_GUARD_SELECTOR = "[data-project-row-guard='true']";
+
 type Props = {
   projects: Project[];
   selectedProjectId: string;
@@ -172,7 +174,13 @@ export default function ProjectList({
                   data-loading={isLoading ? "true" : undefined}
                   ref={(node) => registerProjectRef(p.id, node)}
                   onKeyDown={blockInteraction ? undefined : handleRowKey}
-                  onClick={() => {
+                  onClick={(event) => {
+                    if (
+                      event.target instanceof HTMLElement &&
+                      event.target.closest(PROJECT_ROW_GUARD_SELECTOR)
+                    ) {
+                      return;
+                    }
                     if (blockInteraction || active) return;
                     setSelectedTaskId("");
                     setSelectedProjectId(p.id);
@@ -187,8 +195,7 @@ export default function ProjectList({
                 >
                   <span
                     className="shrink-0"
-                    onMouseDown={(e) => e.stopPropagation()}
-                    onClick={(e) => e.stopPropagation()}
+                    data-project-row-guard="true"
                   >
                     <CheckCircle
                       checked={!!p.done}
@@ -229,6 +236,7 @@ export default function ProjectList({
                       }}
                       disabled={isRowInactive}
                       aria-label={`Rename project ${p.name}`}
+                      data-project-row-guard="true"
                     />
                   ) : (
                     <span className="proj-card__title truncate font-medium">

--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -17,6 +17,7 @@ const taskImageSize = spacingTokens[taskImageSpacingToken - 1];
 const taskImageCssValue = `var(--space-${taskImageSpacingToken})` as const;
 const layoutClasses =
   "[overflow:visible] grid min-h-[var(--space-7)] min-w-0 grid-cols-[auto,1fr,auto] items-center gap-[var(--space-4)] pl-[var(--space-4)] pr-[var(--space-2)] py-[var(--space-2)]";
+const TASK_ROW_GUARD_SELECTOR = "[data-task-row-guard='true']";
 
 type Props = {
   task: DayTask;
@@ -88,9 +89,18 @@ export default function TaskRow({
     [],
   );
 
-  const handleRowClick = React.useCallback(() => {
-    selectTask();
-  }, [selectTask]);
+  const handleRowClick = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      if (
+        event.target instanceof HTMLElement &&
+        event.target.closest(TASK_ROW_GUARD_SELECTOR)
+      ) {
+        return;
+      }
+      selectTask();
+    },
+    [selectTask],
+  );
 
   const handleRowKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLButtonElement>) => {
@@ -181,7 +191,7 @@ export default function TaskRow({
         >
           <div
             className="pointer-events-auto shrink-0 ml-[var(--space-1)]"
-            onClick={(e) => e.stopPropagation()}
+            data-task-row-guard="true"
             onPointerDown={(e) => e.stopPropagation()}
           >
             <CheckCircle
@@ -232,6 +242,7 @@ export default function TaskRow({
                   if (e.key === "Escape") cancel();
                 }}
                 aria-label={renameTaskLabel}
+                data-task-row-guard="true"
               />
             )}
           </div>

--- a/src/components/planner/TodayHeroProjects.tsx
+++ b/src/components/planner/TodayHeroProjects.tsx
@@ -11,6 +11,8 @@ import Input from "@/components/ui/primitives/Input";
 import CheckCircle from "@/components/ui/toggles/CheckCircle";
 import type { Project } from "./plannerTypes";
 
+const PROJECT_OPTION_GUARD_SELECTOR = "[data-project-option-guard='true']";
+
 export type TodayHeroProjectsProps = {
   projects: Project[];
   selectedProjectId: string;
@@ -105,7 +107,13 @@ export default function TodayHeroProjects({
                     id={optionId}
                     aria-selected={isSelected}
                     aria-disabled={isEditing}
-                    onClick={() => {
+                    onClick={(event) => {
+                      if (
+                        event.target instanceof HTMLElement &&
+                        event.target.closest(PROJECT_OPTION_GUARD_SELECTOR)
+                      ) {
+                        return;
+                      }
                       if (!isEditing) onProjectSelect(project.id);
                     }}
                     onKeyDown={(event) => {
@@ -140,15 +148,14 @@ export default function TodayHeroProjects({
                           onProjectRenameCommit(project.id, project.name);
                         }}
                         aria-label={`Rename project ${project.name}`}
-                        onClick={(event) => event.stopPropagation()}
+                        data-project-option-guard="true"
                       />
                     ) : (
-                      <div className="flex min-w-0 items-center gap-[var(--space-3)]">
-                        <span
-                          className="shrink-0"
-                          onMouseDown={(event) => event.stopPropagation()}
-                          onClick={(event) => event.stopPropagation()}
-                        >
+                        <div className="flex min-w-0 items-center gap-[var(--space-3)]">
+                          <span
+                            className="shrink-0"
+                            data-project-option-guard="true"
+                          >
                           <CheckCircle
                             size="sm"
                             checked={project.done}

--- a/src/components/planner/TodayHeroTasks.tsx
+++ b/src/components/planner/TodayHeroTasks.tsx
@@ -10,6 +10,8 @@ import Input from "@/components/ui/primitives/Input";
 import CheckCircle from "@/components/ui/toggles/CheckCircle";
 import type { DayTask } from "./plannerTypes";
 
+const TASK_OPTION_GUARD_SELECTOR = "[data-task-option-guard='true']";
+
 export type TodayHeroTasksProps = {
   projectId: string;
   projectName: string;
@@ -97,6 +99,12 @@ export default function TodayHeroTasks({
                     aria-label={`Select task ${task.title}`}
                     onClick={(event: MouseEvent<HTMLButtonElement>) => {
                       if (event.defaultPrevented) return;
+                      if (
+                        event.target instanceof HTMLElement &&
+                        event.target.closest(TASK_OPTION_GUARD_SELECTOR)
+                      ) {
+                        return;
+                      }
                       if (event.target !== event.currentTarget) return;
                       onTaskSelect(task.id);
                     }}
@@ -134,7 +142,7 @@ export default function TodayHeroTasks({
                     <div className="pointer-events-none flex items-center gap-[var(--space-3)]">
                       <div
                         className="pointer-events-auto"
-                        onClick={(event) => event.stopPropagation()}
+                        data-task-option-guard="true"
                         onPointerDown={(event) => event.stopPropagation()}
                       >
                         <CheckCircle
@@ -160,10 +168,10 @@ export default function TodayHeroTasks({
                           onBlur={() => {
                             onTaskRenameCommit(task.id, task.title);
                           }}
-                          onClick={(event) => event.stopPropagation()}
                           onPointerDown={(event) => event.stopPropagation()}
                           className="pointer-events-auto"
                           aria-label={`Rename task ${task.title}`}
+                          data-task-option-guard="true"
                         />
                       ) : (
                         <button

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -69,6 +69,7 @@ export default function ReviewsPage({
   );
   const panelClass = "mx-auto";
   const detailBaseId = active ? `review-${active.id}` : "review-detail";
+  const sortLabelId = React.useId();
 
   return (
     <>
@@ -101,13 +102,20 @@ export default function ReviewsPage({
                   aria-label="Search reviews"
                   className="md:col-span-8"
                 />
-                <label className="flex w-full flex-col gap-[var(--space-1)] text-left md:col-span-2">
-                  <span className="text-ui font-medium text-muted-foreground">
+                <div
+                  className="flex w-full flex-col gap-[var(--space-1)] text-left md:col-span-2"
+                  aria-labelledby={sortLabelId}
+                >
+                  <span
+                    id={sortLabelId}
+                    className="text-ui font-medium text-muted-foreground"
+                  >
                     Sort
                   </span>
                   <Select
                     variant="animated"
-                    ariaLabel="Sort reviews"
+                    label="Sort reviews"
+                    hideLabel
                     value={sort}
                     onChange={(v) => setSort(v as SortKey)}
                     items={[
@@ -118,7 +126,7 @@ export default function ReviewsPage({
                     className="w-full"
                     size="lg"
                   />
-                </label>
+                </div>
                 <Button
                   type="button"
                   variant="primary"

--- a/src/components/team/MyComps.tsx
+++ b/src/components/team/MyComps.tsx
@@ -416,7 +416,10 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
 
                     {/* notes */}
                     <div className="grid gap-[var(--space-3)]">
-                      <label className="text-label font-medium tracking-[0.02em] text-muted-foreground inline-flex items-center gap-[var(--space-2)]">
+                      <label
+                        className="text-label font-medium tracking-[0.02em] text-muted-foreground inline-flex items-center gap-[var(--space-2)]"
+                        htmlFor={`${c.id}-notes`}
+                      >
                         <NotebookPen className="opacity-80" /> Notes
                       </label>
                       {!editingCard ? (
@@ -427,6 +430,7 @@ export default function MyComps({ query = "", editing = false }: MyCompsProps) {
                         </p>
                       ) : (
                         <Textarea
+                          id={`${c.id}-notes`}
                           dir="ltr"
                           aria-label="Notes"
                           rows={4}

--- a/src/components/ui/Label.tsx
+++ b/src/components/ui/Label.tsx
@@ -7,15 +7,16 @@ import { cn } from "@/lib/utils";
 export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>;
 
 const Label = React.forwardRef<HTMLLabelElement, LabelProps>(function Label(
-  { className, ...props },
-  ref
+  { className, htmlFor, ...props },
+  ref,
 ) {
   return (
     <label
       ref={ref}
+      htmlFor={htmlFor}
       className={cn(
         "text-label font-medium text-muted-foreground mb-[var(--space-2)]",
-        className
+        className,
       )}
       {...props}
     />

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -335,11 +335,13 @@ exports[`ReviewsPage > renders default state 1`] = `
                           </div>
                         </div>
                       </form>
-                      <label
+                      <div
+                        aria-labelledby=":r0:"
                         class="flex w-full flex-col gap-[var(--space-1)] text-left md:col-span-2"
                       >
                         <span
                           class="text-ui font-medium text-muted-foreground"
+                          id=":r0:"
                         >
                           Sort
                         </span>
@@ -347,13 +349,19 @@ exports[`ReviewsPage > renders default state 1`] = `
                           class="glitch-wrap w-full"
                         >
                           <div
+                            class="sr-only"
+                            id=":r2:-label"
+                          >
+                            Sort reviews
+                          </div>
+                          <div
                             class="group inline-flex rounded-[var(--control-radius)] border border-[var(--focus)] focus-within:ring-2 focus-within:ring-[var(--focus)] focus-within:ring-offset-0"
                           >
                             <button
-                              aria-controls=":r1:-listbox"
+                              aria-controls=":r2:-listbox"
                               aria-expanded="false"
                               aria-haspopup="listbox"
-                              aria-label="Sort reviews"
+                              aria-labelledby=":r2:-label"
                               class="_glitchTrigger_843152 relative flex items-center rounded-[var(--control-radius)] overflow-hidden h-[var(--control-h-lg)] px-[var(--space-4)] bg-muted/12 hover:bg-muted/18 focus:[outline:none] focus-visible:[outline:none] transition-colors duration-[var(--dur-quick)] ease-out motion-reduce:transition-none"
                               data-lit="true"
                               data-open="false"
@@ -400,7 +408,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                             </button>
                           </div>
                         </div>
-                      </label>
+                      </div>
                       <button
                         class="relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-[var(--dur-quick)] ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:[outline:none] focus-visible:ring-2 focus-visible:ring-[var(--focus)] disabled:opacity-[var(--disabled)] disabled:pointer-events-none data-[loading=true]:opacity-[var(--loading)] data-[disabled=true]:opacity-[var(--disabled)] data-[disabled=true]:pointer-events-none h-[var(--control-h-md)] px-[var(--space-4)] text-ui gap-[var(--space-2)] [&_svg]:size-[var(--space-5)] w-full whitespace-nowrap md:col-span-2 md:justify-self-end shadow-[var(--btn-primary-shadow-rest)] hover:shadow-[var(--btn-primary-shadow-hover)] active:shadow-[var(--btn-primary-shadow-active)] active:translate-y-[var(--spacing-0-25)] bg-primary-soft border-[hsl(var(--primary)/0.35)] text-[hsl(var(--primary-foreground))] [--hover:theme('colors.interaction.primary.hover')] [--active:theme('colors.interaction.primary.active')]"
                         style="--glow-active: hsl(var(--primary) / 0.35); --btn-primary-hover-shadow: 0 var(--spacing-0-5) calc(var(--space-3) / 2) calc(-1 * var(--spacing-0-25)) hsl(var(--primary) / 0.25); --btn-primary-active-shadow: inset 0 0 0 var(--spacing-0-25) hsl(var(--primary) / 0.6); --btn-primary-shadow-rest: 0 0 calc(var(--space-4) / 2) var(--glow-active); --btn-primary-shadow-hover: 0 0 var(--space-4) var(--glow-active); --btn-primary-shadow-active: var(--btn-primary-active-shadow);"


### PR DESCRIPTION
## Summary
- ensure reminders and comps editors expose proper label associations
- update Reviews sort UI to use the select label API and refresh the snapshot
- guard planner rows with data attributes so click interception stays accessible while still exposing focus-visible styling

## Testing
- npm run lint -- --rule 'jsx-a11y/label-has-associated-control: error'
- npm run lint -- --rule 'jsx-a11y/click-events-have-key-events: error'
- npm run lint -- --rule 'jsx-a11y/no-noninteractive-element-interactions: error'
- npm run lint -- --rule 'jsx-a11y/no-static-element-interactions: error'
- npm run lint -- --rule 'jsx-a11y/alt-text: error'
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3255bbe44832c82ad482867a7ec72