### PR TITLE
Refactor CI to use reusable Node workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,59 +12,45 @@ on:
       - work
 
 jobs:
-  checks:
-    runs-on: ubuntu-latest
+  lint:
+    name: Lint
+    uses: ./.github/workflows/node-base.yml
+    with:
+      run: npm run lint
+      summary-title: Lint
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+  typecheck:
+    name: Typecheck
+    uses: ./.github/workflows/node-base.yml
+    with:
+      run: npm run typecheck
+      summary-title: Typecheck
 
-      - name: Setup Node.js
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
-        with:
-          node-version-file: .nvmrc
-          cache: npm
+  unit:
+    name: Unit Tests
+    uses: ./.github/workflows/node-base.yml
+    with:
+      run: npm test -- --run
+      summary-title: Unit Tests
 
-      - name: Activate npm version from package.json
-        run: |
-          corepack enable
-          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
-
-      - name: Restore Next.js cache
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
-        with:
-          path: .next/cache
-          key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            nextjs-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: npm ci --prefer-offline --no-audit --no-fund
-
-      - name: Audit dependencies
-        run: |
-          set +e
-          npm audit --audit-level=moderate --json > audit-report.json
-          AUDIT_STATUS=$?
-          node scripts/audit-ci-report.mjs audit-report.json
-          REPORT_STATUS=$?
-
-          if [ "$REPORT_STATUS" -ne 0 ]; then
-            exit "$REPORT_STATUS"
-          fi
-
-          if [ "$AUDIT_STATUS" -ne 0 ]; then
-            echo "npm audit reported issues below the high severity threshold."
-          fi
-
-      - name: Run checks
-        run: npm run check
-
-      - name: Summarize results
-        if: always()
-        run: |
-          {
-            echo "## CI Results";
-            echo "- Checks: ${{ job.status }}";
-          } >> "$GITHUB_STEP_SUMMARY"
-
+  build:
+    name: Build
+    needs:
+      - lint
+      - typecheck
+      - unit
+    uses: ./.github/workflows/node-base.yml
+    with:
+      run: |
+        set -euo pipefail
+        npm audit --audit-level=moderate --json > audit-report.json || AUDIT_STATUS=$?
+        if [ -n "${AUDIT_STATUS:-}" ] && [ "$AUDIT_STATUS" -ne 0 ]; then
+          echo "npm audit reported issues below the high severity threshold."
+        fi
+        node scripts/audit-ci-report.mjs audit-report.json
+        npm run build
+      cache-path: .next/cache
+      artifact-name: next-build
+      artifact-path: |
+        .next
+      summary-title: Build

--- a/.github/workflows/node-base.yml
+++ b/.github/workflows/node-base.yml
@@ -1,0 +1,87 @@
+name: Node Base Workflow
+
+on:
+  workflow_call:
+    inputs:
+      run:
+        description: Command to execute after dependencies install
+        required: true
+        type: string
+      cache-path:
+        description: Optional path to cache between runs (newline-delimited for multiple entries)
+        required: false
+        default: ""
+        type: string
+      artifact-name:
+        description: Optional artifact name to upload after the run
+        required: false
+        default: ""
+        type: string
+      artifact-path:
+        description: Optional path (newline-delimited) to upload as an artifact after the run
+        required: false
+        default: ""
+        type: string
+      summary-title:
+        description: Optional title for the job summary section
+        required: false
+        default: ""
+        type: string
+    secrets: {}
+
+jobs:
+  node-base:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Activate package manager via Corepack
+        run: |
+          corepack enable
+          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+
+      - name: Restore project cache
+        if: inputs.cache-path != ''
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+        with:
+          path: ${{ inputs.cache-path }}
+          key: shared-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            shared-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit --no-fund
+
+      - name: Run command
+        run: ${{ inputs.run }}
+
+      - name: Upload artifact
+        if: inputs.artifact-name != '' && inputs.artifact-path != ''
+        uses: actions/upload-artifact@b4b15b8c7f4b6d1b79c82b9e19016f539166271c
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.artifact-path }}
+          if-no-files-found: error
+
+      - name: Summarize results
+        if: always()
+        run: |
+          TITLE="${{ inputs.summary-title }}"
+          if [ -z "$TITLE" ]; then
+            TITLE="${{ github.job }}"
+          fi
+          {
+            echo "## $TITLE";
+            echo "- Status: ${{ job.status }}";
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- add a reusable Node workflow that standardizes checkout, setup, caching, installs, and summaries
- refactor CI to fan out lint, typecheck, unit, and build jobs that consume the shared workflow and publish build artifacts

## Testing
- npm run lint
- npm run typecheck
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d821537dc4832ca996bd49803ef020