### PR TITLE
Fix banner overflow handling for non-sticky banners

### DIFF
--- a/src/components/chrome/Banner.tsx
+++ b/src/components/chrome/Banner.tsx
@@ -28,8 +28,8 @@ export default function Banner({
   return (
     <header
       className={cn(
-        "relative overflow-hidden",
-        sticky ? "sticky top-0 z-30 sticky-blur" : "",
+        "relative",
+        sticky && "overflow-hidden sticky top-0 z-30 sticky-blur",
         className
       )}
     >


### PR DESCRIPTION
## Summary
- gate the banner's overflow clipping behind the sticky flag so overlays can extend outside non-sticky headers

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d730ab5da4832cb41773a2941bd487