### PR TITLE
Align glitch tokens across toggle and review slider

### DIFF
--- a/src/components/gallery/generated-manifest.ts
+++ b/src/components/gallery/generated-manifest.ts
@@ -2592,7 +2592,7 @@ export const galleryPayload = {
               ]
             }
           ],
-          "code": "<div className=\"flex flex-col gap-[var(--space-4)]\">\n  <Toggle leftLabel=\"Strategy\" rightLabel=\"Execute\" />\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--hover]\" />\n    <Toggle\n      leftLabel=\"Left\"\n      rightLabel=\"Right\"\n      className=\"ring-2 ring-[var(--ring)] ring-offset-2 ring-offset-[var(--surface-2)] focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]\"\n    />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--active]\" />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" disabled />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" loading />\n  </div>\n</div>",
+          "code": "<div className=\"flex flex-col gap-[var(--space-4)]\">\n  <Toggle leftLabel=\"Strategy\" rightLabel=\"Execute\" />\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--toggle-hover-surface]\" />\n    <Toggle\n      leftLabel=\"Left\"\n      rightLabel=\"Right\"\n      className=\"ring-2 ring-[var(--toggle-focus-ring)] ring-offset-2 ring-offset-[var(--surface-2)] shadow-[var(--toggle-focus-glow)] focus-visible:ring-2 focus-visible:ring-[var(--toggle-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]\"\n    />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--toggle-active-surface]\" />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" disabled />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" loading />\n  </div>\n</div>",
           "preview": {
             "id": "ui:toggle:interactive"
           },
