### PR TITLE
Fix nested route loading shells for accessibility

### DIFF
--- a/src/app/goals/loading.tsx
+++ b/src/app/goals/loading.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Skeleton } from "@/components/ui";
+import { PageShell, Skeleton } from "@/components/ui";
 
 const TAB_PLACEHOLDERS = ["goals", "reminders", "timer"] as const;
 const QUEUE_PLACEHOLDERS = ["queue-1", "queue-2", "queue-3"] as const;
@@ -9,7 +9,7 @@ const CARD_PLACEHOLDERS = ["reminders", "timer"] as const;
 export default function GoalsLoading() {
   return (
     <>
-      <header className="page-shell py-[var(--space-6)]">
+      <PageShell as="header" className="py-[var(--space-6)]">
         <div className="space-y-[var(--space-4)]">
           <div className="space-y-[var(--space-2)]">
             <Skeleton className="h-[var(--space-3)] w-1/5" radius="sm" />
@@ -28,9 +28,10 @@ export default function GoalsLoading() {
             </div>
           </div>
         </div>
-      </header>
-      <main
-        className="page-shell space-y-[var(--space-6)] py-[var(--space-6)]"
+      </PageShell>
+      <PageShell
+        as="section"
+        className="space-y-[var(--space-6)] py-[var(--space-6)]"
         aria-busy="true"
       >
         <section className="grid gap-[var(--space-6)] lg:grid-cols-12">
@@ -74,7 +75,7 @@ export default function GoalsLoading() {
             ))}
           </aside>
         </section>
-      </main>
+      </PageShell>
     </>
   );
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -4,6 +4,7 @@ import { AlertCircle } from "lucide-react";
 import {
   Button,
   PageHeader,
+  PageShell,
 } from "@/components/ui";
 
 export const metadata: Metadata = {
@@ -15,11 +16,11 @@ export default function NotFound() {
   const headerId = "not-found-header";
 
   return (
-    <main
-      id="main-content"
-      tabIndex={-1}
+    <PageShell
+      as="section"
       className="flex min-h-screen flex-col items-center justify-center gap-[var(--space-3)] px-[var(--space-4)] py-[var(--space-5)] text-center"
       aria-labelledby={headerId}
+      role="region"
     >
       <PageHeader
         header={{
@@ -41,6 +42,6 @@ export default function NotFound() {
           ),
         }}
       />
-    </main>
+    </PageShell>
   );
 }

--- a/src/app/planner/loading.tsx
+++ b/src/app/planner/loading.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Skeleton } from "@/components/ui";
+import { PageShell, Skeleton } from "@/components/ui";
 
 const ACTION_PLACEHOLDERS = ["prev", "today", "next"] as const;
 const WEEKDAY_PLACEHOLDERS = [
@@ -17,7 +17,7 @@ const PANEL_PLACEHOLDERS = ["notes", "summary", "metrics"] as const;
 export default function PlannerLoading() {
   return (
     <>
-      <header className="page-shell py-[var(--space-6)]">
+      <PageShell as="header" className="py-[var(--space-6)]">
         <div className="space-y-[var(--space-4)]">
           <div className="flex flex-wrap items-start justify-between gap-[var(--space-3)]">
             <div className="space-y-[var(--space-2)]">
@@ -48,9 +48,10 @@ export default function PlannerLoading() {
             </div>
           </div>
         </div>
-      </header>
-      <main
-        className="page-shell space-y-[var(--space-6)] py-[var(--space-6)]"
+      </PageShell>
+      <PageShell
+        as="section"
+        className="space-y-[var(--space-6)] py-[var(--space-6)]"
         aria-busy="true"
       >
         <section className="grid gap-[var(--space-6)] lg:grid-cols-12">
@@ -97,7 +98,7 @@ export default function PlannerLoading() {
             ))}
           </ul>
         </section>
-      </main>
+      </PageShell>
     </>
   );
 }

