### PR TITLE
Fix nav bullets, quick actions layout, theme toggle fallback

### DIFF
--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -28,7 +28,7 @@ export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
       aria-label="Primary"
       className="max-w-full overflow-x-auto lg:overflow-x-visible"
     >
-      <ul className="flex flex-nowrap items-center gap-[var(--space-2)]">
+      <ul className="flex list-none flex-nowrap items-center gap-[var(--space-2)]">
         {items.map(({ href, label, mobileIcon: Icon }) => {
           const active = isNavActive(path, href);
 

--- a/src/components/home/QuickActionGrid.tsx
+++ b/src/components/home/QuickActionGrid.tsx
@@ -8,14 +8,15 @@ import { cn } from "@/lib/utils";
 type QuickActionLayout = "stacked" | "grid" | "twelveColumn" | "inline";
 
 const ROOT_CLASSNAME =
-  "[--quick-actions-gap:var(--space-4)] [--quick-actions-column-width:calc(var(--space-4)*14)] [--quick-actions-lift:var(--spacing-0-5)]";
+  "[--quick-actions-gap:var(--space-4)] [--quick-actions-column-width:calc(var(--space-4)*14)] [--quick-actions-lift:var(--spacing-0-5)] md:[--quick-actions-gap:var(--space-3)]";
 
 const layoutClassNames: Record<QuickActionLayout, string> = {
-  stacked: "flex flex-col gap-[var(--quick-actions-gap)]",
+  stacked:
+    "grid grid-cols-1 gap-[var(--quick-actions-gap)] md:grid-flow-col md:[grid-auto-columns:minmax(var(--quick-actions-column-width),1fr)] md:justify-start",
   grid: "grid grid-cols-1 gap-[var(--quick-actions-gap)] sm:grid-cols-[repeat(auto-fit,minmax(var(--quick-actions-column-width),1fr))]",
   twelveColumn: "grid grid-cols-12 gap-[var(--quick-actions-gap)]",
   inline:
-    "flex flex-col gap-[var(--quick-actions-gap)] md:flex-row md:items-center md:justify-between",
+    "flex flex-col gap-[var(--quick-actions-gap)] md:flex-row md:flex-wrap md:items-center md:justify-start",
 };
 
 const buttonBaseClassName =

--- a/src/components/ui/theme/ThemeToggle.tsx
+++ b/src/components/ui/theme/ThemeToggle.tsx
@@ -45,6 +45,8 @@ export default function ThemeToggle({
   const prevVariantRef = React.useRef<Variant>(variant);
   const prevBgRef = React.useRef<Background>(bg);
   const initializedRef = React.useRef(false);
+  const showFallback = !mounted;
+  const groupLabel = `${aria} controls`;
 
   const setVariantPersist = React.useCallback(
     (v: Variant) => setState((prev) => ({ variant: v, bg: prev.bg })),
@@ -111,17 +113,12 @@ export default function ThemeToggle({
     };
   }, [announcement]);
 
-  if (!mounted) {
-    return (
-      <span
-        aria-hidden
-        className={`inline-block h-[var(--control-h-sm)] w-[var(--control-h-sm)] rounded-full bg-input ${className}`}
-      />
-    );
-  }
-
   return (
-    <div className={`flex items-center gap-[var(--space-2)] whitespace-nowrap ${className}`}>
+    <div
+      className={`flex items-center gap-[var(--space-2)] whitespace-nowrap ${className}`}
+      role="group"
+      aria-label={groupLabel}
+    >
       {/* background cycle */}
       <Button
         id={id}
@@ -130,27 +127,40 @@ export default function ThemeToggle({
         tactile
         className="shrink-0 px-[var(--space-2)]"
         aria-label={`${aria}: cycle background`}
-        title="Change background"
+        title={showFallback ? "Theme controls loading" : "Change background"}
         onClick={cycleBg}
-        disabled={isCycleDisabled}
+        disabled={isCycleDisabled || showFallback}
         loading={isCycleLoading}
       >
-        <ImageIcon className="h-[var(--space-4)] w-[var(--space-4)]" />
+        <ImageIcon aria-hidden className="h-[var(--space-4)] w-[var(--space-4)]" />
+        <span className="sr-only">Cycle background</span>
       </Button>
 
       {/* dropdown — no visible title; uses aria label */}
-      <Select
-        variant="animated"
-        ariaLabel={aria}
-        items={items}
-        value={variant}
-        onChange={handleChange}
-        size="sm"
-        buttonClassName="!rounded-full !text-ui !w-auto"
-        matchTriggerWidth={false}
-        align="right"
-        className="shrink-0"
-      />
+      {showFallback ? (
+        <Button
+          variant="secondary"
+          size="sm"
+          className="pointer-events-none !rounded-full !px-[var(--space-3)] !text-ui text-muted-foreground"
+          aria-label={`${aria}: waiting for theme controls`}
+          disabled
+        >
+          {aria}
+        </Button>
+      ) : (
+        <Select
+          variant="animated"
+          ariaLabel={aria}
+          items={items}
+          value={variant}
+          onChange={handleChange}
+          size="sm"
+          buttonClassName="!rounded-full !text-ui !w-auto"
+          matchTriggerWidth={false}
+          align="right"
+          className="shrink-0"
+        />
+      )}
       <div aria-live="polite" className="sr-only">
         {announcement}
       </div>


### PR DESCRIPTION
## Summary
- remove default list markers from the primary navigation list so browser bullets no longer render
- adjust quick action layouts to flow horizontally on wide viewports while keeping spacing on token rhythm
- add an accessible, labeled fallback state for the theme toggle before hydration

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d465129b1c832c9646e840b88d5646