### PR TITLE
Fix deploy-pages action pin

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -85,4 +85,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deploy
-        uses: actions/deploy-pages@de13fcec3a067df1c7717c7c9d62d97ad836d41b
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e


### PR DESCRIPTION
## Summary
- update the GitHub Pages deployment workflow to point to the current actions/deploy-pages v4 commit

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d5c5a09954832c98f1f07969a8e02c