### PR TITLE
Handle QuickActionGrid hash links with anchors

### DIFF
--- a/src/components/home/QuickActionGrid.tsx
+++ b/src/components/home/QuickActionGrid.tsx
@@ -117,7 +117,7 @@ export default function QuickActionGrid({
             ? "noopener noreferrer"
             : rel;
 
-        const childNode = isExternal ? (
+        const childNode = isExternal || isHash ? (
           <a
             href={resolvedHref}
             target={target}

--- a/tests/home/QuickActionGrid.test.tsx
+++ b/tests/home/QuickActionGrid.test.tsx
@@ -59,4 +59,27 @@ describe("QuickActionGrid", () => {
     fireEvent.click(externalLink);
     expect(handleExternal).toHaveBeenCalledTimes(1);
   });
+
+  it("renders hash actions with native anchors without crashing", () => {
+    let renderResult: ReturnType<typeof render> | undefined;
+
+    expect(() => {
+      renderResult = render(
+        <QuickActionGrid
+          actions={[
+            {
+              href: "#hash-action",
+              label: "Hash action",
+            },
+          ]}
+        />,
+      );
+    }).not.toThrow();
+
+    expect(renderResult).toBeDefined();
+    const hashLink = renderResult!.getByRole("link", { name: "Hash action" });
+
+    expect(hashLink).toBeInstanceOf(HTMLAnchorElement);
+    expect(hashLink).toHaveAttribute("href", "#hash-action");
+  });
 });


### PR DESCRIPTION
## Summary
- ensure QuickActionGrid renders hash-only actions with native anchors instead of Next.js Link
- add a component test covering hash actions to prevent regressions

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d7dc95474c832c932233a8e3de45dd