### PR TITLE
Fix ring contrast color variable usage

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -191,7 +191,7 @@ html.no-animations *::after {
 
 /* Global focus & selection styling */
 *:focus-visible {
-  outline: var(--spacing-0-5) solid hsl(var(--ring-contrast));
+  outline: var(--spacing-0-5) solid var(--ring-contrast);
   outline-offset: var(--spacing-0-5);
   box-shadow: 0 0 calc(var(--space-2) - var(--spacing-0-5)) hsl(var(--glow) / 0.6);
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -28,7 +28,7 @@ const config: Config = {
         input: "hsl(var(--input))",
         ring: {
           DEFAULT: "hsl(var(--ring))",
-          contrast: "hsl(var(--ring-contrast))",
+          contrast: "var(--ring-contrast)",
         },
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",


### PR DESCRIPTION
## Summary
- ensure the `ring.contrast` Tailwind color references the CSS variable directly to avoid nested hsl() output
- align the global focus outline color with the updated `--ring-contrast` usage

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3d0793974832cbe91e9e13620261a