### PR TITLE
Adjust PageShell grid spacing on medium breakpoints

### DIFF
--- a/src/components/ui/layout/PageShell.tsx
+++ b/src/components/ui/layout/PageShell.tsx
@@ -50,7 +50,7 @@ export default function PageShell<T extends PageShellElement = "div">({
       {grid ? (
         <div
           className={cn(
-            "grid gap-[var(--space-4)] md:grid-cols-12 lg:gap-[var(--space-5)]",
+            "grid gap-[var(--space-4)] md:grid-cols-12 md:gap-[var(--space-5)]",
             contentClassName
           )}
         >


### PR DESCRIPTION
## Summary
- update the PageShell grid layout so medium breakpoints and above use the larger gutter token

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d6f5ea841c832c8714fbea46d55895