### PR TITLE
Fix dynamicParams re-export warning for components section page

### DIFF
--- a/app/components/[section]/page.tsx
+++ b/app/components/[section]/page.tsx
@@ -1,6 +1,11 @@
-export {
+import ComponentsSectionPage, {
   metadata,
-  dynamicParams,
   generateStaticParams,
-  default,
+  dynamicParams as componentsDynamicParams,
 } from "../../../src/app/components/[section]/page";
+
+export { metadata, generateStaticParams };
+
+export const dynamicParams = componentsDynamicParams;
+
+export default ComponentsSectionPage;


### PR DESCRIPTION
## Summary
- ensure the components section route imports the implementation and re-exports metadata/static params locally
- expose `dynamicParams` as a literal export so Next.js recognizes the setting during build

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d434b9a7b8832cb620da0053c6e5a4