### PR TITLE
Fix complex section slug resolution

### DIFF
--- a/src/components/components/slug.ts
+++ b/src/components/components/slug.ts
@@ -191,15 +191,15 @@ export function resolveComponentsSlug(
     return { view: aliasView, viewExplicit: true };
   }
 
-  const group = GROUP_SLUG_TO_ID.get(normalized);
-  if (group) {
-    return { view: group, viewExplicit: true };
-  }
-
   const section = SECTION_SLUG_TO_ID.get(normalized);
   if (section) {
     const view = SECTION_TO_GROUP.get(section);
     return { section, view, viewExplicit: false };
+  }
+
+  const group = GROUP_SLUG_TO_ID.get(normalized);
+  if (group) {
+    return { view: group, viewExplicit: true };
   }
 
   const directEntry = entrySlugMap.get(normalized);

--- a/tests/components/ComponentsSlug.test.ts
+++ b/tests/components/ComponentsSlug.test.ts
@@ -61,6 +61,14 @@ describe("ComponentsSlug", () => {
     });
   });
 
+  it("resolves complex sections when the slug matches a group", () => {
+    const result = resolveComponentsSlug("components");
+    expect(result).toMatchObject({
+      section: "components",
+      view: "complex",
+    });
+  });
+
   it("returns null for unknown slugs", () => {
     expect(resolveComponentsSlug("unknown")).toBeNull();
   });


### PR DESCRIPTION
## Summary
- prefer component section slugs over matching group slugs so complex gallery routes resolve correctly
- add a regression test covering the overlapping slug scenario

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3d52c5728832ca487f2c0f4ce2ab8