### PR TITLE
Fix configure-pages action reference

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -64,7 +64,7 @@ jobs:
         run: npm ci --prefer-offline --no-audit --no-fund
 
       - name: Setup Pages
-        uses: actions/configure-pages@5a4e5d06a81fbc806ec93c5e7c3a09d8c7b6bed5
+        uses: actions/configure-pages@v5
 
       - name: Build static export
         run: npm run deploy


### PR DESCRIPTION
## Summary
- update the GitHub Pages deployment workflow to use the maintained configure-pages v5 action tag

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d562ab075c832cac490b8216d7230c