### PR TITLE
Fix asset base paths for static export

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import "./themes.css";
 
 import type { Metadata, Viewport } from "next";
+import type { CSSProperties } from "react";
 import { headers } from "next/headers";
 import {
   geistMonoVariable,
@@ -133,6 +134,11 @@ export default async function RootLayout({
 }) {
   let nonce: string | undefined;
   const year = new Date().getFullYear();
+  type AssetStyle = CSSProperties & Record<`--${string}`, string>;
+  const assetUrlStyles: AssetStyle = {
+    "--asset-noise-url": `url("${withBasePath("/noise.svg")}")`,
+    "--asset-glitch-gif-url": `url("${withBasePath("/glitch-gif.gif")}")`,
+  };
 
   if (process.env.GITHUB_PAGES === "true") {
     // Static exports (GitHub Pages) do not provide response headers,
@@ -171,6 +177,7 @@ export default async function RootLayout({
       </head>
       <body
         className={`${geistSansClassName} ${geistSansVariable} ${geistMonoVariable} min-h-screen bg-background text-foreground glitch-root`}
+        style={assetUrlStyles}
       >
         <a
           className="fixed left-[var(--space-4)] top-[var(--space-4)] z-50 inline-flex items-center rounded-[var(--radius-lg)] bg-background px-[var(--space-4)] py-[var(--space-2)] text-ui font-medium text-foreground shadow-outline-subtle outline-none transition-all duration-quick ease-out opacity-0 -translate-y-full pointer-events-none focus-visible:translate-y-0 focus-visible:opacity-100 focus-visible:pointer-events-auto focus-visible:shadow-ring focus-visible:no-underline focus-visible:outline-none hover:shadow-ring focus-visible:active:translate-y-[var(--space-1)]"

--- a/src/components/home/HeroPortraitFrame.tsx
+++ b/src/components/home/HeroPortraitFrame.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import Image from "next/image";
-import { cn } from "@/lib/utils";
+import { cn, withBasePath } from "@/lib/utils";
 
 export interface HeroPortraitFrameProps {
   imageSrc: string;
@@ -63,10 +63,11 @@ export default function HeroPortraitFrame({
   className,
   frame = true,
 }: HeroPortraitFrameProps) {
+  const resolvedImageSrc = withBasePath(imageSrc);
   const baseClassName = "relative isolate flex shrink-0 items-center justify-center";
   const portraitImage = (
     <Image
-      src={imageSrc}
+      src={resolvedImageSrc}
       alt={imageAlt}
       sizes={imageSizes}
       priority={priority}

--- a/src/components/home/WelcomeHeroFigure.tsx
+++ b/src/components/home/WelcomeHeroFigure.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import Image from "next/image";
-import { cn } from "@/lib/utils";
+import { cn, withBasePath } from "@/lib/utils";
 
 type CSSVarStyle = React.CSSProperties & Record<`--${string}`, string>;
 
@@ -100,6 +100,7 @@ export default function WelcomeHeroFigure({
     framed ? "h-full w-full rounded-full" : "h-auto w-full",
   );
   const imageAlt = "Planner assistant sharing a colorful dashboard scene";
+  const resolvedHeroImageSrc = withBasePath(heroImageSrc);
   const sharedImageProps = {
     priority: true,
     loading: "eager" as const,
@@ -148,7 +149,7 @@ export default function WelcomeHeroFigure({
                 className="pointer-events-none absolute inset-0 rounded-full"
                 style={overlayStyle}
               />
-              <Image {...sharedImageProps} alt={imageAlt} src={heroImageSrc} fill />
+              <Image {...sharedImageProps} alt={imageAlt} src={resolvedHeroImageSrc} fill />
             </div>
           </div>
         </>
@@ -156,7 +157,7 @@ export default function WelcomeHeroFigure({
         <Image
           {...sharedImageProps}
           alt={imageAlt}
-          src={heroImageSrc}
+          src={resolvedHeroImageSrc}
           width={heroImageDimensions.width}
           height={heroImageDimensions.height}
         />

--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import * as React from "react";
-import Image from "next/image";
 import {
   PageHeader,
   Header,
@@ -13,6 +12,8 @@ import {
   SearchBar,
   type HeaderTab,
 } from "@/components/ui";
+import Image from "next/image";
+import { withBasePath } from "@/lib/utils";
 import { Bell, CircleUser } from "lucide-react";
 
 type CompactNav = "summary" | "timeline" | "reports";
@@ -44,6 +45,8 @@ const heroFilters: HeaderTab<HeroFilter>[] = [
   { key: "flagged", label: "Flagged" },
   { key: "reviewed", label: "Reviewed" },
 ];
+
+const plannerLogoSrc = withBasePath("/planner-logo.svg");
 
 const tabCopy: Record<MinimalTab, string> = {
   overview: "Track meetings, reviews, and highlights in one streamlined view.",
@@ -294,7 +297,7 @@ export default function PageHeaderDemo() {
             "Plan your day, track goals, and review games with a calm single-frame hero.",
           icon: (
             <Image
-              src="/planner-logo.svg"
+              src={plannerLogoSrc}
               alt="Planner logo"
               width={48}
               height={48}
@@ -362,7 +365,7 @@ export default function PageHeaderDemo() {
           subtitle: "Stage a high-energy announcement right in the app.",
           icon: (
             <Image
-              src="/planner-logo.svg"
+              src={plannerLogoSrc}
               alt="Planner logo"
               width={48}
               height={48}


### PR DESCRIPTION
## Summary
- set root CSS variables for noise and glitch assets using the runtime base path
- ensure hero imagery and demo logos resolve through withBasePath before rendering
- propagate base-path aware image sources through reusable hero components

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d58424d9b8832c9bc824c2fe10eafc