### PR TITLE
Fix persisted theme decoding to avoid invalid classes

### DIFF
--- a/src/lib/theme-context.tsx
+++ b/src/lib/theme-context.tsx
@@ -5,6 +5,7 @@ import { usePersistentState } from "@/lib/db";
 import {
   applyTheme,
   defaultTheme,
+  decodeThemeState,
   BG_CLASSES,
   THEME_STORAGE_KEY,
   type ThemeState,
@@ -20,6 +21,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setTheme] = usePersistentState<ThemeState>(
     THEME_STORAGE_KEY,
     defaultTheme(),
+    { decode: decodeThemeState },
   );
   const defaultThemeRef = React.useRef(defaultTheme());
   const pendingPersistedSyncRef = React.useRef(true);
@@ -53,19 +55,21 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
         ? currentBackgroundClass !== expectedBackgroundClass
         : expectedBackgroundClass !== "";
 
+    const defaultState = defaultThemeRef.current;
+    const isDefaultSelection =
+      theme.variant === defaultState.variant && theme.bg === defaultState.bg;
+
     if (
       pendingPersistedSyncRef.current &&
       documentElement.dataset.themePref === "persisted" &&
-      (themeClassMismatch || backgroundMismatch)
+      (themeClassMismatch || backgroundMismatch) &&
+      !isDefaultSelection
     ) {
       return;
     }
 
     pendingPersistedSyncRef.current = false;
 
-    const defaultState = defaultThemeRef.current;
-    const isDefaultSelection =
-      theme.variant === defaultState.variant && theme.bg === defaultState.bg;
     const shouldPersistPreference =
       documentElement.dataset.themePref === "persisted" || !isDefaultSelection;
 

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -100,6 +100,41 @@ export const VARIANT_LABELS: Record<Variant, string> = VARIANTS.reduce(
   {} as Record<Variant, string>,
 );
 
+const VARIANT_ID_SET = new Set<Variant>(VARIANTS.map((variant) => variant.id));
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isVariant(value: unknown): value is Variant {
+  return typeof value === "string" && VARIANT_ID_SET.has(value as Variant);
+}
+
+function isBackground(value: unknown): value is Background {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    value < BG_CLASSES.length
+  );
+}
+
+export function decodeThemeState(value: unknown): ThemeState | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const rawVariant = value["variant"];
+  if (!isVariant(rawVariant)) {
+    return null;
+  }
+
+  const rawBackground = value["bg"];
+  const background = isBackground(rawBackground) ? rawBackground : 0;
+
+  return { variant: rawVariant, bg: background };
+}
+
 export function defaultTheme(): ThemeState {
   return { variant: "lg", bg: 0 };
 }

--- a/tests/lib/theme-context.test.tsx
+++ b/tests/lib/theme-context.test.tsx
@@ -93,5 +93,30 @@ describe("ThemeProvider", () => {
       }
     });
   });
+
+  it("falls back to the default theme when persisted data is invalid", async () => {
+    const key = createStorageKey(themeModule.THEME_STORAGE_KEY);
+    window.localStorage.setItem(key, JSON.stringify({ variant: "nope", bg: 42 }));
+    document.documentElement.className = "theme-nope";
+    document.documentElement.dataset.themePref = "persisted";
+
+    render(
+      <ThemeProvider>
+        <Consumer />
+      </ThemeProvider>,
+    );
+
+    const defaultState = themeModule.defaultTheme();
+
+    await waitFor(() => {
+      expect(Consumer.lastTheme?.variant).toBe(defaultState.variant);
+      expect(Consumer.lastTheme?.bg).toBe(defaultState.bg);
+    });
+
+    expect(
+      document.documentElement.classList.contains(`theme-${defaultState.variant}`),
+    ).toBe(true);
+    expect(document.documentElement.classList.contains("theme-nope")).toBe(false);
+  });
 });
 


### PR DESCRIPTION
## Summary
- sanitize persisted theme state to ignore invalid variant or background values
- update ThemeProvider to apply sanitized defaults even when bootstrap classes linger
- add a regression test covering invalid persisted theme data

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d69ef4eee4832c91490bd170602f0d