### PR TITLE
Handle empty review search state

### DIFF
--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -80,6 +80,7 @@ export default function ReviewsPage({
 
   const filtered = useReviewFilter(base, q, sort);
   const totalCount = base.length;
+  const hasReviews = totalCount > 0;
   const filteredCount = filtered.length;
 
   const active = React.useMemo(
@@ -89,6 +90,7 @@ export default function ReviewsPage({
   const panelClass = "mx-auto";
   const detailBaseId = active ? `review-${active.id}` : "review-detail";
   const sortLabelId = React.useId();
+  const emptySearchDescriptionId = "reviews-empty-search-description";
 
   return (
     <>
@@ -109,7 +111,7 @@ export default function ReviewsPage({
               totalCount > 0 ? (
                 <span className="pill">Total {totalCount}</span>
               ) : undefined,
-            children: (
+            children: hasReviews ? (
               <div className="grid gap-[var(--space-3)] sm:gap-[var(--space-4)] md:grid-cols-12">
                 <HeroSearchBar
                   round
@@ -150,6 +152,36 @@ export default function ReviewsPage({
                   variant="primary"
                   size="md"
                   className="w-full whitespace-nowrap md:col-span-2 md:justify-self-end"
+                  onClick={handleCreateReview}
+                >
+                  <Plus />
+                  <span>New Review</span>
+                </Button>
+              </div>
+            ) : (
+              <div className="grid gap-[var(--space-3)] sm:gap-[var(--space-4)] md:grid-cols-12">
+                <HeroSearchBar
+                  round
+                  value={q}
+                  onValueChange={undefined}
+                  placeholder="Add a review to unlock search by title, tags, opponent, or patch."
+                  aria-label="Search reviews (disabled until a review exists)"
+                  aria-describedby={emptySearchDescriptionId}
+                  className="md:col-span-8"
+                  debounceMs={300}
+                  disabled
+                />
+                <p
+                  id={emptySearchDescriptionId}
+                  className="text-sm text-muted-foreground md:col-span-8"
+                >
+                  Once you create your first review, you can filter by title, tag combinations, specific opponents, or patch history.
+                </p>
+                <Button
+                  type="button"
+                  variant="primary"
+                  size="md"
+                  className="w-full whitespace-nowrap md:col-span-4 md:justify-self-end"
                   onClick={handleCreateReview}
                 >
                   <Plus />

--- a/tests/components/ComponentsView.test.tsx
+++ b/tests/components/ComponentsView.test.tsx
@@ -7,6 +7,7 @@ import {
   within,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThemeProvider } from "@/lib/theme-context";
 
 vi.mock("@/components/prompts/constants", () => ({
   getGalleryPreview: () => () => <div data-testid="preview" />,
@@ -54,6 +55,10 @@ function createEntry(
   } satisfies GallerySerializableEntry;
 }
 
+function renderWithTheme(node: React.ReactElement) {
+  return render(<ThemeProvider>{node}</ThemeProvider>);
+}
+
 describe("ComponentsView props disclosure", () => {
   it("collapses the props table by default when the prop count exceeds the threshold", () => {
     const propCount = PROPS_DISCLOSURE_COLLAPSE_THRESHOLD + 6;
@@ -61,7 +66,7 @@ describe("ComponentsView props disclosure", () => {
       props: Array.from({ length: propCount }, (_, index) => createProp(index + 1)),
     });
 
-    render(<ComponentsView entry={entry} />);
+    renderWithTheme(<ComponentsView entry={entry} />);
 
     const toggle = screen.getByRole("button", {
       name: `View ${propCount} props`,
@@ -86,7 +91,7 @@ describe("ComponentsView props disclosure", () => {
       props: Array.from({ length: propCount }, (_, index) => createProp(index + 1)),
     });
 
-    render(<ComponentsView entry={entry} />);
+    renderWithTheme(<ComponentsView entry={entry} />);
 
     const toggle = screen.getByRole("button", {
       name: `View ${propCount} props`,
@@ -112,7 +117,7 @@ describe("ComponentsView props disclosure", () => {
       props: Array.from({ length: propCount }, (_, index) => createProp(index + 1)),
     });
 
-    render(<ComponentsView entry={entry} />);
+    renderWithTheme(<ComponentsView entry={entry} />);
 
     const heading = screen.getByRole("heading", { level: 3, name: "Props" });
     const toggle = screen.getByRole("button", {


### PR DESCRIPTION
## Summary
- disable the review search controls when there are no reviews and surface guidance for search terms once content exists
- wrap the ComponentsView disclosure tests in the ThemeProvider to satisfy the theme context dependency

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d814675de8832ca936cf4023978777