### PR TITLE
Refine reusable Node workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,12 @@ jobs:
         fi
         node scripts/audit-ci-report.mjs audit-report.json
         npm run build
-      cache-path: .next/cache
+      cache-paths: |
+        .next/cache
+      cache-key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}') }}
+      cache-restore-keys: |
+        ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}') }}-
+        ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
       artifact-name: next-build
       artifact-path: |
         .next

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -30,53 +30,44 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') }}
+    uses: ./.github/workflows/node-base.yml
+    with:
+      run: npm run deploy
+      summary-title: Next.js static export
+      cache-paths: |
+        .next/cache
+      cache-key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}') }}
+      cache-restore-keys: |
+        ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}') }}-
+        ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+      artifact-name: nextjs-static
+      artifact-path: |
+        out
+      checkout-ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      DEPLOY_ARTIFACT_ONLY: "true"
+
+  deploy:
+    if: ${{ always() && needs.build.result == 'success' }}
+    needs:
+      - build
     runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
-
-      - name: Setup Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
-        with:
-          node-version-file: ".nvmrc"
-          cache: npm
-
-      - name: Activate npm version from package.json
-        run: |
-          corepack enable
-          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
-
-      - name: Restore cache
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
-        with:
-          path: |
-            .next/cache
-          # Generate a new cache whenever packages or source files change.
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}') }}
-          # If source files changed but packages didn't, rebuild from a prior cache.
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}') }}-
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
-
-      - name: Install dependencies
-        run: npm ci --prefer-offline --no-audit --no-fund
-
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
 
-      - name: Build static export
-        run: npm run deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEPLOY_ARTIFACT_ONLY: "true"
+      - name: Download static export
+        uses: actions/download-artifact@30da6e30b1e012badb425c1e3c3cda31487eb53c
+        with:
+          name: nextjs-static
+          path: out
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa

--- a/.github/workflows/node-base.yml
+++ b/.github/workflows/node-base.yml
@@ -7,8 +7,23 @@ on:
         description: Command to execute after dependencies install
         required: true
         type: string
-      cache-path:
-        description: Optional path to cache between runs (newline-delimited for multiple entries)
+      install-command:
+        description: Command used to install project dependencies
+        required: false
+        default: npm ci --prefer-offline --no-audit --no-fund
+        type: string
+      cache-paths:
+        description: Optional newline-delimited cache paths
+        required: false
+        default: ""
+        type: string
+      cache-key:
+        description: Optional cache key override
+        required: false
+        default: ""
+        type: string
+      cache-restore-keys:
+        description: Optional newline-delimited cache restore keys
         required: false
         default: ""
         type: string
@@ -37,6 +52,11 @@ on:
         required: false
         default: false
         type: boolean
+      checkout-ref:
+        description: Optional git ref to checkout instead of the default
+        required: false
+        default: ""
+        type: string
     secrets: {}
 
 jobs:
@@ -48,6 +68,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          ref: ${{ inputs.checkout-ref != '' && inputs.checkout-ref || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
@@ -62,13 +84,12 @@ jobs:
           corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
 
       - name: Restore project cache
-        if: inputs.cache-path != ''
+        if: inputs.cache-paths != ''
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
         with:
-          path: ${{ inputs.cache-path }}
-          key: shared-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            shared-${{ runner.os }}-
+          path: ${{ inputs.cache-paths }}
+          key: ${{ inputs.cache-key != '' && inputs.cache-key || format('node-{0}-{1}', runner.os, hashFiles('package-lock.json')) }}
+          restore-keys: ${{ inputs.cache-restore-keys }}
 
       - name: Determine Playwright version
         if: inputs.install-playwright
@@ -103,7 +124,7 @@ jobs:
           key: playwright-${{ steps.playwright.outputs.version }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
-        run: npm ci --prefer-offline --no-audit --no-fund
+        run: ${{ inputs.install-command }}
 
       - name: Install Playwright browsers
         if: inputs.install-playwright

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,29 @@
+# Continuous integration workflows
+
+This project standardises Node-based automation through the reusable workflow defined at `.github/workflows/node-base.yml`. Jobs in `ci.yml` and deployment flows call into that workflow so dependency management, caching, and Playwright bootstrapping stay consistent.
+
+## `node-base` workflow inputs
+
+| Input | Description |
+| --- | --- |
+| `run` | Command executed after the environment is prepared. |
+| `install-command` | Overrides the dependency installation command (defaults to `npm ci --prefer-offline --no-audit --no-fund`). |
+| `cache-paths` | Newline-delimited list of cache directories. Leave empty to skip caching. |
+| `cache-key` | Optional override for the cache key. When omitted the workflow hashes `package-lock.json`. |
+| `cache-restore-keys` | Optional newline-delimited restore prefixes used by the cache action. |
+| `install-playwright` | Installs Playwright browsers and primes the cache when `true`. |
+| `checkout-ref` | Optional ref or commit SHA passed directly to the checkout action. |
+| `artifact-name` / `artifact-path` | Upload artefacts after the run. Paths can be multi-line. |
+| `artifact-on-failure` | Restrict artefact uploads to failing runs. |
+| `summary-title` | Custom heading for the job summary block. |
+
+## Cache guidance
+
+- Next.js builds cache `.next/cache`. Use the key pattern from `ci.yml` so changes to dependencies or source invalidate the cache while retaining fallbacks for dependency-only changes.
+- Playwright installs cache to `~/.cache/ms-playwright` automatically when `install-playwright` is enabled. The workflow derives the key from the detected Playwright version and lockfile hash.
+- Additional cache directories can be layered by listing each path within `cache-paths`.
+
+## Workflow usage
+
+- `ci.yml` runs linting, type-checking, unit tests, a build (with audit reporting and cached `.next/cache`), and E2E suites that opt into Playwright installation and per-browser artefacts.
+- `nextjs.yml` first calls the reusable workflow with the deployment ref to produce the static export and upload it as an artefact, then a follow-up job configures GitHub Pages and deploys the downloaded export.


### PR DESCRIPTION
## Summary
- extend the reusable Node workflow with configurable install commands, cache settings, and optional checkout refs
- update CI and Next.js workflows to consume the shared workflow and reuse cached Next.js artefacts for deployment
- document CI workflow usage and caching expectations

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d8267a55bc832cac8161e0f4a837bf