### PR TITLE
Polish home visuals for clarity

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1396,17 +1396,24 @@ textarea:-webkit-autofill {
 .glitch-rail {
   background: linear-gradient(
     180deg,
-    hsl(var(--primary) / 0.85) 0%,
-    hsl(var(--accent) / 0.65) 45%,
-    hsl(var(--ring) / 0.85) 100%
+    hsl(var(--primary) / 0.6) 0%,
+    hsl(var(--accent) / 0.45) 45%,
+    hsl(var(--ring) / 0.6) 100%
   );
   background-size: 100% 200%;
   animation: lg-railShift 5.5s ease-in-out infinite;
   box-shadow:
     0 0 calc(var(--space-3) + var(--spacing-0-5))
-      hsl(var(--primary) / 0.35),
+      hsl(var(--primary) / 0.25),
     0 0 calc(var(--space-5) + var(--space-1))
-      hsl(var(--accent) / 0.25);
+      hsl(var(--accent) / 0.18);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glitch-rail {
+    animation: none;
+    background-position: center;
+  }
 }
 .glitch-card {
   position: relative;

--- a/src/components/home/DashboardCard.tsx
+++ b/src/components/home/DashboardCard.tsx
@@ -20,7 +20,7 @@ export default function DashboardCard({
   return (
     <NeoCard className="p-[var(--space-4)] md:p-[var(--space-6)] space-y-[var(--space-4)]">
       <div className="flex items-center justify-between">
-        <h2 className="text-body font-semibold tracking-[-0.01em] text-card-foreground">{title}</h2>
+        <h2 className="text-title font-semibold tracking-[-0.01em] text-card-foreground">{title}</h2>
         {actions}
       </div>
       {children && (

--- a/src/components/home/QuickActionGrid.tsx
+++ b/src/components/home/QuickActionGrid.tsx
@@ -23,7 +23,7 @@ const buttonBaseClassName =
   "rounded-[var(--control-radius)] focus-visible:ring-offset-0 transition-transform duration-quick ease-out motion-reduce:transition-none";
 
 const buttonHoverLiftClassName =
-  "motion-safe:hover:-translate-y-[var(--quick-actions-lift)] motion-reduce:transform-none";
+  "motion-safe:hover:-translate-y-[var(--quick-actions-lift)] motion-safe:focus-visible:-translate-y-[var(--quick-actions-lift)] motion-reduce:transform-none";
 
 const isExternalHref = (href: string): boolean => {
   if (href.startsWith("/")) return false;

--- a/src/components/home/TeamPromptsCard.tsx
+++ b/src/components/home/TeamPromptsCard.tsx
@@ -28,7 +28,7 @@ const teamQuickActions = [
 
 const promptsOverlayGradient = {
   "--seg-active-grad":
-    "linear-gradient(90deg, hsl(var(--primary-soft) / 0.75), hsl(var(--accent-soft) / 0.75), hsl(var(--accent-2) / 0.7))",
+    "linear-gradient(90deg, hsl(var(--primary-soft) / 0.45), hsl(var(--accent-soft) / 0.45), hsl(var(--accent-2) / 0.4))",
 } as React.CSSProperties;
 
 export default function TeamPromptsCard() {


### PR DESCRIPTION
## Summary
- soften the glitch rail glow and respect reduced motion to reduce visual noise
- align dashboard card typography with the title scale and lift quick actions on focus for clearer states
- calm the prompts overlay gradient so copy stays legible while keeping the accent tone

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d72ad8dca4832ca99877a447ebe787