### PR TITLE
Harden routing shell semantics

### DIFF
--- a/app/components/error.tsx
+++ b/app/components/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/components/error";

--- a/app/components/page.tsx
+++ b/app/components/page.tsx
@@ -1,2 +1,2 @@
-export { metadata } from "../../src/app/components/page";
+export { metadata, dynamic } from "../../src/app/components/page";
 export { default } from "../../src/app/components/page";

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../src/app/error";

--- a/app/goals/error.tsx
+++ b/app/goals/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/goals/error";

--- a/app/goals/page.tsx
+++ b/app/goals/page.tsx
@@ -1,2 +1,2 @@
-export { metadata } from "../../src/app/goals/page";
+export { metadata, dynamic } from "../../src/app/goals/page";
 export { default } from "../../src/app/goals/page";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,2 +1,2 @@
-export { metadata } from "../src/app/page";
+export { metadata, dynamic } from "../src/app/page";
 export { default } from "../src/app/page";

--- a/app/planner/error.tsx
+++ b/app/planner/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/planner/error";

--- a/app/planner/page.tsx
+++ b/app/planner/page.tsx
@@ -1,2 +1,2 @@
-export { metadata } from "../../src/app/planner/page";
+export { metadata, dynamic } from "../../src/app/planner/page";
 export { default } from "../../src/app/planner/page";

--- a/app/prompts/error.tsx
+++ b/app/prompts/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/prompts/error";

--- a/app/prompts/page.tsx
+++ b/app/prompts/page.tsx
@@ -1,2 +1,2 @@
-export { metadata } from "../../src/app/prompts/page";
+export { metadata, dynamic } from "../../src/app/prompts/page";
 export { default } from "../../src/app/prompts/page";

--- a/app/reviews/error.tsx
+++ b/app/reviews/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/reviews/error";

--- a/app/reviews/page.tsx
+++ b/app/reviews/page.tsx
@@ -1,2 +1,2 @@
-export { metadata } from "../../src/app/reviews/page";
+export { metadata, dynamic } from "../../src/app/reviews/page";
 export { default } from "../../src/app/reviews/page";

--- a/app/team/error.tsx
+++ b/app/team/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/team/error";

--- a/app/team/page.tsx
+++ b/app/team/page.tsx
@@ -1,2 +1,2 @@
-export { metadata } from "../../src/app/team/page";
+export { metadata, dynamic } from "../../src/app/team/page";
 export { default } from "../../src/app/team/page";

--- a/src/app/components/error.tsx
+++ b/src/app/components/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../error";

--- a/src/app/components/page.tsx
+++ b/src/app/components/page.tsx
@@ -3,6 +3,8 @@ import { Suspense } from "react";
 import ComponentsPage from "@/components/components/ComponentsPage";
 import { PageShell, Spinner } from "@/components/ui";
 
