### PR TITLE
Refactor color tokens to share palette

### DIFF
--- a/src/lib/theme/colors.ts
+++ b/src/lib/theme/colors.ts
@@ -1,0 +1,126 @@
+const cardHairlineOpacity = (percent: number) =>
+  `color-mix(in oklab, var(--card-hairline) ${percent}%, transparent)`;
+
+export const tailwindColorPalette = {
+  border: "hsl(var(--border))",
+  input: "hsl(var(--input))",
+  ring: "hsl(var(--ring))",
+  background: "hsl(var(--background))",
+  foreground: "hsl(var(--foreground))",
+  card: {
+    DEFAULT: "hsl(var(--card))",
+    foreground: "hsl(var(--card-foreground))",
+  },
+  surface: {
+    DEFAULT: "hsl(var(--surface))",
+    foreground: "hsl(var(--foreground))",
+  },
+  "surface-2": {
+    DEFAULT: "hsl(var(--surface-2))",
+    foreground: "hsl(var(--foreground))",
+  },
+  panel: { DEFAULT: "hsl(var(--panel))" },
+  "card-hairline": "var(--card-hairline)",
+  "card-hairline-60": cardHairlineOpacity(60),
+  "card-hairline-70": cardHairlineOpacity(70),
+  "card-hairline-90": cardHairlineOpacity(90),
+  primary: {
+    DEFAULT: "hsl(var(--primary))",
+    foreground: "hsl(var(--primary-foreground))",
+    soft: "hsl(var(--primary-soft))",
+  },
+  accent: {
+    DEFAULT: "hsl(var(--accent))",
+    foreground: "hsl(var(--accent-foreground))",
+    soft: "hsl(var(--accent-soft))",
+    overlay: "var(--accent-overlay)",
+  },
+  on: {
+    accent: "var(--text-on-accent)",
+  },
+  "accent-3": {
+    DEFAULT: "hsl(var(--accent-3))",
+  },
+  "accent-2": {
+    DEFAULT: "hsl(var(--accent-2))",
+    foreground: "hsl(var(--accent-2-foreground))",
+  },
+  glow: "hsl(var(--glow))",
+  "ring-muted": "hsl(var(--ring-muted))",
+  danger: {
+    DEFAULT: "hsl(var(--danger))",
+    foreground: "hsl(var(--danger-foreground))",
+  },
+  warning: {
+    DEFAULT: "hsl(var(--warning))",
+    soft: "hsl(var(--warning-soft))",
+    "soft-strong": "hsl(var(--warning-soft-strong))",
+  },
+  success: {
+    DEFAULT: "hsl(var(--success))",
+    glow: "hsl(var(--success-glow))",
+    soft: "hsl(var(--success-soft))",
+  },
+  tone: {
+    top: "hsl(var(--tone-top))",
+    jg: "hsl(var(--tone-jg))",
+    mid: "hsl(var(--tone-mid))",
+    bot: "hsl(var(--tone-bot))",
+    sup: "hsl(var(--tone-sup))",
+  },
+  "aurora-g": "hsl(var(--aurora-g))",
+  "aurora-g-light": "var(--aurora-g-light)",
+  "aurora-p": "hsl(var(--aurora-p))",
+  "aurora-p-light": "var(--aurora-p-light)",
+  muted: {
+    DEFAULT: "hsl(var(--muted))",
+    foreground: "hsl(var(--muted-foreground))",
+  },
+  "lav-deep": "hsl(var(--lav-deep))",
+  "surface-vhs": "hsl(var(--surface-vhs))",
+  "surface-streak": "hsl(var(--surface-streak))",
+  interaction: {
+    primary: {
+      hover: "hsl(var(--accent) / 0.14)",
+      active: "hsl(var(--accent) / 0.2)",
+    },
+    focus: {
+      hover: "hsl(var(--focus) / 0.14)",
+      active: "hsl(var(--focus) / 0.2)",
+      surfaceHover: "hsl(var(--focus) / 0.25)",
+      surfaceActive: "hsl(var(--focus) / 0.35)",
+      tintHover: "hsl(var(--focus) / 0.1)",
+      tintActive: "hsl(var(--focus) / 0.2)",
+    },
+    accent: {
+      hover: "hsl(var(--accent) / 0.14)",
+      active: "hsl(var(--accent) / 0.2)",
+      surfaceHover: "hsl(var(--accent) / 0.25)",
+      surfaceActive: "hsl(var(--accent) / 0.35)",
+      tintHover: "hsl(var(--accent) / 0.1)",
+      tintActive: "hsl(var(--accent) / 0.2)",
+    },
+    info: {
+      hover: "hsl(var(--accent-2) / 0.14)",
+      active: "hsl(var(--accent-2) / 0.2)",
+      surfaceHover: "hsl(var(--accent-2) / 0.25)",
+      surfaceActive: "hsl(var(--accent-2) / 0.35)",
+      tintHover: "hsl(var(--accent-2) / 0.1)",
+      tintActive: "hsl(var(--accent-2) / 0.2)",
+    },
+    danger: {
+      hover: "hsl(var(--danger) / 0.14)",
+      active: "hsl(var(--danger) / 0.2)",
+      surfaceHover: "hsl(var(--danger) / 0.12)",
+      surfaceActive: "hsl(var(--danger) / 0.1)",
+      tintHover: "hsl(var(--danger) / 0.1)",
+      tintActive: "hsl(var(--danger) / 0.2)",
+    },
+    foreground: {
+      tintHover: "hsl(var(--foreground) / 0.1)",
+      tintActive: "hsl(var(--foreground) / 0.2)",
+    },
+  },
+} as const;
+
+export type TailwindColorPalette = typeof tailwindColorPalette;

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -1,84 +1,30 @@
-export const colorTokens = [
-  "bg-border",
-  "bg-input",
-  "bg-ring",
-  "bg-background",
-  "bg-foreground",
-  "bg-card",
-  "bg-surface",
-  "bg-surface-foreground",
-  "bg-surface-2",
-  "bg-surface-2-foreground",
-  "bg-panel",
-  "bg-card-hairline",
-  "bg-card-hairline-60",
-  "bg-card-hairline-70",
-  "bg-card-hairline-90",
-  "bg-primary",
-  "bg-primary-foreground",
-  "bg-primary-soft",
-  "bg-accent",
-  "bg-accent-foreground",
-  "bg-accent-soft",
-  "bg-accent-overlay",
-  "bg-on-accent",
-  "bg-accent-3",
-  "bg-accent-2",
-  "bg-accent-2-foreground",
-  "bg-glow",
-  "bg-ring-muted",
-  "bg-danger",
-  "bg-danger-foreground",
-  "bg-warning",
-  "bg-warning-soft",
-  "bg-warning-soft-strong",
-  "bg-success",
-  "bg-success-soft",
-  "bg-success-glow",
-  "bg-tone-top",
-  "bg-tone-jg",
-  "bg-tone-mid",
-  "bg-tone-bot",
-  "bg-tone-sup",
-  "bg-aurora-g",
-  "bg-aurora-g-light",
-  "bg-aurora-p",
-  "bg-aurora-p-light",
-  "bg-muted",
-  "bg-muted-foreground",
-  "bg-lav-deep",
-  "bg-surface-vhs",
-  "bg-surface-streak",
-  "bg-card-foreground",
-  "bg-interaction-primary-hover",
-  "bg-interaction-primary-active",
-  "bg-interaction-focus-hover",
-  "bg-interaction-focus-active",
-  "bg-interaction-focus-surfaceHover",
-  "bg-interaction-focus-surfaceActive",
-  "bg-interaction-focus-tintHover",
-  "bg-interaction-focus-tintActive",
-  "bg-interaction-accent-hover",
-  "bg-interaction-accent-active",
-  "bg-interaction-accent-surfaceHover",
-  "bg-interaction-accent-surfaceActive",
-  "bg-interaction-accent-tintHover",
-  "bg-interaction-accent-tintActive",
-  "bg-interaction-info-hover",
-  "bg-interaction-info-active",
-  "bg-interaction-info-surfaceHover",
-  "bg-interaction-info-surfaceActive",
-  "bg-interaction-info-tintHover",
-  "bg-interaction-info-tintActive",
-  "bg-interaction-danger-hover",
-  "bg-interaction-danger-active",
-  "bg-interaction-danger-surfaceHover",
-  "bg-interaction-danger-surfaceActive",
-  "bg-interaction-danger-tintHover",
-  "bg-interaction-danger-tintActive",
-  "bg-interaction-foreground-tintHover",
-  "bg-interaction-foreground-tintActive",
-];
+import { tailwindColorPalette } from "./theme/colors";
+
+type ColorValue = string | { [key: string]: ColorValue };
+
+const flattenColorTokens = (
+  value: { [key: string]: ColorValue },
+  path: string[] = [],
+): string[] =>
+  Object.entries(value).flatMap(([key, entry]) => {
+    if (typeof entry === "string") {
+      const segments = [...path];
+      if (key !== "DEFAULT") {
+        segments.push(key);
+      }
+      const token = segments.join("-");
+      return token ? [`bg-${token}`] : [];
+    }
+
+    if (entry && typeof entry === "object") {
+      const nextPath = key === "DEFAULT" ? path : [...path, key];
+      return flattenColorTokens(entry as { [key: string]: ColorValue }, nextPath);
+    }
+
+    return [];
+  });
+
+export const colorTokens = flattenColorTokens(tailwindColorPalette);
 
 export const spacingTokens = [4, 8, 12, 16, 24, 32, 48, 64];
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,6 +3,7 @@
 // - Dark mode by class; colors map to CSS variables in globals.css
 import type { Config } from "tailwindcss";
 import { spacingTokens, radiusScale } from "./src/lib/tokens";
