### PR TITLE
Fix Vercel Next.js version detection

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "framework": "nextjs",
+  "frameworkVersion": "15.5.3",
+  "buildCommand": "npm run build",
+  "devCommand": "npm run dev"
+}


### PR DESCRIPTION
## Summary
- add a Vercel project configuration that pins the Next.js framework version
- ensure Vercel uses the existing npm build and dev scripts when running the project

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d554a652f8832cbe1d9666f7630498