### PR TITLE
Align shell spacing with 12-column grid

### DIFF
--- a/src/app/page-client.tsx
+++ b/src/app/page-client.tsx
@@ -79,11 +79,15 @@ function HomePageBody({ themeVariant }: { themeVariant: Variant }) {
     <>
       <PageShell
         as="header"
+        grid
         aria-labelledby={heroHeadingId}
-        className="pt-[var(--space-6)] md:pt-[var(--space-8)]"
+        className="pt-6 md:pt-8"
       >
-        <SectionCard aria-labelledby={heroHeadingId}>
-          <SectionCard.Body className="md:p-[var(--space-6)]">
+        <SectionCard
+          aria-labelledby={heroHeadingId}
+          className="col-span-full"
+        >
+          <SectionCard.Body className="md:p-6">
             <HomeHeroSection
               variant={themeVariant}
               actions={heroActions}
@@ -94,11 +98,15 @@ function HomePageBody({ themeVariant }: { themeVariant: Variant }) {
       </PageShell>
       <PageShell
         as="section"
+        grid
         role="region"
         aria-labelledby={overviewHeadingId}
-        className="mt-[var(--space-6)] pb-[var(--space-6)] md:mt-[var(--space-8)] md:pb-[var(--space-8)]"
+        className="mt-6 pb-6 md:mt-8 md:pb-8"
       >
-        <SectionCard aria-labelledby={overviewHeadingId}>
+        <SectionCard
+          aria-labelledby={overviewHeadingId}
+          className="col-span-full"
+        >
           <SectionCard.Header
             id={overviewHeadingId}
             sticky={false}
@@ -106,7 +114,7 @@ function HomePageBody({ themeVariant }: { themeVariant: Variant }) {
             titleAs="h2"
             titleClassName="text-title font-semibold tracking-[-0.01em]"
           />
-          <SectionCard.Body className="md:p-[var(--space-6)]">
+          <SectionCard.Body className="md:p-6">
             <HeroPlannerCards
               variant={themeVariant}
               plannerOverviewProps={plannerOverviewProps}
@@ -124,7 +132,7 @@ export default function Page() {
     <Suspense
       fallback={
         <PageShell as="section" aria-busy="true" role="status">
-          <div className="flex justify-center p-[var(--space-6)]">
+          <div className="flex justify-center p-6">
             <Spinner />
           </div>
         </PageShell>

--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -54,7 +54,7 @@ function Inner() {
   const heroRef = React.useRef<HTMLDivElement>(null);
 
   const right = (
-    <div className="flex items-center gap-[var(--space-2)]">
+    <div className="flex items-center gap-2">
       <Button
         variant="ghost"
         size="sm"
@@ -81,10 +81,11 @@ function Inner() {
 
   return (
     <>
-      <PageShell as="header" className="py-[var(--space-6)]">
+      <PageShell as="header" grid className="py-6">
         {/* Week header (range, nav, totals, day chips) */}
         <PageHeader
-          contentClassName="space-y-[var(--space-2)]"
+          containerClassName="col-span-full"
+          contentClassName="space-y-2"
           header={{
             id: "planner-header",
             tabIndex: -1,
@@ -117,22 +118,24 @@ function Inner() {
 
       <PageShell
         as="main"
-        className="py-[var(--space-6)] space-y-[var(--space-6)]"
+        grid
+        className="py-6"
+        contentClassName="gap-y-6"
         aria-labelledby="planner-header"
       >
         {/* Today + Side column */}
         <section
           aria-label="Today and weekly panels"
-          className="grid grid-cols-1 gap-[var(--space-6)] lg:grid-cols-12"
+          className="col-span-full grid grid-cols-1 gap-6 lg:grid-cols-12"
         >
-          <div className="lg:col-span-8" ref={heroRef}>
+          <div className="col-span-full lg:col-span-8" ref={heroRef}>
             <TodayHero iso={iso} />
           </div>
 
           {/* Sticky only on large so it doesn’t eat the viewport on mobile */}
           <aside
             aria-label="Day notes"
-            className="lg:col-span-4 space-y-[var(--space-6)] lg:sticky lg:top-[var(--header-stack)]"
+            className="col-span-full space-y-6 lg:col-span-4 lg:sticky lg:top-[var(--header-stack)]"
           >
             <WeekNotes iso={iso} />
           </aside>
@@ -141,7 +144,7 @@ function Inner() {
         {/* Week list (Mon→Sun) — anchors used by WeekPicker’s selectAndScroll */}
         <ul
           aria-label="Week days (Monday to Sunday)"
-          className="flex flex-col gap-[var(--space-4)]"
+          className="col-span-full flex flex-col gap-4"
         >
           {dayItems.map((item) => (
             <DayRow key={item.iso} iso={item.iso} isToday={item.isToday} />

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -370,12 +370,12 @@ export default function TeamCompPage() {
         heading: "Builder",
         subtitle,
         children: (
-          <div className="flex flex-col gap-[var(--space-4)]">
-            <div className="flex flex-col gap-[var(--space-2)]">
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
               <span className="text-label font-semibold uppercase tracking-[0.02em] text-muted-foreground">
                 Lane coverage
               </span>
-              <div className="flex flex-wrap gap-[var(--space-2)]">
+              <div className="flex flex-wrap gap-2">
                 {laneSummaries.map((lane) => (
                   <Badge
                     key={lane.key}
@@ -388,7 +388,7 @@ export default function TeamCompPage() {
                 ))}
               </div>
             </div>
-            <div className="flex flex-wrap items-center gap-[var(--space-2)]">
+            <div className="flex flex-wrap items-center gap-2">
               <Badge size="sm" tone={gapTone}>
                 {openLabel}
               </Badge>
@@ -404,7 +404,7 @@ export default function TeamCompPage() {
           </div>
         ),
         actions: (
-          <div className="flex flex-wrap items-center gap-[var(--space-3)] md:gap-[var(--space-4)]">
+          <div className="flex flex-wrap items-center gap-3 md:gap-4">
             <IconButton
               title="Swap Allies ↔ Enemies"
               aria-label="Swap Allies and Enemies"
@@ -454,8 +454,8 @@ export default function TeamCompPage() {
         ),
       },
       actions: (
-        <div className="flex flex-wrap items-center gap-[var(--space-2)]">
-          <div className="flex flex-col items-start gap-[var(--space-1)]">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-col items-start gap-1">
             <Button
               variant="primary"
               size="md"
@@ -467,7 +467,7 @@ export default function TeamCompPage() {
               <Plus />
               <span>New Row</span>
             </Button>
-            <div className="flex items-center gap-[var(--space-1)] text-label text-muted-foreground">
+            <div className="flex items-center gap-1 text-label text-muted-foreground">
               <span>Sends to</span>
               <Badge size="sm" tone="accent">
                 {targetBucket}
@@ -511,13 +511,15 @@ export default function TeamCompPage() {
   return (
     <PageShell
       as="main"
-      className="py-[var(--space-6)] space-y-[var(--space-6)] md:space-y-0 md:grid md:grid-cols-12 md:gap-[var(--space-4)]"
+      grid
+      className="py-6"
+      contentClassName="gap-y-6"
       aria-labelledby="teamcomp-header"
     >
       <PageHeader
-        containerClassName="md:col-span-12"
-        className="rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-4)]"
-        contentClassName="space-y-[var(--space-2)]"
+        containerClassName="col-span-full"
+        className="rounded-card r-card-lg px-4 py-4"
+        contentClassName="space-y-2"
         frameProps={{ variant: "unstyled" }}
         header={{
           id: "teamcomp-header",
@@ -537,7 +539,7 @@ export default function TeamCompPage() {
         hero={hero}
       />
 
-      <section className="grid gap-[var(--space-4)] md:col-span-12 md:grid-cols-12">
+      <section className="col-span-full grid gap-4 md:grid-cols-12">
         {TABS.map((t) => {
           const ids = tabIds[t.key];
           return (
@@ -549,7 +551,7 @@ export default function TeamCompPage() {
               hidden={tab !== t.key}
               tabIndex={tab === t.key ? 0 : -1}
               ref={t.ref}
-              className="md:col-span-12"
+              className="col-span-full"
             >
               {tab === t.key && t.render()}
             </div>


### PR DESCRIPTION
## Summary
- standardize the Planner view to use the PageShell grid with tokenized gaps for the hero, weekly panels, and list
- normalize the Team Comps layout around the shared grid shell and spacing rhythm so tab content spans the 12-column system
- update the home landing sections to participate in the grid shell and spacing tokens for consistent padding and stacking

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d5182fd170832ca4fd7261ae4bbffe