### PR TITLE
Handle ComponentsView when theme context is unavailable

### DIFF
--- a/src/components/prompts/ComponentsView.tsx
+++ b/src/components/prompts/ComponentsView.tsx
@@ -10,8 +10,14 @@ import {
   type GallerySerializableStateDefinition,
 } from "@/components/gallery";
 import { cn } from "@/lib/utils";
-import { applyTheme, VARIANTS, type ThemeState, type Variant } from "@/lib/theme";
-import { useTheme } from "@/lib/theme-context";
+import {
+  applyTheme,
+  VARIANTS,
+  defaultTheme,
+  type ThemeState,
+  type Variant,
+} from "@/lib/theme";
+import { useOptionalTheme } from "@/lib/theme-context";
 
 import { getGalleryPreview } from "./constants";
 
@@ -102,7 +108,9 @@ function ThemeMatrix({
   entryId: string;
   previewRenderer: ReturnType<typeof getGalleryPreview>;
 }) {
-  const [baseTheme] = useTheme();
+  const themeContext = useOptionalTheme();
+  const fallbackTheme = React.useMemo(() => defaultTheme(), []);
+  const baseTheme = themeContext?.[0] ?? fallbackTheme;
   const [activeVariant, setActiveVariant] = React.useState<Variant>(
     baseTheme.variant,
   );

--- a/src/lib/theme-context.tsx
+++ b/src/lib/theme-context.tsx
@@ -134,4 +134,10 @@ export function useTheme(): readonly [
   return ctx;
 }
 
+export function useOptionalTheme():
+  | readonly [ThemeState, React.Dispatch<React.SetStateAction<ThemeState>>]
+  | undefined {
+  return React.useContext(ThemeContext);
+}
+
 export default ThemeProvider;


### PR DESCRIPTION
## Summary
- allow the ComponentsView theme matrix to fall back to the default theme when no provider is present
- expose a `useOptionalTheme` helper so consumers can detect whether a theme provider is available

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d814e65b7c832cb2639aceda7d3e18