### PR TITLE
feat: rotate planner empty states

### DIFF
--- a/src/components/planner/EmptyRow.tsx
+++ b/src/components/planner/EmptyRow.tsx
@@ -1,5 +1,87 @@
 import * as React from "react";
+import { cn } from "@/lib/utils";
 
-export default function EmptyRow({ text }: { text: string }) {
-  return <div className="tasks-placeholder text-label">{text}</div>;
+const DEFAULT_DESCRIPTOR = {
+  id: "static",
+  text: "Nothing queued yet.",
+} as const;
+
+const ROTATING_DESCRIPTORS = [
+  { id: "echo", text: "Awaiting planner echo…" },
+  { id: "buffer", text: "Buffering next step…" },
+  { id: "ghost", text: "Ghost row awaiting sync…" },
+] as const;
+
+type EmptyRowTone = "default" | "muted";
+type EmptyRowVariant = "default" | "rotate";
+
+type EmptyRowProps = {
+  text?: string;
+  tone?: EmptyRowTone;
+  variant?: EmptyRowVariant;
+};
+
+export default function EmptyRow({
+  text,
+  tone = "default",
+  variant = "default",
+}: EmptyRowProps) {
+  const componentId = React.useId();
+
+  const descriptor = React.useMemo(() => {
+    if (text) {
+      return { id: "custom", text } as const;
+    }
+
+    if (variant === "rotate") {
+      const seed = Array.from(componentId).reduce(
+        (total, char) => total + char.charCodeAt(0),
+        0,
+      );
+      const rotating = ROTATING_DESCRIPTORS[seed % ROTATING_DESCRIPTORS.length];
+      return rotating;
+    }
+
+    return DEFAULT_DESCRIPTOR;
+  }, [componentId, text, variant]);
+
+  const secondaryText = React.useMemo(() => {
+    if (variant !== "rotate") return undefined;
+    const seed = Array.from(componentId).reduce(
+      (total, char) => total + char.charCodeAt(0) * 7,
+      0,
+    );
+    return ROTATING_DESCRIPTORS[(seed + 1) % ROTATING_DESCRIPTORS.length];
+  }, [componentId, variant]);
+
+  const isRotating = variant === "rotate";
+  const toneClassName = tone === "muted" ? "text-muted-foreground" : undefined;
+  const primaryClassName = cn(
+    "font-medium",
+    tone === "muted" ? "text-muted-foreground" : "text-foreground",
+  );
+
+  return (
+    <div
+      className={cn("tasks-placeholder text-label", toneClassName)}
+      data-placeholder-tone={tone}
+      data-placeholder-variant={variant}
+      data-placeholder-layer={descriptor.id}
+      data-placeholder-size={isRotating ? "compact" : undefined}
+    >
+      <span className={primaryClassName} data-placeholder-primary>
+        {descriptor.text}
+      </span>
+      {isRotating && secondaryText ? (
+        <span
+          aria-hidden="true"
+          className="text-ui text-muted-foreground"
+          data-placeholder-descriptor
+          data-placeholder-layer-secondary={secondaryText.id}
+        >
+          {secondaryText.text}
+        </span>
+      ) : null}
+    </div>
+  );
 }

--- a/src/components/planner/ProjectList.tsx
+++ b/src/components/planner/ProjectList.tsx
@@ -143,7 +143,7 @@ export default function ProjectList({
           aria-label="Projects"
         >
           <li className="w-full">
-            <EmptyRow text="No projects yet." />
+            <EmptyRow text="No projects yet." tone="muted" variant="rotate" />
           </li>
         </ul>
       )}

--- a/src/components/planner/TaskList.tsx
+++ b/src/components/planner/TaskList.tsx
@@ -83,6 +83,8 @@ export default function TaskList({
       renderEmpty={() => (
         <EmptyRow
           text={hasSelectedProject ? "No tasks yet" : "Select a project to view tasks"}
+          tone={hasSelectedProject ? "default" : "muted"}
+          variant={hasSelectedProject ? "rotate" : "default"}
         />
       )}
       renderList={() => (

--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -198,8 +198,10 @@
 /* Empty states */
 .tasks-placeholder {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: var(--space-1);
   min-height: calc(var(--space-8) + var(--space-5));
   padding: var(--space-3);
   border: var(--hairline-w) dashed hsl(var(--card-hairline) / 0.7);
@@ -210,6 +212,13 @@
     hsl(var(--card) / 0.65),
     hsl(var(--card) / 0.45)
   );
+  text-align: center;
+}
+
+.tasks-placeholder[data-placeholder-size="compact"] {
+  min-height: calc(var(--space-7));
+  padding-top: var(--space-2);
+  padding-bottom: var(--space-2);
 }
 
 /* ============ Week summary tiles ============ */

--- a/src/components/prompts/component-gallery/PlannerPanel.tsx
+++ b/src/components/prompts/component-gallery/PlannerPanel.tsx
@@ -215,7 +215,15 @@ export default function PlannerPanel({ data }: PlannerPanelProps) {
             <DayCardHeader iso="2024-01-01" projectCount={2} doneCount={1} totalCount={3} />
           ),
         },
-        { label: "EmptyRow", element: <EmptyRow text="Nothing here" /> },
+        {
+          label: "EmptyRow",
+          element: (
+            <div className="space-y-[var(--space-2)]">
+              <EmptyRow text="Nothing here" tone="muted" />
+              <EmptyRow text="No backlog items" variant="rotate" />
+            </div>
+          ),
+        },
         {
           label: "TaskRow",
           element: (
@@ -261,7 +269,9 @@ export default function PlannerPanel({ data }: PlannerPanelProps) {
                 </form>
               )}
               isEmpty={false}
-              renderEmpty={() => <EmptyRow text="All caught up" />}
+              renderEmpty={() => (
+                <EmptyRow text="All caught up" tone="muted" variant="rotate" />
+              )}
               renderList={() => (
                 <ul className="space-y-[var(--space-2)]" aria-label="Demo items">
                   {demoProjects.map((project) => (


### PR DESCRIPTION
## Summary
- add tone and variant controls to planner empty rows with rotating descriptors and data hooks
- compact the placeholder styling and adopt rotation in project/task empty renders
- refresh planner gallery previews to snapshot both default and rotating empty states

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d8091f5654832c8ca9067427a2e404