### PR TITLE
Fix PageShell semantics for single main landmark

### DIFF
--- a/src/components/components/ComponentsPageClient.tsx
+++ b/src/components/components/ComponentsPageClient.tsx
@@ -219,7 +219,7 @@ export default function ComponentsPageClient({
       </PageShell>
 
       <PageShell
-        as="main"
+        as="section"
         grid
         aria-labelledby="components-header"
         className="py-[var(--space-6)] md:py-[var(--space-7)] lg:py-[var(--space-8)]"

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -502,7 +502,7 @@ function GoalsPageContent() {
       </PageShell>
 
       <PageShell
-        as="main"
+        as="section"
         aria-labelledby="goals-header"
         className="py-[var(--space-6)]"
       >

--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -111,7 +111,7 @@ function Inner() {
       </PageShell>
 
       <PageShell
-        as="main"
+        as="section"
         grid
         className="py-6"
         contentClassName="gap-y-6"

--- a/src/components/prompts/PromptsPage.tsx
+++ b/src/components/prompts/PromptsPage.tsx
@@ -147,7 +147,7 @@ export default function PromptsPage() {
       </PageShell>
 
       <PageShell
-        as="main"
+        as="section"
         className="space-y-[var(--space-6)] py-[var(--space-6)]"
         aria-labelledby="prompts-header"
       >

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -157,7 +157,7 @@ export default function ReviewsPage({
       </PageShell>
 
       <PageShell
-        as="main"
+        as="section"
         className="py-[var(--space-6)] space-y-[var(--space-6)]"
         aria-labelledby="reviews-header"
       >

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -507,7 +507,7 @@ export default function TeamCompPage() {
 
   return (
     <PageShell
-      as="main"
+      as="section"
       grid
       className="py-6"
       contentClassName="gap-y-6"

--- a/src/components/ui/layout/PageShell.tsx
+++ b/src/components/ui/layout/PageShell.tsx
@@ -36,15 +36,10 @@ export default function PageShell<T extends PageShellElement = "div">({
   ...rest
 }: PageShellProps<T>) {
   const Component = (as ?? "div") as PageShellElement;
-  const mainAccessibilityProps: Partial<React.ComponentPropsWithoutRef<"main">> =
-    Component === "main"
-      ? { id: "main-content", tabIndex: -1 }
-      : {};
 
   return (
     <Component
       className={cn("page-shell", className)}
-      {...mainAccessibilityProps}
       {...rest}
     >
       {grid ? (

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -583,11 +583,9 @@ exports[`ReviewsPage > renders default state 1`] = `
       </div>
     </section>
   </header>
-  <main
+  <section
     aria-labelledby="reviews-header"
     class="page-shell py-[var(--space-6)] space-y-[var(--space-6)]"
-    id="main-content"
-    tabindex="-1"
   >
     <div
       class="grid grid-cols-1 items-start gap-[var(--space-4)] sm:gap-[var(--space-6)] lg:gap-[var(--space-8)] md:grid-cols-6 lg:grid-cols-12"
@@ -779,6 +777,6 @@ exports[`ReviewsPage > renders default state 1`] = `
         </div>
       </div>
     </div>
-  </main>
+  </section>
 </div>
 `;


### PR DESCRIPTION
## Summary
- remove automatic main landmark props from PageShell to avoid duplicate skip targets
- update feature pages to render PageShell as sections under the shared layout main
- refresh ReviewsPage snapshot after landmark update

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d70d64bd28832ca65a2063d8de8ba0