### PR TITLE
Enhance gallery search accessibility

### DIFF
--- a/src/components/gallery-page/ComponentsGalleryPanels.tsx
+++ b/src/components/gallery-page/ComponentsGalleryPanels.tsx
@@ -12,11 +12,13 @@ import Badge from "@/components/ui/primitives/Badge";
 import {
   COMPONENTS_PANEL_ID,
   COMPONENTS_VIEW_TAB_ID_BASE,
+  type Section,
   type ComponentsView,
 } from "./useComponentsGalleryState";
 
 interface ComponentsGalleryPanelsProps {
   readonly view: ComponentsView;
+  readonly section: Section;
   readonly filteredSpecs: readonly GallerySerializableEntry[];
   readonly sectionLabel: string;
   readonly countLabel: string;
@@ -25,10 +27,14 @@ interface ComponentsGalleryPanelsProps {
   readonly componentsPanelRef: React.Ref<HTMLDivElement>;
   readonly tokensPanelRef: React.Ref<HTMLDivElement>;
   readonly tokenGroups: readonly DesignTokenGroup[];
+  readonly firstMatchId: string | null;
+  readonly firstMatchAnchor: string | null;
+  readonly searchSubmitCount: number;
 }
 
 export default function ComponentsGalleryPanels({
   view,
+  section,
   filteredSpecs,
   sectionLabel,
   countLabel,
@@ -37,9 +43,65 @@ export default function ComponentsGalleryPanels({
   componentsPanelRef,
   tokensPanelRef,
   tokenGroups,
+  firstMatchId,
+  firstMatchAnchor,
+  searchSubmitCount,
 }: ComponentsGalleryPanelsProps) {
   const isTokensView = view === "tokens";
   const tokensTabId = `${COMPONENTS_VIEW_TAB_ID_BASE}-tokens-tab`;
+  const hasResults = filteredSpecs.length > 0;
+  const searchAnchor = "#components-search";
+
+  const getScrollBehavior = React.useCallback((): ScrollBehavior => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return "smooth";
+    }
+    try {
+      return window.matchMedia("(prefers-reduced-motion: reduce)").matches
+        ? "auto"
+        : "smooth";
+    } catch {
+      return "smooth";
+    }
+  }, []);
+
+  React.useEffect(() => {
+    if (isTokensView) {
+      return;
+    }
+    if (!firstMatchId || searchSubmitCount === 0) {
+      return;
+    }
+    if (typeof document === "undefined") {
+      return;
+    }
+    const target = document.getElementById(firstMatchId);
+    if (!target) {
+      return;
+    }
+    if (typeof target.scrollIntoView === "function") {
+      try {
+        target.scrollIntoView({ behavior: getScrollBehavior(), block: "start" });
+      } catch {
+        target.scrollIntoView();
+      }
+    }
+    if (target instanceof HTMLElement) {
+      try {
+        target.focus({ preventScroll: true });
+      } catch {
+        target.focus();
+      }
+    }
+  }, [firstMatchId, getScrollBehavior, isTokensView, searchSubmitCount]);
+
+  const specAnchorIdFor = React.useCallback(
+    (spec: GallerySerializableEntry) => `components-${section}-${spec.id}`,
+    [section],
+  );
+
+  const skipLinkClassName =
+    "inline-flex items-center gap-[var(--space-1)] rounded-full px-[var(--space-3)] py-[var(--space-1)] text-caption font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-foreground focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
   return (
     <section className="col-span-full grid gap-[var(--space-6)] md:gap-[var(--space-7)] lg:gap-[var(--space-8)]">
@@ -57,6 +119,19 @@ export default function ComponentsGalleryPanels({
           className="flex flex-col gap-[var(--space-6)]"
           aria-describedby={countDescriptionId}
         >
+          <nav
+            aria-label="Component gallery shortcuts"
+            className="flex flex-wrap gap-[var(--space-2)]"
+          >
+            <a href={searchAnchor} className={skipLinkClassName}>
+              Back to search
+            </a>
+            {hasResults && firstMatchAnchor ? (
+              <a href={firstMatchAnchor} className={skipLinkClassName}>
+                Skip to first result
+              </a>
+            ) : null}
+          </nav>
           <header className="flex flex-wrap items-center justify-between gap-[var(--space-3)]">
             <h2 className="text-ui font-semibold tracking-[-0.01em] text-muted-foreground">
               {sectionLabel} specs
@@ -66,6 +141,9 @@ export default function ComponentsGalleryPanels({
               tone="support"
               size="md"
               className="text-muted-foreground"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
             >
               {countLabel}
             </Badge>
@@ -73,14 +151,27 @@ export default function ComponentsGalleryPanels({
           <div className="grid gap-[var(--space-6)]">
             {filteredSpecs.length === 0 ? (
               <Card>
-                <CardContent className="text-ui text-muted-foreground">
+                <CardContent
+                  className="text-ui text-muted-foreground"
+                  role="status"
+                  aria-live="polite"
+                >
                   No results found
                 </CardContent>
               </Card>
             ) : (
-              filteredSpecs.map((spec) => (
-                <ComponentSpecView key={spec.id} entry={spec} />
-              ))
+              filteredSpecs.map((spec) => {
+                const anchorId = specAnchorIdFor(spec);
+                return (
+                  <ComponentSpecView
+                    key={spec.id}
+                    id={anchorId}
+                    tabIndex={-1}
+                    data-gallery-entry-id={spec.id}
+                    entry={spec}
+                  />
+                );
+              })
             )}
           </div>
         </div>

--- a/src/components/gallery-page/ComponentsPageClient.tsx
+++ b/src/components/gallery-page/ComponentsPageClient.tsx
@@ -62,6 +62,7 @@ export default function ComponentsPageClient({
     section,
     query,
     setQuery,
+    handleSearchSubmit,
     heroCopy,
     heroTabs,
     viewTabs,
@@ -70,6 +71,9 @@ export default function ComponentsPageClient({
     searchLabel,
     searchPlaceholder,
     filteredSpecs,
+    firstMatchId,
+    firstMatchAnchor,
+    searchSubmitCount,
     sectionLabel,
     countLabel,
     countDescriptionId,
@@ -237,6 +241,7 @@ export default function ComponentsPageClient({
                     id: "components-search",
                     value: query,
                     onValueChange: setQuery,
+                    onSubmit: handleSearchSubmit,
                     debounceMs: 300,
                     round: true,
                     variant: "neo",
@@ -268,6 +273,7 @@ export default function ComponentsPageClient({
       >
         <ComponentsGalleryPanels
           view={view}
+          section={section}
           filteredSpecs={filteredSpecs}
           sectionLabel={sectionLabel}
           countLabel={countLabel}
@@ -276,6 +282,9 @@ export default function ComponentsPageClient({
           componentsPanelRef={componentsPanelRef}
           tokensPanelRef={tokensPanelRef}
           tokenGroups={tokenGroups}
+          firstMatchId={firstMatchId}
+          firstMatchAnchor={firstMatchAnchor}
+          searchSubmitCount={searchSubmitCount}
         />
       </PageShell>
     </>

--- a/src/components/gallery-page/useComponentsGalleryState.ts
+++ b/src/components/gallery-page/useComponentsGalleryState.ts
@@ -79,6 +79,7 @@ export interface ComponentsGalleryState {
   readonly section: Section;
   readonly query: string;
   readonly setQuery: React.Dispatch<React.SetStateAction<string>>;
+  readonly handleSearchSubmit: () => void;
   readonly heroCopy: GalleryHeroCopy;
   readonly heroTabs: TabItem[];
   readonly viewTabs: TabItem[];
@@ -87,6 +88,9 @@ export interface ComponentsGalleryState {
   readonly searchLabel: string;
   readonly searchPlaceholder: string;
   readonly filteredSpecs: readonly GallerySerializableEntry[];
+  readonly firstMatchId: string | null;
+  readonly firstMatchAnchor: string | null;
+  readonly searchSubmitCount: number;
   readonly sectionLabel: string;
   readonly countLabel: string;
   readonly countDescriptionId: string;
@@ -146,6 +150,11 @@ export function useComponentsGalleryState({
   const viewParam = searchParams.get("view");
   const [, startTransition] = React.useTransition();
   const [query, setQuery] = usePersistentState("components-query", "");
+  const [searchSubmitCount, setSearchSubmitCount] = React.useState(0);
+
+  const handleSearchSubmit = React.useCallback(() => {
+    setSearchSubmitCount((count) => count + 1);
+  }, []);
 
   const groups = navigation.groups;
 
@@ -426,6 +435,22 @@ export function useComponentsGalleryState({
     }
     return sectionSpecs.filter((spec) => matchesEntryQuery(spec, normalizedQuery));
   }, [query, sectionSpecs]);
+
+  const firstMatch = filteredSpecs[0] ?? null;
+
+  const firstMatchId = React.useMemo(() => {
+    if (!firstMatch) {
+      return null;
+    }
+    return `components-${resolvedSection}-${firstMatch.id}`;
+  }, [firstMatch, resolvedSection]);
+
+  const firstMatchAnchor = React.useMemo(() => {
+    if (!firstMatchId) {
+      return null;
+    }
+    return `#${firstMatchId}`;
+  }, [firstMatchId]);
 
   const filteredCount = filteredSpecs.length;
 
@@ -730,6 +755,7 @@ export function useComponentsGalleryState({
     section: resolvedSection,
     query,
     setQuery,
+    handleSearchSubmit,
     heroCopy,
     heroTabs,
     viewTabs,
@@ -738,6 +764,9 @@ export function useComponentsGalleryState({
     searchLabel,
     searchPlaceholder,
     filteredSpecs,
+    firstMatchId,
+    firstMatchAnchor,
+    searchSubmitCount,
     sectionLabel,
     countLabel,
     countDescriptionId,

--- a/src/components/prompts/ComponentsView.tsx
+++ b/src/components/prompts/ComponentsView.tsx
@@ -13,7 +13,8 @@ import { cn } from "@/lib/utils";
 
 import { getGalleryPreview } from "./constants";
 
-interface ComponentsViewProps {
+interface ComponentsViewProps
+  extends Omit<React.HTMLAttributes<HTMLElement>, "children"> {
   entry: GallerySerializableEntry;
   onCurrentCodeChange?: (code: string | null) => void;
 }
@@ -33,6 +34,7 @@ const containerClassName = cn(
   "px-[var(--space-6)] py-[var(--space-5)]",
   "shadow-neo",
   "focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-card",
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card",
   "before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit]",
   "before:bg-[radial-gradient(125%_85%_at_18%_-25%,hsl(var(--accent)/0.3),transparent_65%),radial-gradient(125%_85%_at_82%_-20%,hsl(var(--ring)/0.28),transparent_60%)]",
   "before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55",
@@ -572,6 +574,8 @@ function StatePreviewCard({
 export default function ComponentsView({
   entry,
   onCurrentCodeChange,
+  className,
+  ...articleProps
 }: ComponentsViewProps) {
   const previewRenderer = React.useMemo(
     () => getGalleryPreview(entry.preview.id),
@@ -666,7 +670,10 @@ export default function ComponentsView({
   );
 
   return (
-    <article className={containerClassName}>
+    <article
+      {...articleProps}
+      className={cn(containerClassName, className)}
+    >
       <header className="flex flex-wrap items-start justify-between gap-[var(--space-4)]">
         <div className="flex-1 space-y-[var(--space-2)]">
           <h2 className="text-title font-semibold tracking-[-0.01em] text-foreground">

--- a/tests/components/ComponentsGalleryPanels.test.tsx
+++ b/tests/components/ComponentsGalleryPanels.test.tsx
@@ -1,0 +1,125 @@
+import * as React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ComponentsGalleryPanels from "@/components/gallery-page/ComponentsGalleryPanels";
+import type { DesignTokenGroup } from "@/components/gallery/types";
+import type { GallerySerializableEntry } from "@/components/gallery/registry";
+
+vi.mock("@/components/prompts/ComponentsView", () => ({
+  default: ({ entry, ...props }: { entry: GallerySerializableEntry } & React.HTMLAttributes<HTMLElement>) => (
+    <article {...props} data-testid={`gallery-entry-${entry.id}`} />
+  ),
+}));
+
+describe("ComponentsGalleryPanels", () => {
+  const originalMatchMedia = window.matchMedia;
+
+  const createBaseProps = () => ({
+    view: "primitives" as const,
+    section: "buttons" as const,
+    filteredSpecs: [
+      {
+        id: "badge",
+        name: "Badge",
+        kind: "primitive",
+        preview: { id: "badge-preview" },
+      },
+    ] satisfies GallerySerializableEntry[],
+    sectionLabel: "Buttons",
+    countLabel: "1 buttons spec",
+    countDescriptionId: "components-count",
+    componentsPanelLabelledBy: "components-label",
+    componentsPanelRef: React.createRef<HTMLDivElement>(),
+    tokensPanelRef: React.createRef<HTMLDivElement>(),
+    tokenGroups: [] as readonly DesignTokenGroup[],
+    firstMatchId: "components-buttons-badge",
+    firstMatchAnchor: "#components-buttons-badge",
+    searchSubmitCount: 0,
+  });
+
+  beforeEach(() => {
+    window.matchMedia = vi
+      .fn(() => ({
+        matches: false,
+        media: "(prefers-reduced-motion: reduce)",
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })) as unknown as typeof window.matchMedia;
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+    vi.restoreAllMocks();
+  });
+
+  it("focuses the first match when a search is submitted", async () => {
+    const baseProps = createBaseProps();
+    const { rerender } = render(<ComponentsGalleryPanels {...baseProps} />);
+
+    const target = document.getElementById("components-buttons-badge") as HTMLElement;
+    expect(target).not.toBeNull();
+
+    const scrollIntoView = vi.fn();
+    target.scrollIntoView = scrollIntoView as unknown as HTMLElement["scrollIntoView"];
+    const focusSpy = vi.spyOn(target, "focus");
+
+    rerender(
+      <ComponentsGalleryPanels
+        {...baseProps}
+        searchSubmitCount={1}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+    });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(target);
+    });
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it("uses instant scrolling when motion reduction is preferred", async () => {
+    window.matchMedia = vi
+      .fn(() => ({
+        matches: true,
+        media: "(prefers-reduced-motion: reduce)",
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })) as unknown as typeof window.matchMedia;
+
+    const baseProps = createBaseProps();
+    const { rerender } = render(<ComponentsGalleryPanels {...baseProps} />);
+
+    const target = document.getElementById("components-buttons-badge") as HTMLElement;
+    const scrollIntoView = vi.fn();
+    target.scrollIntoView = scrollIntoView as unknown as HTMLElement["scrollIntoView"];
+
+    rerender(
+      <ComponentsGalleryPanels
+        {...baseProps}
+        searchSubmitCount={1}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "auto", block: "start" });
+    });
+  });
+
+  it("announces the filtered result count", () => {
+    const baseProps = createBaseProps();
+    const { getAllByRole } = render(<ComponentsGalleryPanels {...baseProps} />);
+
+    const statuses = getAllByRole("status");
+    expect(statuses[0]).toHaveAttribute("aria-live", "polite");
+    expect(statuses[0]).toHaveAttribute("aria-atomic", "true");
+  });
+});

--- a/tests/components/ComponentsGalleryState.test.tsx
+++ b/tests/components/ComponentsGalleryState.test.tsx
@@ -6,7 +6,9 @@ import {
   formatQueryWithHash,
   useComponentsGalleryState,
 } from "@/components/gallery-page/useComponentsGalleryState";
+import { getGallerySectionEntries } from "@/components/prompts/constants";
 import type { GalleryNavigationData } from "@/components/gallery/types";
+import type { GallerySerializableEntry } from "@/components/gallery/registry";
 
 const replaceSpy = vi.fn<(url: string, options?: { scroll: boolean }) => void>();
 let searchParamsString = "";
@@ -117,6 +119,25 @@ describe("useComponentsGalleryState", () => {
     replaceSpy.mockClear();
     replaceSpy.mockImplementation((_url, _options) => {});
     window.location.hash = "";
+  });
+
+  it("provides the first match anchor for the active section", () => {
+    const entry = {
+      id: "badge",
+      name: "Badge",
+      kind: "primitive",
+      preview: { id: "badge-preview" },
+    } satisfies GallerySerializableEntry;
+    vi.mocked(getGallerySectionEntries).mockReturnValueOnce([entry]);
+
+    const { result } = renderHook(() =>
+      useComponentsGalleryState({
+        navigation,
+      }),
+    );
+
+    expect(result.current.firstMatchId).toBe("components-buttons-badge");
+    expect(result.current.firstMatchAnchor).toBe("#components-buttons-badge");
   });
 
   it("preserves the hash fragment when updating the section", async () => {


### PR DESCRIPTION
## Summary
- expose first-match anchors and search submission hooks from the gallery state
- focus the first component search result, add keyboard skip links, and improve result announcements
- allow gallery spec views to accept ids/tabindex and add tests covering focus and announcements

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d80d1da330832c9f1207608e9c95f1