### PR TITLE
Refine chrome banner and navigation styling

### DIFF
--- a/src/components/chrome/Banner.tsx
+++ b/src/components/chrome/Banner.tsx
@@ -28,14 +28,21 @@ export default function Banner({
   return (
     <header
       className={cn(
-        sticky ? "sticky top-0 z-30 sticky-blur border-b border-border" : "",
+        "relative overflow-hidden",
+        sticky ? "sticky top-0 z-30 sticky-blur" : "",
         className
       )}
     >
+      {sticky ? (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-[linear-gradient(90deg,hsl(var(--accent)),hsl(var(--accent-2)),hsl(var(--accent)))] opacity-70"
+        />
+      ) : null}
       <PageShell
         grid
-        className="py-[var(--space-3)]"
-        contentClassName="items-center"
+        className="py-[var(--space-2)]"
+        contentClassName="items-center gap-y-[var(--space-2)]"
       >
         {title ? (
           <div className="col-span-full font-mono text-ui text-muted-foreground md:col-span-8 lg:col-span-9">
@@ -43,7 +50,7 @@ export default function Banner({
           </div>
         ) : null}
         {actions ? (
-          <div className="col-span-full flex items-center justify-end gap-[var(--space-3)] md:col-span-4 md:justify-self-end lg:col-span-3">
+          <div className="col-span-full flex items-center justify-end gap-[var(--space-2)] md:col-span-4 md:justify-self-end lg:col-span-3">
             {actions}
           </div>
         ) : null}

--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -26,9 +26,9 @@ export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
     <nav
       role="navigation"
       aria-label="Primary"
-      className="max-w-full overflow-x-auto lg:overflow-x-visible"
+      className="max-w-full overflow-x-auto pb-[var(--space-1)] lg:overflow-x-visible"
     >
-      <ul className="flex list-none flex-nowrap items-center gap-[var(--space-2)]">
+      <ul className="flex list-none flex-nowrap items-center justify-center gap-[var(--space-1)] md:gap-[var(--space-2)]">
         {items.map(({ href, label, mobileIcon: Icon }) => {
           const active = isNavActive(path, href);
 
@@ -40,13 +40,16 @@ export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
                 aria-current={active ? "page" : undefined}
                 data-active={active ? "true" : undefined}
                 className={cn(
-                  "group relative inline-flex min-h-[var(--control-h-lg)] items-center gap-[var(--space-2)] rounded-card r-card-lg px-[var(--space-4)] py-[var(--space-2)] text-ui font-medium font-mono transition motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
-                  "card-neo-soft",
-                  "hover:bg-interaction-accent-surfaceHover active:bg-interaction-accent-surfaceActive",
+                  "group relative inline-flex h-[var(--control-h-lg)] items-center gap-[var(--space-2)] rounded-full px-[var(--space-4)] text-ui font-medium font-mono tracking-[0.04em] transition motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
+                  "before:absolute before:inset-y-[calc(var(--space-1)/2)] before:inset-x-[var(--space-2)] before:-z-10 before:rounded-full before:bg-background/60 before:opacity-0 before:transition-opacity before:duration-quick before:ease-out",
+                  "after:pointer-events-none after:absolute after:inset-x-[var(--space-2)] after:bottom-0 after:h-px after:rounded-full after:bg-[linear-gradient(90deg,hsl(var(--accent)/0.5),hsl(var(--accent-2)),hsl(var(--accent)/0.5))] after:opacity-0 after:transition-opacity after:duration-quick",
+                  "hover:text-foreground",
+                  "hover:before:opacity-100 focus-visible:before:opacity-100",
+                  "hover:after:opacity-60 focus-visible:after:opacity-80",
                   "disabled:pointer-events-none disabled:opacity-disabled data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-disabled data-[loading=true]:pointer-events-none data-[loading=true]:opacity-loading",
                   active
-                    ? "text-foreground data-[active=true]:ring-1 data-[active=true]:ring-ring"
-                    : "text-muted-foreground hover:text-foreground",
+                    ? "text-foreground before:opacity-100 after:opacity-90"
+                    : "text-muted-foreground",
                 )}
               >
                 {Icon ? (
@@ -64,7 +67,7 @@ export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
                   <motion.span
                     data-testid="nav-underline"
                     layoutId="nav-underline"
-                    className="absolute left-[var(--space-2)] right-[var(--space-2)] -bottom-[var(--space-1)] h-px nav-underline"
+                    className="absolute left-[var(--space-2)] right-[var(--space-2)] -bottom-[var(--space-1)] h-px rounded-full nav-underline shadow-[var(--shadow-glow-sm)]"
                     transition={{
                       type: "tween",
                       duration: reduceMotion ? 0 : 0.25,

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -23,32 +23,46 @@ export type SiteChromeProps = {
 export default function SiteChrome({ children }: SiteChromeProps) {
   return (
     <React.Fragment>
-      <header role="banner" className="sticky top-0 z-50 sticky-blur">
+      <header
+        role="banner"
+        className="sticky top-0 z-50 sticky-blur"
+      >
         {/* Bar content */}
         <PageShell
           grid
-          className="pt-[calc(env(safe-area-inset-top)+var(--space-3))] pb-0 md:pt-[var(--space-3)] md:pb-[var(--space-3)]"
-          contentClassName="items-center"
+          className="relative pt-[calc(env(safe-area-inset-top)+var(--space-2))] pb-[var(--space-2)] md:py-[var(--space-2)]"
+          contentClassName="items-center gap-y-[var(--space-2)]"
         >
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-[linear-gradient(90deg,hsl(var(--accent)),hsl(var(--accent-2)),hsl(var(--accent)))] opacity-70"
+          />
+
           <Link
             href="/"
             aria-label="Home"
-            className="col-span-full flex items-center gap-[var(--space-3)] md:col-span-3 lg:col-span-3"
+            className="col-span-full flex items-center gap-[var(--space-2)] md:col-span-3"
           >
             <span
-              className="h-[var(--space-2)] w-[var(--space-2)] rounded-full animate-pulse bg-accent-overlay shadow-[var(--shadow-glow-sm)]"
-              aria-hidden
-            />
+              aria-hidden="true"
+              className="relative flex h-[var(--space-5)] w-[var(--space-1)] items-center justify-center overflow-hidden rounded-full bg-accent/40 shadow-[var(--shadow-glow-sm)]"
+            >
+              <span className="absolute inset-[calc(var(--space-1)/2)] rounded-full bg-[linear-gradient(180deg,hsl(var(--accent)),hsl(var(--accent-2)))] opacity-90" />
+            </span>
             <BrandWordmark />
           </Link>
 
-          <div className="col-span-full hidden min-w-0 items-center md:col-span-6 md:flex lg:col-span-7">
+          <div className="col-span-full hidden min-w-0 justify-center md:col-span-6 md:flex lg:col-span-6">
             <NavBar />
           </div>
 
-          <div className="col-span-full flex items-center justify-end gap-[var(--space-3)] md:col-span-3 md:justify-self-end lg:col-span-2">
-            <ThemeToggle />
-            <AnimationToggle />
+          <div className="col-span-full flex items-center justify-end md:col-span-3 md:justify-self-end">
+            <div className="inline-flex items-center gap-[var(--space-1)] rounded-full border border-border/60 bg-background/80 px-[var(--space-2)] py-[var(--space-1)] shadow-[var(--shadow-glow-sm)] backdrop-blur">
+              <ThemeToggle className="shrink-0" />
+              <div className="shrink-0">
+                <AnimationToggle />
+              </div>
+            </div>
           </div>
 
           <div className="col-span-full md:hidden">

--- a/tests/chrome/Banner.test.tsx
+++ b/tests/chrome/Banner.test.tsx
@@ -36,12 +36,11 @@ describe("Banner", () => {
     const header = screen.getByRole("banner");
 
     expect(header).toHaveClass(
+      "overflow-hidden",
       "sticky",
       "top-0",
       "z-30",
       "sticky-blur",
-      "border-b",
-      "border-border",
     );
     expect(screen.getByRole("button", { name: "Action" })).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- tighten the top chrome layout with a gradient baseline, focused brand marker, and grouped theme controls
- refresh the primary nav items with centered alignment, hover glow, and reinforced active underline
- update the sticky banner rhythm and expectations to use the new accent baseline

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d72b4223ec832c93dcd9c0932a51ff