### PR TITLE
Add skeleton loading and error states to App Router routes

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../src/app/error";

--- a/app/goals/error.tsx
+++ b/app/goals/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/goals/error";

--- a/app/goals/loading.tsx
+++ b/app/goals/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/goals/loading";

--- a/app/goals/template.tsx
+++ b/app/goals/template.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/goals/template";

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../src/app/loading";

--- a/app/planner/error.tsx
+++ b/app/planner/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/planner/error";

--- a/app/planner/loading.tsx
+++ b/app/planner/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/planner/loading";

--- a/app/planner/template.tsx
+++ b/app/planner/template.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/planner/template";

--- a/app/prompts/error.tsx
+++ b/app/prompts/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/prompts/error";

--- a/app/prompts/loading.tsx
+++ b/app/prompts/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/prompts/loading";

--- a/app/prompts/template.tsx
+++ b/app/prompts/template.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/prompts/template";

--- a/app/reviews/error.tsx
+++ b/app/reviews/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/reviews/error";

--- a/app/reviews/loading.tsx
+++ b/app/reviews/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/reviews/loading";

--- a/app/reviews/template.tsx
+++ b/app/reviews/template.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/reviews/template";

--- a/app/team/error.tsx
+++ b/app/team/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/team/error";

--- a/app/team/loading.tsx
+++ b/app/team/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/team/loading";

--- a/app/team/template.tsx
+++ b/app/team/template.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/app/team/template";

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -1,0 +1,1 @@
+export { default } from "../src/app/template";

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+import type { JSX } from "react";
+import { Button, PageShell } from "@/components/ui";
+
+type ErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function ErrorState({ error, reset }: ErrorProps): JSX.Element {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <PageShell
+      as="main"
+      role="alert"
+      aria-live="assertive"
+      className="flex min-h-[calc(var(--space-8)*5)] flex-col items-center justify-center gap-[var(--space-4)] py-[var(--space-8)] text-center"
+    >
+      <div className="space-y-[var(--space-3)]">
+        <p className="text-title font-semibold tracking-[-0.01em] text-foreground">
+          We lost the thread.
+        </p>
+        <p className="text-ui text-muted-foreground">
+          Something went sideways while loading the home experience. Let’s try that again.
+        </p>
+      </div>
+      <Button variant="primary" size="md" onClick={() => reset()}>
+        Retry load
+      </Button>
+    </PageShell>
+  );
+}

--- a/src/app/goals/error.tsx
+++ b/src/app/goals/error.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+import type { JSX } from "react";
+import { Button, PageShell } from "@/components/ui";
+
+type ErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function GoalsError({ error, reset }: ErrorProps): JSX.Element {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <PageShell
+      as="main"
+      role="alert"
+      aria-live="assertive"
+      className="flex min-h-[calc(var(--space-8)*5)] flex-col items-center justify-center gap-[var(--space-4)] py-[var(--space-8)] text-center"
+    >
+      <div className="space-y-[var(--space-3)]">
+        <p className="text-title font-semibold tracking-[-0.01em] text-foreground">
+          Goals couldn’t load.
+        </p>
+        <p className="text-ui text-muted-foreground">
+          Refresh to restore your goals and reminders. We saved your latest edits.
+        </p>
+      </div>
+      <Button variant="primary" size="md" onClick={() => reset()}>
+        Retry goals
+      </Button>
+    </PageShell>
+  );
+}

