### PR TITLE
Align planner hero gutters with layout tokens

### DIFF
--- a/src/components/home/HeroPlannerCards.tsx
+++ b/src/components/home/HeroPlannerCards.tsx
@@ -12,6 +12,7 @@ import QuickActions from "./QuickActions";
 import ReviewsCard from "./ReviewsCard";
 import TeamPromptsCard from "./TeamPromptsCard";
 import TodayCard from "./TodayCard";
+import { layoutGridGutterClass } from "@/components/ui/layout/PageShell";
 import type { Variant } from "@/lib/theme";
 import { cn } from "@/lib/utils";
 
@@ -38,7 +39,8 @@ export default function HeroPlannerCards({
   return (
     <div
       className={cn(
-        "grid grid-cols-1 gap-[var(--space-6)] md:grid-cols-12",
+        "grid grid-cols-1 md:grid-cols-12",
+        layoutGridGutterClass,
         className,
       )}
     >
@@ -57,7 +59,10 @@ export default function HeroPlannerCards({
         className="pt-[var(--space-4)]"
       />
       <section
-        className="col-span-full grid grid-cols-1 gap-[var(--space-6)] md:grid-cols-12 supports-[grid-template-columns:subgrid]:md:[grid-template-columns:subgrid]"
+        className={cn(
+          "col-span-full grid grid-cols-1 md:grid-cols-12 supports-[grid-template-columns:subgrid]:md:[grid-template-columns:subgrid]",
+          layoutGridGutterClass,
+        )}
       >
         <div className="md:col-span-4">
           <TodayCard />

--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -20,7 +20,7 @@ import type { ISODate } from "./plannerTypes";
 import { PlannerProvider } from "./plannerContext";
 import WeekPicker from "./WeekPicker";
 import { PageHeader } from "@/components/ui";
-import PageShell from "@/components/ui/layout/PageShell";
+import PageShell, { layoutGridGutterClass } from "@/components/ui/layout/PageShell";
 import Button from "@/components/ui/primitives/Button";
 import { CalendarDays, ChevronLeft, ChevronRight } from "lucide-react";
 import { addDays, formatWeekRangeLabel, toISODate } from "@/lib/date";
@@ -114,13 +114,13 @@ function Inner() {
         as="main"
         grid
         className="py-6"
-        contentClassName="gap-y-6"
+        contentClassName="gap-y-[var(--space-5)]"
         aria-labelledby="planner-header"
       >
         {/* Today + Side column */}
         <section
           aria-label="Today and weekly panels"
-          className="col-span-full grid grid-cols-1 gap-6 lg:grid-cols-12"
+          className={`col-span-full grid grid-cols-1 lg:grid-cols-12 ${layoutGridGutterClass}`}
         >
           <div className="col-span-full lg:col-span-8" ref={heroRef}>
             <TodayHero iso={iso} />
@@ -129,7 +129,7 @@ function Inner() {
           {/* Sticky only on large so it doesn’t eat the viewport on mobile */}
           <aside
             aria-label="Day notes"
-            className="col-span-full space-y-6 lg:col-span-4 lg:sticky lg:top-[var(--header-stack)]"
+            className="col-span-full space-y-[var(--space-5)] lg:col-span-4 lg:sticky lg:top-[var(--header-stack)]"
           >
             <WeekNotes iso={iso} />
           </aside>

--- a/src/components/prompts/NeomorphicHeroFrameDemo.tsx
+++ b/src/components/prompts/NeomorphicHeroFrameDemo.tsx
@@ -118,7 +118,7 @@ export default function NeomorphicHeroFrameDemo() {
             </div>
             <div className="flex items-center justify-between rounded-card r-card-md border border-border/30 bg-card/60 px-[var(--space-3)] py-[var(--space-2)] shadow-neo">
               <dt className="font-semibold text-foreground">Grid rhythm</dt>
-              <dd className="text-label">HeroGrid gap-4 · md:gap-6</dd>
+              <dd className="text-label">HeroGrid gap-4 · md:gap-5</dd>
             </div>
             <div className="flex items-center justify-between rounded-card r-card-md border border-border/30 bg-card/60 px-[var(--space-3)] py-[var(--space-2)] shadow-neo">
               <dt className="font-semibold text-foreground">Slot spans</dt>

--- a/src/components/ui/layout/NeomorphicHeroFrame.tsx
+++ b/src/components/ui/layout/NeomorphicHeroFrame.tsx
@@ -233,8 +233,8 @@ const slotBareBaseClass =
 const slotContentClass = "relative z-[1] flex w-full min-w-0 flex-col";
 
 const heroGridGaps: Record<Exclude<HeroVariant, "unstyled">, string> = {
-  default: "gap-[var(--space-4)] md:gap-[var(--space-6)]",
-  compact: "gap-[var(--space-3)] md:gap-[var(--space-4)]",
+  default: "gap-[var(--space-4)] md:gap-[var(--space-5)]",
+  compact: "gap-[var(--space-3)] md:gap-[var(--space-5)]",
   dense: "gap-[var(--space-2)] md:gap-[var(--space-3)]",
 };
 

--- a/src/components/ui/layout/PageShell.tsx
+++ b/src/components/ui/layout/PageShell.tsx
@@ -23,6 +23,9 @@ export type PageShellProps<T extends PageShellElement = "div"> =
   PageShellOwnProps<T> &
     Omit<React.ComponentPropsWithoutRef<T>, keyof PageShellOwnProps<T>>;
 
+export const layoutGridGutterClass =
+  "gap-[var(--space-4)] md:gap-[var(--space-5)]";
+
 /**
  * PageShell — width-constrained wrapper that applies the global `page-shell` class.
  * Use the `grid` prop to opt into the standard 12-column layout inside the shell.
@@ -50,7 +53,8 @@ export default function PageShell<T extends PageShellElement = "div">({
       {grid ? (
         <div
           className={cn(
-            "grid gap-[var(--space-4)] md:grid-cols-12 md:gap-[var(--space-5)]",
+            "grid md:grid-cols-12",
+            layoutGridGutterClass,
             contentClassName
           )}
         >


### PR DESCRIPTION
## Summary
- expose the shared layout grid gutter from PageShell and reuse it across planner grids
- align the hero frame default and compact variants to the md space-5 gutter and refresh gallery copy

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d70d76dcbc832c8e21579f7e1c2c83