### PR TITLE
Add toggle primitives gallery coverage

### DIFF
--- a/src/components/gallery/generated-manifest.ts
+++ b/src/components/gallery/generated-manifest.ts
@@ -17,6 +17,119 @@ export const galleryPayload = {
       "id": "buttons",
       "entries": [
         {
+          "id": "badge",
+          "name": "Badge",
+          "description": "Compact pill with tone-driven styles. Accent tones now meet ≥4.5:1 contrast for white content",
+          "kind": "primitive",
+          "tags": [
+            "badge",
+            "pill"
+          ],
+          "props": [
+            {
+              "name": "tone",
+              "type": "\"neutral\" | \"primary\" | \"accent\" | \"top\" | \"jungle\" | \"mid\" | \"bot\" | \"support\"",
+              "defaultValue": "\"neutral\""
+            },
+            {
+              "name": "size",
+              "type": "\"sm\" | \"md\" | \"lg\" | \"xl\"",
+              "defaultValue": "\"md\"",
+              "description": "Use \"xs\" as an alias for \"sm\" when migrating legacy code."
+            },
+            {
+              "name": "interactive",
+              "type": "boolean",
+              "defaultValue": "false"
+            },
+            {
+              "name": "selected",
+              "type": "boolean",
+              "defaultValue": "false"
+            },
+            {
+              "name": "glitch",
+              "type": "boolean",
+              "defaultValue": "false"
+            }
+          ],
+          "axes": [
+            {
+              "id": "tone",
+              "label": "Tone",
+              "type": "variant",
+              "values": [
+                {
+                  "value": "Neutral"
+                },
+                {
+                  "value": "Accent"
+                },
+                {
+                  "value": "Primary"
+                },
+                {
+                  "value": "Top lane"
+                },
+                {
+                  "value": "Jungle"
+                },
+                {
+                  "value": "Mid lane"
+                },
+                {
+                  "value": "Bot lane"
+                },
+                {
+                  "value": "Support"
+                }
+              ]
+            },
+            {
+              "id": "size",
+              "label": "Size",
+              "type": "variant",
+              "values": [
+                {
+                  "value": "Small"
+                },
+                {
+                  "value": "Medium"
+                },
+                {
+                  "value": "Large"
+                },
+                {
+                  "value": "Extra large"
+                }
+              ]
+            },
+            {
+              "id": "state",
+              "label": "State",
+              "type": "state",
+              "values": [
+                {
+                  "value": "Default"
+                },
+                {
+                  "value": "Interactive"
+                },
+                {
+                  "value": "Selected"
+                },
+                {
+                  "value": "Disabled"
+                }
+              ]
+            }
+          ],
+          "code": "<div className=\"flex flex-col gap-[var(--space-3)]\">\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Badge size=\"sm\">Small</Badge>\n    <Badge size=\"md\">Medium</Badge>\n    <Badge size=\"lg\">Large</Badge>\n    <Badge size=\"xl\">Extra large</Badge>\n  </div>\n  <p className=\"text-caption text-muted-foreground\">\n    <code>xs</code> is available as an alias of <code>sm</code> for legacy badges.\n  </p>\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Badge tone=\"neutral\">Neutral</Badge>\n    <Badge tone=\"accent\">Accent</Badge>\n    <Badge tone=\"primary\">Primary</Badge>\n    <Badge tone=\"primary\" interactive selected>\n      Selected\n    </Badge>\n    <Badge tone=\"accent\" interactive disabled>\n      Disabled\n    </Badge>\n  </div>\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Badge tone=\"top\" glitch>\n      Top lane\n    </Badge>\n    <Badge tone=\"jungle\" glitch>\n      Jungle\n    </Badge>\n    <Badge tone=\"mid\" glitch>\n      Mid lane\n    </Badge>\n    <Badge tone=\"bot\" glitch>\n      Bot lane\n    </Badge>\n    <Badge tone=\"support\" glitch>\n      Support\n    </Badge>\n  </div>\n</div>",
+          "preview": {
+            "id": "ui:badge:tones"
+          }
+        },
+        {
           "id": "button",
           "name": "Button",
           "description": "Tone, size, and interaction states",
@@ -2409,6 +2522,130 @@ export const galleryPayload = {
               }
             }
           ]
+        },
+        {
+          "id": "toggle",
+          "name": "Toggle",
+          "description": "Binary switch with hover, focus, active, disabled, and loading states",
+          "kind": "primitive",
+          "tags": [
+            "toggle",
+            "switch"
+          ],
+          "props": [
+            {
+              "name": "leftLabel",
+              "type": "string"
+            },
+            {
+              "name": "rightLabel",
+              "type": "string"
+            },
+            {
+              "name": "value",
+              "type": "\"Left\" | \"Right\"",
+              "defaultValue": "\"Left\""
+            },
+            {
+              "name": "onChange",
+              "type": "(value: \"Left\" | \"Right\") => void"
+            },
+            {
+              "name": "disabled",
+              "type": "boolean",
+              "defaultValue": "false"
+            },
+            {
+              "name": "loading",
+              "type": "boolean",
+              "defaultValue": "false"
+            },
+            {
+              "name": "className",
+              "type": "string"
+            }
+          ],
+          "axes": [
+            {
+              "id": "state",
+              "label": "State",
+              "type": "state",
+              "values": [
+                {
+                  "value": "Default"
+                },
+                {
+                  "value": "Hover"
+                },
+                {
+                  "value": "Focus-visible"
+                },
+                {
+                  "value": "Active"
+                },
+                {
+                  "value": "Disabled"
+                },
+                {
+                  "value": "Loading"
+                }
+              ]
+            }
+          ],
+          "code": "<div className=\"flex flex-col gap-[var(--space-4)]\">\n  <Toggle leftLabel=\"Strategy\" rightLabel=\"Execute\" />\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--hover]\" />\n    <Toggle\n      leftLabel=\"Left\"\n      rightLabel=\"Right\"\n      className=\"ring-2 ring-[var(--ring)] ring-offset-2 ring-offset-[var(--surface-2)] focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]\"\n    />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--active]\" />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" disabled />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" loading />\n  </div>\n</div>",
+          "preview": {
+            "id": "ui:toggle:interactive"
+          },
+          "states": [
+            {
+              "id": "default",
+              "name": "Default",
+              "code": "<Toggle leftLabel=\"Left\" rightLabel=\"Right\" />",
+              "preview": {
+                "id": "ui:toggle:state:default"
+              }
+            },
+            {
+              "id": "hover",
+              "name": "Hover",
+              "code": "<Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--hover]\" />",
+              "preview": {
+                "id": "ui:toggle:state:hover"
+              }
+            },
+            {
+              "id": "focus-visible",
+              "name": "Focus-visible",
+              "code": "<Toggle\n  leftLabel=\"Left\"\n  rightLabel=\"Right\"\n  className=\"ring-2 ring-[var(--ring)] ring-offset-2 ring-offset-[var(--surface-2)] focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]\"\n/>",
+              "preview": {
+                "id": "ui:toggle:state:focus-visible"
+              }
+            },
+            {
+              "id": "active",
+              "name": "Active",
+              "code": "<Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--active]\" />",
+              "preview": {
+                "id": "ui:toggle:state:active"
+              }
+            },
+            {
+              "id": "disabled",
+              "name": "Disabled",
+              "code": "<Toggle leftLabel=\"Left\" rightLabel=\"Right\" disabled />",
+              "preview": {
+                "id": "ui:toggle:state:disabled"
+              }
+            },
+            {
+              "id": "loading",
+              "name": "Loading",
+              "code": "<Toggle leftLabel=\"Left\" rightLabel=\"Right\" loading />",
+              "preview": {
+                "id": "ui:toggle:state:loading"
+              }
+            }
+          ]
         }
       ]
     },
