### PR TITLE
Refine GlitchProgress zero state styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1024,8 +1024,14 @@ html.bg-intense body::after {
   position: relative;
   height: 10px;
   border-radius: var(--radius-full);
-  background: hsl(var(--foreground) / 0.08);
+  background: hsl(var(--foreground) / 0.06);
   overflow: hidden;
+}
+.glitch-track[data-progress-state="zero"] {
+  background: hsl(var(--foreground) / 0.04);
+}
+.glitch-track[data-progress-state="active"] {
+  background: hsl(var(--foreground) / 0.08);
   box-shadow:
     inset 0 0 0 var(--spacing-0-25) hsl(var(--foreground) / 0.06),
     inset var(--spacing-0-5) var(--spacing-0-5) var(--space-1)
@@ -1040,8 +1046,13 @@ html.bg-intense body::after {
   background: linear-gradient(90deg, hsl(var(--accent)), hsl(var(--accent-2)));
   background-size: 200% 100%;
   transition: width 0.35s cubic-bezier(0.22, 0.99, 0.28, 0.99);
+}
+.glitch-track[data-progress-state="active"] .glitch-fill {
   animation: glitchSheen 3s linear infinite;
   box-shadow: 0 0 var(--space-2) hsl(var(--accent) / 0.5);
+}
+.glitch-track[data-progress-state="zero"] .glitch-fill {
+  height: 0;
 }
 .glitch-scan {
   position: absolute;
@@ -1055,6 +1066,10 @@ html.bg-intense body::after {
   );
   mix-blend-mode: screen;
   pointer-events: none;
+  opacity: 0;
+}
+.glitch-track[data-progress-state="active"] .glitch-scan {
+  opacity: 1;
   animation:
     glitchScan 1.6s steps(8, end) infinite,
     glitchJitter 0.8s steps(3, end) infinite;

--- a/src/components/ui/primitives/GlitchProgress.tsx
+++ b/src/components/ui/primitives/GlitchProgress.tsx
@@ -40,6 +40,7 @@ const GlitchProgress = React.forwardRef<HTMLDivElement, GlitchProgressProps>(
         : Math.min(Math.max(parsedCurrent, 0), parsedTotal);
     const ratio = parsedTotal === 0 ? 0 : normalizedCurrent / parsedTotal;
     const percent = Math.round(ratio * 100);
+    const hasProgress = percent > 0;
     const formattedPercentage =
       formatPercentage?.(percent) ?? `${percent}%`;
 
@@ -69,6 +70,7 @@ const GlitchProgress = React.forwardRef<HTMLDivElement, GlitchProgressProps>(
           !showPercentage && className,
           percent >= 100 && "is-complete",
         )}
+        data-progress-state={hasProgress ? "active" : "zero"}
         role="progressbar"
         aria-valuemin={0}
         aria-valuemax={100}

--- a/tests/primitives/GlitchProgress.test.tsx
+++ b/tests/primitives/GlitchProgress.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import GlitchProgress from "../../src/components/ui/primitives/GlitchProgress";
+
+afterEach(cleanup);
+
+describe("GlitchProgress", () => {
+  it("keeps zero progress state accessible and visible", () => {
+    const { getByRole, getByText } = render(
+      <GlitchProgress current={0} total={100} showPercentage />,
+    );
+
+    const track = getByRole("progressbar");
+    expect(track).toHaveAttribute("data-progress-state", "zero");
+    expect(track).toHaveAttribute("aria-valuenow", "0");
+
+    const fill = track.querySelector<HTMLDivElement>(".glitch-fill");
+    expect(fill).not.toBeNull();
+    expect(fill).toHaveStyle({ width: "0%" });
+
+    expect(getByText("0%")).toBeInTheDocument();
+  });
+
+  it("switches to the active state when progress is non-zero", () => {
+    const { getByRole, getByText } = render(
+      <GlitchProgress current={3} total={4} showPercentage />,
+    );
+
+    const track = getByRole("progressbar");
+    expect(track).toHaveAttribute("data-progress-state", "active");
+    expect(track).toHaveAttribute("aria-valuenow", "75");
+
+    const fill = track.querySelector<HTMLDivElement>(".glitch-fill");
+    expect(fill).not.toBeNull();
+    expect(fill).toHaveStyle({ width: "75%" });
+
+    expect(getByText("75%")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a progress-state attribute to GlitchProgress and ensure the percentage label reflects zero progress
- scope glitch progress animations and shadows to active states while calming the zero track
- cover zero and active GlitchProgress cases with a new DOM test

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d8096b75b8832ca724ecc45b415fbe