### PR TITLE
Ensure GitHub Actions use repository npm version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
 
+      - name: Activate npm version from package.json
+        run: |
+          corepack enable
+          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+
       - name: Restore Next.js cache
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
         with:

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -48,6 +48,11 @@ jobs:
           node-version-file: ".nvmrc"
           cache: npm
 
+      - name: Activate npm version from package.json
+        run: |
+          corepack enable
+          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+
       - name: Restore cache
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
         with:


### PR DESCRIPTION
## Summary
- activate the package-managed npm version in the CI workflow using Corepack
- mirror the npm activation step in the GitHub Pages deployment workflow so both jobs install dependencies with the same toolchain

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d574c8a87c832cab1309cce93b94a0