--- a/src/app/goals/loading.tsx
+++ b/src/app/goals/loading.tsx
@@ -1,0 +1,59 @@
+import type { JSX } from "react";
+import { PageShell, Skeleton } from "@/components/ui";
+
+export default function Loading(): JSX.Element {
+  return (
+    <PageShell
+      as="main"
+      aria-busy="true"
+      className="space-y-[var(--space-5)] py-[var(--space-6)]"
+    >
+      <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/40 p-[var(--space-5)] shadow-neoSoft">
+        <div className="flex flex-col gap-[var(--space-4)] md:flex-row md:items-end md:justify-between">
+          <div className="space-y-[var(--space-3)]">
+            <Skeleton className="h-[var(--space-5)] w-full max-w-[calc(var(--space-8)*3)]" />
+            <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*4)]" />
+          </div>
+          <div className="flex shrink-0 flex-wrap gap-[var(--space-3)]">
+            <Skeleton className="h-[var(--control-h-md)] w-[calc(var(--space-8)*2)] rounded-[var(--control-radius)]" />
+            <Skeleton className="h-[var(--control-h-md)] w-[calc(var(--space-8)*2)] rounded-[var(--control-radius)]" />
+            <Skeleton className="h-[var(--control-h-md)] w-[calc(var(--space-8)*2)] rounded-[var(--control-radius)]" />
+          </div>
+        </div>
+      </div>
+      <div className="grid gap-[var(--space-4)] md:grid-cols-12 lg:gap-[var(--space-5)]">
+        <div className="space-y-[var(--space-4)] md:col-span-7">
+          <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 p-[var(--space-4)] shadow-neoSoft">
+            <div className="space-y-[var(--space-3)]">
+              <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*3)]" />
+              <Skeleton className="h-[calc(var(--space-8)+var(--space-2))] w-full rounded-[var(--radius-xl)]" />
+              <Skeleton className="h-[calc(var(--space-8)+var(--space-2))] w-full rounded-[var(--radius-xl)]" />
+              <Skeleton className="h-[calc(var(--space-8)+var(--space-2))] w-full rounded-[var(--radius-xl)]" />
+            </div>
+          </div>
+          <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 p-[var(--space-4)] shadow-neoSoft">
+            <div className="space-y-[var(--space-3)]">
+              <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*2)]" />
+              <Skeleton className="h-[calc(var(--space-8)*2)] w-full rounded-[var(--radius-xl)]" />
+            </div>
+          </div>
+        </div>
+        <div className="space-y-[var(--space-4)] md:col-span-5">
+          <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 p-[var(--space-4)] shadow-neoSoft">
+            <div className="space-y-[var(--space-3)]">
+              <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*2)]" />
+              <Skeleton className="h-[calc(var(--space-8)+var(--space-3))] w-full rounded-[var(--radius-xl)]" />
+            </div>
+          </div>
+          <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 p-[var(--space-4)] shadow-neoSoft">
+            <div className="space-y-[var(--space-3)]">
+              <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*2)]" />
+              <Skeleton className="h-[calc(var(--space-8)*2)] w-full rounded-[var(--radius-xl)]" />
+              <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*2)]" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </PageShell>
+  );
+}

--- a/src/app/goals/template.tsx
+++ b/src/app/goals/template.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+interface GoalsTemplateProps {
+  children: ReactNode;
+}
+
+export default function GoalsTemplate({ children }: GoalsTemplateProps): ReactNode {
+  return <>{children}</>;
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,44 @@
+import type { JSX } from "react";
+import { PageShell, Skeleton } from "@/components/ui";
+
+export default function Loading(): JSX.Element {
+  return (
+    <>
+      <PageShell as="header" aria-busy="true" className="pt-[var(--space-6)]">
+        <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/40 p-[var(--space-5)] shadow-neoSoft backdrop-blur-md">
+          <div className="flex flex-col gap-[var(--space-4)] md:flex-row md:items-center md:justify-between">
+            <div className="space-y-[var(--space-3)]">
+              <Skeleton className="h-[var(--space-5)] w-full max-w-[calc(var(--space-8)*3)]" />
+              <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*4)]" />
+            </div>
+            <div className="flex shrink-0 flex-col gap-[var(--space-3)] md:flex-row">
+              <Skeleton className="h-[var(--control-h-md)] w-[calc(var(--space-8)*2)] rounded-[var(--control-radius)]" />
+              <Skeleton className="h-[var(--control-h-md)] w-[calc(var(--space-8)*2)] rounded-[var(--control-radius)]" />
+            </div>
+          </div>
+        </div>
+      </PageShell>
+      <PageShell
+        as="main"
+        aria-busy="true"
+        className="mt-[var(--space-6)] pb-[var(--space-6)] md:mt-[var(--space-8)] md:pb-[var(--space-8)]"
+      >
+        <div className="space-y-[var(--space-5)]">
+          <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 p-[var(--space-5)] shadow-neoSoft backdrop-blur-md">
+            <div className="grid gap-[var(--space-4)] md:grid-cols-12 lg:gap-[var(--space-5)]">
+              <div className="space-y-[var(--space-3)] md:col-span-7">
+                <Skeleton className="h-[var(--space-6)] w-full max-w-[calc(var(--space-8)*3)]" />
+                <Skeleton className="h-[calc(var(--space-8)+var(--space-2))] w-full rounded-[var(--radius-xl)]" />
+                <Skeleton className="h-[calc(var(--space-8)+var(--space-2))] w-full rounded-[var(--radius-xl)]" />
+              </div>
+              <div className="space-y-[var(--space-3)] md:col-span-5">
+                <Skeleton className="h-[var(--space-6)] w-full max-w-[calc(var(--space-8)*3)]" />
+                <Skeleton className="h-[calc(var(--space-8)*2)] w-full rounded-[var(--radius-xl)]" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </PageShell>
+    </>
+  );
+}

