### PR TITLE
Optimize review list and reminder performance

### DIFF
--- a/src/components/goals/reminders/ReminderList.tsx
+++ b/src/components/goals/reminders/ReminderList.tsx
@@ -58,10 +58,14 @@ function RemTile({
   onDelete: () => void;
 }) {
   const [editing, setEditing] = React.useState(false);
-  const [title, setTitle] = React.useState(value.title);
-  const [body, setBody] = React.useState(value.body ?? "");
-  const [tagsText, setTagsText] = React.useState(value.tags.join(", "));
+  const [draft, setDraft] = React.useState(() => ({
+    title: value.title,
+    body: value.body ?? "",
+    tagsText: value.tags.join(", "),
+  }));
+  const { title, body, tagsText } = draft;
   const titleRef = React.useRef<HTMLInputElement | null>(null);
+  const joinedTags = React.useMemo(() => value.tags.join(", "), [value.tags]);
 
   useAutoFocus({ ref: titleRef, when: editing });
 
@@ -70,10 +74,12 @@ function RemTile({
       return;
     }
 
-    setTitle(value.title);
-    setBody(value.body ?? "");
-    setTagsText(value.tags.join(", "));
-  }, [editing, value.body, value.tags, value.title]);
+    setDraft({
+      title: value.title,
+      body: value.body ?? "",
+      tagsText: joinedTags,
+    });
+  }, [editing, joinedTags, value.body, value.title]);
 
   const save = React.useCallback(() => {
     const cleanTags = tagsText
@@ -110,7 +116,10 @@ function RemTile({
               ref={titleRef}
               value={title}
               onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-                setTitle(event.currentTarget.value)
+                setDraft((prev) => ({
+                  ...prev,
+                  title: event.currentTarget.value,
+                }))
               }
               onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) =>
                 event.key === "Enter" && save()
@@ -179,7 +188,10 @@ function RemTile({
               placeholder="Short, skimmable sentence."
               value={body}
               onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>
-                setBody(event.currentTarget.value)
+                setDraft((prev) => ({
+                  ...prev,
+                  body: event.currentTarget.value,
+                }))
               }
               className="rounded-[var(--radius-2xl)]"
               resize="resize-y"
@@ -192,7 +204,10 @@ function RemTile({
               placeholder="tags, comma, separated"
               value={tagsText}
               onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-                setTagsText(event.currentTarget.value)
+                setDraft((prev) => ({
+                  ...prev,
+                  tagsText: event.currentTarget.value,
+                }))
               }
             />
 
@@ -255,9 +270,11 @@ function RemTile({
                 variant="ghost"
                 onClick={() => {
                   setEditing(false);
-                  setTitle(value.title);
-                  setBody(value.body ?? "");
-                  setTagsText(value.tags.join(", "));
+                  setDraft({
+                    title: value.title,
+                    body: value.body ?? "",
+                    tagsText: joinedTags,
+                  });
                 }}
               >
                 Cancel

--- a/src/components/reviews/ReviewList.tsx
+++ b/src/components/reviews/ReviewList.tsx
@@ -8,6 +8,8 @@ import ReviewListItem from "./ReviewListItem";
 import { Button } from "@/components/ui";
 import { Tv } from "lucide-react";
 
+export const MAX_VISIBLE_REVIEWS = 200;
+
 export type ReviewListProps = {
   reviews: Review[];
   selectedId: string | null;
@@ -28,6 +30,13 @@ export default function ReviewList({
   hoverRing = false,
 }: ReviewListProps) {
   const count = reviews.length;
+  const visibleReviews = React.useMemo(() => {
+    if (reviews.length <= MAX_VISIBLE_REVIEWS) {
+      return reviews;
+    }
+    return reviews.slice(0, MAX_VISIBLE_REVIEWS);
+  }, [reviews]);
+  const hiddenCount = Math.max(count - visibleReviews.length, 0);
 
   const containerClass = cn(
     "w-full mx-auto rounded-card r-card-lg border border-border/35 bg-card/60 text-card-foreground shadow-outline-subtle",
@@ -62,7 +71,7 @@ export default function ReviewList({
     <section data-scope="reviews" className={containerClass}>
       {headerNode}
       <ul className="flex flex-col gap-[var(--space-3)]">
-        {reviews.map((r) => (
+        {visibleReviews.map((r) => (
           <li key={r.id}>
             <ReviewListItem
               review={r}
@@ -71,6 +80,13 @@ export default function ReviewList({
             />
           </li>
         ))}
+        {hiddenCount > 0 ? (
+          <li>
+            <div className="rounded-card border border-border/35 bg-card/50 px-[var(--space-3)] py-[var(--space-2)] text-label text-muted-foreground">
+              Showing {visibleReviews.length} of {count}. Refine your filters to narrow the list.
+            </div>
+          </li>
+        ) : null}
       </ul>
     </section>
   );

--- a/src/components/reviews/ReviewSummaryTimestamps.tsx
+++ b/src/components/reviews/ReviewSummaryTimestamps.tsx
@@ -11,9 +11,15 @@ export type ReviewSummaryTimestampsProps = {
 export default function ReviewSummaryTimestamps({
   markers,
 }: ReviewSummaryTimestampsProps) {
-  const hasAny = markers.length > 0;
-  const hasTimed = hasAny && markers.some((m) => !m.noteOnly);
-  const hasNoteOnly = hasAny && markers.every((m) => m.noteOnly);
+  const sortedMarkers = React.useMemo(() => {
+    if (markers.length === 0) {
+      return [] as ReviewMarker[];
+    }
+    return [...markers].sort((a, b) => a.seconds - b.seconds);
+  }, [markers]);
+  const hasAny = sortedMarkers.length > 0;
+  const hasTimed = hasAny && sortedMarkers.some((m) => !m.noteOnly);
+  const hasNoteOnly = hasAny && sortedMarkers.every((m) => m.noteOnly);
 
   return (
     <div>
@@ -22,35 +28,33 @@ export default function ReviewSummaryTimestamps({
         <NeonIcon kind="file" on={!!hasNoteOnly} size="xl" staticGlow />
         <div className="h-[var(--hairline-w)] flex-1 bg-gradient-to-r from-foreground/20 via-foreground/5 to-transparent" />
       </div>
-      {!markers.length ? (
+      {!sortedMarkers.length ? (
         <div className="text-ui text-muted-foreground">No timestamps yet.</div>
       ) : (
         <ul className="space-y-[var(--space-2)]">
-          {[...markers]
-            .sort((a, b) => a.seconds - b.seconds)
-            .map((m) => (
-              <ReviewSurface
-                as="li"
-                key={m.id}
-                padding="sm"
-                className="grid grid-cols-[auto_1fr] items-center gap-[var(--space-2)]"
-              >
-                {m.noteOnly ? (
-                  <span
-                    className="pill flex h-[var(--space-6)] w-[calc(var(--space-6)+var(--space-2))] items-center justify-center px-0"
-                    title="Note"
-                    aria-label="Note"
-                  >
-                    <FileText aria-hidden className="icon-xs opacity-80" />
-                  </span>
-                ) : (
-                  <span className="pill h-[var(--space-6)] px-[var(--space-3)] text-ui font-mono tabular-nums leading-none">
-                    {m.time ?? "00:00"}
-                  </span>
-                )}
-                <span className="truncate text-ui">{m.note || "—"}</span>
-              </ReviewSurface>
-            ))}
+          {sortedMarkers.map((m) => (
+            <ReviewSurface
+              as="li"
+              key={m.id}
+              padding="sm"
+              className="grid grid-cols-[auto_1fr] items-center gap-[var(--space-2)]"
+            >
+              {m.noteOnly ? (
+                <span
+                  className="pill flex h-[var(--space-6)] w-[calc(var(--space-6)+var(--space-2))] items-center justify-center px-0"
+                  title="Note"
+                  aria-label="Note"
+                >
+                  <FileText aria-hidden className="icon-xs opacity-80" />
+                </span>
+              ) : (
+                <span className="pill h-[var(--space-6)] px-[var(--space-3)] text-ui font-mono tabular-nums leading-none">
+                  {m.time ?? "00:00"}
+                </span>
+              )}
+              <span className="truncate text-ui">{m.note || "—"}</span>
+            </ReviewSurface>
+          ))}
         </ul>
       )}
     </div>

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import type { Review } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { useReviewFilter } from "@/components/reviews";
-import ReviewList from "./ReviewList";
+import ReviewList, { MAX_VISIBLE_REVIEWS } from "./ReviewList";
 import ReviewEditor from "./ReviewEditor";
 import ReviewSummary from "./ReviewSummary";
 import ReviewPanel from "./ReviewPanel";
@@ -67,6 +67,11 @@ export default function ReviewsPage({
     () => base.find((r) => r.id === selectedId) || null,
     [base, selectedId],
   );
+  const visibleReviewCount = Math.min(filtered.length, MAX_VISIBLE_REVIEWS);
+  const listHeader =
+    filtered.length > MAX_VISIBLE_REVIEWS
+      ? `${visibleReviewCount} of ${filtered.length} shown`
+      : `${filtered.length} shown`;
   const panelClass = "mx-auto";
   const detailBaseId = active ? `review-${active.id}` : "review-detail";
 
@@ -158,7 +163,7 @@ export default function ReviewsPage({
               }}
               onCreate={handleCreateReview}
               className="h-auto overflow-auto p-[var(--space-2)] md:h-[var(--content-viewport-height)]"
-              header={`${filtered.length} shown`}
+              header={listHeader}
               hoverRing
             />
           </nav>


### PR DESCRIPTION
## Summary
- limit review list rendering to the first 200 entries and surface truncated counts in the UI
- memoize timestamp sorting and ensure review headers reflect the visible review total
- consolidate reminder tile draft state to avoid multiple update passes when syncing values

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d325613c0c832cb1122cf7bc3382c2