### PR TITLE
Reorganize component gallery into primitives, patterns, and layouts

### DIFF
--- a/src/components/components/ComponentsGalleryPanels.tsx
+++ b/src/components/components/ComponentsGalleryPanels.tsx
@@ -2,16 +2,13 @@
 
 import * as React from "react";
 
-import ColorsView from "@/components/prompts/ColorsView";
 import ComponentSpecView from "@/components/prompts/ComponentsView";
 import type { GallerySerializableEntry } from "@/components/gallery/registry";
-import type { DesignTokenGroup } from "@/components/gallery/types";
 import { Card, CardContent } from "@/components/ui";
 import Badge from "@/components/ui/primitives/Badge";
 
 import {
   COMPONENTS_PANEL_ID,
-  COMPONENTS_VIEW_TAB_ID_BASE,
   type ComponentsView,
 } from "./useComponentsGalleryState";
 
@@ -22,9 +19,7 @@ interface ComponentsGalleryPanelsProps {
   readonly countLabel: string;
   readonly countDescriptionId: string;
   readonly componentsPanelLabelledBy: string;
-  readonly componentsPanelRef: React.Ref<HTMLDivElement>;
-  readonly tokensPanelRef: React.Ref<HTMLDivElement>;
-  readonly tokenGroups: readonly DesignTokenGroup[];
+  readonly componentsPanelRef: React.MutableRefObject<HTMLDivElement | null>;
 }
 
 export default function ComponentsGalleryPanels({
@@ -35,22 +30,18 @@ export default function ComponentsGalleryPanels({
   countDescriptionId,
   componentsPanelLabelledBy,
   componentsPanelRef,
-  tokensPanelRef,
-  tokenGroups,
 }: ComponentsGalleryPanelsProps) {
-  const isTokensView = view === "tokens";
-  const tokensTabId = `${COMPONENTS_VIEW_TAB_ID_BASE}-tokens-tab`;
-
   return (
-    <section className="col-span-full grid gap-[var(--space-6)] md:gap-[var(--space-7)] lg:gap-[var(--space-8)]">
+    <section
+      id={view}
+      className="col-span-full grid gap-[var(--space-6)] md:gap-[var(--space-7)] lg:gap-[var(--space-8)]"
+    >
       <div
         id={COMPONENTS_PANEL_ID}
         role="tabpanel"
         aria-labelledby={componentsPanelLabelledBy}
-        tabIndex={isTokensView ? -1 : 0}
+        tabIndex={0}
         ref={componentsPanelRef}
-        hidden={isTokensView}
-        aria-hidden={isTokensView}
         className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
       >
         <div
@@ -84,18 +75,6 @@ export default function ComponentsGalleryPanels({
             )}
           </div>
         </div>
-      </div>
-      <div
-        id={`${COMPONENTS_VIEW_TAB_ID_BASE}-tokens-panel`}
-        role="tabpanel"
-        aria-labelledby={tokensTabId}
-        tabIndex={isTokensView ? 0 : -1}
-        ref={tokensPanelRef}
-        hidden={!isTokensView}
-        aria-hidden={!isTokensView}
-        className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-      >
-        <ColorsView groups={tokenGroups} />
       </div>
     </section>
   );

--- a/src/components/components/ComponentsPage.tsx
+++ b/src/components/components/ComponentsPage.tsx
@@ -1,5 +1,4 @@
 import ComponentsPageClient from "./ComponentsPageClient";
-import tokens from "../../../tokens/tokens.js";
 import {
   GALLERY_SECTION_GROUPS,
   type GallerySectionGroupMeta,
@@ -13,11 +12,7 @@ import type {
   GalleryNavigationData,
   GalleryNavigationGroup,
   GalleryNavigationSection,
-  DesignTokenGroup,
 } from "@/components/gallery/types";
-import { buildDesignTokenGroups } from "@/lib/design-token-registry";
-
-const DESIGN_TOKEN_GROUPS = buildDesignTokenGroups(tokens);
 
 const formatSectionLabel = (section: GallerySectionMeta): string => {
   if (section.label) {
@@ -71,9 +66,6 @@ const buildGalleryNavigation = (): GalleryNavigationData => {
 
 export default function ComponentsPage() {
   const navigation = buildGalleryNavigation();
-  const tokenGroups: readonly DesignTokenGroup[] = DESIGN_TOKEN_GROUPS;
 
-  return (
-    <ComponentsPageClient navigation={navigation} tokenGroups={tokenGroups} />
-  );
+  return <ComponentsPageClient navigation={navigation} />;
 }

--- a/src/components/components/slug.ts
+++ b/src/components/components/slug.ts
@@ -54,8 +54,10 @@ for (const group of GALLERY_SECTION_GROUPS) {
 }
 
 const VIEW_ALIAS = new Map<string, GallerySectionGroupKey>([
-  ["colors", "tokens"],
-  ["styles", "tokens"],
+  ["colors", "primitives"],
+  ["styles", "primitives"],
+  ["tokens", "primitives"],
+  ["complex", "layouts"],
   ["elements", "primitives"],
 ]);
 

--- a/src/components/gallery/metadata.ts
+++ b/src/components/gallery/metadata.ts
@@ -1,10 +1,6 @@
 import type { GallerySectionId } from "./registry";
 
-export type GallerySectionGroupKey =
-  | "primitives"
-  | "components"
-  | "complex"
-  | "tokens";
+export type GallerySectionGroupKey = "primitives" | "patterns" | "layouts";
 
 export interface GalleryHeroCopy {
   eyebrow: string;
@@ -30,192 +26,187 @@ export const GALLERY_SECTION_GROUPS: readonly GallerySectionGroupMeta[] = [
     id: "primitives",
     label: "Primitives",
     copy: {
-      eyebrow: "Interaction basics",
+      eyebrow: "Foundational UI",
       heading: "Planner interface primitives",
       subtitle:
-        "Buttons, inputs, toggles, and feedback cues that keep everyday flows quick.",
+        "Buttons, inputs, toggles, and feedback cues that make everyday actions immediate.",
     },
     sections: [
       {
         id: "buttons",
+        label: "Buttons",
         copy: {
-          eyebrow: "Action triggers",
-          heading: "Action-ready button components",
+          eyebrow: "Actions",
+          heading: "Buttons and triggers",
           subtitle:
-            "Primary, segmented, and icon buttons that keep Planner workflows moving.",
+            "Primary, segmented, and icon buttons for decisive Planner interactions.",
         },
       },
       {
         id: "inputs",
+        label: "Inputs",
         copy: {
-          eyebrow: "Data entry",
-          heading: "Focused input components",
+          eyebrow: "Capture",
+          heading: "Inputs and fields",
           subtitle:
-            "Fields, textareas, and selectors tuned for confident capture and review.",
+            "Text, selection, and form fields tuned for confident capture and review.",
         },
       },
       {
         id: "toggles",
+        label: "Toggles",
         copy: {
           eyebrow: "Preferences",
-          heading: "Toggle and control components",
+          heading: "Toggles and selectors",
           subtitle:
-            "Switches and selectors that flip Planner settings instantly.",
+            "Switches, selectors, and filters that personalize Planner without friction.",
         },
       },
       {
         id: "feedback",
+        label: "Feedback",
         copy: {
-          eyebrow: "Status",
-          heading: "Feedback and state components",
+          eyebrow: "State",
+          heading: "Feedback and status",
           subtitle:
-            "Spinners, skeletons, and snackbars for communicating system status.",
+            "Spinners, skeletons, and inline alerts that keep status visible across flows.",
         },
       },
     ],
   },
   {
-    id: "components",
-    label: "Components",
+    id: "patterns",
+    label: "Patterns",
     copy: {
-      eyebrow: "Patterns",
-      heading: "Composable Planner components",
+      eyebrow: "Reusable flows",
+      heading: "Planner interaction patterns",
       subtitle:
-        "Prompts, layout shells, and card frameworks that shape expressive surfaces.",
+        "Prompts, cards, and utilities that package guidance and insight for any surface.",
     },
     sections: [
       {
         id: "prompts",
+        label: "Prompts",
         copy: {
           eyebrow: "Guidance",
-          heading: "Prompt and messaging components",
+          heading: "Prompts and messaging",
           subtitle:
-            "Dialogs, sheets, and toasts that deliver the right nudge at the right moment.",
+            "Dialogs, sheets, and toasts that deliver the right coaching moment.",
         },
       },
       {
         id: "cards",
+        label: "Cards",
         copy: {
           eyebrow: "Summaries",
-          heading: "Card and surface components",
+          heading: "Cards and overviews",
           subtitle:
-            "Progress cards and shells that package Planner insights cleanly.",
-        },
-      },
-      {
-        id: "layout",
-        copy: {
-          eyebrow: "Structure",
-          heading: "Layout and container components",
-          subtitle:
-            "Shells, overlays, and navigation scaffolding that organize Planner surfaces.",
-        },
-      },
-      {
-        id: "page-header",
-        copy: {
-          eyebrow: "First impression",
-          heading: "Hero and page header components",
-          subtitle:
-            "Framed intros, hero shells, and portrait accents for high-impact screens.",
+            "Progress and scouting cards that surface signal without noise.",
         },
       },
       {
         id: "misc",
+        label: "Utilities",
         copy: {
-          eyebrow: "Utilities",
-          heading: "Utility and experimental components",
+          eyebrow: "Support",
+          heading: "Utility patterns",
           subtitle:
-            "Supporting patterns and helpers that round out the system.",
+            "Supporting components and helpers that round out Planner experiences.",
         },
       },
     ],
   },
   {
-    id: "complex",
-    label: "Complex",
+    id: "layouts",
+    label: "Layouts",
     copy: {
-      eyebrow: "Workflows",
-      heading: "Planner experience frameworks",
+      eyebrow: "Workspace structure",
+      heading: "Planner layout systems",
       subtitle:
-        "Boards, dashboards, and companion surfaces that orchestrate end-to-end flows.",
+        "Shells, navigation, and dashboards that organize Planner's cross-squad work.",
     },
     sections: [
       {
+        id: "layout",
+        label: "Containers",
+        copy: {
+          eyebrow: "Structure",
+          heading: "Layout and container systems",
+          subtitle:
+            "Shells, overlays, and scaffolds that frame Planner content with rhythm.",
+        },
+      },
+      {
+        id: "page-header",
+        label: "Page headers",
+        copy: {
+          eyebrow: "Introductions",
+          heading: "Hero and header layouts",
+          subtitle:
+            "Framed intros, hero shells, and portrait slots for standout screens.",
+        },
+      },
+      {
         id: "homepage",
+        label: "Homepage",
         copy: {
           eyebrow: "Landing",
-          heading: "Homepage welcome surfaces",
+          heading: "Homepage surfaces",
           subtitle:
-            "Hero frames, portraits, and quick actions that open Planner with energy.",
+            "Hero frames, portraits, and quick actions that open Planner with momentum.",
         },
       },
       {
         id: "reviews",
+        label: "Reviews",
         copy: {
           eyebrow: "Insights",
-          heading: "Review analysis surfaces",
+          heading: "Review analysis layouts",
           subtitle:
             "Score panels, scouting forms, and pillar tools tuned for match retrospectives.",
         },
       },
       {
         id: "planner",
+        label: "Planner",
         copy: {
-          eyebrow: "Core surfaces",
-          heading: "Planner navigation systems",
+          eyebrow: "Daily ops",
+          heading: "Planner navigation surfaces",
           subtitle:
             "Boards, schedules, and route controls that anchor day-to-day focus.",
         },
       },
       {
         id: "goals",
+        label: "Goals",
         copy: {
           eyebrow: "Progress",
-          heading: "Goals tracking flows",
+          heading: "Goals tracking layouts",
           subtitle:
             "Lists, reminders, and focus timers that keep momentum visible.",
         },
       },
       {
         id: "team",
+        label: "Team",
         copy: {
           eyebrow: "Roster",
-          heading: "Team collaboration surfaces",
+          heading: "Team collaboration layouts",
           subtitle:
             "Champion lists, side selectors, and pillar badges for coordinating the squad.",
         },
       },
       {
         id: "components",
+        label: "Workspace",
         copy: {
           eyebrow: "Library",
-          heading: "Components workspace shells",
+          heading: "Components workspace layouts",
           subtitle:
             "Gallery scaffolding, theming controls, and reference frames for deep dives.",
         },
       },
-      {
-        id: "prompts",
-        copy: {
-          eyebrow: "Guidance",
-          heading: "Prompts workspace surfaces",
-          subtitle:
-            "Lists, editors, and demos shaping Planner's coaching moments.",
-        },
-      },
     ],
-  },
-  {
-    id: "tokens",
-    label: "Tokens",
-    copy: {
-      eyebrow: "Foundations",
-      heading: "Planner design tokens",
-      subtitle:
-        "Color, spacing, typography, motion, and effects that keep every surface aligned.",
-    },
-    sections: [],
   },
 ] as const;
 

--- a/tests/components/ComponentsGalleryState.test.tsx
+++ b/tests/components/ComponentsGalleryState.test.tsx
@@ -67,12 +67,33 @@ const navigation: GalleryNavigationData = {
       ],
     },
     {
-      id: "complex",
-      label: "Complex",
+      id: "patterns",
+      label: "Patterns",
       copy: {
-        eyebrow: "Complex",
-        heading: "Complex",
-        subtitle: "Complex components",
+        eyebrow: "Patterns",
+        heading: "Patterns",
+        subtitle: "Pattern components",
+      },
+      sections: [
+        {
+          id: "prompts",
+          label: "Prompts",
+          copy: {
+            eyebrow: "Prompts",
+            heading: "Prompts",
+            subtitle: "Prompt components",
+          },
+          groupId: "patterns",
+        },
+      ],
+    },
+    {
+      id: "layouts",
+      label: "Layouts",
+      copy: {
+        eyebrow: "Layouts",
+        heading: "Layouts",
+        subtitle: "Layout components",
       },
       sections: [
         {
@@ -83,7 +104,7 @@ const navigation: GalleryNavigationData = {
             heading: "Homepage",
             subtitle: "Homepage components",
           },
-          groupId: "complex",
+          groupId: "layouts",
         },
       ],
     },
@@ -140,8 +161,32 @@ describe("useComponentsGalleryState", () => {
         navigation,
       }),
     );
-    expect(stylesHook.result.current.view).toBe("tokens");
+    expect(stylesHook.result.current.view).toBe("primitives");
     stylesHook.unmount();
+
+    searchParamsString = new URLSearchParams({
+      section: "buttons",
+      view: "components",
+    }).toString();
+    const componentsHook = renderHook(() =>
+      useComponentsGalleryState({
+        navigation,
+      }),
+    );
+    expect(componentsHook.result.current.view).toBe("patterns");
+    componentsHook.unmount();
+
+    searchParamsString = new URLSearchParams({
+      section: "buttons",
+      view: "complex",
+    }).toString();
+    const complexHook = renderHook(() =>
+      useComponentsGalleryState({
+        navigation,
+      }),
+    );
+    expect(complexHook.result.current.view).toBe("layouts");
+    complexHook.unmount();
   });
 
   it("omits the question mark when all query params are cleared", () => {
@@ -235,11 +280,11 @@ describe("useComponentsGalleryState", () => {
     window.location.hash = "";
 
     act(() => {
-      result.current.handleViewChange("complex");
+      result.current.handleViewChange("layouts");
     });
 
     await waitFor(() => {
-      expect(result.current.view).toBe("complex");
+      expect(result.current.view).toBe("layouts");
     });
 
     replaceSpy.mockClear();
@@ -300,8 +345,8 @@ describe("useComponentsGalleryState", () => {
     expect(replaceSpy.mock.calls.some(([url]) => url === "?")).toBe(false);
   });
 
-  it("defaults to the complex homepage section when section param is missing", () => {
-    searchParamsString = new URLSearchParams({ view: "complex" }).toString();
+  it("defaults to the layouts homepage section when section param is missing", () => {
+    searchParamsString = new URLSearchParams({ view: "layouts" }).toString();
 
     const { result } = renderHook(() =>
       useComponentsGalleryState({
@@ -309,7 +354,7 @@ describe("useComponentsGalleryState", () => {
       }),
     );
 
-    expect(result.current.view).toBe("complex");
+    expect(result.current.view).toBe("layouts");
     expect(result.current.section).toBe("homepage");
   });
 });

--- a/tests/components/ComponentsSlug.test.ts
+++ b/tests/components/ComponentsSlug.test.ts
@@ -28,18 +28,18 @@ describe("ComponentsSlug", () => {
     const result = resolveComponentsSlug("theme-splits");
     expect(result).toMatchObject({
       section: "layout",
-      view: "components",
+      view: "layouts",
     });
     expect(result?.query).toBe("Split");
   });
 
   it("maps view aliases", () => {
     const colorsResult = resolveComponentsSlug("colors");
-    expect(colorsResult).toMatchObject({ view: "tokens", viewExplicit: true });
+    expect(colorsResult).toMatchObject({ view: "primitives", viewExplicit: true });
     expect(colorsResult?.section).toBeUndefined();
 
     const stylesResult = resolveComponentsSlug("styles");
-    expect(stylesResult).toMatchObject({ view: "tokens", viewExplicit: true });
+    expect(stylesResult).toMatchObject({ view: "primitives", viewExplicit: true });
     expect(stylesResult?.section).toBeUndefined();
 
     const elementsResult = resolveComponentsSlug("elements");
@@ -51,21 +51,21 @@ describe("ComponentsSlug", () => {
     const sectionResult = resolveComponentsSlug("prompts");
     expect(sectionResult).toMatchObject({
       section: "prompts",
-      view: "components",
+      view: "patterns",
     });
 
     const entryResult = resolveComponentsSlug("prompt-list");
     expect(entryResult).toMatchObject({
       section: "prompts",
-      view: "components",
+      view: "patterns",
     });
   });
 
-  it("resolves complex sections when the slug matches a group", () => {
+  it("resolves layout sections when the slug matches a group", () => {
     const result = resolveComponentsSlug("components");
     expect(result).toMatchObject({
       section: "components",
-      view: "complex",
+      view: "layouts",
     });
   });
 


### PR DESCRIPTION
## Summary
- refresh gallery metadata to define primitives, patterns, and layouts groups with updated copy
- streamline gallery state and UI to remove the tokens view, add anchor navigation, and expose new section labels
- adjust slug and gallery state tests to match the revised view aliases and structure

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d733e71310832c96206616e12a135c