### PR TITLE
Fix GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -79,7 +79,7 @@ jobs:
           DEPLOY_ARTIFACT_ONLY: "true"
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462e409cc
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./out
 


### PR DESCRIPTION
## Summary
- replace the deleted commit SHA for `actions/upload-pages-artifact` with the supported v3 tag so the deploy job can fetch the action again

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d58eff161c832c9157b8ef36bf80d8