### PR TITLE
Fix planner row guard for non-HTML targets

### DIFF
--- a/src/components/planner/ProjectList.tsx
+++ b/src/components/planner/ProjectList.tsx
@@ -176,7 +176,7 @@ export default function ProjectList({
                   onKeyDown={blockInteraction ? undefined : handleRowKey}
                   onClick={(event) => {
                     if (
-                      event.target instanceof HTMLElement &&
+                      event.target instanceof Element &&
                       event.target.closest(PROJECT_ROW_GUARD_SELECTOR)
                     ) {
                       return;

--- a/src/components/planner/TaskRow.tsx
+++ b/src/components/planner/TaskRow.tsx
@@ -121,7 +121,7 @@ export default function TaskRow({
   const handleRowClick = React.useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       if (
-        event.target instanceof HTMLElement &&
+        event.target instanceof Element &&
         event.target.closest(TASK_ROW_GUARD_SELECTOR)
       ) {
         return;

--- a/src/components/planner/TodayHeroProjects.tsx
+++ b/src/components/planner/TodayHeroProjects.tsx
@@ -109,7 +109,7 @@ export default function TodayHeroProjects({
                     aria-disabled={isEditing}
                     onClick={(event) => {
                       if (
-                        event.target instanceof HTMLElement &&
+                        event.target instanceof Element &&
                         event.target.closest(PROJECT_OPTION_GUARD_SELECTOR)
                       ) {
                         return;

--- a/src/components/planner/TodayHeroTasks.tsx
+++ b/src/components/planner/TodayHeroTasks.tsx
@@ -100,7 +100,7 @@ export default function TodayHeroTasks({
                     onClick={(event: MouseEvent<HTMLButtonElement>) => {
                       if (event.defaultPrevented) return;
                       if (
-                        event.target instanceof HTMLElement &&
+                        event.target instanceof Element &&
                         event.target.closest(TASK_OPTION_GUARD_SELECTOR)
                       ) {
                         return;


### PR DESCRIPTION
## Summary
- use Element guards for planner row click handlers so SVG toggle clicks do not trigger row selection

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3376f00f4832c9fb952d26d4621c3