### PR TITLE
Fix app icon re-export

### DIFF
--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -1,1 +1,2 @@
-export { size, contentType, dynamic, default } from "../src/app/icon";
+export { size, contentType, dynamic } from "../src/app/icon";
+export { default } from "../src/app/icon";


### PR DESCRIPTION
## Summary
- ensure the App Router icon bridge re-exports the implementation from src/app
- avoid broken token imports when the app directory is used during deployment

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d5a49b6874832c87a4a4dae385e320