### PR TITLE
Refine home hero layout and navigation styling

### DIFF
--- a/src/app/page-client.tsx
+++ b/src/app/page-client.tsx
@@ -9,12 +9,17 @@ import {
   useHomePlannerOverview,
 } from "@/components/home";
 import type { HeroPlannerHighlight } from "@/components/home";
-import { PageShell, Button, ThemeToggle, Spinner } from "@/components/ui";
+import {
+  PageShell,
+  Button,
+  ThemeToggle,
+  Spinner,
+  SectionCard,
+} from "@/components/ui";
 import { PlannerProvider } from "@/components/planner";
 import { useTheme } from "@/lib/theme-context";
 import { useThemeQuerySync } from "@/lib/theme-hooks";
 import type { Variant } from "@/lib/theme";
-import { cn } from "@/lib/utils";
 
 const weeklyHighlights = [
   {
@@ -50,6 +55,8 @@ function HomePageContent() {
 
 function HomePageBody({ themeVariant }: { themeVariant: Variant }) {
   const plannerOverviewProps = useHomePlannerOverview();
+  const heroHeadingId = "home-hero-heading";
+  const overviewHeadingId = "home-overview-heading";
   const heroActions = React.useMemo<React.ReactNode>(
     () => (
       <>
@@ -68,50 +75,45 @@ function HomePageBody({ themeVariant }: { themeVariant: Variant }) {
     [],
   );
 
-  const heroSurfaceClass =
-    "relative z-10 isolate rounded-[var(--radius-2xl)] bg-card/30 shadow-neoSoft backdrop-blur-lg";
-  const floatingPaddingClass =
-    "p-[var(--space-4)] md:p-[var(--space-5)]";
-
-  const frameClass = "relative isolate rounded-[var(--radius-2xl)]";
-  const frameBackdropClass =
-    "pointer-events-none absolute inset-0 -z-10 rounded-[inherit] border border-border/40 bg-panel/70 shadow-neo-inset";
-  const frameContentClass =
-    "relative space-y-[var(--space-6)] p-[var(--space-4)] md:space-y-[var(--space-8)] md:p-[var(--space-5)]";
-  const renderFramedSection = (content: React.ReactNode) => (
-    <div className={frameClass}>
-      <div aria-hidden className={frameBackdropClass} />
-      <div className={frameContentClass}>{content}</div>
-    </div>
-  );
-
   return (
     <>
       <PageShell
         as="header"
-        aria-labelledby="home-header"
-        className="pt-[var(--space-6)]"
+        aria-labelledby={heroHeadingId}
+        className="pt-[var(--space-6)] md:pt-[var(--space-8)]"
       >
-        {renderFramedSection(
-          <div className={cn(heroSurfaceClass, floatingPaddingClass)}>
-            <HomeHeroSection variant={themeVariant} actions={heroActions} />
-          </div>,
-        )}
+        <SectionCard aria-labelledby={heroHeadingId}>
+          <SectionCard.Body className="md:p-[var(--space-6)]">
+            <HomeHeroSection
+              variant={themeVariant}
+              actions={heroActions}
+              headingId={heroHeadingId}
+            />
+          </SectionCard.Body>
+        </SectionCard>
       </PageShell>
       <PageShell
         as="section"
         role="region"
-        aria-labelledby="home-header"
+        aria-labelledby={overviewHeadingId}
         className="mt-[var(--space-6)] pb-[var(--space-6)] md:mt-[var(--space-8)] md:pb-[var(--space-8)]"
       >
-        {renderFramedSection(
-          <HeroPlannerCards
-            variant={themeVariant}
-            plannerOverviewProps={plannerOverviewProps}
-            highlights={weeklyHighlights}
-            className={floatingPaddingClass}
-          />,
-        )}
+        <SectionCard aria-labelledby={overviewHeadingId}>
+          <SectionCard.Header
+            id={overviewHeadingId}
+            sticky={false}
+            title="Planner overview"
+            titleAs="h2"
+            titleClassName="text-title font-semibold tracking-[-0.01em]"
+          />
+          <SectionCard.Body className="md:p-[var(--space-6)]">
+            <HeroPlannerCards
+              variant={themeVariant}
+              plannerOverviewProps={plannerOverviewProps}
+              highlights={weeklyHighlights}
+            />
+          </SectionCard.Body>
+        </SectionCard>
       </PageShell>
     </>
   );

--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -28,8 +28,8 @@ export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
       aria-label="Primary"
       className="max-w-full overflow-x-auto lg:overflow-x-visible"
     >
-      <ul className="flex flex-nowrap items-center gap-x-[var(--space-2)] gap-y-[var(--space-2)]">
-        {items.map(({ href, label }) => {
+      <ul className="flex flex-nowrap items-center gap-[var(--space-2)]">
+        {items.map(({ href, label, mobileIcon: Icon }) => {
           const active = isNavActive(path, href);
 
           return (
@@ -37,28 +37,24 @@ export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
               <Link
                 href={href}
                 aria-current={active ? "page" : undefined}
+                data-active={active ? "true" : undefined}
                 className={cn(
-                  "group relative inline-flex min-h-[var(--control-h-lg)] items-center rounded-[var(--radius-2xl)] border px-[var(--space-4)] py-[var(--space-3)] font-mono text-ui transition motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:bg-interaction-focus-surfaceActive active:text-foreground",
-                  "bg-[hsl(var(--card)/0.85)]",
-                  "supports-[background:color-mix(in_oklab,hsl(var(--card))_85%,transparent)]:bg-[color:color-mix(in_oklab,hsl(var(--card))_85%,transparent)]",
+                  "group relative inline-flex min-h-[var(--control-h-lg)] items-center gap-[var(--space-2)] rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-2)] text-ui font-medium font-mono transition motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
+                  "card-neo-soft",
                   active
-                    ? "text-foreground border-ring shadow-nav-active"
-                    : "text-muted-foreground border-transparent hover:border-border hover:bg-interaction-focus-surfaceHover",
+                    ? "text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
                 )}
               >
+                {Icon ? (
+                  <span
+                    aria-hidden="true"
+                    className="flex size-[var(--icon-size-md)] items-center justify-center text-muted-foreground transition-colors group-hover:text-foreground group-focus-visible:text-foreground"
+                  >
+                    <Icon aria-hidden="true" className="size-full" />
+                  </span>
+                ) : null}
                 <span className="relative z-10">{label}</span>
-
-                {/* hover sheen */}
-                <span
-                  aria-hidden
-                  className="pointer-events-none absolute inset-0 rounded-[var(--radius-2xl)] opacity-0 transition group-hover:opacity-100 nav-hover-sheen"
-                />
-
-                {/* faint scanlines */}
-                <span
-                  aria-hidden
-                  className="pointer-events-none absolute inset-0 rounded-[var(--radius-2xl)] opacity-20 nav-scanlines"
-                />
 
                 {/* animated underline shared across tabs */}
                 {active && (

--- a/src/components/home/HeroPlannerCards.tsx
+++ b/src/components/home/HeroPlannerCards.tsx
@@ -38,9 +38,7 @@ export default function HeroPlannerCards({
   return (
     <div
       className={cn(
-        "grid grid-cols-1 gap-y-[var(--space-7)] md:grid-cols-12",
-        "relative z-10 isolate rounded-[var(--radius-2xl)] border border-border/50 bg-card/30 shadow-neoSoft backdrop-blur-lg",
-        "p-[var(--space-4)] md:p-[var(--space-5)]",
+        "grid grid-cols-1 gap-[var(--space-6)] md:grid-cols-12",
         className,
       )}
     >

--- a/src/components/home/home-landing/HomeHeroSection.tsx
+++ b/src/components/home/home-landing/HomeHeroSection.tsx
@@ -2,13 +2,16 @@
 
 import * as React from "react";
 import { Home } from "lucide-react";
-import { PageHeader, type HeroSlots } from "@/components/ui";
 import WelcomeHeroFigure from "../WelcomeHeroFigure";
 import type { HomeHeroSectionProps } from "./types";
 
 const subtleVariants = new Set(["noir"]);
 
-export default function HomeHeroSection({ variant, actions }: HomeHeroSectionProps) {
+export default function HomeHeroSection({
+  variant,
+  actions,
+  headingId,
+}: HomeHeroSectionProps) {
   const haloTone = React.useMemo(
     () => (subtleVariants.has(variant) ? "subtle" : "default"),
     [variant],
@@ -23,64 +26,47 @@ export default function HomeHeroSection({ variant, actions }: HomeHeroSectionPro
     [actions],
   );
 
-  const heroFrameSlots = React.useMemo<HeroSlots | undefined>(() => {
-    if (!hasActionContent) {
-      return undefined;
-    }
-
-    return {
-      actions: {
-        node: (
-          <div className="flex w-full flex-wrap items-center justify-center gap-[var(--space-2)] sm:flex-nowrap sm:justify-end sm:gap-[var(--space-3)]">
-            {actions}
-          </div>
-        ),
-        className:
-          "w-full rounded-card r-card-lg border border-border/50 bg-card/80 px-[var(--space-3)] py-[var(--space-2)] shadow-neoSoft transition-[box-shadow] duration-chill ease-out hover:shadow-neo focus-within:ring-1 focus-within:ring-ring/60",
-        label: "Home hero quick actions",
-        unstyled: true,
-      },
-    } satisfies HeroSlots;
-  }, [actions, hasActionContent]);
-
   return (
-    <section
-      id="landing-hero"
-      role="region"
-      aria-label="Intro"
-      className="grid grid-cols-12 gap-[var(--space-4)] pb-[var(--space-2)] md:pb-[var(--space-3)]"
+    <div
+      className="grid gap-[var(--space-5)] md:grid-cols-12 md:items-center"
       data-theme-variant={variant}
     >
-      <div className="col-span-12">
-        <PageHeader
-          frameProps={heroFrameSlots ? { slots: heroFrameSlots } : undefined}
-          header={{
-            id: "home-header",
-            heading: "Welcome to Planner",
-            subtitle: "Plan your day, track goals, and review games.",
-            icon: <Home className="text-foreground" />,
-            sticky: false,
-            barClassName: "flex-wrap gap-y-[var(--space-3)] md:flex-nowrap",
-            right: (
-              <div className="flex basis-full items-center justify-center md:basis-auto md:justify-end md:pl-[var(--space-3)]">
-                <WelcomeHeroFigure
-                  className="w-full max-w-[calc(var(--space-8)*4)] md:max-w-[calc(var(--space-8)*4.5)] lg:max-w-[calc(var(--space-8)*5)]"
-                  haloTone={haloTone}
-                  showGlitchRail={showGlitchRail}
-                  framed={false}
-                />
-              </div>
-            ),
-          }}
-          hero={{
-            heading: "Your day at a glance",
-            sticky: false,
-            barVariant: "flat",
-            glitch: "subtle",
-            topClassName: "top-[var(--header-stack)]",
-          }}
+      <div className="flex flex-col gap-[var(--space-4)] md:col-span-6">
+        <div className="flex items-center gap-[var(--space-2)] text-muted-foreground">
+          <Home aria-hidden="true" className="size-[var(--icon-size-lg)]" />
+          <span className="text-label font-semibold uppercase">
+            Planner
+          </span>
+        </div>
+        <div className="space-y-[var(--space-3)]">
+          <h1
+            id={headingId}
+            className="text-balance text-title-lg font-semibold tracking-[-0.01em] text-foreground"
+          >
+            Welcome to Planner
+          </h1>
+          <p className="text-body text-muted-foreground">
+            Plan your day, track goals, and review games.
+          </p>
+        </div>
+        {hasActionContent ? (
+          <div
+            role="group"
+            aria-label="Home hero actions"
+            className="flex flex-wrap items-center gap-[var(--space-3)]"
+          >
+            {actions}
+          </div>
+        ) : null}
+      </div>
+      <div className="flex justify-center md:col-span-6 md:justify-end">
+        <WelcomeHeroFigure
+          className="w-full max-w-[calc(var(--space-8)*4)] md:max-w-[calc(var(--space-8)*4.5)] lg:max-w-[calc(var(--space-8)*5)]"
+          haloTone={haloTone}
+          showGlitchRail={showGlitchRail}
+          framed={false}
         />
       </div>
-    </section>
+    </div>
   );
 }

--- a/src/components/home/home-landing/types.ts
+++ b/src/components/home/home-landing/types.ts
@@ -84,5 +84,6 @@ export interface PlannerOverviewProps {
 
 export interface HomeHeroSectionProps {
   variant: Variant;
-  actions: ReactNode;
+  actions?: ReactNode;
+  headingId: string;
 }

--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -3939,18 +3939,40 @@ React.useEffect(() => {
       description:
         "Composite hero surface combining quick actions, overview metrics, and planner highlights for the landing page.",
       element: (
-        <HeroPlannerCards
-          variant="aurora"
-          plannerOverviewProps={heroPlannerOverviewDemo}
-          highlights={heroPlannerHighlightsDemo}
-        />
+        <UiSectionCard aria-labelledby="hero-planner-cards-heading">
+          <UiSectionCard.Header
+            id="hero-planner-cards-heading"
+            sticky={false}
+            title="Planner overview"
+            titleAs="h2"
+            titleClassName="text-title font-semibold tracking-[-0.01em]"
+          />
+          <UiSectionCard.Body className="md:p-[var(--space-6)]">
+            <HeroPlannerCards
+              variant="aurora"
+              plannerOverviewProps={heroPlannerOverviewDemo}
+              highlights={heroPlannerHighlightsDemo}
+            />
+          </UiSectionCard.Body>
+        </UiSectionCard>
       ),
       tags: ["planner", "homepage", "hero"],
-      code: `<HeroPlannerCards
-  variant="aurora"
-  plannerOverviewProps={plannerOverviewProps}
-  highlights={weeklyHighlights}
-/>`,
+      code: `<SectionCard aria-labelledby="planner-overview-heading">
+  <SectionCard.Header
+    id="planner-overview-heading"
+    sticky={false}
+    title="Planner overview"
+    titleAs="h2"
+    titleClassName="text-title font-semibold tracking-[-0.01em]"
+  />
+  <SectionCard.Body>
+    <HeroPlannerCards
+      variant="aurora"
+      plannerOverviewProps={plannerOverviewProps}
+      highlights={weeklyHighlights}
+    />
+  </SectionCard.Body>
+</SectionCard>`,
     },
     {
       id: "hero-portrait-frame",


### PR DESCRIPTION
## Summary
- Align the top navigation with icon+label tabs that reuse the neumorphic card treatment and accessible state tokens
- Rebuild the home hero and planner overview sections on SectionCard surfaces with consistent typography, actions, and aria labelling
- Update the component gallery example to demonstrate the SectionCard-wrapped HeroPlannerCards pattern

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d41850a2f0832c8936c49093cfc44e