### PR TITLE
Fix record validator to reject arrays

### DIFF
--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -2,7 +2,7 @@
 // Shared runtime type guards and validators.
 
 export function isRecord<T = unknown>(value: unknown): value is Record<string, T> {
-  return typeof value === "object" && value !== null;
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 export function isStringArray(value: unknown): value is string[] {

--- a/tests/lib/accessibilityHelpers.test.tsx
+++ b/tests/lib/accessibilityHelpers.test.tsx
@@ -129,7 +129,7 @@ describe("utility coverage", () => {
 
   it("guards validators against edge case inputs", () => {
     expect(isRecord({ alpha: 1 })).toBe(true);
-    expect(isRecord([])).toBe(true);
+    expect(isRecord([])).toBe(false);
     expect(isRecord(null)).toBe(false);
     expect(isRecord(42)).toBe(false);
 


### PR DESCRIPTION
## Summary
- ensure the `isRecord` validator rejects array inputs
- update validator coverage tests to match the corrected guard

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d66851ff6c832cbc2ee73878efca80