+import { tailwindColorPalette } from "./src/lib/theme/colors";
 
 const progressWidthSafelist = Array.from({ length: 101 }, (_, index) => `w-[${index}%]`);
 
@@ -14,136 +15,13 @@ const borderRadiusTokens = Object.entries(radiusScale).reduce(
   {} as Record<string, string>,
 );
 
-const cardHairlineOpacity = (percent: number) =>
-  `color-mix(in oklab, var(--card-hairline) ${percent}%, transparent)`;
-
 const config: Config = {
   darkMode: "class",
   content: ["./app/**/*.{ts,tsx}", "./src/**/*.{ts,tsx}"],
   safelist: progressWidthSafelist,
   theme: {
     extend: {
-      colors: {
-        border: "hsl(var(--border))",
-        input: "hsl(var(--input))",
-        ring: "hsl(var(--ring))",
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
-        card: {
-          DEFAULT: "hsl(var(--card))",
-          foreground: "hsl(var(--card-foreground))",
-        },
-        surface: {
-          DEFAULT: "hsl(var(--surface))",
-          foreground: "hsl(var(--foreground))",
-        },
-        "surface-2": {
-          DEFAULT: "hsl(var(--surface-2))",
-          foreground: "hsl(var(--foreground))",
-        },
-        panel: { DEFAULT: "hsl(var(--panel))" },
-        "card-hairline": "var(--card-hairline)",
-        "card-hairline-60": cardHairlineOpacity(60),
-        "card-hairline-70": cardHairlineOpacity(70),
-        "card-hairline-90": cardHairlineOpacity(90),
-        primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))",
-          soft: "hsl(var(--primary-soft))",
-        },
-        accent: {
-          DEFAULT: "hsl(var(--accent))",
-          foreground: "hsl(var(--accent-foreground))",
-          soft: "hsl(var(--accent-soft))",
-          overlay: "var(--accent-overlay)",
-        },
-        on: {
-          accent: "var(--text-on-accent)",
-        },
-        "accent-3": {
-          DEFAULT: "hsl(var(--accent-3))",
-        },
-        "accent-2": {
-          DEFAULT: "hsl(var(--accent-2))",
-          foreground: "hsl(var(--accent-2-foreground))",
-        },
-        glow: "hsl(var(--glow))",
-        "ring-muted": "hsl(var(--ring-muted))",
-        danger: {
-          DEFAULT: "hsl(var(--danger))",
-          foreground: "hsl(var(--danger-foreground))",
-        },
-        warning: {
-          DEFAULT: "hsl(var(--warning))",
-          soft: "hsl(var(--warning-soft))",
-          "soft-strong": "hsl(var(--warning-soft-strong))",
-        },
-        success: {
-          DEFAULT: "hsl(var(--success))",
-          glow: "hsl(var(--success-glow))",
-          soft: "hsl(var(--success-soft))",
-        },
-        tone: {
-          top: "hsl(var(--tone-top))",
-          jg: "hsl(var(--tone-jg))",
-          mid: "hsl(var(--tone-mid))",
-          bot: "hsl(var(--tone-bot))",
-          sup: "hsl(var(--tone-sup))",
-        },
-        "aurora-g": "hsl(var(--aurora-g))",
-        "aurora-g-light": "var(--aurora-g-light)",
-        "aurora-p": "hsl(var(--aurora-p))",
-        "aurora-p-light": "var(--aurora-p-light)",
-        muted: {
-          DEFAULT: "hsl(var(--muted))",
-          foreground: "hsl(var(--muted-foreground))",
-        },
-        "lav-deep": "hsl(var(--lav-deep))",
-        "surface-vhs": "hsl(var(--surface-vhs))",
-        "surface-streak": "hsl(var(--surface-streak))",
-        interaction: {
-          primary: {
-            hover: "hsl(var(--accent) / 0.14)",
-            active: "hsl(var(--accent) / 0.2)",
-          },
-          focus: {
-            hover: "hsl(var(--focus) / 0.14)",
-            active: "hsl(var(--focus) / 0.2)",
-            surfaceHover: "hsl(var(--focus) / 0.25)",
-            surfaceActive: "hsl(var(--focus) / 0.35)",
-            tintHover: "hsl(var(--focus) / 0.1)",
-            tintActive: "hsl(var(--focus) / 0.2)",
-          },
-          accent: {
-            hover: "hsl(var(--accent) / 0.14)",
-            active: "hsl(var(--accent) / 0.2)",
-            surfaceHover: "hsl(var(--accent) / 0.25)",
-            surfaceActive: "hsl(var(--accent) / 0.35)",
-            tintHover: "hsl(var(--accent) / 0.1)",
-            tintActive: "hsl(var(--accent) / 0.2)",
-          },
-          info: {
-            hover: "hsl(var(--accent-2) / 0.14)",
-            active: "hsl(var(--accent-2) / 0.2)",
-            surfaceHover: "hsl(var(--accent-2) / 0.25)",
-            surfaceActive: "hsl(var(--accent-2) / 0.35)",
-            tintHover: "hsl(var(--accent-2) / 0.1)",
-            tintActive: "hsl(var(--accent-2) / 0.2)",
-          },
-          danger: {
-            hover: "hsl(var(--danger) / 0.14)",
-            active: "hsl(var(--danger) / 0.2)",
-            surfaceHover: "hsl(var(--danger) / 0.12)",
-            surfaceActive: "hsl(var(--danger) / 0.1)",
-            tintHover: "hsl(var(--danger) / 0.1)",
-            tintActive: "hsl(var(--danger) / 0.2)",
-          },
-          foreground: {
-            tintHover: "hsl(var(--foreground) / 0.1)",
-            tintActive: "hsl(var(--foreground) / 0.2)",
-          },
-        },
-      },
+      colors: tailwindColorPalette,
       borderColor: {
         "card-hairline": "var(--card-hairline)",
       },


### PR DESCRIPTION
## Summary
- extract the Tailwind color palette into a shared module so tokens and config stay in sync
- update the Tailwind configuration to reuse the shared palette export
- generate the `colorTokens` list programmatically from the shared palette to prevent missing entries

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3cf399dd0832cb4cffab4af4ac25f