### PR TITLE
Align PageHeader styling across pages

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -22,16 +22,13 @@ export default function NotFound() {
       aria-labelledby={headerId}
     >
       <PageHeader
-        className="rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-5)]"
         header={{
           id: headerId,
           heading: "Page not found",
           icon: <AlertCircle className="opacity-80" />,
         }}
         hero={{
-          frame: false,
           heading: "This page does not exist",
-          padding: "none",
           actions: (
             <Button asChild>
               <Link href="/">Go home</Link>

--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -85,7 +85,6 @@ function Inner() {
         {/* Week header (range, nav, totals, day chips) */}
         <PageHeader
           containerClassName="col-span-full"
-          contentClassName="space-y-2"
           header={{
             id: "planner-header",
             tabIndex: -1,
@@ -97,13 +96,8 @@ function Inner() {
             sticky: false,
           }}
           hero={{
-            frame: false,
             sticky: false,
-            rail: false,
-            padding: "none",
-            barClassName: "hidden",
-            className: "planner-header__hero",
-            heading: <span className="sr-only">Week picker</span>,
+            heading: "Week controls",
             children: (
               <>
                 <WeekPicker />

--- a/src/components/prompts/PromptsHeader.tsx
+++ b/src/components/prompts/PromptsHeader.tsx
@@ -47,10 +47,8 @@ export default function PromptsHeader({
         ),
       }}
       hero={{
-        frame: false,
         sticky: false,
         tone: "supportive",
-        padding: "none",
         topClassName: "top-[var(--header-stack)]",
         heading: (
           <span className="sr-only" id={`${id}-hero`}>

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -92,8 +92,6 @@ export default function ReviewsPage({
     <>
       <PageShell as="header" className="py-[var(--space-6)]">
         <PageHeader
-          className="rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-4)]"
-          contentClassName="space-y-[var(--space-2)]"
           header={{
             id: "reviews-header",
             heading: "Reviews",
@@ -103,10 +101,7 @@ export default function ReviewsPage({
             sticky: false,
           }}
           hero={{
-            frame: false,
             sticky: false,
-            topClassName: "top-[var(--header-stack)]",
-            padding: "none",
             heading: "Browse Reviews",
             subtitle: <span className="pill">Total {base.length}</span>,
             children: (

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -284,10 +284,8 @@ export default function TeamCompPage() {
         subTab === "sheet" ? "cheatSheet" : "myComps";
       return {
         as: "section",
-        frame: false,
         sticky: true,
         topClassName: "top-[var(--header-stack)]",
-        padding: "none",
         eyebrow: active?.label,
         heading: "Comps",
         subtitle:
@@ -436,11 +434,9 @@ export default function TeamCompPage() {
     }
     return {
       as: "section",
-      frame: false,
       sticky: false,
       topClassName: "top-[var(--header-stack)]",
       rail: true,
-      padding: "none",
       heading: "Clear Speed Buckets",
       dividerTint: "primary",
       search: {
@@ -519,9 +515,6 @@ export default function TeamCompPage() {
     >
       <PageHeader
         containerClassName="col-span-full"
-        className="rounded-card r-card-lg px-4 py-4"
-        contentClassName="space-y-2"
-        frameProps={{ variant: "unstyled" }}
         header={{
           id: "teamcomp-header",
           eyebrow: "Comps",

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -138,7 +138,7 @@ exports[`ReviewsPage > renders default state 1`] = `
     
       </style>
       <div
-        class="group/hero-frame relative z-0 isolate flex flex-col overflow-visible hero-focus border border-border/55 bg-card/70 text-foreground shadow-outline-subtle hero2-frame hero2-neomorph before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:rounded-[inherit] before:transition before:duration-300 before:ease-out before:content-[''] motion-reduce:before:transition-none has-[:focus-visible]:before:[--hero2-focus-ring:var(--hero2-focus-ring-active)] data-[has-focus=true]:before:[--hero2-focus-ring:var(--hero2-focus-ring-active)] rounded-card r-card-lg md:px-[var(--space-7)] md:py-[var(--space-7)] lg:px-[var(--space-8)] lg:py-[var(--space-8)] rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-4)]"
+        class="group/hero-frame relative z-0 isolate flex flex-col overflow-visible hero-focus border border-border/55 bg-card/70 text-foreground shadow-outline-subtle hero2-frame hero2-neomorph before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:rounded-[inherit] before:transition before:duration-300 before:ease-out before:content-[''] motion-reduce:before:transition-none has-[:focus-visible]:before:[--hero2-focus-ring:var(--hero2-focus-ring-active)] data-[has-focus=true]:before:[--hero2-focus-ring:var(--hero2-focus-ring-active)] rounded-card r-card-lg px-[var(--space-6)] py-[var(--space-6)] md:px-[var(--space-7)] md:py-[var(--space-7)] lg:px-[var(--space-8)] lg:py-[var(--space-8)]"
         data-variant="default"
         style="--hero-slot-divider: var(--ring);"
         tabindex="-1"
@@ -147,7 +147,7 @@ exports[`ReviewsPage > renders default state 1`] = `
           class="relative z-[1] space-y-[var(--space-5)] md:space-y-[var(--space-6)]"
         >
           <div
-            class="relative z-[2] md:space-y-[var(--space-6)] space-y-[var(--space-2)]"
+            class="relative z-[2] space-y-[var(--space-5)] md:space-y-[var(--space-6)]"
           >
             <header
               class="z-[999] relative isolate border-b border-card-hairline-60 bg-surface/80 backdrop-blur after:absolute after:left-0 after:bottom-0 after:h-px after:w-full after:bg-gradient-to-r after:z-[2] after:from-card-hairline after:via-card-hairline-70 after:to-transparent"
@@ -204,14 +204,145 @@ exports[`ReviewsPage > renders default state 1`] = `
               </div>
             </header>
             <section>
+              <style
+                global="true"
+                jsx="true"
+              >
+                
+      .hero2-neomorph {
+        background: linear-gradient(
+          145deg,
+          hsl(var(--card)),
+          hsl(var(--panel))
+        );
+        --hero2-shadow-key: var(--shadow);
+        --hero2-shadow-ambient: inset 0 0 0 calc(var(--hairline-w) * 1.5)
+          hsl(var(--shadow-color) / 0.18);
+        box-shadow: var(--hero2-shadow-ambient), var(--hero2-shadow-key);
+        position: relative;
+        --hero2-focus-ring-rest: 0 0 0 0 hsl(var(--ring) / 0),
+          0 0 0 0 hsl(var(--ring) / 0);
+        --hero2-focus-ring-active: 0 0 0 calc(var(--hairline-w) * 1)
+          hsl(var(--ring)),
+          var(--shadow-glow-lg);
+        --hero2-focus-ring: var(--hero2-focus-ring-rest);
+        --hero2-glow-top-left-color: hsl(var(--highlight) / 0.55);
+        --hero2-glow-top-left-soft: hsl(var(--highlight) / 0.08);
+        --hero2-glow-bottom-right-color: hsl(var(--shadow-color) / 0.42);
+        --hero2-glow-bottom-right-soft: hsl(var(--shadow-color) / 0.14);
+        --hero2-glow-top-left: radial-gradient(
+          140% 140% at 0% 0%,
+          var(--hero2-glow-top-left-color) 0%,
+          var(--hero2-glow-top-left-soft) 45%,
+          transparent 75%
+        );
+        --hero2-glow-bottom-right: radial-gradient(
+          160% 160% at 100% 100%,
+          var(--hero2-glow-bottom-right-color) 0%,
+          var(--hero2-glow-bottom-right-soft) 55%,
+          transparent 82%
+        );
+      }
+      .hero2-neomorph::before,
+      .hero2-neomorph::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        pointer-events: none;
+        z-index: -1;
+        opacity: 1;
+      }
+      .hero2-neomorph::before {
+        background: var(--hero2-glow-top-left);
+        box-shadow: var(--hero2-focus-ring);
+        transition: box-shadow var(--dur-quick, 160ms) ease-out;
+      }
+      .hero2-neomorph::after {
+        background: var(--hero2-glow-bottom-right);
+      }
+      @supports (
+        color: color-mix(
+          in oklab,
+          hsl(var(--highlight)),
+          hsl(var(--background))
+        )
+      ) {
+        .hero2-neomorph {
+          --hero2-shadow-ambient: inset 0 0 0 calc(var(--hairline-w) * 1.5)
+            color-mix(
+              in oklab,
+              hsl(var(--shadow-color)) 28%,
+              hsl(var(--highlight))
+            );
+          --hero2-glow-top-left-color: color-mix(
+            in oklab,
+            hsl(var(--highlight)) 72%,
+            hsl(var(--shadow-color))
+          );
+          --hero2-glow-top-left-soft: color-mix(
+            in oklab,
+            hsl(var(--highlight)) 22%,
+            hsl(var(--background) / 0)
+          );
+          --hero2-glow-bottom-right-color: color-mix(
+            in oklab,
+            hsl(var(--shadow-color)) 82%,
+            hsl(var(--highlight))
+          );
+          --hero2-glow-bottom-right-soft: color-mix(
+            in oklab,
+            hsl(var(--shadow-color)) 28%,
+            hsl(var(--background) / 0)
+          );
+        }
+      }
+      @media (prefers-contrast: more) {
+        .hero2-frame {
+          border-color: hsl(var(--foreground) / 0.7) !important;
+        }
+        .hero2-neomorph {
+          --hero2-shadow-key: 0 0 var(--space-4)
+            hsl(var(--foreground) / 0.75);
+          --hero2-shadow-ambient: inset 0 0 0 calc(var(--hairline-w) * 2)
+            hsl(var(--foreground) / 0.7);
+          box-shadow: var(--hero2-shadow-ambient), var(--hero2-shadow-key);
+          --hero2-glow-top-left: none;
+          --hero2-glow-bottom-right: none;
+          --hero2-focus-ring-rest: 0 0 0 0 hsl(var(--foreground) / 0),
+            0 0 0 0 hsl(var(--foreground) / 0);
+          --hero2-focus-ring-active: 0 0 0 calc(var(--hairline-w) * 2)
+            hsl(var(--foreground) / 0.9),
+            0 0 0 0 hsl(var(--foreground) / 0.6);
+        }
+      }
+      @media (forced-colors: active) {
+        .hero2-frame {
+          border-color: CanvasText !important;
+          background: Canvas !important;
+        }
+        .hero2-neomorph {
+          background: Canvas !important;
+          box-shadow: none !important;
+          --hero2-glow-top-left: none;
+          --hero2-glow-bottom-right: none;
+          --hero2-focus-ring-rest: 0 0 0 0 Canvas,
+            0 0 0 0 Canvas;
+          --hero2-focus-ring-active: 0 0 0 calc(var(--hairline-w) * 2)
+            CanvasText,
+            0 0 0 0 CanvasText;
+        }
+      }
+    
+              </style>
               <div
-                class=""
+                class="group/hero relative z-0 isolate overflow-hidden rounded-card r-card-lg border border-border/55 bg-card/70 text-foreground shadow-outline-subtle hero2-frame hero2-neomorph px-[var(--space-6)] py-[var(--space-6)] md:px-[var(--space-7)] md:py-[var(--space-7)] lg:px-[var(--space-8)] lg:py-[var(--space-8)]"
               >
                 <div
-                  class="relative z-[2] grid grid-cols-1 md:grid-cols-12 items-start md:items-center gap-y-[var(--space-2)] md:gap-y-0 md:gap-x-[var(--space-4)] lg:gap-x-[var(--space-5)] py-[var(--space-4)] md:py-[var(--space-5)]"
+                  class="relative z-[2] grid grid-cols-1 md:grid-cols-12 items-start md:items-center gap-y-[var(--space-4)] md:gap-y-0 md:gap-x-[var(--space-4)] lg:gap-x-[var(--space-6)]"
                 >
                   <div
-                    class="relative col-span-full md:col-span-8 flex min-w-0 flex-wrap items-start md:flex-nowrap md:items-center gap-[var(--space-2)] md:gap-[var(--space-4)]"
+                    class="relative col-span-full md:col-span-8 flex min-w-0 flex-wrap items-start md:flex-nowrap md:items-center gap-[var(--space-4)] md:gap-[var(--space-5)]"
                   >
                     <div
                       class="min-w-0"
@@ -220,7 +351,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                         class="flex min-w-0 flex-wrap items-baseline gap-x-[var(--space-2)] gap-y-[var(--space-1)]"
                       >
                         <h2
-                          class="font-semibold tracking-[-0.01em] text-balance break-words text-foreground text-title md:text-title"
+                          class="font-semibold tracking-[-0.01em] text-balance break-words text-foreground text-title md:text-title hero2-title"
                           data-text="Browse Reviews"
                         >
                           Browse Reviews
@@ -240,7 +371,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                   </div>
                 </div>
                 <div
-                  class="relative z-[2] mt-[var(--space-4)] md:mt-[var(--space-5)] flex flex-col gap-[var(--space-4)] md:gap-[var(--space-5)]"
+                  class="relative z-[2] mt-[var(--space-5)] md:mt-[var(--space-6)] flex flex-col gap-[var(--space-5)] md:gap-[var(--space-6)]"
                 >
                   <div
                     class=""
@@ -441,6 +572,10 @@ exports[`ReviewsPage > renders default state 1`] = `
                     </div>
                   </div>
                 </div>
+                <div
+                  aria-hidden="true"
+                  class="absolute inset-0 rounded-card r-card-lg ring-1 ring-inset ring-border/55"
+                />
               </div>
             </section>
           </div>


### PR DESCRIPTION
## Summary
- let not-found, prompts, reviews, team comps, and planner rely on the default PageHeader frame for consistent styling
- update the ReviewsPage snapshot to cover the refreshed hero layout

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d6af1ef200832cb1acad43b882ad64