### PR TITLE
Normalize planner grid gutters

### DIFF
--- a/src/components/home/HeroPlannerCards.tsx
+++ b/src/components/home/HeroPlannerCards.tsx
@@ -12,6 +12,7 @@ import QuickActions from "./QuickActions";
 import ReviewsCard from "./ReviewsCard";
 import TeamPromptsCard from "./TeamPromptsCard";
 import TodayCard from "./TodayCard";
+import { layoutGridClassName } from "@/components/ui/layout/PageShell";
 import type { Variant } from "@/lib/theme";
 import { cn } from "@/lib/utils";
 
@@ -37,10 +38,7 @@ export default function HeroPlannerCards({
 }: HeroPlannerCardsProps) {
   return (
     <div
-      className={cn(
-        "grid grid-cols-1 gap-[var(--space-6)] md:grid-cols-12",
-        className,
-      )}
+      className={cn(layoutGridClassName, "md:grid-cols-12", className)}
     >
       <div
         className="col-span-full grid items-start gap-[var(--space-4)] md:grid-cols-12 supports-[grid-template-columns:subgrid]:md:[grid-template-columns:subgrid]"
@@ -57,7 +55,10 @@ export default function HeroPlannerCards({
         className="pt-[var(--space-4)]"
       />
       <section
-        className="col-span-full grid grid-cols-1 gap-[var(--space-6)] md:grid-cols-12 supports-[grid-template-columns:subgrid]:md:[grid-template-columns:subgrid]"
+        className={cn(
+          layoutGridClassName,
+          "col-span-full md:grid-cols-12 supports-[grid-template-columns:subgrid]:md:[grid-template-columns:subgrid]",
+        )}
       >
         <div className="md:col-span-4">
           <TodayCard />

--- a/src/components/home/TeamPromptsCard.tsx
+++ b/src/components/home/TeamPromptsCard.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import DashboardCard from "./DashboardCard";
 import QuickActionGrid from "./QuickActionGrid";
+import { layoutGridClassName } from "@/components/ui/layout/PageShell";
 
 const teamQuickActions = [
   {
@@ -32,7 +33,7 @@ const promptsOverlayGradient = {
 
 export default function TeamPromptsCard() {
   return (
-    <div className="grid grid-cols-1 gap-[var(--space-6)] md:grid-cols-12">
+    <div className={`${layoutGridClassName} md:grid-cols-12`}>
       <div className="md:col-span-6">
         <DashboardCard title="Team quick actions">
           <QuickActionGrid

--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -20,7 +20,7 @@ import type { ISODate } from "./plannerTypes";
 import { PlannerProvider } from "./plannerContext";
 import WeekPicker from "./WeekPicker";
 import { PageHeader } from "@/components/ui";
-import PageShell from "@/components/ui/layout/PageShell";
+import PageShell, { layoutGridClassName } from "@/components/ui/layout/PageShell";
 import Button from "@/components/ui/primitives/Button";
 import { CalendarDays, ChevronLeft, ChevronRight } from "lucide-react";
 import { addDays, formatWeekRangeLabel, toISODate } from "@/lib/date";
@@ -120,7 +120,7 @@ function Inner() {
         {/* Today + Side column */}
         <section
           aria-label="Today and weekly panels"
-          className="col-span-full grid grid-cols-1 gap-6 lg:grid-cols-12"
+          className={`${layoutGridClassName} col-span-full lg:grid-cols-12`}
         >
           <div className="col-span-full lg:col-span-8" ref={heroRef}>
             <TodayHero iso={iso} />

--- a/src/components/prompts/component-gallery/ButtonsPanel.tsx
+++ b/src/components/prompts/component-gallery/ButtonsPanel.tsx
@@ -17,6 +17,7 @@ import {
   Toggle,
 } from "@/components/ui";
 import SegmentedButton from "@/components/ui/primitives/SegmentedButton";
+import { layoutGridClassName } from "@/components/ui/layout/PageShell";
 import { cn } from "@/lib/utils";
 import GalleryItem from "../GalleryItem";
 import IconButtonShowcase from "../IconButtonShowcase";
@@ -26,8 +27,7 @@ interface ButtonsPanelProps {
   data: ButtonsPanelData;
 }
 
-const GRID_CLASS =
-  "grid grid-cols-1 gap-[var(--space-6)] sm:grid-cols-2 md:grid-cols-12 md:gap-[var(--space-8)]";
+const GRID_CLASS = cn(layoutGridClassName, "sm:grid-cols-2 md:grid-cols-12");
 type PanelItem = { label: string; element: React.ReactNode; className?: string };
 
 export default function ButtonsPanel({ data }: ButtonsPanelProps) {

--- a/src/components/prompts/component-gallery/InputsPanel.tsx
+++ b/src/components/prompts/component-gallery/InputsPanel.tsx
@@ -11,13 +11,13 @@ import {
   SettingsSelect,
   Textarea,
 } from "@/components/ui";
+import { layoutGridClassName } from "@/components/ui/layout/PageShell";
 import { cn } from "@/lib/utils";
 import GalleryItem from "../GalleryItem";
 import { selectItems } from "./ComponentGallery.demoData";
 import type { InputsPanelData } from "./useComponentGalleryState";
 
-const GRID_CLASS =
-  "grid grid-cols-1 gap-[var(--space-6)] sm:grid-cols-2 md:grid-cols-12 md:gap-[var(--space-8)]";
+const GRID_CLASS = cn(layoutGridClassName, "sm:grid-cols-2 md:grid-cols-12");
 const fieldStoryHref = "/storybook/?path=/story/primitives-field--state-gallery";
 type PanelItem = { label: string; element: React.ReactNode; className?: string };
 

--- a/src/components/prompts/component-gallery/MiscPanel.tsx
+++ b/src/components/prompts/component-gallery/MiscPanel.tsx
@@ -33,12 +33,12 @@ import {
   ScoreMeter,
 } from "@/components/reviews";
 import GalleryItem from "../GalleryItem";
+import { layoutGridClassName } from "@/components/ui/layout/PageShell";
 import { cn } from "@/lib/utils";
 import { demoReview } from "./ComponentGallery.demoData";
 import type { MiscPanelData } from "./useComponentGalleryState";
 
-const GRID_CLASS =
-  "grid grid-cols-1 gap-[var(--space-6)] sm:grid-cols-2 md:grid-cols-12 md:gap-[var(--space-8)]";
+const GRID_CLASS = cn(layoutGridClassName, "sm:grid-cols-2 md:grid-cols-12");
 type PanelItem = { label: string; element: React.ReactNode; className?: string };
 
 interface MiscPanelProps {

--- a/src/components/prompts/component-gallery/PlannerPanel.tsx
+++ b/src/components/prompts/component-gallery/PlannerPanel.tsx
@@ -15,6 +15,7 @@ import {
   WeekPickerShell,
 } from "@/components/planner";
 import { Input } from "@/components/ui";
+import { layoutGridClassName } from "@/components/ui/layout/PageShell";
 import { cn } from "@/lib/utils";
 import GalleryItem from "../GalleryItem";
 import {
@@ -25,8 +26,7 @@ import {
 import WeekPickerDemo from "./WeekPickerDemo";
 import type { PlannerPanelData } from "./useComponentGalleryState";
 
-const GRID_CLASS =
-  "grid grid-cols-1 gap-[var(--space-6)] sm:grid-cols-2 md:grid-cols-12 md:gap-[var(--space-8)]";
+const GRID_CLASS = cn(layoutGridClassName, "sm:grid-cols-2 md:grid-cols-12");
 
 type WeekPickerShellDemoDay = {
   readonly iso: string;

--- a/src/components/prompts/component-gallery/PromptsPanel.tsx
+++ b/src/components/prompts/component-gallery/PromptsPanel.tsx
@@ -14,11 +14,11 @@ import PromptsComposePanel from "../PromptsComposePanel";
 import PromptsDemos from "../PromptsDemos";
 import PromptsHeader from "../PromptsHeader";
 import WelcomeHeroFigure from "@/components/home/WelcomeHeroFigure";
+import { layoutGridClassName } from "@/components/ui/layout/PageShell";
 import { cn } from "@/lib/utils";
 import type { PromptsPanelData } from "./useComponentGalleryState";
 
-const GRID_CLASS =
-  "grid grid-cols-1 gap-[var(--space-6)] sm:grid-cols-2 md:grid-cols-12 md:gap-[var(--space-8)]";
+const GRID_CLASS = cn(layoutGridClassName, "sm:grid-cols-2 md:grid-cols-12");
 type PanelItem = { label: string; element: React.ReactNode; className?: string };
 
 interface PromptsPanelProps {

--- a/src/components/ui/layout/NeomorphicHeroFrame.tsx
+++ b/src/components/ui/layout/NeomorphicHeroFrame.tsx
@@ -233,8 +233,8 @@ const slotBareBaseClass =
 const slotContentClass = "relative z-[1] flex w-full min-w-0 flex-col";
 
 const heroGridGaps: Record<Exclude<HeroVariant, "unstyled">, string> = {
-  default: "gap-[var(--space-4)] md:gap-[var(--space-6)]",
-  compact: "gap-[var(--space-3)] md:gap-[var(--space-4)]",
+  default: "gap-[var(--space-4)] md:gap-[var(--space-5)]",
+  compact: "gap-[var(--space-3)] md:gap-[var(--space-5)]",
   dense: "gap-[var(--space-2)] md:gap-[var(--space-3)]",
 };
 

--- a/src/components/ui/layout/PageShell.tsx
+++ b/src/components/ui/layout/PageShell.tsx
@@ -27,6 +27,9 @@ export type PageShellProps<T extends PageShellElement = "div"> =
  * PageShell — width-constrained wrapper that applies the global `page-shell` class.
  * Use the `grid` prop to opt into the standard 12-column layout inside the shell.
  */
+export const layoutGridClassName =
+  "[--grid-gutter:var(--space-4)] grid grid-cols-1 gap-[var(--grid-gutter)] md:[--grid-gutter:var(--space-5)]";
+
 export default function PageShell<T extends PageShellElement = "div">({
   as,
   className,
@@ -45,8 +48,9 @@ export default function PageShell<T extends PageShellElement = "div">({
       {grid ? (
         <div
           className={cn(
-            "[--grid-gutter:var(--space-4)] grid gap-[var(--grid-gutter)] md:grid-cols-12 md:[--grid-gutter:var(--space-5)]",
-            contentClassName
+            layoutGridClassName,
+            "md:grid-cols-12",
+            contentClassName,
           )}
         >
           {children}


### PR DESCRIPTION
## Summary
- add a reusable layoutGridClassName helper so planner surfaces reuse the same gutter tokens
- switch planner and gallery grids to the shared layout gutter and tighten hero frame medium gaps

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d71993b278832c94b74b77f56f935a