### PR TITLE
Normalize layout spacing tokens

### DIFF
--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -54,7 +54,7 @@ function Inner() {
   const heroRef = React.useRef<HTMLDivElement>(null);
 
   const right = (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-[var(--space-2)]">
       <Button
         variant="ghost"
         size="sm"
@@ -81,7 +81,7 @@ function Inner() {
 
   return (
     <>
-      <PageShell as="header" grid className="py-6">
+      <PageShell as="header" grid className="py-[var(--space-6)]">
         {/* Week header (range, nav, totals, day chips) */}
         <PageHeader
           containerClassName="col-span-full"
@@ -113,8 +113,8 @@ function Inner() {
       <PageShell
         as="section"
         grid
-        className="py-6"
-        contentClassName="gap-y-6"
+        className="py-[var(--space-6)]"
+        contentClassName="gap-y-[var(--space-6)]"
         aria-labelledby="planner-header"
       >
         {/* Today + Side column */}
@@ -129,7 +129,7 @@ function Inner() {
           {/* Sticky only on large so it doesn’t eat the viewport on mobile */}
           <aside
             aria-label="Day notes"
-            className="col-span-full space-y-6 lg:col-span-4 lg:sticky lg:top-[var(--header-stack)]"
+            className="col-span-full space-y-[var(--space-6)] lg:col-span-4 lg:sticky lg:top-[var(--header-stack)]"
           >
             <WeekNotes iso={iso} />
           </aside>
@@ -138,7 +138,7 @@ function Inner() {
         {/* Week list (Mon→Sun) — anchors used by WeekPicker’s selectAndScroll */}
         <ul
           aria-label="Week days (Monday to Sunday)"
-          className="col-span-full flex flex-col gap-4"
+          className="col-span-full flex flex-col gap-[var(--space-4)]"
         >
           {dayItems.map((item) => (
             <DayRow key={item.iso} iso={item.iso} isToday={item.isToday} />

--- a/src/components/team/TeamCompPage.tsx
+++ b/src/components/team/TeamCompPage.tsx
@@ -369,12 +369,12 @@ export default function TeamCompPage() {
         heading: "Builder",
         subtitle,
         children: (
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-[var(--space-4)]">
+            <div className="flex flex-col gap-[var(--space-2)]">
               <span className="text-label font-semibold uppercase tracking-[0.02em] text-muted-foreground">
                 Lane coverage
               </span>
-              <div className="flex flex-wrap gap-2">
+              <div className="flex flex-wrap gap-[var(--space-2)]">
                 {laneSummaries.map((lane) => (
                   <Badge
                     key={lane.key}
@@ -387,7 +387,7 @@ export default function TeamCompPage() {
                 ))}
               </div>
             </div>
-            <div className="flex flex-wrap items-center gap-2">
+            <div className="flex flex-wrap items-center gap-[var(--space-2)]">
               <Badge size="sm" tone={gapTone}>
                 {openLabel}
               </Badge>
@@ -403,7 +403,7 @@ export default function TeamCompPage() {
           </div>
         ),
         actions: (
-          <div className="flex flex-wrap items-center gap-3 md:gap-4">
+          <div className="flex flex-wrap items-center gap-[var(--space-3)] md:gap-[var(--space-4)]">
             <IconButton
               title="Swap Allies ↔ Enemies"
               aria-label="Swap Allies and Enemies"
@@ -451,8 +451,8 @@ export default function TeamCompPage() {
         ),
       },
       actions: (
-        <div className="flex flex-wrap items-center gap-2">
-          <div className="flex flex-col items-start gap-1">
+        <div className="flex flex-wrap items-center gap-[var(--space-2)]">
+          <div className="flex flex-col items-start gap-[var(--space-1)]">
             <Button
               variant="primary"
               size="md"
@@ -464,7 +464,7 @@ export default function TeamCompPage() {
               <Plus />
               <span>New Row</span>
             </Button>
-            <div className="flex items-center gap-1 text-label text-muted-foreground">
+            <div className="flex items-center gap-[var(--space-1)] text-label text-muted-foreground">
               <span>Sends to</span>
               <Badge size="sm" tone="accent">
                 {targetBucket}
@@ -509,8 +509,8 @@ export default function TeamCompPage() {
     <PageShell
       as="section"
       grid
-      className="py-6"
-      contentClassName="gap-y-6"
+      className="py-[var(--space-6)]"
+      contentClassName="gap-y-[var(--space-6)]"
       aria-labelledby="teamcomp-header"
     >
       <PageHeader
@@ -533,7 +533,7 @@ export default function TeamCompPage() {
         hero={hero}
       />
 
-      <section className="col-span-full grid gap-4 md:grid-cols-12">
+      <section className="col-span-full grid gap-[var(--space-4)] md:grid-cols-12">
         {TABS.map((t) => {
           const ids = tabIds[t.key];
           return (


### PR DESCRIPTION
## Summary
- align planner and team comp shells with spacing tokens so headers, rails, and lists follow the shared grid rhythm

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d7288a8b5c832ca9077c2289c211a4