### PR TITLE
Fix error route reexports to declare client directives

### DIFF
--- a/app/reviews/error.tsx
+++ b/app/reviews/error.tsx
@@ -1,1 +1,3 @@
+"use client";
+
 export { default } from "../../src/app/reviews/error";

--- a/app/team/error.tsx
+++ b/app/team/error.tsx
@@ -1,1 +1,3 @@
+"use client";
+
 export { default } from "../../src/app/team/error";


### PR DESCRIPTION
## Summary
- add the client directive to the reviews error boundary reexport so Next.js treats it as a client component
- add the client directive to the team error boundary reexport for the same reason

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3ddca478c832cbbb2cdfb9b3a4b42