### PR TITLE
fix: require scroll parent ref for virtualized list

### DIFF
--- a/src/components/ui/primitives/VirtualizedList.tsx
+++ b/src/components/ui/primitives/VirtualizedList.tsx
@@ -10,7 +10,7 @@ type VirtualizedListProps<Item> = {
   overscan?: number;
   renderItem: (item: Item, index: number) => React.ReactElement;
   getKey?: (item: Item, index: number) => React.Key;
-  scrollParentRef?: React.RefObject<HTMLElement | null>;
+  scrollParentRef: React.RefObject<HTMLElement | null>;
   renderSpacer?: RenderSpacer;
 };
 


### PR DESCRIPTION
## Summary
- require a scroll container ref when using VirtualizedList so the runtime guard matches the TypeScript surface

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d55d3dc3ac832c9b06fb5b008d8ca1