@@ -2608,7 +2608,7 @@ export const galleryPayload = {
             {
               "id": "hover",
               "name": "Hover",
-              "code": "<Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--hover]\" />",
+              "code": "<Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--toggle-hover-surface]\" />",
               "preview": {
                 "id": "ui:toggle:state:hover"
               }
@@ -2616,7 +2616,7 @@ export const galleryPayload = {
             {
               "id": "focus-visible",
               "name": "Focus-visible",
-              "code": "<Toggle\n  leftLabel=\"Left\"\n  rightLabel=\"Right\"\n  className=\"ring-2 ring-[var(--ring)] ring-offset-2 ring-offset-[var(--surface-2)] focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]\"\n/>",
+              "code": "<Toggle\n  leftLabel=\"Left\"\n  rightLabel=\"Right\"\n  className=\"ring-2 ring-[var(--toggle-focus-ring)] ring-offset-2 ring-offset-[var(--surface-2)] shadow-[var(--toggle-focus-glow)] focus-visible:ring-2 focus-visible:ring-[var(--toggle-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]\"\n/>",
               "preview": {
                 "id": "ui:toggle:state:focus-visible"
               }
@@ -2624,7 +2624,7 @@ export const galleryPayload = {
             {
               "id": "active",
               "name": "Active",
-              "code": "<Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--active]\" />",
+              "code": "<Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--toggle-active-surface]\" />",
               "preview": {
                 "id": "ui:toggle:state:active"
               }
@@ -2776,7 +2776,7 @@ export const galleryPayload = {
             "slider"
           ],
           "kind": "complex",
-          "code": "<div className=\"w-[calc(var(--space-8)*3.5)]\">\n  <ReviewSurface padding=\"inline\" className=\"relative h-[var(--control-h-lg)]\">\n    <ReviewSliderTrack value={7} tone=\"score\" variant=\"input\" />\n  </ReviewSurface>\n</div>",
+          "code": "<div className=\"w-[calc(var(--space-8)*3.5)] space-y-[var(--space-3)]\">\n  <ReviewSurface padding=\"inline\" className=\"relative h-[var(--control-h-lg)]\">\n    <ReviewSliderTrack value={7} tone=\"score\" variant=\"input\" />\n  </ReviewSurface>\n  <ReviewSurface padding=\"inline\" className=\"relative h-[var(--control-h-lg)]\">\n    <ReviewSliderTrack value={6} tone=\"focus\" variant=\"input\" />\n  </ReviewSurface>\n</div>",
           "preview": {
             "id": "prompts:reviews:review-slider-track"
           }
@@ -5165,7 +5165,7 @@ export const galleryPayload = {
             ]
           }
         ],
-        "code": "<div className=\"flex flex-col gap-[var(--space-4)]\">\n  <Toggle leftLabel=\"Strategy\" rightLabel=\"Execute\" />\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--hover]\" />\n    <Toggle\n      leftLabel=\"Left\"\n      rightLabel=\"Right\"\n      className=\"ring-2 ring-[var(--ring)] ring-offset-2 ring-offset-[var(--surface-2)] focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]\"\n    />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--active]\" />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" disabled />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" loading />\n  </div>\n</div>",
+        "code": "<div className=\"flex flex-col gap-[var(--space-4)]\">\n  <Toggle leftLabel=\"Strategy\" rightLabel=\"Execute\" />\n  <div className=\"flex flex-wrap gap-[var(--space-2)]\">\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--toggle-hover-surface]\" />\n    <Toggle\n      leftLabel=\"Left\"\n      rightLabel=\"Right\"\n      className=\"ring-2 ring-[var(--toggle-focus-ring)] ring-offset-2 ring-offset-[var(--surface-2)] shadow-[var(--toggle-focus-glow)] focus-visible:ring-2 focus-visible:ring-[var(--toggle-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]\"\n    />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--toggle-active-surface]\" />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" disabled />\n    <Toggle leftLabel=\"Left\" rightLabel=\"Right\" loading />\n  </div>\n</div>",
         "preview": {
           "id": "ui:toggle:interactive"
         },
@@ -5181,7 +5181,7 @@ export const galleryPayload = {
           {
             "id": "hover",
             "name": "Hover",
-            "code": "<Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--hover]\" />",
+            "code": "<Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--toggle-hover-surface]\" />",
             "preview": {
               "id": "ui:toggle:state:hover"
             }
@@ -5189,7 +5189,7 @@ export const galleryPayload = {
           {
             "id": "focus-visible",
             "name": "Focus-visible",
-            "code": "<Toggle\n  leftLabel=\"Left\"\n  rightLabel=\"Right\"\n  className=\"ring-2 ring-[var(--ring)] ring-offset-2 ring-offset-[var(--surface-2)] focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]\"\n/>",
+            "code": "<Toggle\n  leftLabel=\"Left\"\n  rightLabel=\"Right\"\n  className=\"ring-2 ring-[var(--toggle-focus-ring)] ring-offset-2 ring-offset-[var(--surface-2)] shadow-[var(--toggle-focus-glow)] focus-visible:ring-2 focus-visible:ring-[var(--toggle-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]\"\n/>",
             "preview": {
               "id": "ui:toggle:state:focus-visible"
             }
@@ -5197,7 +5197,7 @@ export const galleryPayload = {
           {
             "id": "active",
             "name": "Active",
-            "code": "<Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--active]\" />",
+            "code": "<Toggle leftLabel=\"Left\" rightLabel=\"Right\" className=\"bg-[--toggle-active-surface]\" />",
             "preview": {
               "id": "ui:toggle:state:active"
             }
@@ -6221,7 +6221,7 @@ export const galleryPayload = {
           "slider"
         ],
         "kind": "complex",
-        "code": "<div className=\"w-[calc(var(--space-8)*3.5)]\">\n  <ReviewSurface padding=\"inline\" className=\"relative h-[var(--control-h-lg)]\">\n    <ReviewSliderTrack value={7} tone=\"score\" variant=\"input\" />\n  </ReviewSurface>\n</div>",
+        "code": "<div className=\"w-[calc(var(--space-8)*3.5)] space-y-[var(--space-3)]\">\n  <ReviewSurface padding=\"inline\" className=\"relative h-[var(--control-h-lg)]\">\n    <ReviewSliderTrack value={7} tone=\"score\" variant=\"input\" />\n  </ReviewSurface>\n  <ReviewSurface padding=\"inline\" className=\"relative h-[var(--control-h-lg)]\">\n    <ReviewSliderTrack value={6} tone=\"focus\" variant=\"input\" />\n  </ReviewSurface>\n</div>",
         "preview": {
           "id": "prompts:reviews:review-slider-track"
         }

--- a/src/components/prompts/component-gallery/MiscPanel.tsx
+++ b/src/components/prompts/component-gallery/MiscPanel.tsx
@@ -257,9 +257,12 @@ export default function MiscPanel({ data }: MiscPanelProps) {
         {
           label: "ReviewSliderTrack",
           element: (
-            <div className="w-56">
+            <div className="w-56 space-y-[var(--space-2)]">
               <ReviewSurface padding="inline" className="relative h-[var(--control-h-lg)]">
                 <ReviewSliderTrack value={7} tone="score" variant="display" />
+              </ReviewSurface>
+              <ReviewSurface padding="inline" className="relative h-[var(--control-h-lg)]">
+                <ReviewSliderTrack value={6} tone="focus" variant="display" />
               </ReviewSurface>
             </div>
           ),

--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -1378,9 +1378,14 @@ function BottomNavStatesDemo({ mode = "combined" }: { mode?: BottomNavDemoMode }
 
 function ReviewSliderTrackDemo() {
   return (
-    <ReviewSurface padding="inline" className="relative h-[var(--control-h-lg)]">
-      <ReviewSliderTrack value={7} tone="score" variant="input" />
-    </ReviewSurface>
+    <div className="flex flex-col gap-[var(--space-3)]">
+      <ReviewSurface padding="inline" className="relative h-[var(--control-h-lg)]">
+        <ReviewSliderTrack value={7} tone="score" variant="input" />
+      </ReviewSurface>
+      <ReviewSurface padding="inline" className="relative h-[var(--control-h-lg)]">
+        <ReviewSliderTrack value={6} tone="focus" variant="input" />
+      </ReviewSurface>
+    </div>
   );
 }
 

--- a/src/components/reviews/ReviewSliderTrack.tsx
+++ b/src/components/reviews/ReviewSliderTrack.tsx
@@ -14,9 +14,11 @@ type ReviewSliderTrackProps = {
   knobClassName?: string;
 };
 
-const gradientClassNames: Record<ReviewSliderTone, string> = {
-  score: "bg-gradient-to-r from-primary to-accent [--ring:var(--primary)]",
-  focus: "bg-gradient-to-r from-accent to-primary [--ring:var(--accent)]",
+const toneTokenClassNames: Record<ReviewSliderTone, string> = {
+  score:
+    "[--slider-fill-tint:hsl(var(--accent)/0.35)] [--slider-fill-tint-hover:hsl(var(--accent)/0.45)] [--slider-fill-tint-active:hsl(var(--accent)/0.55)] [--slider-focus-ring:var(--ring-contrast)] [--slider-knob-hover-surface:hsl(var(--accent)/0.28)] [--slider-knob-active-surface:hsl(var(--accent)/0.36)] [--slider-knob-focus-ring:var(--ring-contrast)]",
+  focus:
+    "[--slider-fill-tint:hsl(var(--focus)/0.35)] [--slider-fill-tint-hover:hsl(var(--focus)/0.45)] [--slider-fill-tint-active:hsl(var(--focus)/0.55)] [--slider-focus-ring:var(--ring-contrast)] [--slider-knob-hover-surface:hsl(var(--focus)/0.3)] [--slider-knob-active-surface:hsl(var(--focus)/0.4)] [--slider-knob-focus-ring:var(--ring-contrast)]",
 };
 
 const knobSizeByVariant: Record<ReviewSliderVariant, string> = {
@@ -24,20 +26,6 @@ const knobSizeByVariant: Record<ReviewSliderVariant, string> = {
     "left-[var(--progress)] h-[calc(var(--space-4)+var(--space-1))] w-[calc(var(--space-4)+var(--space-1))] -translate-x-1/2",
   input:
     "h-[calc(var(--space-4)+var(--space-1))] w-[calc(var(--space-4)+var(--space-1))]",
-};
-
-const fillInteractionClassNames: Record<ReviewSliderTone, string> = {
-  score:
-    "group-hover:ring-[theme('colors.interaction.accent.tintHover')] group-active:ring-[theme('colors.interaction.accent.tintActive')]",
-  focus:
-    "group-hover:ring-[theme('colors.interaction.focus.tintHover')] group-active:ring-[theme('colors.interaction.focus.tintActive')]",
-};
-
-const knobInteractionClassNames: Record<ReviewSliderTone, string> = {
-  score:
-    "group-hover:bg-[theme('colors.interaction.accent.surfaceHover')] group-active:bg-[theme('colors.interaction.accent.surfaceActive')] group-hover:border-transparent group-active:border-transparent group-hover:shadow-control-hover group-active:shadow-control",
-  focus:
-    "group-hover:bg-[theme('colors.interaction.focus.surfaceHover')] group-active:bg-[theme('colors.interaction.focus.surfaceActive')] group-hover:border-transparent group-active:border-transparent group-hover:shadow-control-hover group-active:shadow-control",
 };
 
 const ReviewSliderTrack = ({
@@ -75,26 +63,37 @@ const ReviewSliderTrack = ({
   return (
     <div
       className={cn(
-        "absolute left-[var(--space-4)] right-[var(--space-4)] top-1/2 -translate-y-1/2",
+        "group/slider absolute left-[var(--space-4)] right-[var(--space-4)] top-1/2 -translate-y-1/2",
+        "[--slider-fill-background:var(--edge-iris)] [--slider-fill-shadow:var(--shadow-glow-sm)] [--slider-fill-shadow-hover:var(--shadow-glow-md)] [--slider-fill-shadow-active:var(--shadow-glow-lg)]",
+        "[--slider-knob-shadow:var(--shadow-glow-sm)] [--slider-knob-shadow-hover:var(--shadow-glow-md)] [--slider-knob-shadow-active:var(--shadow-glow-lg)]",
+        toneTokenClassNames[tone],
         className,
       )}
       style={sliderStyle}
+      data-tone={tone}
+      data-variant={variant}
     >
       <div
         className={cn(
-          "relative h-[var(--space-2)] w-full rounded-full bg-muted shadow-neo-inset",
+          "relative h-[var(--space-2)] w-full overflow-hidden rounded-full bg-muted shadow-[var(--shadow-neo-inset)]",
+          "before:pointer-events-none before:absolute before:inset-0 before:rounded-full before:bg-[var(--card-overlay-scanlines)] before:opacity-0 before:transition-opacity before:duration-quick before:ease-out",
+          isInteractive
+            ? "group-hover/slider:before:opacity-70 group-active/slider:before:opacity-90 group-focus-visible/slider:before:opacity-80"
+            : undefined,
           trackClassName,
         )}
       >
         <div
           className={cn(
-            "absolute left-0 top-0 h-[var(--space-2)] rounded-full shadow-ring",
-            gradientClassNames[tone],
+            "absolute left-0 top-0 h-[var(--space-2)] rounded-full [background:var(--slider-fill-background)] shadow-[var(--slider-fill-shadow)]",
+            "after:pointer-events-none after:absolute after:inset-0 after:rounded-full after:bg-[--slider-fill-tint] after:opacity-80 after:transition-colors after:duration-quick after:ease-out",
             variant === "display" ? "progress-fill" : undefined,
             isInteractive &&
               cn(
-                "ring-1 ring-transparent transition-[box-shadow] duration-quick ease-out",
-                fillInteractionClassNames[tone],
+                "ring-1 ring-transparent transition-[box-shadow,opacity] duration-quick ease-out",
+                "group-hover/slider:[--slider-fill-shadow:var(--slider-fill-shadow-hover)] group-active/slider:[--slider-fill-shadow:var(--slider-fill-shadow-active)]",
+                "group-hover/slider:after:bg-[--slider-fill-tint-hover] group-active/slider:after:bg-[--slider-fill-tint-active]",
+                "group-focus-visible/slider:ring-[var(--slider-focus-ring)]",
               ),
             fillClassName,
           )}
@@ -102,12 +101,14 @@ const ReviewSliderTrack = ({
         />
         <div
           className={cn(
-            "absolute top-1/2 -translate-y-1/2 rounded-full border border-border bg-card shadow-neoSoft",
+            "absolute top-1/2 -translate-y-1/2 rounded-full border border-border bg-card shadow-[var(--slider-knob-shadow)]",
             knobSizeByVariant[variant],
             isInteractive &&
               cn(
                 "transition-[background-color,border-color,box-shadow] duration-quick ease-out",
-                knobInteractionClassNames[tone],
+                "group-hover/slider:bg-[--slider-knob-hover-surface] group-active/slider:bg-[--slider-knob-active-surface] group-hover/slider:border-transparent group-active/slider:border-transparent",
+                "group-hover/slider:[--slider-knob-shadow:var(--slider-knob-shadow-hover)] group-active/slider:[--slider-knob-shadow:var(--slider-knob-shadow-active)]",
+                "group-focus-visible/slider:ring-2 group-focus-visible/slider:ring-[var(--slider-knob-focus-ring)] group-focus-visible/slider:shadow-[var(--slider-knob-shadow-active)]",
               ),
             knobClassName,
           )}

--- a/src/components/ui/toggles/Toggle.gallery.tsx
+++ b/src/components/ui/toggles/Toggle.gallery.tsx
@@ -24,25 +24,25 @@ const TOGGLE_STATES: readonly ToggleState[] = [
   {
     id: "hover",
     name: "Hover",
-    className: "bg-[--hover]",
-    code: `<Toggle leftLabel="Left" rightLabel="Right" className="bg-[--hover]" />`,
+    className: "bg-[--toggle-hover-surface]",
+    code: `<Toggle leftLabel="Left" rightLabel="Right" className="bg-[--toggle-hover-surface]" />`,
   },
   {
     id: "focus-visible",
     name: "Focus-visible",
     className:
-      "ring-2 ring-[var(--ring)] ring-offset-2 ring-offset-[var(--surface-2)] focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]",
+      "ring-2 ring-[var(--toggle-focus-ring)] ring-offset-2 ring-offset-[var(--surface-2)] shadow-[var(--toggle-focus-glow)] focus-visible:ring-2 focus-visible:ring-[var(--toggle-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]",
     code: `<Toggle
   leftLabel="Left"
   rightLabel="Right"
-  className="ring-2 ring-[var(--ring)] ring-offset-2 ring-offset-[var(--surface-2)] focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]"
+  className="ring-2 ring-[var(--toggle-focus-ring)] ring-offset-2 ring-offset-[var(--surface-2)] shadow-[var(--toggle-focus-glow)] focus-visible:ring-2 focus-visible:ring-[var(--toggle-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]"
 />`,
   },
   {
     id: "active",
     name: "Active",
-    className: "bg-[--active]",
-    code: `<Toggle leftLabel="Left" rightLabel="Right" className="bg-[--active]" />`,
+    className: "bg-[--toggle-active-surface]",
+    code: `<Toggle leftLabel="Left" rightLabel="Right" className="bg-[--toggle-active-surface]" />`,
   },
   {
     id: "disabled",
@@ -138,13 +138,13 @@ export default defineGallerySection({
   <Toggle leftLabel="Strategy" rightLabel="Execute" />
   <div className="flex flex-wrap gap-[var(--space-2)]">
     <Toggle leftLabel="Left" rightLabel="Right" />
-    <Toggle leftLabel="Left" rightLabel="Right" className="bg-[--hover]" />
+    <Toggle leftLabel="Left" rightLabel="Right" className="bg-[--toggle-hover-surface]" />
     <Toggle
       leftLabel="Left"
       rightLabel="Right"
-      className="ring-2 ring-[var(--ring)] ring-offset-2 ring-offset-[var(--surface-2)] focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]"
+      className="ring-2 ring-[var(--toggle-focus-ring)] ring-offset-2 ring-offset-[var(--surface-2)] shadow-[var(--toggle-focus-glow)] focus-visible:ring-2 focus-visible:ring-[var(--toggle-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]"
     />
-    <Toggle leftLabel="Left" rightLabel="Right" className="bg-[--active]" />
+    <Toggle leftLabel="Left" rightLabel="Right" className="bg-[--toggle-active-surface]" />
     <Toggle leftLabel="Left" rightLabel="Right" disabled />
     <Toggle leftLabel="Left" rightLabel="Right" loading />
   </div>

--- a/src/components/ui/toggles/Toggle.tsx
+++ b/src/components/ui/toggles/Toggle.tsx
@@ -15,6 +15,9 @@ type ToggleIndicatorStyle = CSSProperties & {
   "--toggle-indicator-gradient"?: string;
 };
 
+const STATE_TOKEN_CLASSES =
+  "[--toggle-hover-surface:hsl(var(--accent)/0.16)] [--toggle-active-surface:hsl(var(--accent)/0.26)] [--toggle-focus-ring:var(--ring-contrast)] [--toggle-focus-glow:var(--shadow-glow-md)]";
+
 const createLabelGlow = (color: string): ToggleLabelStyle => ({
   "--glow-active": color,
   textShadow: "var(--shadow-glow-md)",
@@ -44,7 +47,7 @@ export default function Toggle({
   const indicatorStyle: ToggleIndicatorStyle = {
     width: "calc(50% - var(--space-1))",
     transform: `translateX(${isRight ? "100%" : "0"})`,
-    "--toggle-indicator-gradient": "var(--seg-active-grad)",
+    "--toggle-indicator-gradient": "var(--edge-iris)",
   };
   const leftLabelStyle = !isRight
     ? createLabelGlow("hsl(var(--team-blue) / 0.35)")
@@ -83,11 +86,13 @@ export default function Toggle({
         "group relative inline-flex h-[var(--control-h-md)] items-center rounded-full border",
         "w-[calc(var(--space-8)*4)]",
         "border-border bg-card overflow-hidden",
-        "hover:bg-[--hover] active:bg-[--active]",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        "hover:bg-[--toggle-hover-surface] active:bg-[--toggle-active-surface]",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--toggle-focus-ring)] focus-visible:shadow-[var(--toggle-focus-glow)]",
         "disabled:opacity-disabled disabled:pointer-events-none",
         "data-[loading=true]:opacity-loading data-[loading=true]:pointer-events-none",
-        "[--hover:hsl(var(--accent)/0.08)] [--active:hsl(var(--accent)/0.15)]",
+        "before:pointer-events-none before:absolute before:inset-[calc(var(--space-1)/2)] before:rounded-full before:bg-[var(--card-overlay-scanlines)] before:opacity-0 before:transition-opacity before:duration-quick before:ease-out",
+        "hover:before:opacity-70 focus-visible:before:opacity-80 active:before:opacity-90",
+        STATE_TOKEN_CLASSES,
         className,
       )}
       data-side={value}
@@ -100,7 +105,7 @@ export default function Toggle({
       {/* Sliding indicator */}
       <span
         aria-hidden
-        className="absolute top-[var(--space-1)] bottom-[var(--space-1)] left-[var(--space-1)] rounded-full transition-transform duration-quick ease-snap motion-reduce:transition-none group-active:scale-95 group-disabled:opacity-disabled group-data-[loading=true]:opacity-loading group-focus-visible:ring-2 group-focus-visible:ring-ring [background:var(--toggle-indicator-gradient,var(--seg-active-grad))] shadow-[var(--shadow-neo-soft)]"
+        className="absolute top-[var(--space-1)] bottom-[var(--space-1)] left-[var(--space-1)] rounded-full transition-transform duration-quick ease-snap motion-reduce:transition-none group-active:scale-95 group-disabled:opacity-disabled group-data-[loading=true]:opacity-loading group-focus-visible:ring-2 group-focus-visible:ring-[var(--toggle-focus-ring)] [background:var(--toggle-indicator-gradient,var(--edge-iris))] shadow-[var(--toggle-indicator-shadow,var(--shadow-glow-sm))] group-hover:[--toggle-indicator-shadow:var(--shadow-glow-md)] group-active:[--toggle-indicator-shadow:var(--shadow-glow-lg)] group-focus-visible:[--toggle-indicator-shadow:var(--shadow-glow-lg)]"
         style={indicatorStyle}
       />
 

--- a/storybook/src/components/reviews/ReviewSurface.stories.tsx
+++ b/storybook/src/components/reviews/ReviewSurface.stories.tsx
@@ -41,12 +41,20 @@ export const SliderTrack: Story = {
     children: undefined,
   },
   render: (args) => (
-    <ReviewSurface
-      {...args}
-      className={cn("relative h-[var(--control-h-lg)] w-64", args.className)}
-    >
-      <ReviewSliderTrack value={7} tone="score" variant="display" />
-    </ReviewSurface>
+    <div className="flex w-64 flex-col gap-[var(--space-3)]">
+      <ReviewSurface
+        {...args}
+        className={cn("relative h-[var(--control-h-lg)]", args.className)}
+      >
+        <ReviewSliderTrack value={7} tone="score" variant="display" />
+      </ReviewSurface>
+      <ReviewSurface
+        {...args}
+        className={cn("relative h-[var(--control-h-lg)]", args.className)}
+      >
+        <ReviewSliderTrack value={6} tone="focus" variant="display" />
+      </ReviewSurface>
+    </div>
   ),
   parameters: {
     docs: {

--- a/tests/reviews/ReviewSliderTrack.test.tsx
+++ b/tests/reviews/ReviewSliderTrack.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import ReviewSliderTrack from "@/components/reviews/ReviewSliderTrack";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ReviewSliderTrack", () => {
+  it("applies glitch tokens for the score tone", () => {
+    const { container } = render(
+      <ReviewSliderTrack value={7} tone="score" variant="input" />,
+    );
+
+    const root = container.querySelector("[data-tone='score']");
+    expect(root).not.toBeNull();
+    expect(root?.className).toContain(
+      "[--slider-fill-background:var(--edge-iris)]",
+    );
+    expect(root?.className).toContain(
+      "[--slider-fill-tint:hsl(var(--accent)/0.35)]",
+    );
+
+    const track = root?.querySelector("div");
+    const fill = track?.firstElementChild as HTMLElement | null;
+    expect(fill?.className).toContain("[background:var(--slider-fill-background)]");
+    expect(fill?.className).toContain("shadow-[var(--slider-fill-shadow)]");
+  });
+
+  it("switches state tokens for the focus tone", () => {
+    const { container } = render(
+      <ReviewSliderTrack value={6} tone="focus" variant="input" />,
+    );
+
+    const root = container.querySelector("[data-tone='focus']");
+    expect(root).not.toBeNull();
+    expect(root?.className).toContain(
+      "[--slider-fill-tint:hsl(var(--focus)/0.35)]",
+    );
+    expect(root?.className).toContain(
+      "[--slider-knob-hover-surface:hsl(var(--focus)/0.3)]",
+    );
+  });
+});

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -475,17 +475,19 @@ exports[`ReviewEditor > renders default state 1`] = `
             value="5"
           />
           <div
-            class="absolute left-[var(--space-4)] right-[var(--space-4)] top-1/2 -translate-y-1/2"
+            class="group/slider absolute left-[var(--space-4)] right-[var(--space-4)] top-1/2 -translate-y-1/2 [--slider-fill-background:var(--edge-iris)] [--slider-fill-shadow:var(--shadow-glow-sm)] [--slider-fill-shadow-hover:var(--shadow-glow-md)] [--slider-fill-shadow-active:var(--shadow-glow-lg)] [--slider-knob-shadow:var(--shadow-glow-sm)] [--slider-knob-shadow-hover:var(--shadow-glow-md)] [--slider-knob-shadow-active:var(--shadow-glow-lg)] [--slider-fill-tint:hsl(var(--accent)/0.35)] [--slider-fill-tint-hover:hsl(var(--accent)/0.45)] [--slider-fill-tint-active:hsl(var(--accent)/0.55)] [--slider-focus-ring:var(--ring-contrast)] [--slider-knob-hover-surface:hsl(var(--accent)/0.28)] [--slider-knob-active-surface:hsl(var(--accent)/0.36)] [--slider-knob-focus-ring:var(--ring-contrast)]"
+            data-tone="score"
+            data-variant="input"
           >
             <div
-              class="relative h-[var(--space-2)] w-full rounded-full bg-muted shadow-neo-inset"
+              class="relative h-[var(--space-2)] w-full overflow-hidden rounded-full bg-muted shadow-[var(--shadow-neo-inset)] before:pointer-events-none before:absolute before:inset-0 before:rounded-full before:bg-[var(--card-overlay-scanlines)] before:opacity-0 before:transition-opacity before:duration-quick before:ease-out group-hover/slider:before:opacity-70 group-active/slider:before:opacity-90 group-focus-visible/slider:before:opacity-80"
             >
               <div
-                class="absolute left-0 top-0 h-[var(--space-2)] rounded-full shadow-ring bg-gradient-to-r from-primary to-accent [--ring:var(--primary)] ring-1 ring-transparent transition-[box-shadow] duration-quick ease-out group-hover:ring-[theme('colors.interaction.accent.tintHover')] group-active:ring-[theme('colors.interaction.accent.tintActive')]"
+                class="absolute left-0 top-0 h-[var(--space-2)] rounded-full [background:var(--slider-fill-background)] shadow-[var(--slider-fill-shadow)] after:pointer-events-none after:absolute after:inset-0 after:rounded-full after:bg-[--slider-fill-tint] after:opacity-80 after:transition-colors after:duration-quick after:ease-out ring-1 ring-transparent transition-[box-shadow,opacity] duration-quick ease-out group-hover/slider:[--slider-fill-shadow:var(--slider-fill-shadow-hover)] group-active/slider:[--slider-fill-shadow:var(--slider-fill-shadow-active)] group-hover/slider:after:bg-[--slider-fill-tint-hover] group-active/slider:after:bg-[--slider-fill-tint-active] group-focus-visible/slider:ring-[var(--slider-focus-ring)]"
                 style="width: calc(50% + var(--space-2) + var(--space-1) / 2);"
               />
               <div
-                class="absolute top-1/2 -translate-y-1/2 rounded-full border border-border bg-card shadow-neoSoft h-[calc(var(--space-4)+var(--space-1))] w-[calc(var(--space-4)+var(--space-1))] transition-[background-color,border-color,box-shadow] duration-quick ease-out group-hover:bg-[theme('colors.interaction.accent.surfaceHover')] group-active:bg-[theme('colors.interaction.accent.surfaceActive')] group-hover:border-transparent group-active:border-transparent group-hover:shadow-control-hover group-active:shadow-control"
+                class="absolute top-1/2 -translate-y-1/2 rounded-full border border-border bg-card shadow-[var(--slider-knob-shadow)] h-[calc(var(--space-4)+var(--space-1))] w-[calc(var(--space-4)+var(--space-1))] transition-[background-color,border-color,box-shadow] duration-quick ease-out group-hover/slider:bg-[--slider-knob-hover-surface] group-active/slider:bg-[--slider-knob-active-surface] group-hover/slider:border-transparent group-active/slider:border-transparent group-hover/slider:[--slider-knob-shadow:var(--slider-knob-shadow-hover)] group-active/slider:[--slider-knob-shadow:var(--slider-knob-shadow-active)] group-focus-visible/slider:ring-2 group-focus-visible/slider:ring-[var(--slider-knob-focus-ring)] group-focus-visible/slider:shadow-[var(--slider-knob-shadow-active)]"
                 style="left: calc(50% - (var(--space-2) + var(--space-1) / 2));"
               />
             </div>

--- a/tests/ui/Toggle.test.tsx
+++ b/tests/ui/Toggle.test.tsx
@@ -31,4 +31,13 @@ describe('Toggle', () => {
 
     expect(button).not.toHaveAttribute('aria-busy');
   });
+
+  it('exposes glitch state tokens for styling', () => {
+    const { getByRole } = render(<Toggle leftLabel="Left" rightLabel="Right" />);
+    const button = getByRole('switch');
+
+    expect(button.className).toContain('[--toggle-hover-surface:hsl(var(--accent)/0.16)]');
+    expect(button.className).toContain('[--toggle-active-surface:hsl(var(--accent)/0.26)]');
+    expect(button.className).toContain('[--toggle-focus-ring:var(--ring-contrast)]');
+  });
 });


### PR DESCRIPTION
## Summary
- retheme the Toggle control to use glitch edge, glow, and scanline tokens with accessible state variables
- refresh ReviewSliderTrack styling and demos to adopt glitch gradients and expose tone-specific state tokens
- update prompts, gallery, storybook entries, and regression tests to cover both slider tones and new toggle state tokens

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d80d1b992c832c9207013e90d676e3