### PR TITLE
Fix aria-invalid normalization

### DIFF
--- a/src/lib/useFieldIds.ts
+++ b/src/lib/useFieldIds.ts
@@ -47,7 +47,13 @@ export function useFieldIds(
 
   const { id, name } = useFieldNaming(namingOptions);
 
-  const isInvalid = ariaInvalid === true || ariaInvalid === "true";
+  const normalizedInvalid =
+    typeof ariaInvalid === "string" ? ariaInvalid.trim().toLowerCase() : null;
+  const isInvalid =
+    ariaInvalid === true ||
+    (normalizedInvalid !== null &&
+      normalizedInvalid.length > 0 &&
+      normalizedInvalid !== "false");
 
   return { id, name, isInvalid };
 }

--- a/tests/lib/accessibilityHelpers.test.tsx
+++ b/tests/lib/accessibilityHelpers.test.tsx
@@ -94,6 +94,9 @@ describe("accessibility helpers", () => {
     rerender(<FieldProbe ariaInvalid={true} />);
     expect(screen.getByTestId("invalid-flag")).toHaveTextContent("true");
 
+    rerender(<FieldProbe ariaInvalid="grammar" />);
+    expect(screen.getByTestId("invalid-flag")).toHaveTextContent("true");
+
     rerender(<FieldProbe ariaInvalid="false" />);
     expect(screen.getByTestId("invalid-flag")).toHaveTextContent("false");
 


### PR DESCRIPTION
## Summary
- treat non-false aria-invalid strings as invalid in useFieldIds so grammar/spelling values are respected
- extend accessibility helper test coverage to assert grammar states remain invalid

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d5a7f5f0a4832c9b3b09d18751f5c8