### PR TITLE
Debounce search interactions

### DIFF
--- a/src/components/components/ComponentsPageClient.tsx
+++ b/src/components/components/ComponentsPageClient.tsx
@@ -197,7 +197,7 @@ export default function ComponentsPageClient({
                     id: "components-search",
                     value: query,
                     onValueChange: setQuery,
-                    debounceMs: 250,
+                    debounceMs: 300,
                     round: true,
                     variant: "neo",
                     label: searchLabel,

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -435,7 +435,7 @@ function GoalsPageContent() {
       value: query,
       onValueChange: handleReminderSearchChange,
       placeholder: "Search title, text, tags…",
-      debounceMs: 80,
+      debounceMs: 300,
       "aria-label": "Search reminders",
       right: (
         <div className="flex items-center gap-[var(--space-2)]">

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -118,6 +118,7 @@ export default function ReviewsPage({
                   placeholder="Search title, tags, opponent, patch…"
                   aria-label="Search reviews"
                   className="md:col-span-8"
+                  debounceMs={300}
                 />
                 <div
                   className="flex w-full flex-col gap-[var(--space-1)] text-left md:col-span-2"

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -307,6 +307,7 @@ export default function TeamCompPage() {
           onValueChange: setQuery,
           placeholder: "Search…",
           round: true,
+          debounceMs: 300,
           "aria-label":
             subTab === "sheet"
               ? "Search cheat sheet entries"
@@ -447,7 +448,7 @@ export default function TeamCompPage() {
         onValueChange: setClearsQuery,
         placeholder: "Filter by champion, type, or note...",
         round: true,
-        debounceMs: 80,
+        debounceMs: 300,
         "aria-label": "Search jungle clear buckets",
         right: (
           <span className="text-label opacity-80">{clearsCount} shown</span>

--- a/tests/reviews/ReviewsPage.test.tsx
+++ b/tests/reviews/ReviewsPage.test.tsx
@@ -75,7 +75,7 @@ describe("ReviewsPage", () => {
     vi.useFakeTimers();
     fireEvent.change(search, { target: { value: "Gamma" } });
     act(() => {
-      vi.advanceTimersByTime(250);
+      vi.advanceTimersByTime(300);
     });
     expect(screen.getByText("Gamma")).toBeInTheDocument();
     expect(screen.queryByText("Alpha")).toBeNull();


### PR DESCRIPTION
## Summary
- debounce the reminders panel search with shared state to reduce redundant filtering
- standardize hero search components across reviews, team comps, goals, and components gallery to 300ms delays
- align the reviews page unit test with the new debounce interval

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d54037544c832cadb90706792e1f49