--- a/src/app/prompts/loading.tsx
+++ b/src/app/prompts/loading.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Skeleton } from "@/components/ui";
+import { PageShell, Skeleton } from "@/components/ui";
 
 const CHIP_PLACEHOLDERS = [
   "hover",
@@ -15,7 +15,7 @@ const PROMPT_CARDS = ["prompt-1", "prompt-2", "prompt-3"] as const;
 export default function PromptsLoading() {
   return (
     <>
-      <header className="page-shell py-[var(--space-6)]">
+      <PageShell as="header" className="py-[var(--space-6)]">
         <div className="rounded-card card-neo-soft shadow-neo-strong p-[var(--space-4)] space-y-[var(--space-4)]">
           <div className="flex flex-wrap items-center justify-between gap-[var(--space-3)]">
             <div className="space-y-[var(--space-2)]">
@@ -41,9 +41,10 @@ export default function PromptsLoading() {
             <Skeleton className="h-[var(--space-6)] w-[calc(var(--space-8)*2)]" radius="full" />
           </div>
         </div>
-      </header>
-      <main
-        className="page-shell space-y-[var(--space-6)] py-[var(--space-6)]"
+      </PageShell>
+      <PageShell
+        as="section"
+        className="space-y-[var(--space-6)] py-[var(--space-6)]"
         aria-busy="true"
       >
         <nav className="rounded-card card-neo-soft shadow-neo-strong p-[var(--space-4)]">
@@ -73,7 +74,7 @@ export default function PromptsLoading() {
             </article>
           ))}
         </section>
-      </main>
+      </PageShell>
     </>
   );
 }

--- a/src/app/reviews/loading.tsx
+++ b/src/app/reviews/loading.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Skeleton } from "@/components/ui";
+import { PageShell, Skeleton } from "@/components/ui";
 
 const FILTER_PLACEHOLDERS = ["filter-sort", "filter-tags"] as const;
 const LIST_PLACEHOLDERS = [
@@ -15,7 +15,7 @@ const DETAIL_SECTIONS = ["summary", "edit"] as const;
 export default function ReviewsLoading() {
   return (
     <>
-      <header className="page-shell py-[var(--space-6)]">
+      <PageShell as="header" className="py-[var(--space-6)]">
         <div className="rounded-card card-neo-soft shadow-neo-strong p-[var(--space-4)] space-y-[var(--space-4)]">
           <div className="space-y-[var(--space-2)]">
             <Skeleton className="h-[var(--space-3)] w-1/4" radius="sm" />
@@ -30,9 +30,10 @@ export default function ReviewsLoading() {
             <Skeleton className="md:col-span-2 h-[var(--space-8)]" radius="card" />
           </div>
         </div>
-      </header>
-      <main
-        className="page-shell space-y-[var(--space-6)] py-[var(--space-6)]"
+      </PageShell>
+      <PageShell
+        as="section"
+        className="space-y-[var(--space-6)] py-[var(--space-6)]"
         aria-busy="true"
       >
         <section className="grid gap-[var(--space-4)] md:grid-cols-6 lg:grid-cols-12">
@@ -82,7 +83,7 @@ export default function ReviewsLoading() {
             </article>
           </section>
         </section>
-      </main>
+      </PageShell>
     </>
   );
 }

--- a/src/app/team/loading.tsx
+++ b/src/app/team/loading.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Skeleton } from "@/components/ui";
+import { PageShell, Skeleton } from "@/components/ui";
 
 const MAIN_TABS = ["cheat", "builder", "clears"] as const;
 const SUB_TABS = ["sheet", "comps"] as const;
@@ -10,7 +10,7 @@ const PANEL_ROWS = ["lane-1", "lane-2", "lane-3"] as const;
 export default function TeamLoading() {
   return (
     <>
-      <header className="page-shell space-y-[var(--space-6)] py-[var(--space-6)]">
+      <PageShell as="header" className="space-y-[var(--space-6)] py-[var(--space-6)]">
         <div className="rounded-card card-neo-soft shadow-neo-strong p-[var(--space-4)] space-y-[var(--space-4)]">
           <div className="flex flex-wrap items-start justify-between gap-[var(--space-3)]">
             <div className="space-y-[var(--space-2)]">
@@ -39,9 +39,10 @@ export default function TeamLoading() {
             ))}
           </div>
         </div>
-      </header>
-      <main
-        className="page-shell space-y-[var(--space-6)] py-[var(--space-6)]"
+      </PageShell>
+      <PageShell
+        as="section"
+        className="space-y-[var(--space-6)] py-[var(--space-6)]"
         aria-busy="true"
       >
         <section className="rounded-card card-neo-soft shadow-neo-strong p-[var(--space-4)] space-y-[var(--space-4)]">
@@ -83,7 +84,7 @@ export default function TeamLoading() {
             ))}
           </div>
         </section>
-      </main>
+      </PageShell>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- replace nested `<main>` usage in route loading states with `PageShell` sections to respect the layout landmark structure
- update the not-found screen to reuse `PageShell` instead of duplicating the `main-content` id

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d71dddcc98832c972c1dcadb67cecd