@@ -3251,125 +3488,125 @@ export const galleryPayload = {
           "preview": {
             "id": "prompts:misc:cat-companion"
           }
-        },
-        {
-          "id": "badge",
-          "name": "Badge",
-          "description": "Compact pill with tone-driven styles. Accent tones now meet ≥4.5:1 contrast for white content",
-          "kind": "primitive",
-          "tags": [
-            "badge",
-            "pill"
-          ],
-          "props": [
-            {
-              "name": "tone",
-              "type": "\"neutral\" | \"primary\" | \"accent\" | \"top\" | \"jungle\" | \"mid\" | \"bot\" | \"support\"",
-              "defaultValue": "\"neutral\""
-            },
-            {
-              "name": "size",
-              "type": "\"sm\" | \"md\" | \"lg\" | \"xl\"",
-              "defaultValue": "\"md\"",
-              "description": "Use \"xs\" as an alias for \"sm\" when migrating legacy code."
-            },
-            {
-              "name": "interactive",
-              "type": "boolean",
-              "defaultValue": "false"
-            },
-            {
-              "name": "selected",
-              "type": "boolean",
-              "defaultValue": "false"
-            },
-            {
-              "name": "glitch",
-              "type": "boolean",
-              "defaultValue": "false"
-            }
-          ],
-          "axes": [
-            {
-              "id": "tone",
-              "label": "Tone",
-              "type": "variant",
-              "values": [
-                {
-                  "value": "Neutral"
-                },
-                {
-                  "value": "Accent"
-                },
-                {
-                  "value": "Primary"
-                },
-                {
-                  "value": "Top lane"
-                },
-                {
-                  "value": "Jungle"
-                },
-                {
-                  "value": "Mid lane"
-                },
-                {
-                  "value": "Bot lane"
-                },
-                {
-                  "value": "Support"
-                }
-              ]
-            },
-            {
-              "id": "size",
-              "label": "Size",
-              "type": "variant",
-              "values": [
-                {
-                  "value": "Small"
-                },
-                {
-                  "value": "Medium"
-                },
-                {
-                  "value": "Large"
-                },
-                {
-                  "value": "Extra large"
-                }
-              ]
-            },
-            {
-              "id": "state",
-              "label": "State",
-              "type": "state",
-              "values": [
-                {
-                  "value": "Default"
-                },
-                {
-                  "value": "Interactive"
-                },
-                {
-                  "value": "Selected"
-                },
-                {
-                  "value": "Disabled"
-                }
-              ]
-            }
-          ],
-          "code": "<div className=\"flex flex-col gap-[var(--space-3)]\">\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Badge size=\"sm\">Small</Badge>\n    <Badge size=\"md\">Medium</Badge>\n    <Badge size=\"lg\">Large</Badge>\n    <Badge size=\"xl\">Extra large</Badge>\n  </div>\n  <p className=\"text-caption text-muted-foreground\">\n    <code>xs</code> is available as an alias of <code>sm</code> for legacy badges.\n  </p>\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Badge tone=\"neutral\">Neutral</Badge>\n    <Badge tone=\"accent\">Accent</Badge>\n    <Badge tone=\"primary\">Primary</Badge>\n    <Badge tone=\"primary\" interactive selected>\n      Selected\n    </Badge>\n    <Badge tone=\"accent\" interactive disabled>\n      Disabled\n    </Badge>\n  </div>\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Badge tone=\"top\" glitch>\n      Top lane\n    </Badge>\n    <Badge tone=\"jungle\" glitch>\n      Jungle\n    </Badge>\n    <Badge tone=\"mid\" glitch>\n      Mid lane\n    </Badge>\n    <Badge tone=\"bot\" glitch>\n      Bot lane\n    </Badge>\n    <Badge tone=\"support\" glitch>\n      Support\n    </Badge>\n  </div>\n</div>",
-          "preview": {
-            "id": "ui:badge:tones"
-          }
         }
       ]
     }
   ],
   "byKind": {
     "primitive": [
+      {
+        "id": "badge",
+        "name": "Badge",
+        "description": "Compact pill with tone-driven styles. Accent tones now meet ≥4.5:1 contrast for white content",
+        "kind": "primitive",
+        "tags": [
+          "badge",
+          "pill"
+        ],
+        "props": [
+          {
+            "name": "tone",
+            "type": "\"neutral\" | \"primary\" | \"accent\" | \"top\" | \"jungle\" | \"mid\" | \"bot\" | \"support\"",
+            "defaultValue": "\"neutral\""
+          },
+          {
+            "name": "size",
+            "type": "\"sm\" | \"md\" | \"lg\" | \"xl\"",
+            "defaultValue": "\"md\"",
+            "description": "Use \"xs\" as an alias for \"sm\" when migrating legacy code."
+          },
+          {
+            "name": "interactive",
+            "type": "boolean",
+            "defaultValue": "false"
+          },
+          {
+            "name": "selected",
+            "type": "boolean",
+            "defaultValue": "false"
+          },
+          {
+            "name": "glitch",
+            "type": "boolean",
+            "defaultValue": "false"
+          }
+        ],
+        "axes": [
+          {
+            "id": "tone",
+            "label": "Tone",
+            "type": "variant",
+            "values": [
+              {
+                "value": "Neutral"
+              },
+              {
+                "value": "Accent"
+              },
+              {
+                "value": "Primary"
+              },
+              {
+                "value": "Top lane"
+              },
+              {
+                "value": "Jungle"
+              },
+              {
+                "value": "Mid lane"
+              },
+              {
+                "value": "Bot lane"
+              },
+              {
+                "value": "Support"
+              }
+            ]
+          },
+          {
+            "id": "size",
+            "label": "Size",
+            "type": "variant",
+            "values": [
+              {
+                "value": "Small"
+              },
+              {
+                "value": "Medium"
+              },
+              {
+                "value": "Large"
+              },
+              {
+                "value": "Extra large"
+              }
+            ]
+          },
+          {
+            "id": "state",
+            "label": "State",
+            "type": "state",
+            "values": [
+              {
+                "value": "Default"
+              },
+              {
+                "value": "Interactive"
+              },
+              {
+                "value": "Selected"
+              },
+              {
+                "value": "Disabled"
+              }
+            ]
+          }
+        ],
+        "code": "<div className=\"flex flex-col gap-[var(--space-3)]\">\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Badge size=\"sm\">Small</Badge>\n    <Badge size=\"md\">Medium</Badge>\n    <Badge size=\"lg\">Large</Badge>\n    <Badge size=\"xl\">Extra large</Badge>\n  </div>\n  <p className=\"text-caption text-muted-foreground\">\n    <code>xs</code> is available as an alias of <code>sm</code> for legacy badges.\n  </p>\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Badge tone=\"neutral\">Neutral</Badge>\n    <Badge tone=\"accent\">Accent</Badge>\n    <Badge tone=\"primary\">Primary</Badge>\n    <Badge tone=\"primary\" interactive selected>\n      Selected\n    </Badge>\n    <Badge tone=\"accent\" interactive disabled>\n      Disabled\n    </Badge>\n  </div>\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Badge tone=\"top\" glitch>\n      Top lane\n    </Badge>\n    <Badge tone=\"jungle\" glitch>\n      Jungle\n    </Badge>\n    <Badge tone=\"mid\" glitch>\n      Mid lane\n    </Badge>\n    <Badge tone=\"bot\" glitch>\n      Bot lane\n    </Badge>\n    <Badge tone=\"support\" glitch>\n      Support\n    </Badge>\n  </div>\n</div>",
+        "preview": {
+          "id": "ui:badge:tones"
+        }
+      },
       {
         "id": "button",
         "name": "Button",
@@ -4860,93 +5097,48 @@ export const galleryPayload = {
         ]
       },
       {
-        "id": "badge",
-        "name": "Badge",
-        "description": "Compact pill with tone-driven styles. Accent tones now meet ≥4.5:1 contrast for white content",
+        "id": "toggle",
+        "name": "Toggle",
+        "description": "Binary switch with hover, focus, active, disabled, and loading states",
         "kind": "primitive",
         "tags": [
-          "badge",
-          "pill"
+          "toggle",
+          "switch"
         ],
         "props": [
           {
-            "name": "tone",
-            "type": "\"neutral\" | \"primary\" | \"accent\" | \"top\" | \"jungle\" | \"mid\" | \"bot\" | \"support\"",
-            "defaultValue": "\"neutral\""
+            "name": "leftLabel",
+            "type": "string"
           },
           {
-            "name": "size",
-            "type": "\"sm\" | \"md\" | \"lg\" | \"xl\"",
-            "defaultValue": "\"md\"",
-            "description": "Use \"xs\" as an alias for \"sm\" when migrating legacy code."
+            "name": "rightLabel",
+            "type": "string"
           },
           {
-            "name": "interactive",
+            "name": "value",
+            "type": "\"Left\" | \"Right\"",
+            "defaultValue": "\"Left\""
+          },
+          {
+            "name": "onChange",
+            "type": "(value: \"Left\" | \"Right\") => void"
+          },
+          {
+            "name": "disabled",
             "type": "boolean",
             "defaultValue": "false"
           },
           {
-            "name": "selected",
+            "name": "loading",
             "type": "boolean",
             "defaultValue": "false"
           },
           {
-            "name": "glitch",
-            "type": "boolean",
-            "defaultValue": "false"
+            "name": "className",
+            "type": "string"
           }
         ],
         "axes": [
-          {
-            "id": "tone",
-            "label": "Tone",
-            "type": "variant",
-            "values": [
-              {
-                "value": "Neutral"
-              },
-              {
-                "value": "Accent"
-              },
-              {
-                "value": "Primary"
-              },
-              {
-                "value": "Top lane"
-              },
-              {
-                "value": "Jungle"
-              },
-              {
-                "value": "Mid lane"
-              },
-              {
-                "value": "Bot lane"
-              },
-              {
-                "value": "Support"
-              }
-            ]
-          },
-          {
-            "id": "size",
-            "label": "Size",
-            "type": "variant",
-            "values": [
-              {
-                "value": "Small"
-              },
-              {
-                "value": "Medium"
-              },
-              {
-                "value": "Large"
-              },
-              {
-                "value": "Extra large"
-              }
-            ]
-          },
           {
             "id": "state",
             "label": "State",
@@ -4956,21 +5148,77 @@ export const galleryPayload = {
                 "value": "Default"
               },
               {
-                "value": "Interactive"
+                "value": "Hover"
               },
               {
-                "value": "Selected"
+                "value": "Focus-visible"
+              },
+              {
+                "value": "Active"
               },
               {
                 "value": "Disabled"
+              },
+              {
+                "value": "Loading"
               }
             ]
           }
         ],
-        "code": "<div className=\"flex flex-col gap-[var(--space-3)]\">\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Badge size=\"sm\">Small</Badge>\n    <Badge size=\"md\">Medium</Badge>\n    <Badge size=\"lg\">Large</Badge>\n    <Badge size=\"xl\">Extra large</Badge>\n  </div>\n  <p className=\"text-caption text-muted-foreground\">\n    <code>xs</code> is available as an alias of <code>sm</code> for legacy badges.\n  </p>\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Badge tone=\"neutral\">Neutral</Badge>\n    <Badge tone=\"accent\">Accent</Badge>\n    <Badge tone=\"primary\">Primary</Badge>\n    <Badge tone=\"primary\" interactive selected>\n      Selected\n    </Badge>\n    <Badge tone=\"accent\" interactive disabled>\n      Disabled\n    </Badge>\n  </div>\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Badge tone=\"top\" glitch>\n      Top lane\n    </Badge>\n    <Badge tone=\"jungle\" glitch>\n      Jungle\n    </Badge>\n    <Badge tone=\"mid\" glitch>\n      Mid lane\n    </Badge>\n    <Badge tone=\"bot\" glitch>\n      Bot lane\n    </Badge>\n    <Badge tone=\"support\" glitch>\n      Support\n    </Badge>\n  </div>\n</div>",
+        "code": "<div className=\"flex flex-col gap-[var(--space-4)]\">\n  <Toggle leftLabel=\"Strategy\" rightLabel=\"Execute\" />\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--hover]\" />\n    <Toggle\n      leftLabel=\"Left\"\n      rightLabel=\"Right\"\n      className=\"ring-2 ring-[var(--ring)] ring-offset-2 ring-offset-[var(--surface-2)] focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]\"\n    />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--active]\" />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" disabled />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" loading />\n  </div>\n</div>",
         "preview": {
-          "id": "ui:badge:tones"
-        }
+          "id": "ui:toggle:interactive"
+        },
+        "states": [
+          {
+            "id": "default",
+            "name": "Default",
+            "code": "<Toggle leftLabel=\"Left\" rightLabel=\"Right\" />",
+            "preview": {
+              "id": "ui:toggle:state:default"
+            }
+          },
+          {
+            "id": "hover",
+            "name": "Hover",
+            "code": "<Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--hover]\" />",
+            "preview": {
+              "id": "ui:toggle:state:hover"
+            }
+          },
+          {
+            "id": "focus-visible",
+            "name": "Focus-visible",
+            "code": "<Toggle\n  leftLabel=\"Left\"\n  rightLabel=\"Right\"\n  className=\"ring-2 ring-[var(--ring)] ring-offset-2 ring-offset-[var(--surface-2)] focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]\"\n/>",
+            "preview": {
+              "id": "ui:toggle:state:focus-visible"
+            }
+          },
+          {
+            "id": "active",
+            "name": "Active",
+            "code": "<Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--active]\" />",
+            "preview": {
+              "id": "ui:toggle:state:active"
+            }
+          },
+          {
+            "id": "disabled",
+            "name": "Disabled",
+            "code": "<Toggle leftLabel=\"Left\" rightLabel=\"Right\" disabled />",
+            "preview": {
+              "id": "ui:toggle:state:disabled"
+            }
+          },
+          {
+            "id": "loading",
+            "name": "Loading",
+            "code": "<Toggle leftLabel=\"Left\" rightLabel=\"Right\" loading />",
+            "preview": {
+              "id": "ui:toggle:state:loading"
+            }
+          }
+        ]
       }
     ],
     "component": [
@@ -6968,6 +7216,18 @@ export const galleryPreviewModules = [
       "ui:textarea:state:read-only",
       "ui:textarea:state:disabled",
       "ui:textarea:state:loading",
+    ],
+  },
+  {
+    loader: () => import("../ui/toggles/Toggle.gallery"),
+    previewIds: [
+      "ui:toggle:interactive",
+      "ui:toggle:state:default",
+      "ui:toggle:state:hover",
+      "ui:toggle:state:focus-visible",
+      "ui:toggle:state:active",
+      "ui:toggle:state:disabled",
+      "ui:toggle:state:loading",
     ],
   },
 ] satisfies readonly GalleryPreviewModuleManifest[];

