### PR TITLE
Align planner panel viewport spacing tokens

### DIFF
--- a/src/components/planner/PlannerListPanel.tsx
+++ b/src/components/planner/PlannerListPanel.tsx
@@ -10,6 +10,7 @@ type PlannerListPanelProps = {
   isEmpty: boolean;
   className?: string;
   viewportClassName?: string;
+  viewportInsetClassName?: string;
   viewportStyle?: React.CSSProperties;
   viewportProps?: React.HTMLAttributes<HTMLDivElement>;
 };
@@ -21,6 +22,7 @@ export default function PlannerListPanel({
   isEmpty,
   className,
   viewportClassName,
+  viewportInsetClassName = "card-pad",
   viewportStyle,
   viewportProps,
 }: PlannerListPanelProps) {
@@ -44,7 +46,8 @@ export default function PlannerListPanel({
       <div
         {...restViewportProps}
         className={cn(
-          "w-full overflow-y-auto px-[var(--space-2)] py-[var(--space-2)]",
+          "w-full overflow-y-auto",
+          viewportInsetClassName,
           viewportPropsClassName,
           viewportClassName,
         )}

--- a/src/components/planner/ProjectList.tsx
+++ b/src/components/planner/ProjectList.tsx
@@ -286,7 +286,6 @@ export default function ProjectList({
         </ul>
       )}
       viewportClassName={cn(
-        "px-0 w-full",
         projectsScrollable ? undefined : "overflow-visible",
       )}
       viewportStyle={

--- a/src/components/planner/TaskList.tsx
+++ b/src/components/planner/TaskList.tsx
@@ -87,7 +87,7 @@ export default function TaskList({
       )}
       renderList={() => (
         <ul
-          className="space-y-[var(--space-2)] [&>li:first-child]:mt-[var(--space-2)] [&>li:last-child]:mb-[var(--space-2)]"
+          className="space-y-[var(--space-2)]"
           aria-label="Tasks"
         >
           {tasksForSelected.map((t) => (
@@ -110,7 +110,10 @@ export default function TaskList({
           ))}
         </ul>
       )}
-      viewportClassName="min-h-[calc(var(--space-8)*2)] max-h-[calc(var(--space-8)*5)]"
+      viewportStyle={{
+        minHeight: "calc(var(--space-8) * 2)",
+        maxHeight: "calc(var(--space-8) * 5)",
+      }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- default PlannerListPanel viewport inset to the shared card-pad token with an override hook
- drop consumer spacing overrides in project and task lists while retaining height controls

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d80a3f4a38832cb0398a5ccb51d0cf