### PR TITLE
Fix misc panel virtualization height token

### DIFF
--- a/src/components/prompts/component-gallery/MiscPanel.tsx
+++ b/src/components/prompts/component-gallery/MiscPanel.tsx
@@ -58,7 +58,7 @@ const VirtualizedListDemo = React.memo(function VirtualizedListDemo() {
       </div>
       <div
         ref={scrollParentRef}
-        className="max-h-[calc(var(--space-12)*3)] overflow-y-auto text-ui"
+        className="max-h-[calc(var(--space-8)*3)] overflow-y-auto text-ui"
       >
         <table className="w-full text-left text-xs">
           <tbody>


### PR DESCRIPTION
## Summary
- replace the misc panel virtualized list cap with an existing spacing token so the gallery grid stays aligned

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d6bc5ae610832c9aad87b6b1d7a08a