--- a/src/app/planner/error.tsx
+++ b/src/app/planner/error.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+import type { JSX } from "react";
+import { Button, PageShell } from "@/components/ui";
+
+type ErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function PlannerError({ error, reset }: ErrorProps): JSX.Element {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <PageShell
+      as="main"
+      role="alert"
+      aria-live="assertive"
+      className="flex min-h-[calc(var(--space-8)*5)] flex-col items-center justify-center gap-[var(--space-4)] py-[var(--space-8)] text-center"
+    >
+      <div className="space-y-[var(--space-3)]">
+        <p className="text-title font-semibold tracking-[-0.01em] text-foreground">
+          Planner hit a snag.
+        </p>
+        <p className="text-ui text-muted-foreground">
+          Reload to recover your workspace. Draft edits are stored locally until sync resumes.
+        </p>
+      </div>
+      <Button variant="primary" size="md" onClick={() => reset()}>
+        Retry planner
+      </Button>
+    </PageShell>
+  );
+}

--- a/src/app/planner/loading.tsx
+++ b/src/app/planner/loading.tsx
@@ -1,0 +1,63 @@
+import type { JSX } from "react";
+import { PageShell, Skeleton } from "@/components/ui";
+
+export default function Loading(): JSX.Element {
+  return (
+    <PageShell
+      as="main"
+      aria-busy="true"
+      className="space-y-[var(--space-5)] py-[var(--space-6)]"
+    >
+      <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/40 p-[var(--space-5)] shadow-neoSoft">
+        <div className="flex flex-wrap items-center justify-between gap-[var(--space-4)]">
+          <div className="space-y-[var(--space-2)]">
+            <Skeleton className="h-[var(--space-5)] w-full max-w-[calc(var(--space-8)*3)]" />
+            <Skeleton className="h-[var(--space-3)] w-full max-w-[calc(var(--space-8)*4)]" />
+          </div>
+          <div className="flex shrink-0 flex-wrap gap-[var(--space-3)]">
+            <Skeleton className="h-[var(--control-h-md)] w-[calc(var(--space-8)*2)] rounded-[var(--control-radius)]" />
+            <Skeleton className="h-[var(--control-h-md)] w-[calc(var(--space-8)*2)] rounded-[var(--control-radius)]" />
+            <Skeleton className="h-[var(--control-h-md)] w-[calc(var(--space-8)*2)] rounded-[var(--control-radius)]" />
+          </div>
+        </div>
+      </div>
+      <div className="grid gap-[var(--space-4)] md:grid-cols-12 lg:gap-[var(--space-5)]">
+        <div className="space-y-[var(--space-4)] md:col-span-8">
+          <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 p-[var(--space-4)] shadow-neoSoft">
+            <div className="grid gap-[var(--space-3)] md:grid-cols-7">
+              <Skeleton className="h-[calc(var(--space-8)+var(--space-2))] rounded-[var(--radius-xl)] md:col-span-1" />
+              <Skeleton className="h-[calc(var(--space-8)*3)] rounded-[var(--radius-xl)] md:col-span-6" />
+            </div>
+            <div className="mt-[var(--space-4)] grid gap-[var(--space-3)] md:grid-cols-3">
+              <Skeleton className="h-[calc(var(--space-8)*2)] rounded-[var(--radius-xl)]" />
+              <Skeleton className="h-[calc(var(--space-8)*2)] rounded-[var(--radius-xl)]" />
+              <Skeleton className="h-[calc(var(--space-8)*2)] rounded-[var(--radius-xl)]" />
+            </div>
+          </div>
+          <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 p-[var(--space-4)] shadow-neoSoft">
+            <div className="space-y-[var(--space-3)]">
+              <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*3)]" />
+              <Skeleton className="h-[calc(var(--space-8)*2)] w-full rounded-[var(--radius-xl)]" />
+              <Skeleton className="h-[calc(var(--space-8)*2)] w-full rounded-[var(--radius-xl)]" />
+            </div>
+          </div>
+        </div>
+        <div className="space-y-[var(--space-4)] md:col-span-4">
+          <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 p-[var(--space-4)] shadow-neoSoft">
+            <div className="space-y-[var(--space-3)]">
+              <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*2)]" />
+              <Skeleton className="h-[calc(var(--space-8)*2)] w-full rounded-[var(--radius-xl)]" />
+              <Skeleton className="h-[calc(var(--space-8)+var(--space-2))] w-full rounded-[var(--radius-xl)]" />
+            </div>
+          </div>
+          <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 p-[var(--space-4)] shadow-neoSoft">
+            <div className="space-y-[var(--space-3)]">
+              <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*2)]" />
+              <Skeleton className="h-[calc(var(--space-8)*2)] w-full rounded-[var(--radius-xl)]" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </PageShell>
+  );
+}

