### PR TITLE
Fix root layout theming metadata and safe-area spacing

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,7 @@ import {
   geistSansClassName,
   geistSansVariable,
 } from "./fonts";
+import tokens from "../../tokens/tokens.js";
 import SiteChrome from "@/components/chrome/SiteChrome";
 import { CatCompanion, PageShell } from "@/components/ui";
 import { withBasePath } from "@/lib/utils";
@@ -24,6 +25,16 @@ export const metadata: Metadata = {
     template: "%s · Planner",
   },
   description: "Local-first planner for organizing tasks and goals",
+  themeColor: [
+    {
+      media: "(prefers-color-scheme: dark)",
+      color: `hsl(${tokens.background})`,
+    },
+    {
+      media: "(prefers-color-scheme: light)",
+      color: `hsl(${tokens.foreground})`,
+    },
+  ],
 };
 
 /**
@@ -54,9 +65,11 @@ export default async function RootLayout({
       lang="en"
       className="theme-lg"
       suppressHydrationWarning
+      style={{ colorScheme: "dark" }}
     >
       <head>
         {nonce ? <meta property="csp-nonce" content={nonce} /> : null}
+        <meta name="color-scheme" content="dark light" />
         <Script
           id="theme-bootstrap"
           strategy="beforeInteractive"

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -27,7 +27,7 @@ export default function SiteChrome({ children }: SiteChromeProps) {
         {/* Bar content */}
         <PageShell
           grid
-          className="pt-[var(--space-3)] pb-0 md:pb-[var(--space-3)]"
+          className="pt-[calc(env(safe-area-inset-top)+var(--space-3))] pb-0 md:pt-[var(--space-3)] md:pb-[var(--space-3)]"
           contentClassName="items-center"
         >
           <Link


### PR DESCRIPTION
## Summary
- add theme color metadata and color-scheme hints so the root layout renders with dark UI chrome on first paint
- set the initial html color-scheme to dark for SSR and keep CSP nonce handling intact
- pad the sticky SiteChrome header with the safe-area inset before hydration to avoid notch overlap

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3d82d84ec832c8e6d03d500f6e6d7