### PR TITLE
Move theme color metadata into viewport export

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import "./globals.css";
 // Load tokens + per-theme backdrops AFTER globals so overrides win.
 import "./themes.css";
 
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { headers } from "next/headers";
 import {
   geistMonoVariable,
@@ -25,6 +25,9 @@ export const metadata: Metadata = {
     template: "%s · Planner",
   },
   description: "Local-first planner for organizing tasks and goals",
+};
+
+export const viewport: Viewport = {
   themeColor: [
     {
       media: "(prefers-color-scheme: dark)",


### PR DESCRIPTION
## Summary
- move the root layout theme color definition from route metadata to the viewport export to satisfy Next.js requirements

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d430c5fc6c832ca1ac925eae765994