### PR TITLE
Refine PageShell rhythm and safe-area handling

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -25,8 +25,10 @@ This project ships with a small design system based on Tailwind CSS and CSS vari
 - Use a 12‑column grid with 24px gutters.
 - Spacing tokens: `1`=4px, `2`=8px, `3`=12px, `4`=16px, `5`=24px, `6`=32px, `7`=48px, `8`=64px.
 - Wrap page-level content with `.page-shell` or the `<PageShell />` component to get the shared container rhythm: `space-6` on
-  small screens, `space-7` at `md`, and `space-8` at `lg`. Add vertical padding per view instead of redefining horizontal
-  gutters. The shell's maximum width is governed by `--shell-width`, with `--shell-max` available for per-page overrides ([tokens.css](../tokens/tokens.css), [globals.css](../src/app/globals.css)).
+  small screens, `space-7` at `md`, and `space-8` at `lg`. Use the component's `padding` prop to pick spacing tokens and the
+  `stack` prop to manage vertical rhythm between sections. `safeArea="top" | "bottom" | "both"` adds viewport insets for
+  notched displays. The shell's maximum width is governed by `--shell-width`, with `--shell-max` available for per-page overrides
+  ([tokens.css](../tokens/tokens.css), [globals.css](../src/app/globals.css)).
 - When pairing a hero header with body content, place the hero inside a `<PageShell as="header">` before the `<PageShell as="main">`. The main shell automatically exposes `id="main-content"` so the "Skip to main content" link lands after the header frame.
 
 ## Typography

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -37,7 +37,7 @@ export function RouteErrorContent({
       as="section"
       role="alert"
       aria-live="assertive"
-      className="py-[var(--space-8)]"
+      padding={8}
     >
       <div className="flex max-w-prose flex-col gap-[var(--space-4)]">
         <div className="space-y-[var(--space-2)]">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -72,6 +72,137 @@
     max-width: var(--shell-max, var(--shell-width));
     margin-inline: auto;
     padding-inline: var(--space-6);
+    --page-shell-block-start: 0px;
+    --page-shell-block-end: 0px;
+    --page-shell-stack: 0px;
+    --page-shell-safe-area-top: 0px;
+    --page-shell-safe-area-bottom: 0px;
+    padding-block-start: calc(
+      var(--page-shell-block-start) + var(--page-shell-safe-area-top)
+    );
+    padding-block-end: calc(
+      var(--page-shell-block-end) + var(--page-shell-safe-area-bottom)
+    );
+  }
+
+  .page-shell[data-padding-top="0"] {
+    --page-shell-block-start: 0px;
+  }
+
+  .page-shell[data-padding-top="1"] {
+    --page-shell-block-start: var(--space-1);
+  }
+
+  .page-shell[data-padding-top="2"] {
+    --page-shell-block-start: var(--space-2);
+  }
+
+  .page-shell[data-padding-top="3"] {
+    --page-shell-block-start: var(--space-3);
+  }
+
+  .page-shell[data-padding-top="4"] {
+    --page-shell-block-start: var(--space-4);
+  }
+
+  .page-shell[data-padding-top="5"] {
+    --page-shell-block-start: var(--space-5);
+  }
+
+  .page-shell[data-padding-top="6"] {
+    --page-shell-block-start: var(--space-6);
+  }
+
+  .page-shell[data-padding-top="7"] {
+    --page-shell-block-start: var(--space-7);
+  }
+
+  .page-shell[data-padding-top="8"] {
+    --page-shell-block-start: var(--space-8);
+  }
+
+  .page-shell[data-padding-bottom="0"] {
+    --page-shell-block-end: 0px;
+  }
+
+  .page-shell[data-padding-bottom="1"] {
+    --page-shell-block-end: var(--space-1);
+  }
+
+  .page-shell[data-padding-bottom="2"] {
+    --page-shell-block-end: var(--space-2);
+  }
+
+  .page-shell[data-padding-bottom="3"] {
+    --page-shell-block-end: var(--space-3);
+  }
+
+  .page-shell[data-padding-bottom="4"] {
+    --page-shell-block-end: var(--space-4);
+  }
+
+  .page-shell[data-padding-bottom="5"] {
+    --page-shell-block-end: var(--space-5);
+  }
+
+  .page-shell[data-padding-bottom="6"] {
+    --page-shell-block-end: var(--space-6);
+  }
+
+  .page-shell[data-padding-bottom="7"] {
+    --page-shell-block-end: var(--space-7);
+  }
+
+  .page-shell[data-padding-bottom="8"] {
+    --page-shell-block-end: var(--space-8);
+  }
+
+  .page-shell[data-stack="0"] {
+    --page-shell-stack: 0px;
+  }
+
+  .page-shell[data-stack="1"] {
+    --page-shell-stack: var(--space-1);
+  }
+
+  .page-shell[data-stack="2"] {
+    --page-shell-stack: var(--space-2);
+  }
+
+  .page-shell[data-stack="3"] {
+    --page-shell-stack: var(--space-3);
+  }
+
+  .page-shell[data-stack="4"] {
+    --page-shell-stack: var(--space-4);
+  }
+
+  .page-shell[data-stack="5"] {
+    --page-shell-stack: var(--space-5);
+  }
+
+  .page-shell[data-stack="6"] {
+    --page-shell-stack: var(--space-6);
+  }
+
+  .page-shell[data-stack="7"] {
+    --page-shell-stack: var(--space-7);
+  }
+
+  .page-shell[data-stack="8"] {
+    --page-shell-stack: var(--space-8);
+  }
+
+  .page-shell[data-safe-area-top="true"] {
+    --page-shell-safe-area-top: env(safe-area-inset-top);
+  }
+
+  .page-shell[data-safe-area-bottom="true"] {
+    --page-shell-safe-area-bottom: env(safe-area-inset-bottom);
+  }
+
+  .page-shell > :where(*:not([hidden])) + :where(*) {
+    margin-block-start: var(--page-shell-stack);
   }
 
   @media (min-width: 48rem) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -111,7 +111,10 @@ export default async function RootLayout({
                   role="contentinfo"
                   className="mt-[var(--space-8)] border-t border-border bg-surface"
                 >
-                  <PageShell className="flex flex-col gap-[var(--space-1)] py-[var(--space-5)] text-label text-muted-foreground md:flex-row md:items-center md:justify-between">
+                  <PageShell
+                    className="flex flex-col gap-[var(--space-1)] text-label text-muted-foreground md:flex-row md:items-center md:justify-between"
+                    padding={5}
+                  >
                     <p className="text-ui font-medium text-foreground">
                       Planner keeps local-first goals organized so every ritual stays actionable.
                     </p>

--- a/src/app/page-client.tsx
+++ b/src/app/page-client.tsx
@@ -90,7 +90,7 @@ function HomePageBody({ themeVariant }: { themeVariant: Variant }) {
       <PageShell
         as="header"
         aria-labelledby="home-header"
-        className="pt-[var(--space-6)]"
+        padding={{ top: 6, bottom: 0 }}
       >
         {renderFramedSection(
           <div className={cn(heroSurfaceClass, floatingPaddingClass)}>
@@ -102,7 +102,9 @@ function HomePageBody({ themeVariant }: { themeVariant: Variant }) {
         as="section"
         role="region"
         aria-labelledby="home-header"
-        className="mt-[var(--space-6)] pb-[var(--space-6)] md:mt-[var(--space-8)] md:pb-[var(--space-8)]"
+        className="mt-[var(--space-6)] md:mt-[var(--space-8)]"
+        padding={{ top: 0, bottom: 6 }}
+        slots={{ root: "md:[--page-shell-block-end:var(--space-8)]" }}
       >
         {renderFramedSection(
           <HeroPlannerCards

--- a/src/components/chrome/Banner.tsx
+++ b/src/components/chrome/Banner.tsx
@@ -34,8 +34,8 @@ export default function Banner({
     >
       <PageShell
         grid
-        className="py-[var(--space-3)]"
-        contentClassName="items-center"
+        padding={3}
+        slots={{ content: "items-center" }}
       >
         {title ? (
           <div className="col-span-full font-mono text-ui text-muted-foreground md:col-span-8 lg:col-span-9">

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -27,8 +27,13 @@ export default function SiteChrome({ children }: SiteChromeProps) {
         {/* Bar content */}
         <PageShell
           grid
-          className="pt-[calc(env(safe-area-inset-top)+var(--space-3))] pb-0 md:pt-[var(--space-3)] md:pb-[var(--space-3)]"
-          contentClassName="items-center"
+          padding={{ top: 3, bottom: 0 }}
+          safeArea="top"
+          slots={{
+            root:
+              "md:[--page-shell-block-start:var(--space-3)] md:[--page-shell-block-end:var(--space-3)]",
+            content: "items-center",
+          }}
         >
           <Link
             href="/"

--- a/src/components/components/ComponentsPageClient.tsx
+++ b/src/components/components/ComponentsPageClient.tsx
@@ -83,7 +83,11 @@ export default function ComponentsPageClient({
     <>
       <PageShell
         as="header"
-        className="py-[var(--space-6)] md:py-[var(--space-7)] lg:py-[var(--space-8)]"
+        padding={6}
+        slots={{
+          root:
+            "md:[--page-shell-block-start:var(--space-7)] md:[--page-shell-block-end:var(--space-7)] lg:[--page-shell-block-start:var(--space-8)] lg:[--page-shell-block-end:var(--space-8)]",
+        }}
       >
         <PageHeader
           containerClassName="relative isolate col-span-full"
@@ -222,8 +226,13 @@ export default function ComponentsPageClient({
         as="main"
         grid
         aria-labelledby="components-header"
-        className="py-[var(--space-6)] md:py-[var(--space-7)] lg:py-[var(--space-8)]"
-        contentClassName="gap-y-[var(--space-6)] md:gap-y-[var(--space-7)] lg:gap-y-[var(--space-8)]"
+        padding={6}
+        slots={{
+          root:
+            "md:[--page-shell-block-start:var(--space-7)] md:[--page-shell-block-end:var(--space-7)] lg:[--page-shell-block-start:var(--space-8)] lg:[--page-shell-block-end:var(--space-8)]",
+          content:
+            "gap-y-[var(--space-6)] md:gap-y-[var(--space-7)] lg:gap-y-[var(--space-8)]",
+        }}
       >
         <ComponentsGalleryPanels
           view={view}

--- a/src/components/gallery/generated-manifest.ts
+++ b/src/components/gallery/generated-manifest.ts
@@ -1648,7 +1648,7 @@ export const galleryPayload = {
             "shell"
           ],
           "kind": "component",
-          "code": "<PageShell\n  grid\n  className=\"py-[var(--space-6)]\"\n  contentClassName=\"items-start\"\n>\n  <div className=\"col-span-full text-label font-semibold tracking-[0.02em] text-muted-foreground md:col-span-7\">\n    Page shell content\n  </div>\n  <div className=\"col-span-full flex items-center justify-end gap-[var(--space-3)] md:col-span-5 md:justify-self-end\">\n    <Button size=\"sm\">Primary</Button>\n    <Button size=\"sm\" variant=\"ghost\">\n      Secondary\n    </Button>\n  </div>\n</PageShell>",
+          "code": "<PageShell\n  grid\n  padding={6}\n  slots={{ content: \"items-start\" }}\n>\n  <div className=\"col-span-full text-label font-semibold tracking-[0.02em] text-muted-foreground md:col-span-7\">\n    Page shell content\n  </div>\n  <div className=\"col-span-full flex items-center justify-end gap-[var(--space-3)] md:col-span-5 md:justify-self-end\">\n    <Button size=\"sm\">Primary</Button>\n    <Button size=\"sm\" variant=\"ghost\">\n      Secondary\n    </Button>\n  </div>\n</PageShell>",
           "preview": {
             "id": "prompts:layout:page-shell"
           }
@@ -5296,7 +5296,7 @@ export const galleryPayload = {
           "shell"
         ],
         "kind": "component",
-        "code": "<PageShell\n  grid\n  className=\"py-[var(--space-6)]\"\n  contentClassName=\"items-start\"\n>\n  <div className=\"col-span-full text-label font-semibold tracking-[0.02em] text-muted-foreground md:col-span-7\">\n    Page shell content\n  </div>\n  <div className=\"col-span-full flex items-center justify-end gap-[var(--space-3)] md:col-span-5 md:justify-self-end\">\n    <Button size=\"sm\">Primary</Button>\n    <Button size=\"sm\" variant=\"ghost\">\n      Secondary\n    </Button>\n  </div>\n</PageShell>",
+        "code": "<PageShell\n  grid\n  padding={6}\n  slots={{ content: \"items-start\" }}\n>\n  <div className=\"col-span-full text-label font-semibold tracking-[0.02em] text-muted-foreground md:col-span-7\">\n    Page shell content\n  </div>\n  <div className=\"col-span-full flex items-center justify-end gap-[var(--space-3)] md:col-span-5 md:justify-self-end\">\n    <Button size=\"sm\">Primary</Button>\n    <Button size=\"sm\" variant=\"ghost\">\n      Secondary\n    </Button>\n  </div>\n</PageShell>",
         "preview": {
           "id": "prompts:layout:page-shell"
         }

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -416,7 +416,7 @@ function GoalsPageContent() {
 
   return (
     <>
-      <PageShell as="header" className="py-[var(--space-6)]">
+      <PageShell as="header">
         <PageHeader
           header={{
             id: "goals-header",
@@ -452,11 +452,7 @@ function GoalsPageContent() {
         />
       </PageShell>
 
-      <PageShell
-        as="main"
-        aria-labelledby="goals-header"
-        className="py-[var(--space-6)]"
-      >
+      <PageShell as="main" aria-labelledby="goals-header">
         <div className="grid gap-[var(--space-6)]">
           {/* ======= PANELS ======= */}
           <div

--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -81,7 +81,7 @@ function Inner() {
 
   return (
     <>
-      <PageShell as="header" className="py-[var(--space-6)]">
+      <PageShell as="header">
         {/* Week header (range, nav, totals, day chips) */}
         <PageHeader
           contentClassName="space-y-[var(--space-2)]"
@@ -117,7 +117,7 @@ function Inner() {
 
       <PageShell
         as="main"
-        className="py-[var(--space-6)] space-y-[var(--space-6)]"
+        stack={6}
         aria-labelledby="planner-header"
       >
         {/* Today + Side column */}

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -135,7 +135,7 @@ export default function PromptsPage() {
 
   return (
     <>
-      <PageShell as="header" className="py-[var(--space-6)]">
+      <PageShell as="header">
         <PromptsHeader
           id="prompts-header"
           count={activeCount}
@@ -146,11 +146,7 @@ export default function PromptsPage() {
         />
       </PageShell>
 
-      <PageShell
-        as="main"
-        className="space-y-[var(--space-6)] py-[var(--space-6)]"
-        aria-labelledby="prompts-header"
-      >
+      <PageShell as="main" stack={6} aria-labelledby="prompts-header">
         <Tabs value={activeTab} onValueChange={setActiveTab} idBase="prompts-tabs">
           <TabList
             items={tabItems}

--- a/src/components/prompts/component-gallery/MiscPanel.tsx
+++ b/src/components/prompts/component-gallery/MiscPanel.tsx
@@ -138,8 +138,9 @@ export default function MiscPanel({ data }: MiscPanelProps) {
           element: (
             <PageShell
               grid
-              className="rounded-card border border-border/40 bg-surface/60 py-[var(--space-6)]"
-              contentClassName="items-start"
+              padding={6}
+              className="rounded-card border border-border/40 bg-surface/60"
+              slots={{ content: "items-start" }}
             >
               <div className="col-span-full text-label font-semibold tracking-[0.02em] text-muted-foreground md:col-span-7">
                 PageShell

--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -2838,11 +2838,7 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
       description:
         "Responsive page container. Enable the grid prop and wrap sections in col-span-* to align to the shell template.",
       element: (
-        <PageShell
-          grid
-          className="py-[var(--space-6)]"
-          contentClassName="items-start"
-        >
+        <PageShell grid padding={6} slots={{ content: "items-start" }}>
           <div className="col-span-full text-label font-semibold tracking-[0.02em] text-muted-foreground md:col-span-7">
             Page shell content
           </div>
@@ -2857,8 +2853,8 @@ const LEGACY_SPEC_DATA: Record<GallerySectionId, LegacySpec[]> = {
       tags: ["layout", "shell"],
       code: `<PageShell
   grid
-  className="py-[var(--space-6)]"
-  contentClassName="items-start"
+  padding={6}
+  slots={{ content: "items-start" }}
 >
   <div className="col-span-full text-label font-semibold tracking-[0.02em] text-muted-foreground md:col-span-7">
     Page shell content

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -73,7 +73,7 @@ export default function ReviewsPage({
 
   return (
     <>
-      <PageShell as="header" className="py-[var(--space-6)]">
+      <PageShell as="header">
         <PageHeader
           className="rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-4)]"
           contentClassName="space-y-[var(--space-2)]"
@@ -143,11 +143,7 @@ export default function ReviewsPage({
         />
       </PageShell>
 
-      <PageShell
-        as="main"
-        className="py-[var(--space-6)] space-y-[var(--space-6)]"
-        aria-labelledby="reviews-header"
-      >
+      <PageShell as="main" stack={6} aria-labelledby="reviews-header">
         <div
           className={cn(
             "grid grid-cols-1 items-start gap-[var(--space-4)] sm:gap-[var(--space-6)] lg:gap-[var(--space-8)] md:grid-cols-6 lg:grid-cols-12",

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -495,8 +495,10 @@ export default function TeamCompPage() {
   return (
     <PageShell
       as="main"
-      className="py-[var(--space-6)] space-y-[var(--space-6)] md:space-y-0 md:grid md:grid-cols-12 md:gap-[var(--space-4)]"
+      stack={6}
       aria-labelledby="teamcomp-header"
+      className="md:grid md:grid-cols-12 md:gap-[var(--space-4)]"
+      slots={{ root: "md:[--page-shell-stack:0px]" }}
     >
       <PageHeader
         containerClassName="md:col-span-12"

--- a/src/components/ui/layout/PageShell.tsx
+++ b/src/components/ui/layout/PageShell.tsx
@@ -6,6 +6,23 @@ import { cn } from "@/lib/utils";
 
 type PageShellElement = "div" | "main" | "section" | "article" | "aside" | "header" | "footer" | "nav";
 
+type PageShellSpacing = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+
+type PageShellPadding =
+  | PageShellSpacing
+  | {
+      block?: PageShellSpacing;
+      top?: PageShellSpacing;
+      bottom?: PageShellSpacing;
+    };
+
+type PageShellSafeArea = "top" | "bottom" | "both";
+
+export type PageShellSlots = {
+  root?: string;
+  content?: string;
+};
+
 type PageShellOwnProps<T extends PageShellElement = "div"> = {
   /** Semantic element for the shell container. Defaults to a <div>. */
   as?: T;
@@ -17,6 +34,20 @@ type PageShellOwnProps<T extends PageShellElement = "div"> = {
   grid?: boolean;
   /** Additional classes for the inner grid container when `grid` is enabled. */
   contentClassName?: string;
+  /**
+   * Controls the vertical padding applied by the shell using spacing tokens.
+   * Accepts a single token or overrides for block/top/bottom values.
+   */
+  padding?: PageShellPadding;
+  /** Sets the vertical rhythm (equivalent to Tailwind's space-y utilities). */
+  stack?: PageShellSpacing;
+  /**
+   * Adds viewport safe-area insets to the chosen edges.
+   * Useful for sticky chrome near notches and home indicators.
+   */
+  safeArea?: PageShellSafeArea;
+  /** Optional slot overrides for the root wrapper and the inner grid. */
+  slots?: PageShellSlots;
 };
 
 export type PageShellProps<T extends PageShellElement = "div"> =
@@ -27,23 +58,52 @@ export type PageShellProps<T extends PageShellElement = "div"> =
  * PageShell — width-constrained wrapper that applies the global `page-shell` class.
  * Use the `grid` prop to opt into the standard 12-column layout inside the shell.
  */
+const DEFAULT_PADDING: PageShellSpacing = 6;
+
+function resolvePadding(input: PageShellPadding | undefined) {
+  if (typeof input === "number") {
+    return { top: input, bottom: input };
+  }
+  const block = input?.block ?? DEFAULT_PADDING;
+  return {
+    top: input?.top ?? block,
+    bottom: input?.bottom ?? block,
+  };
+}
+
 export default function PageShell<T extends PageShellElement = "div">({
   as,
   className,
   grid = false,
   contentClassName,
+  padding,
+  stack = 0,
+  safeArea,
+  slots,
   children,
   ...rest
 }: PageShellProps<T>) {
   const Component = (as ?? "div") as PageShellElement;
+  const { top: paddingTop, bottom: paddingBottom } = resolvePadding(padding);
+  const resolvedStack = stack ?? 0;
+  const safeAreaTop = safeArea === "top" || safeArea === "both";
+  const safeAreaBottom = safeArea === "bottom" || safeArea === "both";
   const mainAccessibilityProps: Partial<React.ComponentPropsWithoutRef<"main">> =
     Component === "main"
       ? { id: "main-content", tabIndex: -1 }
       : {};
 
+  const rootClassName = cn("page-shell", slots?.root, className);
+  const resolvedContentClassName = cn(slots?.content, contentClassName);
+
   return (
     <Component
-      className={cn("page-shell", className)}
+      className={rootClassName}
+      data-padding-top={paddingTop}
+      data-padding-bottom={paddingBottom}
+      data-stack={resolvedStack}
+      data-safe-area-top={safeAreaTop ? "true" : undefined}
+      data-safe-area-bottom={safeAreaBottom ? "true" : undefined}
       {...mainAccessibilityProps}
       {...rest}
     >
@@ -51,7 +111,7 @@ export default function PageShell<T extends PageShellElement = "div">({
         <div
           className={cn(
             "grid gap-[var(--space-4)] md:grid-cols-12 lg:gap-[var(--space-5)]",
-            contentClassName
+            resolvedContentClassName
           )}
         >
           {children}

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -3,7 +3,10 @@
 exports[`ReviewsPage > renders default state 1`] = `
 <div>
   <header
-    class="page-shell py-[var(--space-6)]"
+    class="page-shell"
+    data-padding-bottom="6"
+    data-padding-top="6"
+    data-stack="0"
   >
     <section>
       <style
@@ -458,7 +461,10 @@ exports[`ReviewsPage > renders default state 1`] = `
   </header>
   <main
     aria-labelledby="reviews-header"
-    class="page-shell py-[var(--space-6)] space-y-[var(--space-6)]"
+    class="page-shell"
+    data-padding-bottom="6"
+    data-padding-top="6"
+    data-stack="6"
     id="main-content"
     tabindex="-1"
   >


### PR DESCRIPTION
## Summary
- teach PageShell to expose typed padding, stack, safe-area, and slot hooks so the component owns vertical rhythm
- update global shell styling and consumer pages (planner, prompts, reviews, team, chrome, etc.) to rely on the new API instead of bespoke padding classes
- refresh design-system guidance and gallery examples to demonstrate the revised PageShell usage

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3e5ecfd34832cb013da3986ace76d