### PR TITLE
Add theme matrix preview to ComponentsView

### DIFF
--- a/tests/prompts/ComponentsViewThemeMatrix.test.tsx
+++ b/tests/prompts/ComponentsViewThemeMatrix.test.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import ComponentsView from "@/components/prompts/ComponentsView";
+import { ThemeProvider } from "@/lib/theme-context";
+import { VARIANTS } from "@/lib/theme";
+import * as themeModule from "@/lib/theme";
+import type { GallerySerializableEntry } from "@/components/gallery";
+
+vi.mock("@/components/prompts/constants", () => ({
+  getGalleryPreview: (id: string) => () => (
+    <div data-testid="gallery-preview">Preview for {id}</div>
+  ),
+}));
+
+describe("ComponentsView theme matrix", () => {
+  const applyThemeSpy = vi.spyOn(themeModule, "applyTheme");
+
+  const entry: GallerySerializableEntry = {
+    id: "test-entry",
+    name: "Test entry",
+    kind: "component",
+    preview: { id: "test-preview" },
+  };
+
+  const originalMatchMedia = window.matchMedia;
+
+  beforeAll(() => {
+    if (!window.matchMedia) {
+      window.matchMedia = vi
+        .fn()
+        .mockReturnValue({
+          matches: true,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }) as unknown as typeof window.matchMedia;
+    }
+  });
+
+  beforeEach(() => {
+    document.documentElement.className = "theme-lg";
+    document.documentElement.dataset.themePref = "persisted";
+    document.documentElement.style.colorScheme = "dark";
+    applyThemeSpy.mockImplementation(() => {});
+    applyThemeSpy.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  afterAll(() => {
+    applyThemeSpy.mockRestore();
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it("renders a radio control for each theme variant", () => {
+    render(
+      <ThemeProvider>
+        <ComponentsView entry={entry} />
+      </ThemeProvider>,
+    );
+
+    for (const variant of VARIANTS) {
+      expect(
+        screen.getByRole("radio", { name: variant.label }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("applies each theme variant and matches snapshots", () => {
+    const { container } = render(
+      <ThemeProvider>
+        <ComponentsView entry={entry} />
+      </ThemeProvider>,
+    );
+
+    // Ignore theme applications triggered by initial hydration.
+    applyThemeSpy.mockClear();
+
+    for (const variant of VARIANTS) {
+      const control = screen.getByRole("radio", { name: variant.label });
+      fireEvent.click(control);
+
+      if (applyThemeSpy.mock.calls.length > 0) {
+        expect(applyThemeSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ variant: variant.id }),
+        );
+      }
+
+      expect(container.firstChild).toMatchSnapshot(variant.id);
+      applyThemeSpy.mockClear();
+    }
+  });
+});

--- a/tests/prompts/__snapshots__/ComponentsViewThemeMatrix.test.tsx.snap
+++ b/tests/prompts/__snapshots__/ComponentsViewThemeMatrix.test.tsx.snap
@@ -1,0 +1,1121 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ComponentsView theme matrix > applies each theme variant and matches snapshots > aurora 1`] = `
+<article
+  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-[hsl(var(--card-hairline)/0.75)] bg-[linear-gradient(140deg,hsl(var(--card)/0.95),hsl(var(--surface-2)/0.78))] px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-card before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-[radial-gradient(125%_85%_at_18%_-25%,hsl(var(--accent)/0.3),transparent_65%),radial-gradient(125%_85%_at_82%_-20%,hsl(var(--ring)/0.28),transparent_60%)] before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-[linear-gradient(120deg,hsl(var(--accent)/0.12)_0%,transparent_58%,hsl(var(--ring)/0.16)_100%),repeating-linear-gradient(0deg,hsl(var(--ring)/0.12)_0,hsl(var(--ring)/0.12)_var(--hairline-w),transparent_var(--hairline-w),transparent_calc(var(--space-3)))] after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
+>
+  <header
+    class="flex flex-wrap items-start justify-between gap-[var(--space-4)]"
+  >
+    <div
+      class="flex-1 space-y-[var(--space-2)]"
+    >
+      <h2
+        class="text-title font-semibold tracking-[-0.01em] text-foreground"
+      >
+        Test entry
+      </h2>
+    </div>
+  </header>
+  <section
+    aria-labelledby=":r5:"
+    class="space-y-[var(--space-3)]"
+  >
+    <h3
+      class="text-ui font-semibold tracking-[-0.01em] text-muted-foreground"
+      id=":r5:"
+    >
+      Themes
+    </h3>
+    <div
+      class="space-y-[var(--space-2)]"
+    >
+      <p
+        class="text-label text-muted-foreground"
+        id=":r6:"
+      >
+        Preview this component across Planner themes.
+      </p>
+      <div
+        aria-labelledby=":r6:"
+        class="flex flex-wrap gap-[var(--space-2)]"
+        role="radiogroup"
+      >
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Glitch
+        </button>
+        <button
+          aria-checked="true"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          role="radio"
+          tabindex="0"
+          type="button"
+        >
+          Aurora
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Kitten
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Oceanic
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Citrus
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Noir
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Hardstuck
+        </button>
+      </div>
+    </div>
+    <div
+      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-[linear-gradient(90deg,hsl(var(--accent)/0.28),transparent_55%,hsl(var(--accent-2)/0.32))] after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
+    >
+      <div
+        data-testid="gallery-preview"
+      >
+        Preview for 
+        test-preview
+      </div>
+    </div>
+    <p
+      class="text-caption text-muted-foreground"
+    >
+      Showing the 
+       
+      <span
+        class="font-medium text-foreground"
+      >
+        Aurora
+      </span>
+       
+      theme.
+    </p>
+  </section>
+  <section
+    aria-labelledby=":r8:"
+    class="space-y-[var(--space-3)]"
+  >
+    <h3
+      class="text-ui font-semibold tracking-[-0.01em] text-muted-foreground"
+      id=":r8:"
+    >
+      Used on
+    </h3>
+    <div
+      class="space-y-[var(--space-3)] rounded-card r-card-md border border-[hsl(var(--card-hairline)/0.6)] bg-[hsl(var(--surface-2)/0.6)] p-[var(--space-4)] text-label text-muted-foreground shadow-[var(--shadow-inset-hairline)]"
+    >
+      <div
+        class="flex flex-wrap gap-[var(--space-2)]"
+      >
+        <span
+          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
+        >
+          Global
+        </span>
+      </div>
+      <p>
+        No page placements yet. This component is available across Planner.
+      </p>
+    </div>
+  </section>
+</article>
+`;
+
+exports[`ComponentsView theme matrix > applies each theme variant and matches snapshots > citrus 1`] = `
+<article
+  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-[hsl(var(--card-hairline)/0.75)] bg-[linear-gradient(140deg,hsl(var(--card)/0.95),hsl(var(--surface-2)/0.78))] px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-card before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-[radial-gradient(125%_85%_at_18%_-25%,hsl(var(--accent)/0.3),transparent_65%),radial-gradient(125%_85%_at_82%_-20%,hsl(var(--ring)/0.28),transparent_60%)] before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-[linear-gradient(120deg,hsl(var(--accent)/0.12)_0%,transparent_58%,hsl(var(--ring)/0.16)_100%),repeating-linear-gradient(0deg,hsl(var(--ring)/0.12)_0,hsl(var(--ring)/0.12)_var(--hairline-w),transparent_var(--hairline-w),transparent_calc(var(--space-3)))] after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
+>
+  <header
+    class="flex flex-wrap items-start justify-between gap-[var(--space-4)]"
+  >
+    <div
+      class="flex-1 space-y-[var(--space-2)]"
+    >
+      <h2
+        class="text-title font-semibold tracking-[-0.01em] text-foreground"
+      >
+        Test entry
+      </h2>
+    </div>
+  </header>
+  <section
+    aria-labelledby=":r5:"
+    class="space-y-[var(--space-3)]"
+  >
+    <h3
+      class="text-ui font-semibold tracking-[-0.01em] text-muted-foreground"
+      id=":r5:"
+    >
+      Themes
+    </h3>
+    <div
+      class="space-y-[var(--space-2)]"
+    >
+      <p
+        class="text-label text-muted-foreground"
+        id=":r6:"
+      >
+        Preview this component across Planner themes.
+      </p>
+      <div
+        aria-labelledby=":r6:"
+        class="flex flex-wrap gap-[var(--space-2)]"
+        role="radiogroup"
+      >
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Glitch
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Aurora
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Kitten
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Oceanic
+        </button>
+        <button
+          aria-checked="true"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          role="radio"
+          tabindex="0"
+          type="button"
+        >
+          Citrus
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Noir
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Hardstuck
+        </button>
+      </div>
+    </div>
+    <div
+      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-[linear-gradient(90deg,hsl(var(--accent)/0.28),transparent_55%,hsl(var(--accent-2)/0.32))] after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
+    >
+      <div
+        data-testid="gallery-preview"
+      >
+        Preview for 
+        test-preview
+      </div>
+    </div>
+    <p
+      class="text-caption text-muted-foreground"
+    >
+      Showing the 
+       
+      <span
+        class="font-medium text-foreground"
+      >
+        Citrus
+      </span>
+       
+      theme.
+    </p>
+  </section>
+  <section
+    aria-labelledby=":r8:"
+    class="space-y-[var(--space-3)]"
+  >
+    <h3
+      class="text-ui font-semibold tracking-[-0.01em] text-muted-foreground"
+      id=":r8:"
+    >
+      Used on
+    </h3>
+    <div
+      class="space-y-[var(--space-3)] rounded-card r-card-md border border-[hsl(var(--card-hairline)/0.6)] bg-[hsl(var(--surface-2)/0.6)] p-[var(--space-4)] text-label text-muted-foreground shadow-[var(--shadow-inset-hairline)]"
+    >
+      <div
+        class="flex flex-wrap gap-[var(--space-2)]"
+      >
+        <span
+          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
+        >
+          Global
+        </span>
+      </div>
+      <p>
+        No page placements yet. This component is available across Planner.
+      </p>
+    </div>
+  </section>
+</article>
+`;
+
+exports[`ComponentsView theme matrix > applies each theme variant and matches snapshots > hardstuck 1`] = `
+<article
+  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-[hsl(var(--card-hairline)/0.75)] bg-[linear-gradient(140deg,hsl(var(--card)/0.95),hsl(var(--surface-2)/0.78))] px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-card before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-[radial-gradient(125%_85%_at_18%_-25%,hsl(var(--accent)/0.3),transparent_65%),radial-gradient(125%_85%_at_82%_-20%,hsl(var(--ring)/0.28),transparent_60%)] before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-[linear-gradient(120deg,hsl(var(--accent)/0.12)_0%,transparent_58%,hsl(var(--ring)/0.16)_100%),repeating-linear-gradient(0deg,hsl(var(--ring)/0.12)_0,hsl(var(--ring)/0.12)_var(--hairline-w),transparent_var(--hairline-w),transparent_calc(var(--space-3)))] after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
+>
+  <header
+    class="flex flex-wrap items-start justify-between gap-[var(--space-4)]"
+  >
+    <div
+      class="flex-1 space-y-[var(--space-2)]"
+    >
+      <h2
+        class="text-title font-semibold tracking-[-0.01em] text-foreground"
+      >
+        Test entry
+      </h2>
+    </div>
+  </header>
+  <section
+    aria-labelledby=":r5:"
+    class="space-y-[var(--space-3)]"
+  >
+    <h3
+      class="text-ui font-semibold tracking-[-0.01em] text-muted-foreground"
+      id=":r5:"
+    >
+      Themes
+    </h3>
+    <div
+      class="space-y-[var(--space-2)]"
+    >
+      <p
+        class="text-label text-muted-foreground"
+        id=":r6:"
+      >
+        Preview this component across Planner themes.
+      </p>
+      <div
+        aria-labelledby=":r6:"
+        class="flex flex-wrap gap-[var(--space-2)]"
+        role="radiogroup"
+      >
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Glitch
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Aurora
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Kitten
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Oceanic
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Citrus
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Noir
+        </button>
+        <button
+          aria-checked="true"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          role="radio"
+          tabindex="0"
+          type="button"
+        >
+          Hardstuck
+        </button>
+      </div>
+    </div>
+    <div
+      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-[linear-gradient(90deg,hsl(var(--accent)/0.28),transparent_55%,hsl(var(--accent-2)/0.32))] after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
+    >
+      <div
+        data-testid="gallery-preview"
+      >
+        Preview for 
+        test-preview
+      </div>
+    </div>
+    <p
+      class="text-caption text-muted-foreground"
+    >
+      Showing the 
+       
+      <span
+        class="font-medium text-foreground"
+      >
+        Hardstuck
+      </span>
+       
+      theme.
+    </p>
+  </section>
+  <section
+    aria-labelledby=":r8:"
+    class="space-y-[var(--space-3)]"
+  >
+    <h3
+      class="text-ui font-semibold tracking-[-0.01em] text-muted-foreground"
+      id=":r8:"
+    >
+      Used on
+    </h3>
+    <div
+      class="space-y-[var(--space-3)] rounded-card r-card-md border border-[hsl(var(--card-hairline)/0.6)] bg-[hsl(var(--surface-2)/0.6)] p-[var(--space-4)] text-label text-muted-foreground shadow-[var(--shadow-inset-hairline)]"
+    >
+      <div
+        class="flex flex-wrap gap-[var(--space-2)]"
+      >
+        <span
+          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
+        >
+          Global
+        </span>
+      </div>
+      <p>
+        No page placements yet. This component is available across Planner.
+      </p>
+    </div>
+  </section>
+</article>
+`;
+
+exports[`ComponentsView theme matrix > applies each theme variant and matches snapshots > kitten 1`] = `
+<article
+  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-[hsl(var(--card-hairline)/0.75)] bg-[linear-gradient(140deg,hsl(var(--card)/0.95),hsl(var(--surface-2)/0.78))] px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-card before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-[radial-gradient(125%_85%_at_18%_-25%,hsl(var(--accent)/0.3),transparent_65%),radial-gradient(125%_85%_at_82%_-20%,hsl(var(--ring)/0.28),transparent_60%)] before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-[linear-gradient(120deg,hsl(var(--accent)/0.12)_0%,transparent_58%,hsl(var(--ring)/0.16)_100%),repeating-linear-gradient(0deg,hsl(var(--ring)/0.12)_0,hsl(var(--ring)/0.12)_var(--hairline-w),transparent_var(--hairline-w),transparent_calc(var(--space-3)))] after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
+>
+  <header
+    class="flex flex-wrap items-start justify-between gap-[var(--space-4)]"
+  >
+    <div
+      class="flex-1 space-y-[var(--space-2)]"
+    >
+      <h2
+        class="text-title font-semibold tracking-[-0.01em] text-foreground"
+      >
+        Test entry
+      </h2>
+    </div>
+  </header>
+  <section
+    aria-labelledby=":r5:"
+    class="space-y-[var(--space-3)]"
+  >
+    <h3
+      class="text-ui font-semibold tracking-[-0.01em] text-muted-foreground"
+      id=":r5:"
+    >
+      Themes
+    </h3>
+    <div
+      class="space-y-[var(--space-2)]"
+    >
+      <p
+        class="text-label text-muted-foreground"
+        id=":r6:"
+      >
+        Preview this component across Planner themes.
+      </p>
+      <div
+        aria-labelledby=":r6:"
+        class="flex flex-wrap gap-[var(--space-2)]"
+        role="radiogroup"
+      >
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Glitch
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Aurora
+        </button>
+        <button
+          aria-checked="true"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          role="radio"
+          tabindex="0"
+          type="button"
+        >
+          Kitten
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Oceanic
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Citrus
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Noir
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Hardstuck
+        </button>
+      </div>
+    </div>
+    <div
+      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-[linear-gradient(90deg,hsl(var(--accent)/0.28),transparent_55%,hsl(var(--accent-2)/0.32))] after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
+    >
+      <div
+        data-testid="gallery-preview"
+      >
+        Preview for 
+        test-preview
+      </div>
+    </div>
+    <p
+      class="text-caption text-muted-foreground"
+    >
+      Showing the 
+       
+      <span
+        class="font-medium text-foreground"
+      >
+        Kitten
+      </span>
+       
+      theme.
+    </p>
+  </section>
+  <section
+    aria-labelledby=":r8:"
+    class="space-y-[var(--space-3)]"
+  >
+    <h3
+      class="text-ui font-semibold tracking-[-0.01em] text-muted-foreground"
+      id=":r8:"
+    >
+      Used on
+    </h3>
+    <div
+      class="space-y-[var(--space-3)] rounded-card r-card-md border border-[hsl(var(--card-hairline)/0.6)] bg-[hsl(var(--surface-2)/0.6)] p-[var(--space-4)] text-label text-muted-foreground shadow-[var(--shadow-inset-hairline)]"
+    >
+      <div
+        class="flex flex-wrap gap-[var(--space-2)]"
+      >
+        <span
+          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
+        >
+          Global
+        </span>
+      </div>
+      <p>
+        No page placements yet. This component is available across Planner.
+      </p>
+    </div>
+  </section>
+</article>
+`;
+
+exports[`ComponentsView theme matrix > applies each theme variant and matches snapshots > lg 1`] = `
+<article
+  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-[hsl(var(--card-hairline)/0.75)] bg-[linear-gradient(140deg,hsl(var(--card)/0.95),hsl(var(--surface-2)/0.78))] px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-card before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-[radial-gradient(125%_85%_at_18%_-25%,hsl(var(--accent)/0.3),transparent_65%),radial-gradient(125%_85%_at_82%_-20%,hsl(var(--ring)/0.28),transparent_60%)] before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-[linear-gradient(120deg,hsl(var(--accent)/0.12)_0%,transparent_58%,hsl(var(--ring)/0.16)_100%),repeating-linear-gradient(0deg,hsl(var(--ring)/0.12)_0,hsl(var(--ring)/0.12)_var(--hairline-w),transparent_var(--hairline-w),transparent_calc(var(--space-3)))] after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
+>
+  <header
+    class="flex flex-wrap items-start justify-between gap-[var(--space-4)]"
+  >
+    <div
+      class="flex-1 space-y-[var(--space-2)]"
+    >
+      <h2
+        class="text-title font-semibold tracking-[-0.01em] text-foreground"
+      >
+        Test entry
+      </h2>
+    </div>
+  </header>
+  <section
+    aria-labelledby=":r5:"
+    class="space-y-[var(--space-3)]"
+  >
+    <h3
+      class="text-ui font-semibold tracking-[-0.01em] text-muted-foreground"
+      id=":r5:"
+    >
+      Themes
+    </h3>
+    <div
+      class="space-y-[var(--space-2)]"
+    >
+      <p
+        class="text-label text-muted-foreground"
+        id=":r6:"
+      >
+        Preview this component across Planner themes.
+      </p>
+      <div
+        aria-labelledby=":r6:"
+        class="flex flex-wrap gap-[var(--space-2)]"
+        role="radiogroup"
+      >
+        <button
+          aria-checked="true"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          role="radio"
+          tabindex="0"
+          type="button"
+        >
+          Glitch
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Aurora
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Kitten
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Oceanic
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Citrus
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Noir
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Hardstuck
+        </button>
+      </div>
+    </div>
+    <div
+      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-[linear-gradient(90deg,hsl(var(--accent)/0.28),transparent_55%,hsl(var(--accent-2)/0.32))] after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
+    >
+      <div
+        data-testid="gallery-preview"
+      >
+        Preview for 
+        test-preview
+      </div>
+    </div>
+    <p
+      class="text-caption text-muted-foreground"
+    >
+      Showing the 
+       
+      <span
+        class="font-medium text-foreground"
+      >
+        Glitch
+      </span>
+       
+      theme.
+    </p>
+  </section>
+  <section
+    aria-labelledby=":r8:"
+    class="space-y-[var(--space-3)]"
+  >
+    <h3
+      class="text-ui font-semibold tracking-[-0.01em] text-muted-foreground"
+      id=":r8:"
+    >
+      Used on
+    </h3>
+    <div
+      class="space-y-[var(--space-3)] rounded-card r-card-md border border-[hsl(var(--card-hairline)/0.6)] bg-[hsl(var(--surface-2)/0.6)] p-[var(--space-4)] text-label text-muted-foreground shadow-[var(--shadow-inset-hairline)]"
+    >
+      <div
+        class="flex flex-wrap gap-[var(--space-2)]"
+      >
+        <span
+          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
+        >
+          Global
+        </span>
+      </div>
+      <p>
+        No page placements yet. This component is available across Planner.
+      </p>
+    </div>
+  </section>
+</article>
+`;
+
+exports[`ComponentsView theme matrix > applies each theme variant and matches snapshots > noir 1`] = `
+<article
+  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-[hsl(var(--card-hairline)/0.75)] bg-[linear-gradient(140deg,hsl(var(--card)/0.95),hsl(var(--surface-2)/0.78))] px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-card before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-[radial-gradient(125%_85%_at_18%_-25%,hsl(var(--accent)/0.3),transparent_65%),radial-gradient(125%_85%_at_82%_-20%,hsl(var(--ring)/0.28),transparent_60%)] before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-[linear-gradient(120deg,hsl(var(--accent)/0.12)_0%,transparent_58%,hsl(var(--ring)/0.16)_100%),repeating-linear-gradient(0deg,hsl(var(--ring)/0.12)_0,hsl(var(--ring)/0.12)_var(--hairline-w),transparent_var(--hairline-w),transparent_calc(var(--space-3)))] after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
+>
+  <header
+    class="flex flex-wrap items-start justify-between gap-[var(--space-4)]"
+  >
+    <div
+      class="flex-1 space-y-[var(--space-2)]"
+    >
+      <h2
+        class="text-title font-semibold tracking-[-0.01em] text-foreground"
+      >
+        Test entry
+      </h2>
+    </div>
+  </header>
+  <section
+    aria-labelledby=":r5:"
+    class="space-y-[var(--space-3)]"
+  >
+    <h3
+      class="text-ui font-semibold tracking-[-0.01em] text-muted-foreground"
+      id=":r5:"
+    >
+      Themes
+    </h3>
+    <div
+      class="space-y-[var(--space-2)]"
+    >
+      <p
+        class="text-label text-muted-foreground"
+        id=":r6:"
+      >
+        Preview this component across Planner themes.
+      </p>
+      <div
+        aria-labelledby=":r6:"
+        class="flex flex-wrap gap-[var(--space-2)]"
+        role="radiogroup"
+      >
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Glitch
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Aurora
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Kitten
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Oceanic
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Citrus
+        </button>
+        <button
+          aria-checked="true"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          role="radio"
+          tabindex="0"
+          type="button"
+        >
+          Noir
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Hardstuck
+        </button>
+      </div>
+    </div>
+    <div
+      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-[linear-gradient(90deg,hsl(var(--accent)/0.28),transparent_55%,hsl(var(--accent-2)/0.32))] after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
+    >
+      <div
+        data-testid="gallery-preview"
+      >
+        Preview for 
+        test-preview
+      </div>
+    </div>
+    <p
+      class="text-caption text-muted-foreground"
+    >
+      Showing the 
+       
+      <span
+        class="font-medium text-foreground"
+      >
+        Noir
+      </span>
+       
+      theme.
+    </p>
+  </section>
+  <section
+    aria-labelledby=":r8:"
+    class="space-y-[var(--space-3)]"
+  >
+    <h3
+      class="text-ui font-semibold tracking-[-0.01em] text-muted-foreground"
+      id=":r8:"
+    >
+      Used on
+    </h3>
+    <div
+      class="space-y-[var(--space-3)] rounded-card r-card-md border border-[hsl(var(--card-hairline)/0.6)] bg-[hsl(var(--surface-2)/0.6)] p-[var(--space-4)] text-label text-muted-foreground shadow-[var(--shadow-inset-hairline)]"
+    >
+      <div
+        class="flex flex-wrap gap-[var(--space-2)]"
+      >
+        <span
+          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
+        >
+          Global
+        </span>
+      </div>
+      <p>
+        No page placements yet. This component is available across Planner.
+      </p>
+    </div>
+  </section>
+</article>
+`;
+
+exports[`ComponentsView theme matrix > applies each theme variant and matches snapshots > ocean 1`] = `
+<article
+  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-[hsl(var(--card-hairline)/0.75)] bg-[linear-gradient(140deg,hsl(var(--card)/0.95),hsl(var(--surface-2)/0.78))] px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-card before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-[radial-gradient(125%_85%_at_18%_-25%,hsl(var(--accent)/0.3),transparent_65%),radial-gradient(125%_85%_at_82%_-20%,hsl(var(--ring)/0.28),transparent_60%)] before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-[linear-gradient(120deg,hsl(var(--accent)/0.12)_0%,transparent_58%,hsl(var(--ring)/0.16)_100%),repeating-linear-gradient(0deg,hsl(var(--ring)/0.12)_0,hsl(var(--ring)/0.12)_var(--hairline-w),transparent_var(--hairline-w),transparent_calc(var(--space-3)))] after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
+>
+  <header
+    class="flex flex-wrap items-start justify-between gap-[var(--space-4)]"
+  >
+    <div
+      class="flex-1 space-y-[var(--space-2)]"
+    >
+      <h2
+        class="text-title font-semibold tracking-[-0.01em] text-foreground"
+      >
+        Test entry
+      </h2>
+    </div>
+  </header>
+  <section
+    aria-labelledby=":r5:"
+    class="space-y-[var(--space-3)]"
+  >
+    <h3
+      class="text-ui font-semibold tracking-[-0.01em] text-muted-foreground"
+      id=":r5:"
+    >
+      Themes
+    </h3>
+    <div
+      class="space-y-[var(--space-2)]"
+    >
+      <p
+        class="text-label text-muted-foreground"
+        id=":r6:"
+      >
+        Preview this component across Planner themes.
+      </p>
+      <div
+        aria-labelledby=":r6:"
+        class="flex flex-wrap gap-[var(--space-2)]"
+        role="radiogroup"
+      >
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Glitch
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Aurora
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Kitten
+        </button>
+        <button
+          aria-checked="true"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          role="radio"
+          tabindex="0"
+          type="button"
+        >
+          Oceanic
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Citrus
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Noir
+        </button>
+        <button
+          aria-checked="false"
+          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          role="radio"
+          tabindex="-1"
+          type="button"
+        >
+          Hardstuck
+        </button>
+      </div>
+    </div>
+    <div
+      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-[linear-gradient(90deg,hsl(var(--accent)/0.28),transparent_55%,hsl(var(--accent-2)/0.32))] after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
+    >
+      <div
+        data-testid="gallery-preview"
+      >
+        Preview for 
+        test-preview
+      </div>
+    </div>
+    <p
+      class="text-caption text-muted-foreground"
+    >
+      Showing the 
+       
+      <span
+        class="font-medium text-foreground"
+      >
+        Oceanic
+      </span>
+       
+      theme.
+    </p>
+  </section>
+  <section
+    aria-labelledby=":r8:"
+    class="space-y-[var(--space-3)]"
+  >
+    <h3
+      class="text-ui font-semibold tracking-[-0.01em] text-muted-foreground"
+      id=":r8:"
+    >
+      Used on
+    </h3>
+    <div
+      class="space-y-[var(--space-3)] rounded-card r-card-md border border-[hsl(var(--card-hairline)/0.6)] bg-[hsl(var(--surface-2)/0.6)] p-[var(--space-4)] text-label text-muted-foreground shadow-[var(--shadow-inset-hairline)]"
+    >
+      <div
+        class="flex flex-wrap gap-[var(--space-2)]"
+      >
+        <span
+          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
+        >
+          Global
+        </span>
+      </div>
+      <p>
+        No page placements yet. This component is available across Planner.
+      </p>
+    </div>
+  </section>
+</article>
+`;


### PR DESCRIPTION
## Summary
- add a ThemeMatrix helper that previews gallery components across all theme variants with keyboard-accessible controls
- apply theme changes per variant while restoring the original selection when leaving the preview
- cover the new theme matrix with snapshot tests spanning every variant

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d80d1ab6e8832cb4323ac850104ed1