--- a/src/app/planner/template.tsx
+++ b/src/app/planner/template.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+interface PlannerTemplateProps {
+  children: ReactNode;
+}
+
+export default function PlannerTemplate({ children }: PlannerTemplateProps): ReactNode {
+  return <>{children}</>;
+}

--- a/src/app/prompts/error.tsx
+++ b/src/app/prompts/error.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+import type { JSX } from "react";
+import { Button, PageShell } from "@/components/ui";
+
+type ErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function PromptsError({ error, reset }: ErrorProps): JSX.Element {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <PageShell
+      as="main"
+      role="alert"
+      aria-live="assertive"
+      className="flex min-h-[calc(var(--space-8)*5)] flex-col items-center justify-center gap-[var(--space-4)] py-[var(--space-8)] text-center"
+    >
+      <div className="space-y-[var(--space-3)]">
+        <p className="text-title font-semibold tracking-[-0.01em] text-foreground">
+          Prompts are offline.
+        </p>
+        <p className="text-ui text-muted-foreground">
+          Try reloading to reconnect your saved prompt library and component demos.
+        </p>
+      </div>
+      <Button variant="primary" size="md" onClick={() => reset()}>
+        Retry prompts
+      </Button>
+    </PageShell>
+  );
+}

--- a/src/app/prompts/loading.tsx
+++ b/src/app/prompts/loading.tsx
@@ -1,0 +1,55 @@
+import type { JSX } from "react";
+import { PageShell, Skeleton } from "@/components/ui";
+
+export default function Loading(): JSX.Element {
+  return (
+    <PageShell
+      as="main"
+      aria-busy="true"
+      className="space-y-[var(--space-5)] py-[var(--space-6)]"
+    >
+      <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/40 p-[var(--space-5)] shadow-neoSoft">
+        <div className="space-y-[var(--space-3)]">
+          <Skeleton className="h-[var(--space-5)] w-full max-w-[calc(var(--space-8)*3)]" />
+          <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*5)]" />
+          <div className="flex flex-wrap gap-[var(--space-3)] pt-[var(--space-2)]">
+            <Skeleton className="h-[var(--control-h-md)] w-[calc(var(--space-8)*2)] rounded-[var(--control-radius)]" />
+            <Skeleton className="h-[var(--control-h-md)] w-[calc(var(--space-8)*2)] rounded-[var(--control-radius)]" />
+            <Skeleton className="h-[var(--control-h-md)] w-[calc(var(--space-8)*2)] rounded-[var(--control-radius)]" />
+          </div>
+        </div>
+      </div>
+      <div className="grid gap-[var(--space-4)] md:grid-cols-12 lg:gap-[var(--space-5)]">
+        <div className="space-y-[var(--space-4)] md:col-span-8">
+          {[0, 1, 2].map((index) => (
+            <div
+              key={`prompt-card-${index}`}
+              className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 p-[var(--space-4)] shadow-neoSoft"
+            >
+              <div className="space-y-[var(--space-3)]">
+                <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*3)]" />
+                <Skeleton className="h-[calc(var(--space-8)+var(--space-2))] w-full rounded-[var(--radius-xl)]" />
+                <Skeleton className="h-[calc(var(--space-8)+var(--space-2))] w-full rounded-[var(--radius-xl)]" />
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="space-y-[var(--space-4)] md:col-span-4">
+          <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 p-[var(--space-4)] shadow-neoSoft">
+            <div className="space-y-[var(--space-3)]">
+              <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*2)]" />
+              <Skeleton className="h-[calc(var(--space-8)*2)] w-full rounded-[var(--radius-xl)]" />
+              <Skeleton className="h-[calc(var(--space-8)*2)] w-full rounded-[var(--radius-xl)]" />
+            </div>
+          </div>
+          <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 p-[var(--space-4)] shadow-neoSoft">
+            <div className="space-y-[var(--space-3)]">
+              <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*2)]" />
+              <Skeleton className="h-[calc(var(--space-8)+var(--space-3))] w-full rounded-[var(--radius-xl)]" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </PageShell>
+  );
+}