+export const dynamic = "force-static";
+
 export const metadata: Metadata = {
   title: "Components",
   description: "Browse Planner UI building blocks and examples.",
@@ -12,7 +14,7 @@ export default function ComponentsRoute() {
   return (
     <Suspense
       fallback={
-        <PageShell as="main" aria-busy="true">
+        <PageShell as="section" aria-busy="true" role="status">
           <div className="flex justify-center p-[var(--space-5)]">
             <Spinner />
           </div>

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { Button, PageShell } from "@/components/ui";
+
+type RouteError = Error & { digest?: string };
+
+type ErrorBoundaryProps = {
+  error: RouteError;
+  reset: () => void;
+};
+
+export default function RouteErrorBoundary({ error, reset }: ErrorBoundaryProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <PageShell
+      as="section"
+      role="alert"
+      aria-live="assertive"
+      className="py-[var(--space-8)]"
+    >
+      <div className="flex max-w-prose flex-col gap-[var(--space-4)]">
+        <div className="space-y-[var(--space-2)]">
+          <h1 className="text-display-sm font-semibold text-foreground">
+            Something went wrong
+          </h1>
+          <p className="text-body text-muted-foreground">
+            This section hit an error, but the rest of Planner is still running. Try again or return home.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-[var(--space-3)]">
+          <Button variant="primary" onClick={reset}>
+            Try again
+          </Button>
+          <Button asChild variant="ghost">
+            <Link href="/">Go to dashboard</Link>
+          </Button>
+        </div>
+      </div>
+    </PageShell>
+  );
+}

--- a/src/app/goals/error.tsx
+++ b/src/app/goals/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../error";

--- a/src/app/goals/page.tsx
+++ b/src/app/goals/page.tsx
@@ -1,6 +1,8 @@
 import { type Metadata } from "next";
 import { GoalsPage } from "@/components/goals";
 
+export const dynamic = "force-static";
+
 export const metadata: Metadata = {
   title: "Goals",
   description: "Track and manage your goals.",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -73,6 +73,14 @@ export default async function RootLayout({
         >
           Skip to main content
         </a>
+        <noscript>
+          <div
+            role="status"
+            className="w-full border-b border-border bg-surface px-[var(--space-4)] py-[var(--space-2)] text-center text-ui font-medium text-foreground"
+          >
+            Animations stay optional—Planner works fully without JavaScript.
+          </div>
+        </noscript>
         <StyledJsxRegistry nonce={nonce}>
           <ThemeProvider>
             <div aria-hidden className="page-backdrop">

--- a/src/app/page-client.tsx
+++ b/src/app/page-client.tsx
@@ -99,7 +99,8 @@ function HomePageBody({ themeVariant }: { themeVariant: Variant }) {
         )}
       </PageShell>
       <PageShell
-        as="main"
+        as="section"
+        role="region"
         aria-labelledby="home-header"
         className="mt-[var(--space-6)] pb-[var(--space-6)] md:mt-[var(--space-8)] md:pb-[var(--space-8)]"
       >
@@ -120,7 +121,7 @@ export default function Page() {
   return (
     <Suspense
       fallback={
-        <PageShell as="main" aria-busy="true">
+        <PageShell as="section" aria-busy="true" role="status">
           <div className="flex justify-center p-[var(--space-6)]">
             <Spinner />
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 
+export const dynamic = "force-static";
+
 export const metadata: Metadata = {
   title: "Planner · Your day at a glance",
   description:

--- a/src/app/planner/error.tsx
+++ b/src/app/planner/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../error";

--- a/src/app/planner/page.tsx
+++ b/src/app/planner/page.tsx
@@ -4,6 +4,8 @@
 import type { Metadata } from "next";
 import { PlannerPage } from "@/components/planner";
 
+export const dynamic = "force-static";
+
 export const metadata: Metadata = {
   title: "Planner",
   description: "Organize your tasks and goals using the Planner.",

--- a/src/app/prompts/error.tsx
+++ b/src/app/prompts/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../error";

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import PromptsPage from "@/components/prompts/PromptsPage";
 
+export const dynamic = "force-static";
+
 export const metadata: Metadata = {
   title: "Saved Prompts Library",
   description:

--- a/src/app/reviews/error.tsx
+++ b/src/app/reviews/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../error";

--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -2,6 +2,8 @@
 import type { Metadata } from "next";
 import { ReviewPage } from "@/components/reviews";
 
+export const dynamic = "force-static";
+
 export const metadata: Metadata = {
   title: "Reviews",
   description: "Browse community reviews",

--- a/src/app/team/error.tsx
+++ b/src/app/team/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../error";

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import TeamCompPage from "@/components/team/TeamCompPage";
 
+export const dynamic = "force-static";
+
 export const metadata: Metadata = {
   title: "Team",
   description: "Meet the team behind Planner.",


### PR DESCRIPTION
## Summary
- add a `<noscript>` banner and keep page content under a single semantic `<main>` wrapper
- force static generation on top-level routes while keeping Suspense fallbacks regional
- add shared error boundaries for each route segment so individual pages fail gracefully

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3d5d86490832c8fc370966e656aff