### PR TITLE
Fix re-exports for components section route configuration

### DIFF
--- a/app/components/[section]/page.tsx
+++ b/app/components/[section]/page.tsx
@@ -1,10 +1,6 @@
-export { metadata } from "../../../src/app/components/[section]/page";
-export { default } from "../../../src/app/components/[section]/page";
-
-import {
-  dynamicParams as dynamicParamsConfig,
-  generateStaticParams as generateStaticParamsFn,
+export {
+  metadata,
+  dynamicParams,
+  generateStaticParams,
+  default,
 } from "../../../src/app/components/[section]/page";
-
-export const dynamicParams = dynamicParamsConfig;
-export const generateStaticParams = generateStaticParamsFn;


### PR DESCRIPTION
## Summary
- fix the components section route wrapper to re-export the Next.js config fields directly from the source implementation so they are recognized during builds

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d40025fae8832ca423973912540d48