--- a/src/app/prompts/template.tsx
+++ b/src/app/prompts/template.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+interface PromptsTemplateProps {
+  children: ReactNode;
+}
+
+export default function PromptsTemplate({ children }: PromptsTemplateProps): ReactNode {
+  return <>{children}</>;
+}

--- a/src/app/reviews/error.tsx
+++ b/src/app/reviews/error.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+import type { JSX } from "react";
+import { Button, PageShell } from "@/components/ui";
+
+type ErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function ReviewsError({ error, reset }: ErrorProps): JSX.Element {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <PageShell
+      as="main"
+      role="alert"
+      aria-live="assertive"
+      className="flex min-h-[calc(var(--space-8)*5)] flex-col items-center justify-center gap-[var(--space-4)] py-[var(--space-8)] text-center"
+    >
+      <div className="space-y-[var(--space-3)]">
+        <p className="text-title font-semibold tracking-[-0.01em] text-foreground">
+          Reviews timed out.
+        </p>
+        <p className="text-ui text-muted-foreground">
+          Give it another try to pull the latest recaps and match history markers.
+        </p>
+      </div>
+      <Button variant="primary" size="md" onClick={() => reset()}>
+        Retry reviews
+      </Button>
+    </PageShell>
+  );
+}

--- a/src/app/reviews/loading.tsx
+++ b/src/app/reviews/loading.tsx
@@ -1,0 +1,59 @@
+import type { JSX } from "react";
+import { PageShell, Skeleton } from "@/components/ui";
+
+export default function Loading(): JSX.Element {
+  return (
+    <PageShell
+      as="main"
+      aria-busy="true"
+      className="space-y-[var(--space-5)] py-[var(--space-6)]"
+    >
+      <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/40 p-[var(--space-5)] shadow-neoSoft">
+        <div className="flex flex-wrap items-center justify-between gap-[var(--space-4)]">
+          <div className="space-y-[var(--space-3)]">
+            <Skeleton className="h-[var(--space-5)] w-full max-w-[calc(var(--space-8)*3)]" />
+            <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*4)]" />
+          </div>
+          <div className="flex shrink-0 flex-wrap gap-[var(--space-3)]">
+            <Skeleton className="h-[var(--control-h-md)] w-[calc(var(--space-8)*2)] rounded-[var(--control-radius)]" />
+            <Skeleton className="h-[var(--control-h-md)] w-[calc(var(--space-8)*2)] rounded-[var(--control-radius)]" />
+          </div>
+        </div>
+      </div>
+      <div className="grid gap-[var(--space-4)] md:grid-cols-12 lg:gap-[var(--space-5)]">
+        <div className="space-y-[var(--space-4)] md:col-span-7">
+          {[0, 1, 2].map((index) => (
+            <div
+              key={`review-card-${index}`}
+              className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 p-[var(--space-4)] shadow-neoSoft"
+            >
+              <div className="flex flex-col gap-[var(--space-3)] md:flex-row md:items-start md:gap-[var(--space-4)]">
+                <Skeleton className="h-[calc(var(--space-8)+var(--space-2))] w-full rounded-[var(--radius-xl)] md:w-[calc(var(--space-8)*3)]" />
+                <div className="flex-1 space-y-[var(--space-3)]">
+                  <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*3)]" />
+                  <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*2+var(--space-4))]" />
+                  <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*2)]" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="space-y-[var(--space-4)] md:col-span-5">
+          <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 p-[var(--space-4)] shadow-neoSoft">
+            <div className="space-y-[var(--space-3)]">
+              <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*2)]" />
+              <Skeleton className="h-[calc(var(--space-8)*2)] w-full rounded-[var(--radius-xl)]" />
+              <Skeleton className="h-[calc(var(--space-8)*2)] w-full rounded-[var(--radius-xl)]" />
+            </div>
+          </div>
+          <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 p-[var(--space-4)] shadow-neoSoft">
+            <div className="space-y-[var(--space-3)]">
+              <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*2)]" />
+              <Skeleton className="h-[calc(var(--space-8)+var(--space-3))] w-full rounded-[var(--radius-xl)]" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </PageShell>
+  );
+}

