### PR TITLE
Align home hero spacing with design tokens

### DIFF
--- a/src/app/page-client.tsx
+++ b/src/app/page-client.tsx
@@ -81,13 +81,13 @@ function HomePageBody({ themeVariant }: { themeVariant: Variant }) {
         as="header"
         grid
         aria-labelledby={heroHeadingId}
-        className="pt-6 md:pt-8"
+        className="pt-[var(--space-6)] md:pt-[var(--space-8)]"
       >
         <SectionCard
           aria-labelledby={heroHeadingId}
           className="col-span-full"
         >
-          <SectionCard.Body className="md:p-6">
+          <SectionCard.Body className="md:p-[var(--space-6)]">
             <HomeHeroSection
               variant={themeVariant}
               actions={heroActions}
@@ -101,7 +101,7 @@ function HomePageBody({ themeVariant }: { themeVariant: Variant }) {
         grid
         role="region"
         aria-labelledby={overviewHeadingId}
-        className="mt-6 pb-6 md:mt-8 md:pb-8"
+        className="mt-[var(--space-6)] pb-[var(--space-6)] md:mt-[var(--space-8)] md:pb-[var(--space-8)]"
       >
         <SectionCard
           aria-labelledby={overviewHeadingId}
@@ -114,7 +114,7 @@ function HomePageBody({ themeVariant }: { themeVariant: Variant }) {
             titleAs="h2"
             titleClassName="text-title font-semibold tracking-[-0.01em]"
           />
-          <SectionCard.Body className="md:p-6">
+          <SectionCard.Body className="md:p-[var(--space-6)]">
             <HeroPlannerCards
               variant={themeVariant}
               plannerOverviewProps={plannerOverviewProps}
@@ -132,7 +132,7 @@ export default function Page() {
     <Suspense
       fallback={
         <PageShell as="section" aria-busy="true" role="status">
-          <div className="flex justify-center p-6">
+          <div className="flex justify-center p-[var(--space-6)]">
             <Spinner />
           </div>
         </PageShell>


### PR DESCRIPTION
## Summary
- replace raw tailwind spacing classes on the home hero layout with spacing tokens
- update the overview card padding and suspense fallback padding to use the shared token scale

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d556d796ac832cb80bdd8e977a5a3f