### PR TITLE
Add aurora light token fallbacks for non color-mix browsers

### DIFF
--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -58,6 +58,13 @@
       hsl(var(--border)) 82%,
       hsl(var(--accent)) 18%
     );
+    --aurora-g-light: color-mix(in oklab, hsl(var(--accent-2)) 37.5%, white);
+    --aurora-p-light: color-mix(in oklab, hsl(var(--accent)) 37.5%, white);
+  }
+
+  html.theme-aurora {
+    --aurora-g-light: color-mix(in oklab, hsl(var(--accent-2)) 37.5%, white);
+    --aurora-p-light: color-mix(in oklab, hsl(var(--accent)) 37.5%, white);
   }
 }
 
@@ -104,9 +111,9 @@ html.theme-aurora {
   --success: 148 72% 48%;
   --success-glow: 148 72% 38% / 0.6;
   --aurora-g: var(--accent-2);
-  --aurora-g-light: color-mix(in oklab, hsl(var(--accent-2)) 37.5%, white);
+  --aurora-g-light: var(--aurora-g);
   --aurora-p: var(--accent);
-  --aurora-p-light: color-mix(in oklab, hsl(var(--accent)) 37.5%, white);
+  --aurora-p-light: var(--aurora-p);
   --shadow-base: 280 32% 6%;
   --edge-iris: conic-gradient(
     from 180deg,

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -54,9 +54,9 @@
   --tone-bot: 195 75% 56%;
   --tone-sup: 320 72% 60%;
   --aurora-g: var(--accent-2);
-  --aurora-g-light: color-mix(in oklab, hsl(var(--accent-2)) 37.5%, white);
+  --aurora-g-light: var(--aurora-g);
   --aurora-p: var(--accent);
-  --aurora-p-light: color-mix(in oklab, hsl(var(--accent)) 37.5%, white);
+  --aurora-p-light: var(--aurora-p);
   --icon-fg: 250 96% 78%;
   --accent-overlay: hsl(var(--accent));
   --ring-contrast: hsl(var(--ring));
@@ -228,4 +228,11 @@
   --radius-xl: 16px;
   --radius-2xl: 24px;
   --radius-full: 9999px;
+}
+
+@supports (color: color-mix(in oklab, white, black)) {
+  :root {
+    --aurora-g-light: color-mix(in oklab, hsl(var(--accent-2)) 37.5%, white);
+    --aurora-p-light: color-mix(in oklab, hsl(var(--accent)) 37.5%, white);
+  }
 }


### PR DESCRIPTION
## Summary
- default the aurora light tokens to their solid counterparts for legacy browsers
- gate the blended aurora variants behind color-mix support in both global tokens and the aurora theme overrides

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d6bc648fe8832cb4139e158ba3db16