### PR TITLE
Fix Vercel installs missing dev dependencies

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,6 @@
   "framework": "nextjs",
   "frameworkVersion": "15.5.3",
   "buildCommand": "npm run build",
-  "devCommand": "npm run dev"
+  "devCommand": "npm run dev",
+  "installCommand": "npm install --include=dev"
 }


### PR DESCRIPTION
## Summary
- ensure Vercel installs the dev dependencies required by the TypeScript build scripts by overriding the install command

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d564dadf38832cbf6c3e847dbb9957