### PR TITLE
Fix danger foreground contrast for semantic tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,7 +6,7 @@
   :root {
     --shell-max: var(--shell-width);
     --accent-2-foreground: var(--accent-foreground);
-    --danger-foreground: var(--highlight);
+    --danger-foreground: 0 0% 6%;
     --asset-noise-url: url("/noise.svg");
     --asset-glitch-gif-url: url("/glitch-gif.gif");
     --settings-column-width: calc(var(--space-4) * 14);


### PR DESCRIPTION
## Summary
- update the danger foreground token to use a dark text value that meets WCAG contrast on error surfaces

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d71c273bb0832c9fe91a91c334db65