### PR TITLE
Align hero planner layout with subgrid

### DIFF
--- a/src/components/home/HeroPlannerCards.tsx
+++ b/src/components/home/HeroPlannerCards.tsx
@@ -38,13 +38,15 @@ export default function HeroPlannerCards({
   return (
     <div
       className={cn(
-        "space-y-[var(--space-7)]",
+        "grid grid-cols-1 gap-y-[var(--space-7)] md:grid-cols-12",
         "relative z-10 isolate rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 shadow-neoSoft backdrop-blur-lg",
         "p-[var(--space-4)] md:p-[var(--space-5)]",
         className,
       )}
     >
-      <div className="grid items-start gap-[var(--space-4)] md:grid-cols-12">
+      <div
+        className="col-span-full grid items-start gap-[var(--space-4)] md:grid-cols-12 supports-[grid-template-columns:subgrid]:md:[grid-template-columns:subgrid]"
+      >
         <div className="md:col-span-6">
           <QuickActions />
         </div>
@@ -52,10 +54,13 @@ export default function HeroPlannerCards({
           <IsometricRoom variant={variant} />
         </div>
       </div>
-      <div className="pt-[var(--space-4)]">
-        <PlannerOverview {...plannerOverviewProps} />
-      </div>
-      <section className="grid grid-cols-1 gap-[var(--space-6)] md:grid-cols-12">
+      <PlannerOverview
+        {...plannerOverviewProps}
+        className="pt-[var(--space-4)]"
+      />
+      <section
+        className="col-span-full grid grid-cols-1 gap-[var(--space-6)] md:grid-cols-12 supports-[grid-template-columns:subgrid]:md:[grid-template-columns:subgrid]"
+      >
         <div className="md:col-span-4">
           <TodayCard />
         </div>

--- a/src/components/home/home-landing/PlannerOverview.tsx
+++ b/src/components/home/home-landing/PlannerOverview.tsx
@@ -6,22 +6,34 @@ import PlannerOverviewFocusCard from "./PlannerOverviewFocusCard";
 import PlannerOverviewGoalsCard from "./PlannerOverviewGoalsCard";
 import PlannerOverviewSummaryCard from "./PlannerOverviewSummaryCard";
 import type { PlannerOverviewProps } from "./types";
+import { cn } from "@/lib/utils";
+
+interface PlannerOverviewComponentProps extends PlannerOverviewProps {
+  className?: string;
+}
 
 export default function PlannerOverview({
   summary,
   focus,
   goals,
   calendar,
-}: PlannerOverviewProps) {
+  className,
+}: PlannerOverviewComponentProps) {
   return React.useMemo(
     () => (
-      <div className="grid grid-cols-12 gap-[var(--space-5)]">
+      <div
+        className={cn(
+          "col-span-full grid grid-cols-12 gap-[var(--space-5)]",
+          "supports-[grid-template-columns:subgrid]:md:[grid-template-columns:subgrid]",
+          className,
+        )}
+      >
         <PlannerOverviewSummaryCard {...summary} />
         <PlannerOverviewFocusCard {...focus} />
         <PlannerOverviewGoalsCard {...goals} />
         <PlannerOverviewCalendarCard {...calendar} />
       </div>
     ),
-    [calendar, focus, goals, summary],
+    [calendar, className, focus, goals, summary],
   );
 }


### PR DESCRIPTION
## Summary
- convert the hero planner surface to a grid/subgrid layout so quick actions, overview, and dashboard sections share the same column tracks
- allow PlannerOverview to receive custom classes and adopt subgrid columns, keeping its cards aligned with the parent grid

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3d5acc1f0832c9150839da908abb4