### PR TITLE
feat: sync gallery previews with token selection

### DIFF
--- a/docs/qa-manual.md
+++ b/docs/qa-manual.md
@@ -12,3 +12,7 @@ For each page verify:
 
 - Pointer activation: Open the components gallery, select the "Tokens" view with the mouse, and confirm the tab content does not scroll and the active tab keeps focus.
 - Keyboard activation: Use the keyboard to move between the gallery view tabs, activate the "Tokens" view with Enter/Space and confirm focus moves into the tokens panel. Move back to the components view with the keyboard and ensure focus shifts into the component panel instead of staying on the tab.
+
+## Accessibility checklist
+
+- Token overrides: In the Tokens view, toggle a color, radius, and shadow token with both pointer and keyboard input. Confirm the cards expose `aria-pressed`, previews update while a token is active, and deselecting restores the baseline presentation.

--- a/src/components/gallery/TokenPreviewBoundary.tsx
+++ b/src/components/gallery/TokenPreviewBoundary.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+
+import { useTokenOverrides } from "./token-overrides-store";
+
+const TOKEN_TO_CSS_VARIABLE: Record<string, readonly string[]> = {
+  color: ["--accent"],
+  radius: ["--radius-card"],
+  shadow: ["--shadow-neo", "--shadow-neo-soft"],
+};
+
+function buildStyle(overrides: ReturnType<typeof useTokenOverrides>) {
+  const style: React.CSSProperties = { display: "contents" };
+  const styleRecord = style as Record<string, string>;
+
+  for (const [category, token] of Object.entries(overrides)) {
+    const variables = TOKEN_TO_CSS_VARIABLE[category as keyof typeof TOKEN_TO_CSS_VARIABLE];
+    if (!token || !variables) {
+      continue;
+    }
+
+    for (const variable of variables) {
+      styleRecord[variable] = `var(${token.cssVar})`;
+    }
+  }
+
+  return style;
+}
+
+export default function TokenPreviewBoundary({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}) {
+  const overrides = useTokenOverrides();
+  const style = React.useMemo(() => buildStyle(overrides), [overrides]);
+
+  return (
+    <div data-token-preview-overrides="" style={style}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/gallery/runtime.ts
+++ b/src/components/gallery/runtime.ts
@@ -5,6 +5,7 @@ import {
   galleryPreviewModules,
   type GalleryPreviewModuleManifest,
 } from "./generated-manifest";
+import TokenPreviewBoundary from "./TokenPreviewBoundary";
 import type {
   GalleryEntryKind,
   GalleryPreviewRenderer,
@@ -134,7 +135,11 @@ export const getGalleryPreviewRenderer = (
 
   const LazyComponent = getLazyPreviewComponent(id, manifest);
   const renderer: GalleryPreviewRenderer = () =>
-    React.createElement(LazyComponent);
+    React.createElement(
+      TokenPreviewBoundary,
+      undefined,
+      React.createElement(LazyComponent),
+    );
 
   previewRendererCache.set(id, renderer);
   return renderer;

--- a/src/components/gallery/token-overrides-store.ts
+++ b/src/components/gallery/token-overrides-store.ts
@@ -1,0 +1,82 @@
+import { useSyncExternalStore } from "react";
+
+import type { DesignTokenMeta } from "@/lib/design-token-registry";
+
+type MutableTokenOverridesState = Partial<
+  Record<DesignTokenMeta["category"], DesignTokenMeta>
+>;
+
+export type TokenOverridesState = Readonly<MutableTokenOverridesState>;
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+
+let state: TokenOverridesState = Object.freeze({});
+
+function emit() {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function setState(next: MutableTokenOverridesState) {
+  state = Object.freeze(next) as TokenOverridesState;
+  emit();
+}
+
+export function subscribeTokenOverrides(listener: Listener) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getTokenOverridesSnapshot(): TokenOverridesState {
+  return state;
+}
+
+export function useTokenOverrides(): TokenOverridesState {
+  return useSyncExternalStore(
+    subscribeTokenOverrides,
+    getTokenOverridesSnapshot,
+    getTokenOverridesSnapshot,
+  );
+}
+
+export function toggleTokenOverride(token: DesignTokenMeta) {
+  const current = state[token.category];
+  const next: MutableTokenOverridesState = { ...state };
+
+  if (current && current.name === token.name) {
+    delete next[token.category];
+  } else {
+    next[token.category] = token;
+  }
+
+  setState(next);
+}
+
+export function clearTokenOverride(category: DesignTokenMeta["category"]) {
+  if (!state[category]) {
+    return;
+  }
+
+  const next: MutableTokenOverridesState = { ...state };
+  delete next[category];
+  setState(next);
+}
+
+export function isTokenSelected(
+  token: DesignTokenMeta,
+  overrides: TokenOverridesState,
+): boolean {
+  const current = overrides[token.category];
+  return current?.name === token.name;
+}
+
+export function getSelectedToken(
+  category: DesignTokenMeta["category"],
+): DesignTokenMeta | undefined {
+  return state[category];
+}


### PR DESCRIPTION
## Summary
- add a shared token override store and wrap gallery previews so selected tokens temporarily override accent, radius, and shadow variables
- allow token cards in the Tokens view to toggle selection with accessible semantics and keep copy interactions separate
- document the new override workflow in the accessibility checklist so QA covers keyboard and pointer expectations

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d738fafdbc832c8f6114e46f0e61dc