### PR TITLE
Add scroll offset for components gallery

### DIFF
--- a/src/components/gallery-page/ComponentsPageClient.tsx
+++ b/src/components/gallery-page/ComponentsPageClient.tsx
@@ -263,7 +263,7 @@ export default function ComponentsPageClient({
         id={`components-${view}`}
         grid
         aria-labelledby="components-header"
-        className="py-[var(--space-6)] md:py-[var(--space-7)] lg:py-[var(--space-8)]"
+        className="scroll-mt-[calc(env(safe-area-inset-top)+var(--header-stack)+var(--space-2))] py-[var(--space-6)] md:py-[var(--space-7)] lg:py-[var(--space-8)]"
         contentClassName="gap-y-[var(--space-6)] md:gap-y-[var(--space-7)] lg:gap-y-[var(--space-8)]"
       >
         <ComponentsGalleryPanels


### PR DESCRIPTION
## Summary
- add a scroll margin offset to the components gallery content section so anchored navigation lands below the sticky chrome

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d7d3d3b0e0832cbcf832e8c8b2cd70