### PR TITLE
Align PageShell grid gutter spacing

### DIFF
--- a/src/components/ui/layout/PageShell.tsx
+++ b/src/components/ui/layout/PageShell.tsx
@@ -50,7 +50,7 @@ export default function PageShell<T extends PageShellElement = "div">({
       {grid ? (
         <div
           className={cn(
-            "grid gap-[var(--space-4)] md:grid-cols-12 md:gap-[var(--space-5)]",
+            "[--grid-gutter:var(--space-4)] grid gap-[var(--grid-gutter)] md:grid-cols-12 md:[--grid-gutter:var(--space-5)]",
             contentClassName
           )}
         >


### PR DESCRIPTION
## Summary
- ensure the PageShell grid gutter uses a shared custom property so medium and larger breakpoints stay on the space-5 token

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d70d75ab04832c9946da1bf27cea66