### PR TITLE
Align reminders search min width with spacing tokens

### DIFF
--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -98,6 +98,8 @@ const GROUP_TABS: Array<{ key: Group | "all"; label: string }> = [
   { key: "review", label: "Review" },
 ];
 
+export const REMINDERS_SEARCH_MIN_WIDTH = "calc(var(--space-8)*3.5)";
+
 /* ---------- component ---------- */
 
 export default function Reminders() {
@@ -219,7 +221,10 @@ export default function Reminders() {
           {/* header row (no Quick Add here anymore) */}
           <div className="flex flex-wrap items-center gap-[var(--space-2)] sm:gap-[var(--space-3)] w-full">
             {/* search */}
-            <div className="relative flex-1 min-w-56">
+            <div
+              className="relative flex-1"
+              style={{ minWidth: REMINDERS_SEARCH_MIN_WIDTH }}
+            >
               <Search
                 aria-hidden
                 className="icon-md pointer-events-none absolute left-[var(--space-4)] top-1/2 -translate-y-1/2 text-muted-foreground opacity-70"


### PR DESCRIPTION
## Summary
- replace the reminders search min-width utility with a spacing token-based calc value
- export the search width constant alongside the component for potential reuse

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d7d9e065ec832c9be5364657b94a92