--- a/src/components/gallery/usage.json
+++ b/src/components/gallery/usage.json
@@ -1,4 +1,5 @@
 {
+  "badge": [],
   "button": [
     "/"
   ],
@@ -21,7 +22,12 @@
   "section-card-variants": [],
   "page-shell": [
     "/",
-    "/components"
+    "/components",
+    "/goals",
+    "/planner",
+    "/prompts",
+    "/reviews",
+    "/team"
   ],
   "sheet-demo": [],
   "modal-demo": [],
@@ -93,6 +99,5 @@
   ],
   "cat-companion": [
     "/"
-  ],
-  "badge": []
+  ]
 }

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -100,3 +100,4 @@ export { default as SegmentedButtonGallery } from "./primitives/SegmentedButton.
 export { default as TabsGallery } from "./primitives/Tabs.gallery";
 export { default as TextareaGallery } from "./primitives/Textarea.gallery";
 export { default as SelectGallery } from "./Select.gallery";
+export { default as ToggleGallery } from "./toggles/Toggle.gallery";

--- a/src/components/ui/primitives/Badge.gallery.tsx
+++ b/src/components/ui/primitives/Badge.gallery.tsx
@@ -57,7 +57,7 @@ function BadgeGalleryPreview() {
 }
 
 export default defineGallerySection({
-  id: "misc",
+  id: "buttons",
   entries: [
     {
       id: "badge",

--- a/src/components/ui/toggles/Toggle.gallery.tsx
+++ b/src/components/ui/toggles/Toggle.gallery.tsx
@@ -1,0 +1,154 @@
+import * as React from "react";
+
+import { createGalleryPreview, defineGallerySection } from "@/components/gallery/registry";
+import { cn } from "@/lib/utils";
+
+import Toggle from "./Toggle";
+
+type ToggleProps = React.ComponentProps<typeof Toggle>;
+
+type ToggleState = {
+  id: string;
+  name: string;
+  className?: string;
+  props?: Partial<ToggleProps>;
+  code: string;
+};
+
+const TOGGLE_STATES: readonly ToggleState[] = [
+  {
+    id: "default",
+    name: "Default",
+    code: `<Toggle leftLabel="Left" rightLabel="Right" />`,
+  },
+  {
+    id: "hover",
+    name: "Hover",
+    className: "bg-[--hover]",
+    code: `<Toggle leftLabel="Left" rightLabel="Right" className="bg-[--hover]" />`,
+  },
+  {
+    id: "focus-visible",
+    name: "Focus-visible",
+    className:
+      "ring-2 ring-[var(--ring)] ring-offset-2 ring-offset-[var(--surface-2)] focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]",
+    code: `<Toggle
+  leftLabel="Left"
+  rightLabel="Right"
+  className="ring-2 ring-[var(--ring)] ring-offset-2 ring-offset-[var(--surface-2)] focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]"
+/>`,
+  },
+  {
+    id: "active",
+    name: "Active",
+    className: "bg-[--active]",
+    code: `<Toggle leftLabel="Left" rightLabel="Right" className="bg-[--active]" />`,
+  },
+  {
+    id: "disabled",
+    name: "Disabled",
+    props: { disabled: true },
+    code: `<Toggle leftLabel="Left" rightLabel="Right" disabled />`,
+  },
+  {
+    id: "loading",
+    name: "Loading",
+    props: { loading: true },
+    code: `<Toggle leftLabel="Left" rightLabel="Right" loading />`,
+  },
+] as const;
+
+function ToggleStatePreview({ state }: { state: ToggleState }) {
+  const { className, props } = state;
+  const mergedClassName = cn(className, props?.className);
+
+  return (
+    <Toggle
+      leftLabel={props?.leftLabel ?? "Left"}
+      rightLabel={props?.rightLabel ?? "Right"}
+      {...props}
+      className={mergedClassName}
+    />
+  );
+}
+
+function ToggleGalleryPreview() {
+  const [value, setValue] = React.useState<ToggleProps["value"]>("Left");
+
+  return (
+    <div className="flex flex-col gap-[var(--space-4)]">
+      <Toggle
+        leftLabel="Strategy"
+        rightLabel="Execute"
+        value={value}
+        onChange={(next) => setValue(next)}
+      />
+      <div className="flex flex-col gap-[var(--space-2)]">
+        <p className="text-caption text-muted-foreground">States</p>
+        <div className="flex flex-wrap gap-[var(--space-2)]">
+          {TOGGLE_STATES.map((state) => (
+            <ToggleStatePreview key={state.id} state={state} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default defineGallerySection({
+  id: "toggles",
+  entries: [
+    {
+      id: "toggle",
+      name: "Toggle",
+      description: "Binary switch with hover, focus, active, disabled, and loading states",
+      kind: "primitive",
+      tags: ["toggle", "switch"],
+      props: [
+        { name: "leftLabel", type: "string" },
+        { name: "rightLabel", type: "string" },
+        { name: "value", type: '"Left" | "Right"', defaultValue: '"Left"' },
+        { name: "onChange", type: '(value: "Left" | "Right") => void' },
+        { name: "disabled", type: "boolean", defaultValue: "false" },
+        { name: "loading", type: "boolean", defaultValue: "false" },
+        { name: "className", type: "string" },
+      ],
+      axes: [
+        {
+          id: "state",
+          label: "State",
+          type: "state",
+          values: TOGGLE_STATES.map(({ name }) => ({ value: name })),
+        },
+      ],
+      preview: createGalleryPreview({
+        id: "ui:toggle:interactive",
+        render: () => <ToggleGalleryPreview />,
+      }),
+      states: TOGGLE_STATES.map((state) => ({
+        id: state.id,
+        name: state.name,
+        code: state.code,
+        preview: createGalleryPreview({
+          id: `ui:toggle:state:${state.id}`,
+          render: () => <ToggleStatePreview state={state} />,
+        }),
+      })),
+      code: `<div className="flex flex-col gap-[var(--space-4)]">
+  <Toggle leftLabel="Strategy" rightLabel="Execute" />
+  <div className="flex flex-wrap gap-[var(--space-2)]">
+    <Toggle leftLabel="Left" rightLabel="Right" />
+    <Toggle leftLabel="Left" rightLabel="Right" className="bg-[--hover]" />
+    <Toggle
+      leftLabel="Left"
+      rightLabel="Right"
+      className="ring-2 ring-[var(--ring)] ring-offset-2 ring-offset-[var(--surface-2)] focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]"
+    />
+    <Toggle leftLabel="Left" rightLabel="Right" className="bg-[--active]" />
+    <Toggle leftLabel="Left" rightLabel="Right" disabled />
+    <Toggle leftLabel="Left" rightLabel="Right" loading />
+  </div>
+</div>`,
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- add a primitives gallery module for Toggle with state previews and export it through the UI index
- align the badge gallery with the primitives buttons section and rebuild the gallery manifest
- regenerate gallery usage data so the new toggles entries surface in the payload

## Testing
- npm run build-gallery-usage
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d73386d500832c8a9d2560afae2974