--- a/src/app/reviews/template.tsx
+++ b/src/app/reviews/template.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+interface ReviewsTemplateProps {
+  children: ReactNode;
+}
+
+export default function ReviewsTemplate({ children }: ReviewsTemplateProps): ReactNode {
+  return <>{children}</>;
+}

--- a/src/app/team/error.tsx
+++ b/src/app/team/error.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+import type { JSX } from "react";
+import { Button, PageShell } from "@/components/ui";
+
+type ErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function TeamError({ error, reset }: ErrorProps): JSX.Element {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <PageShell
+      as="main"
+      role="alert"
+      aria-live="assertive"
+      className="flex min-h-[calc(var(--space-8)*5)] flex-col items-center justify-center gap-[var(--space-4)] py-[var(--space-8)] text-center"
+    >
+      <div className="space-y-[var(--space-3)]">
+        <p className="text-title font-semibold tracking-[-0.01em] text-foreground">
+          Team roster failed to load.
+        </p>
+        <p className="text-ui text-muted-foreground">
+          Give the page a quick refresh to bring back the roster and highlight reels.
+        </p>
+      </div>
+      <Button variant="primary" size="md" onClick={() => reset()}>
+        Retry team page
+      </Button>
+    </PageShell>
+  );
+}

--- a/src/app/team/loading.tsx
+++ b/src/app/team/loading.tsx
@@ -1,0 +1,43 @@
+import type { JSX } from "react";
+import { PageShell, Skeleton } from "@/components/ui";
+
+export default function Loading(): JSX.Element {
+  return (
+    <PageShell
+      as="main"
+      aria-busy="true"
+      className="space-y-[var(--space-5)] py-[var(--space-6)]"
+    >
+      <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/40 p-[var(--space-5)] shadow-neoSoft">
+        <div className="grid gap-[var(--space-4)] md:grid-cols-12 lg:gap-[var(--space-5)]">
+          <div className="space-y-[var(--space-3)] md:col-span-7">
+            <Skeleton className="h-[var(--space-5)] w-full max-w-[calc(var(--space-8)*3)]" />
+            <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*4)]" />
+            <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*3)]" />
+          </div>
+          <div className="flex flex-col gap-[var(--space-3)] md:col-span-5">
+            <Skeleton className="h-[var(--control-h-md)] w-full rounded-[var(--control-radius)]" />
+            <Skeleton className="h-[var(--control-h-md)] w-full rounded-[var(--control-radius)]" />
+          </div>
+        </div>
+      </div>
+      <div className="grid gap-[var(--space-4)] md:grid-cols-12 lg:gap-[var(--space-5)]">
+        {[0, 1, 2, 3].map((index) => (
+          <div
+            key={`team-card-${index}`}
+            className="rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 p-[var(--space-4)] shadow-neoSoft md:col-span-6"
+          >
+            <div className="flex flex-col gap-[var(--space-3)] sm:flex-row sm:items-center sm:gap-[var(--space-4)]">
+              <Skeleton className="h-[calc(var(--space-8)+var(--space-2))] w-full rounded-full sm:h-[calc(var(--space-8)*2)] sm:w-[calc(var(--space-8)*2)]" />
+              <div className="flex-1 space-y-[var(--space-3)]">
+                <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*3)]" />
+                <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*2+var(--space-4))]" />
+                <Skeleton className="h-[var(--space-4)] w-full max-w-[calc(var(--space-8)*2)]" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </PageShell>
+  );
+}

--- a/src/app/team/template.tsx
+++ b/src/app/team/template.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+interface TeamTemplateProps {
+  children: ReactNode;
+}
+
+export default function TeamTemplate({ children }: TeamTemplateProps): ReactNode {
+  return <>{children}</>;
+}

--- a/src/app/template.tsx
+++ b/src/app/template.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+interface TemplateProps {
+  children: ReactNode;
+}
+
+export default function Template({ children }: TemplateProps): ReactNode {
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- add loading skeleton views for the home, goals, planner, prompts, reviews, and team routes
- wire up localized error boundaries and templates for the same routes to support reset flows
- expose the new components through app directory re-exports so the App Router picks them up

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3d5c0ba3c832c8079f73ccda5105e