### PR TITLE
feat: extract cat companion icon

### DIFF
--- a/src/components/ui/CatCompanion.tsx
+++ b/src/components/ui/CatCompanion.tsx
@@ -1,19 +1,14 @@
 import * as React from "react";
+import CatCompanionIcon from "@/icons/CatCompanionIcon";
 
 export default function CatCompanion() {
   return (
     <div className="fixed bottom-[var(--space-4)] left-[var(--space-4)] z-50 pointer-events-none select-none">
-      <svg
+      <CatCompanionIcon
         className="w-[var(--space-8)] h-[var(--space-8)] text-accent motion-safe:animate-[cat-float_3s_ease-in-out_infinite]"
-        role="img"
         aria-label="Cat companion"
         tabIndex={-1}
-        focusable="false"
-        viewBox="0 0 24 24"
-        fill="currentColor"
-      >
-        <path d="M12 5c.67 0 1.35.09 2 .26 1.78-2 5.03-2.84 6.42-2.26 1.4.58-.42 7-.42 7 .57 1.07 1 2.24 1 3.44C21 17.9 16.97 21 12 21s-9-3-9-7.56c0-1.25.5-2.4 1-3.44 0 0-1.89-6.42-.5-7 1.39-.58 4.72.23 6.5 2.23A9.04 9.04 0 0 1 12 5Z" />
-      </svg>
+      />
     </div>
   );
 }

--- a/src/icons/CatCompanionIcon.tsx
+++ b/src/icons/CatCompanionIcon.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+
+export type CatCompanionIconProps = React.SVGProps<SVGSVGElement>;
+
+const CAT_COMPANION_PATH =
+  "M12 5c.67 0 1.35.09 2 .26 1.78-2 5.03-2.84 6.42-2.26 1.4.58-.42 7-.42 7 .57 1.07 1 2.24 1 3.44C21 17.9 16.97 21 " +
+  "12 21s-9-3-9-7.56c0-1.25.5-2.4 1-3.44 0 0-1.89-6.42-.5-7 1.39-.58 4.72.23 6.5 2.23A9.04 9.04 0 0 1 12 5Z";
+
+const CatCompanionIcon = React.forwardRef<SVGSVGElement, CatCompanionIconProps>(
+  (
+    {
+      className,
+      "aria-label": ariaLabel,
+      "aria-hidden": ariaHidden,
+      role,
+      focusable,
+      ...rest
+    },
+    ref
+  ) => {
+    const computedRole = role ?? (ariaLabel ? "img" : "presentation");
+    const computedAriaHidden = ariaHidden ?? (ariaLabel ? undefined : true);
+    const computedFocusable = focusable ?? false;
+
+    return (
+      <svg
+        ref={ref}
+        className={className}
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        role={computedRole}
+        aria-label={ariaLabel}
+        aria-hidden={computedAriaHidden}
+        focusable={computedFocusable}
+        {...rest}
+      >
+        <path d={CAT_COMPANION_PATH} />
+      </svg>
+    );
+  }
+);
+
+CatCompanionIcon.displayName = "CatCompanionIcon";
+
+export default CatCompanionIcon;

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -1,2 +1,3 @@
 export { default as TimerRingIcon } from "./TimerRingIcon";
 export { default as ProgressRingIcon } from "./ProgressRingIcon";
+export { default as CatCompanionIcon } from "./CatCompanionIcon";


### PR DESCRIPTION
## Summary
- add a reusable CatCompanionIcon component that forwards standard SVG props
- switch CatCompanion to render the extracted icon while preserving animation and labelling
- re-export the new icon from the icons barrel for broader reuse

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d734945b4c832ca316ce43317881de