### PR TITLE
Tighten planner CRUD guards

### DIFF
--- a/src/components/planner/dayCrud.ts
+++ b/src/components/planner/dayCrud.ts
@@ -54,6 +54,8 @@ export function addProject(day: DayRecord, id: string, name: string) {
 export function renameProject(day: DayRecord, id: string, name: string) {
   const title = name.trim();
   if (!title) return day;
+  const project = day.projects.find((p) => p.id === id);
+  if (!project || project.name === title) return day;
   return finalizeDay(day, {
     projects: day.projects.map((p) =>
       p.id === id ? { ...p, name: title } : p,
@@ -98,6 +100,8 @@ export function addTask(
 export function renameTask(day: DayRecord, id: string, next: string) {
   const title = next.trim();
   if (!title) return day;
+  const task = day.tasks.find((t) => t.id === id);
+  if (!task || task.title === title) return day;
   return finalizeDay(day, {
     tasks: day.tasks.map((t) => (t.id === id ? { ...t, title } : t)),
   });

--- a/src/components/planner/plannerCrud.ts
+++ b/src/components/planner/plannerCrud.ts
@@ -25,8 +25,10 @@ export function setFocus(day: DayRecord, focus: string): DayRecord {
 
 export function makeCrud(iso: ISODate, upsertDay: UpsertDay) {
   const addProject = (name: string) => {
+    const trimmed = name.trim();
+    if (!trimmed) return undefined;
     const id = uid("proj");
-    upsertDay(iso, (d) => dayAddProject(d, id, name));
+    upsertDay(iso, (d) => dayAddProject(d, id, trimmed));
     return id;
   };
 
@@ -40,8 +42,10 @@ export function makeCrud(iso: ISODate, upsertDay: UpsertDay) {
     upsertDay(iso, (d) => dayRemoveProject(d, id));
 
   const addTask = (title: string, projectId?: string) => {
+    const trimmed = title.trim();
+    if (!trimmed) return undefined;
     const id = uid("task");
-    upsertDay(iso, (d) => dayAddTask(d, id, title, projectId));
+    upsertDay(iso, (d) => dayAddTask(d, id, trimmed, projectId));
     return id;
   };
 

--- a/src/components/planner/usePlannerStore.ts
+++ b/src/components/planner/usePlannerStore.ts
@@ -184,6 +184,7 @@ export function usePlannerActions() {
       const trimmed = name.trim();
       if (!trimmed) return;
       const id = makeCrud(iso, upsertDay).addProject(trimmed);
+      if (!id) return;
       select?.(id);
       return id;
     },
@@ -196,6 +197,7 @@ export function usePlannerActions() {
       const trimmed = title.trim();
       if (!trimmed) return;
       const id = makeCrud(iso, upsertDay).addTask(trimmed, projectId);
+      if (!id) return;
       select?.(id);
       return id;
     },

--- a/tests/planner/DayCard.test.tsx
+++ b/tests/planner/DayCard.test.tsx
@@ -41,7 +41,7 @@ describe("DayCard", () => {
 
     let pid = "";
     act(() => {
-      pid = harnessRef.current!.day.addProject("Proj");
+      pid = harnessRef.current!.day.addProject("Proj")!;
     });
 
     await waitFor(() => {

--- a/tests/planner/UsePlannerStore.test.tsx
+++ b/tests/planner/UsePlannerStore.test.tsx
@@ -35,7 +35,7 @@ describe("UsePlannerStore", () => {
 
     let projectId = "";
     act(() => {
-      projectId = result.current.planner.addProject("Proj A");
+      projectId = result.current.planner.addProject("Proj A")!;
     });
     expect(result.current.day.projects).toHaveLength(1);
     expect(result.current.day.projects[0].name).toBe("Proj A");
@@ -52,7 +52,7 @@ describe("UsePlannerStore", () => {
     let taskId = "";
     let secondTaskId = "";
     act(() => {
-      taskId = result.current.planner.addTask("Task 1", projectId);
+      taskId = result.current.planner.addTask("Task 1", projectId)!;
     });
     expect(result.current.day.tasks).toHaveLength(1);
     expect(result.current.planner.day.tasksByProject[projectId]).toEqual([
@@ -60,7 +60,7 @@ describe("UsePlannerStore", () => {
     ]);
 
     act(() => {
-      secondTaskId = result.current.planner.addTask("Task 2", projectId);
+      secondTaskId = result.current.planner.addTask("Task 2", projectId)!;
     });
     expect(result.current.day.tasks).toHaveLength(2);
     expect(result.current.planner.day.tasksByProject[projectId]).toEqual([
@@ -140,7 +140,7 @@ describe("UsePlannerStore", () => {
 
     let projectId = "";
     act(() => {
-      projectId = result.current.addProject("Focus Project");
+      projectId = result.current.addProject("Focus Project")!;
     });
     expectUntouched();
 
@@ -156,7 +156,7 @@ describe("UsePlannerStore", () => {
 
     let taskId = "";
     act(() => {
-      taskId = result.current.addTask("Focus Task", projectId);
+      taskId = result.current.addTask("Focus Task", projectId)!;
     });
     expectUntouched();
 
@@ -207,7 +207,7 @@ describe("UsePlannerStore", () => {
 
     let t1 = "";
     act(() => {
-      t1 = result.current.addTask("First");
+      t1 = result.current.addTask("First")!;
       result.current.addTask("Second");
     });
     expect(result.current.totalCount).toBe(2);

--- a/tests/planner/UseSelection.test.tsx
+++ b/tests/planner/UseSelection.test.tsx
@@ -65,11 +65,11 @@ describe("UseSelection", () => {
 
     let pid = "";
     act(() => {
-      pid = result.current.planner.addProject("Proj");
+      pid = result.current.planner.addProject("Proj")!;
     });
     let tid = "";
     act(() => {
-      tid = result.current.planner.addTask("Task", pid);
+      tid = result.current.planner.addTask("Task", pid)!;
     });
 
     expect(result.current.selectedProject).toBe("");
@@ -120,11 +120,11 @@ describe("UseSelection", () => {
 
     let projectId = "";
     act(() => {
-      projectId = result.current.planner.addProject("Project");
+      projectId = result.current.planner.addProject("Project")!;
     });
     let taskId = "";
     act(() => {
-      taskId = result.current.planner.addTask("Task", projectId);
+      taskId = result.current.planner.addTask("Task", projectId)!;
     });
 
     await waitFor(() => {
@@ -156,7 +156,7 @@ describe("UseSelection", () => {
     expect(selectionSetSpy.mock.calls.length).toBe(baseCalls + 1);
 
     act(() => {
-      projectId = result.current.planner.addProject("Next Project");
+      projectId = result.current.planner.addProject("Next Project")!;
     });
 
     act(() => result.current.setSelectedProject(projectId));
@@ -178,7 +178,7 @@ describe("UseSelection", () => {
     expect(selectionSetSpy.mock.calls.length).toBe(projectCleanupCalls + 1);
 
     act(() => {
-      projectId = result.current.planner.addProject("Final Project");
+      projectId = result.current.planner.addProject("Final Project")!;
     });
 
     act(() => result.current.setSelectedProject(projectId));


### PR DESCRIPTION
## Summary
- ensure planner CRUD creation helpers trim input and skip ID generation when nothing would persist
- short-circuit day-level rename reducers when the trimmed name matches the existing record
- guard planner actions and tests against optional IDs returned from creation helpers

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3e8fcf2ac832c93c0972d94de6095