### PR TITLE
feat: refresh planner empty states

### DIFF
--- a/src/components/planner/EmptyRow.tsx
+++ b/src/components/planner/EmptyRow.tsx
@@ -1,5 +1,64 @@
 import * as React from "react";
+import Button from "@/components/ui/primitives/Button";
+import { cn } from "@/lib/utils";
 
-export default function EmptyRow({ text }: { text: string }) {
-  return <div className="tasks-placeholder text-label">{text}</div>;
+type EmptyRowAction =
+  | {
+      label: string;
+      onClick: () => void;
+      href?: undefined;
+      target?: undefined;
+      rel?: undefined;
+    }
+  | {
+      label: string;
+      href: string;
+      onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+      target?: React.AnchorHTMLAttributes<HTMLAnchorElement>["target"];
+      rel?: React.AnchorHTMLAttributes<HTMLAnchorElement>["rel"];
+    };
+
+type EmptyRowProps = {
+  heading: string;
+  helperText: string;
+  icon?: React.ReactNode;
+  action?: EmptyRowAction;
+  className?: string;
+};
+
+export default function EmptyRow({
+  heading,
+  helperText,
+  icon,
+  action,
+  className,
+}: EmptyRowProps) {
+  return (
+    <div className={cn("tasks-placeholder", className)} role="status">
+      {icon ? (
+        <div className="tasks-placeholder__icon" aria-hidden="true">
+          {icon}
+        </div>
+      ) : null}
+      <div className="tasks-placeholder__content">
+        <h3 className="tasks-placeholder__heading">{heading}</h3>
+        <p className="tasks-placeholder__helper">{helperText}</p>
+      </div>
+      {action ? (
+        <div className="tasks-placeholder__cta">
+          {"href" in action ? (
+            <Button asChild size="sm" variant="secondary" tone="primary">
+              <a href={action.href} onClick={action.onClick} target={action.target} rel={action.rel}>
+                {action.label}
+              </a>
+            </Button>
+          ) : (
+            <Button size="sm" variant="secondary" tone="primary" onClick={action.onClick}>
+              {action.label}
+            </Button>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
 }

--- a/src/components/planner/ProjectList.tsx
+++ b/src/components/planner/ProjectList.tsx
@@ -5,7 +5,7 @@ import Label from "@/components/ui/Label";
 import Input from "@/components/ui/primitives/Input";
 import IconButton from "@/components/ui/primitives/IconButton";
 import CheckCircle from "@/components/ui/toggles/CheckCircle";
-import { Pencil, Trash2 } from "lucide-react";
+import { FolderPlus, Pencil, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import EmptyRow from "./EmptyRow";
 import PlannerListPanel from "./PlannerListPanel";
@@ -40,6 +40,7 @@ export default function ProjectList({
   );
   const [editingProjectName, setEditingProjectName] = React.useState("");
   const [draftProject, setDraftProject] = React.useState("");
+  const newProjectInputRef = React.useRef<HTMLInputElement | null>(null);
   const projectRefs = React.useRef<Map<string, HTMLDivElement | null>>(new Map());
   const projectsScrollable = projects.length > 3;
   const multiple = projects.length > 1;
@@ -133,6 +134,7 @@ export default function ProjectList({
             placeholder="> new project…"
             value={draftProject}
             onChange={(e) => setDraftProject(e.target.value)}
+            ref={newProjectInputRef}
           />
         </form>
       )}
@@ -143,7 +145,18 @@ export default function ProjectList({
           aria-label="Projects"
         >
           <li className="w-full">
-            <EmptyRow text="No projects yet." />
+            <EmptyRow
+              icon={<FolderPlus />}
+              heading="No projects yet"
+              helperText="Create a project to start grouping your work."
+              action={{
+                label: "Create your first project",
+                onClick: () => {
+                  newProjectInputRef.current?.focus();
+                  newProjectInputRef.current?.select();
+                },
+              }}
+            />
           </li>
         </ul>
       )}

--- a/src/components/planner/TaskList.tsx
+++ b/src/components/planner/TaskList.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import Label from "@/components/ui/Label";
 import Input from "@/components/ui/primitives/Input";
+import { Inbox, ListPlus } from "lucide-react";
 import EmptyRow from "./EmptyRow";
 import PlannerListPanel from "./PlannerListPanel";
 import TaskRow from "./TaskRow";
@@ -34,6 +35,7 @@ export default function TaskList({
   setSelectedTaskId,
 }: Props) {
   const [draftTask, setDraftTask] = React.useState("");
+  const newTaskInputRef = React.useRef<HTMLInputElement | null>(null);
   const newTaskInputId = React.useId();
   const tasksForSelected = React.useMemo(
     () => {
@@ -74,6 +76,7 @@ export default function TaskList({
                   placeholder="> add task…"
                   value={draftTask}
                   onChange={(e) => setDraftTask(e.target.value)}
+                  ref={newTaskInputRef}
                 />
               </form>
             )
@@ -82,7 +85,26 @@ export default function TaskList({
       isEmpty={isEmpty}
       renderEmpty={() => (
         <EmptyRow
-          text={hasSelectedProject ? "No tasks yet" : "Select a project to view tasks"}
+          icon={hasSelectedProject ? <ListPlus /> : <Inbox />}
+          heading={
+            hasSelectedProject ? "No tasks yet" : "Choose a project to view tasks"
+          }
+          helperText={
+            hasSelectedProject
+              ? "Add tasks to break work into focused steps."
+              : "Select a project from the list to see its tasks."
+          }
+          action={
+            hasSelectedProject
+              ? {
+                  label: "Add a task",
+                  onClick: () => {
+                    newTaskInputRef.current?.focus();
+                    newTaskInputRef.current?.select();
+                  },
+                }
+              : undefined
+          }
         />
       )}
       renderList={() => (

--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -197,19 +197,73 @@
 
 /* Empty states */
 .tasks-placeholder {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: calc(var(--space-8) + var(--space-5));
-  padding: var(--space-3);
+  --empty-min: calc(var(--space-8) + var(--space-5));
+  display: grid;
+  justify-items: center;
+  align-content: center;
+  gap: var(--space-3);
+  text-align: center;
+  min-height: var(--empty-min);
+  padding: var(--space-4);
   border: var(--hairline-w) dashed hsl(var(--card-hairline) / 0.7);
-  border-radius: var(--radius-lg);
-  color: hsl(var(--muted-foreground));
+  border-radius: var(--radius-xl);
   background: linear-gradient(
     180deg,
-    hsl(var(--card) / 0.65),
-    hsl(var(--card) / 0.45)
+    hsl(var(--card) / 0.7),
+    hsl(var(--panel) / 0.6)
   );
+  color: hsl(var(--muted-foreground));
+  box-shadow: 0 0 0 var(--hairline-w) hsl(var(--card-hairline) / 0.35);
+}
+
+.tasks-placeholder__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(var(--space-8) + var(--space-2));
+  height: calc(var(--space-8) + var(--space-2));
+  border-radius: var(--radius-full);
+  background: hsl(var(--card) / 0.55);
+  box-shadow: inset 0 0 0 var(--hairline-w) hsl(var(--card-hairline) / 0.45);
+  color: hsl(var(--accent-2));
+}
+
+.tasks-placeholder__icon > svg {
+  width: var(--icon-size-lg);
+  height: var(--icon-size-lg);
+}
+
+.tasks-placeholder__content {
+  display: grid;
+  gap: var(--space-1);
+  max-width: calc(var(--space-8) * 5);
+}
+
+.tasks-placeholder__heading {
+  margin: 0;
+  font: inherit;
+  color: hsl(var(--foreground));
+  font-size: var(--font-title);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.tasks-placeholder__helper {
+  margin: 0;
+  color: hsl(var(--muted-foreground));
+  font-size: var(--font-body);
+  line-height: 1.4;
+}
+
+.tasks-placeholder__cta {
+  display: flex;
+  justify-content: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tasks-placeholder {
+    transition: none;
+  }
 }
 
 /* ============ Week summary tiles ============ */

--- a/src/components/prompts/component-gallery/PlannerPanel.tsx
+++ b/src/components/prompts/component-gallery/PlannerPanel.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { GoalsProgress, GoalsTabs } from "@/components/goals";
+import { Sparkles } from "lucide-react";
 import {
   DayRow,
   DayCardHeader,
@@ -215,7 +216,16 @@ export default function PlannerPanel({ data }: PlannerPanelProps) {
             <DayCardHeader iso="2024-01-01" projectCount={2} doneCount={1} totalCount={3} />
           ),
         },
-        { label: "EmptyRow", element: <EmptyRow text="Nothing here" /> },
+        {
+          label: "EmptyRow",
+          element: (
+            <EmptyRow
+              icon={<Sparkles />}
+              heading="All caught up"
+              helperText="You're on top of your plan. Enjoy the breather."
+            />
+          ),
+        },
         {
           label: "TaskRow",
           element: (
@@ -261,7 +271,13 @@ export default function PlannerPanel({ data }: PlannerPanelProps) {
                 </form>
               )}
               isEmpty={false}
-              renderEmpty={() => <EmptyRow text="All caught up" />}
+              renderEmpty={() => (
+                <EmptyRow
+                  icon={<Sparkles />}
+                  heading="All caught up"
+                  helperText="You're on top of your plan. Enjoy the breather."
+                />
+              )}
               renderList={() => (
                 <ul className="space-y-[var(--space-2)]" aria-label="Demo items">
                   {demoProjects.map((project) => (


### PR DESCRIPTION
## Summary
- replace the planner EmptyRow with a token-aligned layout that supports icons, helper copy, and optional calls to action
- update project and task lists to surface focused empty states and quick actions
- refresh planner styles and gallery demos to showcase the new presentation

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d80a407614832c9608064f5f7a4c84