### PR TITLE
Add icon placement matrix to button gallery

### DIFF
--- a/src/components/ui/primitives/Button.gallery.tsx
+++ b/src/components/ui/primitives/Button.gallery.tsx
@@ -3,7 +3,7 @@ import { Plus } from "lucide-react";
 
 import { createGalleryPreview, defineGallerySection } from "@/components/gallery/registry";
 
-import Button from "./Button";
+import Button, { buttonSizes, type ButtonSize } from "./Button";
 
 type ButtonStateSpec = {
   id: string;
@@ -57,6 +57,20 @@ const BUTTON_STATES: readonly ButtonStateSpec[] = [
   },
 ];
 
+const BUTTON_SIZE_ORDER: readonly ButtonSize[] = ["sm", "md", "lg", "xl"];
+
+const BUTTON_SIZE_LABELS: Record<ButtonSize, string> = {
+  sm: "Small",
+  md: "Medium",
+  lg: "Large",
+  xl: "Extra large",
+};
+
+const ICON_VARIANTS = [
+  { id: "leading", label: "Leading icon" },
+  { id: "trailing", label: "Trailing icon" },
+] as const;
+
 function ButtonStatePreview({ state }: { state: ButtonStateSpec }) {
   const { className, props } = state;
   return <Button className={className} {...props} />;
@@ -80,23 +94,30 @@ function ButtonGalleryPreview() {
         </Button>
         <Button disabled>Disabled</Button>
       </div>
-      <div className="flex flex-wrap items-center gap-[var(--space-2)]">
-        <Button size="sm">
-          <Plus aria-hidden />
-          Small
-        </Button>
-        <Button size="md">
-          <Plus aria-hidden />
-          Medium
-        </Button>
-        <Button size="lg">
-          <Plus aria-hidden />
-          Large
-        </Button>
-        <Button size="xl">
-          <Plus aria-hidden />
-          Extra large
-        </Button>
+      <div className="space-y-[var(--space-2)]">
+        <div className="grid grid-cols-[max-content_repeat(2,minmax(0,1fr))] gap-[var(--space-3)] text-label text-muted-foreground">
+          <span className="sr-only">Size</span>
+          {ICON_VARIANTS.map((variant) => (
+            <span key={variant.id}>{variant.label}</span>
+          ))}
+        </div>
+        {BUTTON_SIZE_ORDER.map((size) => (
+          <div
+            key={size}
+            className={`grid grid-cols-1 items-center sm:grid-cols-[max-content_repeat(2,minmax(0,1fr))] ${buttonSizes[size].gap}`}
+          >
+            <span className="text-label text-muted-foreground sm:text-ui">
+              {BUTTON_SIZE_LABELS[size]}
+            </span>
+            {ICON_VARIANTS.map((variant) => (
+              <Button key={variant.id} size={size}>
+                {variant.id === "leading" ? <Plus aria-hidden /> : null}
+                {BUTTON_SIZE_LABELS[size]}
+                {variant.id === "trailing" ? <Plus aria-hidden /> : null}
+              </Button>
+            ))}
+          </div>
+        ))}
       </div>
       <div className="flex flex-wrap gap-[var(--space-2)]">
         {BUTTON_STATES.map((state) => (
@@ -113,7 +134,7 @@ export default defineGallerySection({
     {
       id: "button",
       name: "Button",
-      description: "Tone, size, and interaction states",
+      description: "Tone, size, icon placement, and interaction states",
       kind: "primitive",
       tags: ["button", "action"],
       props: [
@@ -146,6 +167,15 @@ export default defineGallerySection({
             { value: "Info" },
             { value: "Danger" },
           ],
+        },
+        {
+          id: "size",
+          label: "Size & icons",
+          type: "variant",
+          values: BUTTON_SIZE_ORDER.map((size) => ({
+            value: BUTTON_SIZE_LABELS[size],
+            description: `Leading and trailing icons align to the ${BUTTON_SIZE_LABELS[size].toLowerCase()} control gap.`,
+          })),
         },
         {
           id: "state",
@@ -183,23 +213,56 @@ export default defineGallerySection({
     </Button>
     <Button disabled>Disabled</Button>
   </div>
-  <div className="flex flex-wrap items-center gap-[var(--space-2)]">
-    <Button size="sm">
-      <Plus />
-      Small
-    </Button>
-    <Button size="md">
-      <Plus />
-      Medium
-    </Button>
-    <Button size="lg">
-      <Plus />
-      Large
-    </Button>
-    <Button size="xl">
-      <Plus />
-      Extra large
-    </Button>
+  <div className="space-y-[var(--space-2)]">
+    <div className="grid grid-cols-[max-content_repeat(2,minmax(0,1fr))] gap-[var(--space-3)] text-label text-muted-foreground">
+      <span className="sr-only">Size</span>
+      <span>Leading icon</span>
+      <span>Trailing icon</span>
+    </div>
+    <div className="grid grid-cols-1 items-center gap-[var(--space-1)] sm:grid-cols-[max-content_repeat(2,minmax(0,1fr))]">
+      <span className="text-label text-muted-foreground sm:text-ui">Small</span>
+      <Button size="sm">
+        <Plus aria-hidden />
+        Small
+      </Button>
+      <Button size="sm">
+        Small
+        <Plus aria-hidden />
+      </Button>
+    </div>
+    <div className="grid grid-cols-1 items-center gap-[var(--space-2)] sm:grid-cols-[max-content_repeat(2,minmax(0,1fr))]">
+      <span className="text-label text-muted-foreground sm:text-ui">Medium</span>
+      <Button size="md">
+        <Plus aria-hidden />
+        Medium
+      </Button>
+      <Button size="md">
+        Medium
+        <Plus aria-hidden />
+      </Button>
+    </div>
+    <div className="grid grid-cols-1 items-center gap-[var(--space-4)] sm:grid-cols-[max-content_repeat(2,minmax(0,1fr))]">
+      <span className="text-label text-muted-foreground sm:text-ui">Large</span>
+      <Button size="lg">
+        <Plus aria-hidden />
+        Large
+      </Button>
+      <Button size="lg">
+        Large
+        <Plus aria-hidden />
+      </Button>
+    </div>
+    <div className="grid grid-cols-1 items-center gap-[calc(var(--control-h-xl)/3)] sm:grid-cols-[max-content_repeat(2,minmax(0,1fr))]">
+      <span className="text-label text-muted-foreground sm:text-ui">Extra large</span>
+      <Button size="xl">
+        <Plus aria-hidden />
+        Extra large
+      </Button>
+      <Button size="xl">
+        Extra large
+        <Plus aria-hidden />
+      </Button>
+    </div>
   </div>
   <div className="flex flex-wrap gap-[var(--space-2)]">
     <Button>Default</Button>


### PR DESCRIPTION
## Summary
- add a size-by-icon placement matrix to the button gallery preview, reusing button spacing tokens
- document the new icon matrix via gallery axes metadata and update the component code sample

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d7347c2c68832c8ea22f14c43cc369