### PR TITLE
Add props disclosure accordion to ComponentsView

### DIFF
--- a/src/components/prompts/ComponentsView.tsx
+++ b/src/components/prompts/ComponentsView.tsx
@@ -13,6 +13,8 @@ import { cn } from "@/lib/utils";
 
 import { getGalleryPreview } from "./constants";
 
+export const PROPS_DISCLOSURE_COLLAPSE_THRESHOLD = 6;
+
 interface ComponentsViewProps {
   entry: GallerySerializableEntry;
   onCurrentCodeChange?: (code: string | null) => void;
@@ -125,14 +127,55 @@ function PropsTable({
   props: NonNullable<GallerySerializableEntry["props"]>;
 }) {
   const headingId = React.useId();
+  const panelId = React.useId();
+  const firstCellRef = React.useRef<HTMLTableCellElement>(null);
+  const shouldCollapseByDefault =
+    props.length > PROPS_DISCLOSURE_COLLAPSE_THRESHOLD;
+  const [expanded, setExpanded] = React.useState(!shouldCollapseByDefault);
+  const previousExpanded = React.useRef(expanded);
+
+  React.useEffect(() => {
+    if (expanded && !previousExpanded.current) {
+      firstCellRef.current?.focus();
+    }
+    previousExpanded.current = expanded;
+  }, [expanded]);
+
+  const toggleLabel = expanded
+    ? "Hide props"
+    : `View ${props.length} props`;
+
+  const handleToggle = () => {
+    setExpanded((current) => !current);
+  };
 
   return (
     <section
       aria-labelledby={headingId}
       className="space-y-[var(--space-3)]"
     >
-      <SectionHeading id={headingId}>Props</SectionHeading>
+      <div className="flex items-center justify-between gap-[var(--space-3)]">
+        <SectionHeading id={headingId}>Props</SectionHeading>
+        <button
+          type="button"
+          onClick={handleToggle}
+          aria-expanded={expanded}
+          aria-controls={panelId}
+          className={cn(
+            "text-label font-medium text-foreground",
+            "underline-offset-4 transition hover:underline",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card",
+          )}
+        >
+          {toggleLabel}
+        </button>
+      </div>
       <div
+        id={panelId}
+        role="region"
+        aria-labelledby={headingId}
+        hidden={!expanded}
+        aria-hidden={expanded ? undefined : true}
         className="overflow-x-auto rounded-card r-card-md border border-[hsl(var(--card-hairline)/0.6)] bg-[hsl(var(--surface-2)/0.6)] shadow-[var(--shadow-inset-hairline)]"
       >
         <table className="w-full min-w-[calc(var(--space-8)*7)] border-separate border-spacing-0 text-left">
@@ -153,12 +196,16 @@ function PropsTable({
             </tr>
           </thead>
           <tbody>
-            {props.map((prop) => (
+            {props.map((prop, index) => (
               <tr
                 key={prop.name}
                 className="border-t border-[hsl(var(--card-hairline)/0.4)] text-label"
               >
-                <td className="px-[var(--space-4)] py-[var(--space-3)] font-medium text-foreground">
+                <td
+                  ref={index === 0 ? firstCellRef : undefined}
+                  tabIndex={index === 0 ? -1 : undefined}
+                  className="px-[var(--space-4)] py-[var(--space-3)] font-medium text-foreground"
+                >
                   {prop.name}
                   {prop.required ? (
                     <span className="ml-[var(--space-2)] text-caption text-danger">

--- a/tests/components/ComponentsView.test.tsx
+++ b/tests/components/ComponentsView.test.tsx
@@ -1,0 +1,128 @@
+import * as React from "react";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/prompts/constants", () => ({
+  getGalleryPreview: () => () => <div data-testid="preview" />,
+}));
+
+import ComponentsView, {
+  PROPS_DISCLOSURE_COLLAPSE_THRESHOLD,
+} from "@/components/prompts/ComponentsView";
+import type { GallerySerializableEntry } from "@/components/gallery";
+
+type GalleryProp = NonNullable<GallerySerializableEntry["props"]>[number];
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function createProp(index: number, overrides: Partial<GalleryProp> = {}): GalleryProp {
+  const name = overrides.name ?? `prop-${index}`;
+  return {
+    name,
+    type: overrides.type ?? "string",
+    required: overrides.required,
+    defaultValue: overrides.defaultValue,
+    description: overrides.description,
+  };
+}
+
+function createEntry(
+  overrides: Partial<GallerySerializableEntry> = {},
+): GallerySerializableEntry {
+  return {
+    id: "component-entry",
+    name: "Component entry",
+    kind: "component",
+    preview: { id: "component-preview" },
+    props: overrides.props ?? [],
+    axes: overrides.axes,
+    usage: overrides.usage,
+    related: overrides.related,
+    code: overrides.code,
+    states: overrides.states,
+    description: overrides.description,
+    tags: overrides.tags,
+  } satisfies GallerySerializableEntry;
+}
+
+describe("ComponentsView props disclosure", () => {
+  it("collapses the props table by default when the prop count exceeds the threshold", () => {
+    const propCount = PROPS_DISCLOSURE_COLLAPSE_THRESHOLD + 6;
+    const entry = createEntry({
+      props: Array.from({ length: propCount }, (_, index) => createProp(index + 1)),
+    });
+
+    render(<ComponentsView entry={entry} />);
+
+    const toggle = screen.getByRole("button", {
+      name: `View ${propCount} props`,
+    });
+
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    const panelId = toggle.getAttribute("aria-controls");
+    expect(panelId).toBeTruthy();
+    const panel = panelId ? document.getElementById(panelId) : null;
+    expect(panel).not.toBeNull();
+    expect(panel).toHaveAttribute("hidden");
+    expect(panel).toHaveAttribute("aria-hidden", "true");
+    expect(panel).toHaveAttribute("role", "region");
+
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+
+  it("expands the props table on toggle and focuses the first prop cell", async () => {
+    const propCount = PROPS_DISCLOSURE_COLLAPSE_THRESHOLD + 1;
+    const entry = createEntry({
+      props: Array.from({ length: propCount }, (_, index) => createProp(index + 1)),
+    });
+
+    render(<ComponentsView entry={entry} />);
+
+    const toggle = screen.getByRole("button", {
+      name: `View ${propCount} props`,
+    });
+
+    toggle.click();
+
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute("aria-expanded", "true");
+    });
+    expect(toggle).toHaveTextContent("Hide props");
+
+    const table = screen.getByRole("table");
+    const firstCell = within(table).getAllByRole("cell")[0];
+    await waitFor(() => {
+      expect(firstCell).toHaveFocus();
+    });
+  });
+
+  it("associates the disclosure controls with the props heading", () => {
+    const propCount = PROPS_DISCLOSURE_COLLAPSE_THRESHOLD + 2;
+    const entry = createEntry({
+      props: Array.from({ length: propCount }, (_, index) => createProp(index + 1)),
+    });
+
+    render(<ComponentsView entry={entry} />);
+
+    const heading = screen.getByRole("heading", { level: 3, name: "Props" });
+    const toggle = screen.getByRole("button", {
+      name: `View ${propCount} props`,
+    });
+    const panelId = toggle.getAttribute("aria-controls");
+    expect(panelId).toBeTruthy();
+
+    const panel = panelId ? document.getElementById(panelId) : null;
+    expect(panel).not.toBeNull();
+    expect(panel).toHaveAttribute("aria-labelledby", heading.id);
+  });
+});


### PR DESCRIPTION
## Summary
- wrap the components view props table in an accessible disclosure that collapses when prop counts exceed the threshold
- focus the first prop cell after expansion, expose the collapse threshold constant, and keep the toggle label in sync
- add tests covering the disclosure toggle behaviour and aria wiring for the props table

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d80d19f8a8832c914e8c63b433095e