### PR TITLE
Fix dynamic params re-export

### DIFF
--- a/app/components/[section]/page.tsx
+++ b/app/components/[section]/page.tsx
@@ -1,11 +1,12 @@
 import ComponentsSectionPage, {
   metadata,
   generateStaticParams,
-  dynamicParams as componentsDynamicParams,
 } from "../../../src/app/components/[section]/page";
+
+type ComponentsDynamicParams = typeof import("../../../src/app/components/[section]/page").dynamicParams;
 
 export { metadata, generateStaticParams };
 
-export const dynamicParams = componentsDynamicParams;
+export const dynamicParams: ComponentsDynamicParams = false;
 
 export default ComponentsSectionPage;


### PR DESCRIPTION
## Summary
- inline the `dynamicParams` value in the app router shim for `/components/[section]`
- ensure the value is exported as a literal while keeping type alignment with the source page

## Testing
- CI=1 npm run build
- CI=1 npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d438ce2608832c934371b18c34022b