### PR TITLE
Add manual visual regression workflow and docs

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,0 +1,102 @@
+name: Visual Regression
+
+on:
+  workflow_dispatch:
+    inputs:
+      target-ref:
+        description: Optional branch, tag, or commit to checkout before running the suite
+        required: false
+        default: ""
+      environment:
+        description: Optional environment label to record in the run summary
+        required: false
+        default: ""
+
+jobs:
+  visual-diff:
+    name: Visual diff (${{ matrix.title }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: chromium-desktop
+            project: chromium
+            title: Chromium · Desktop
+            device: Desktop viewport
+          - id: firefox-desktop
+            project: firefox
+            title: Firefox · Desktop
+            device: Desktop viewport
+          - id: webkit-desktop
+            project: webkit
+            title: WebKit · Desktop
+            device: Desktop viewport
+    uses: ./.github/workflows/node-base.yml
+    with:
+      run: |
+        set -euo pipefail
+
+        if [ -n "${{ inputs.target-ref }}" ]; then
+          git fetch --no-tags --prune --depth=1 origin "${{ inputs.target-ref }}"
+          git checkout --progress --force FETCH_HEAD
+        fi
+
+        export VISUAL_ENVIRONMENT="${{ inputs.environment }}"
+        export VISUAL_DEVICE="${{ matrix.device }}"
+
+        OUTPUT_DIR="playwright-visual/${{ matrix.id }}"
+        mkdir -p "$OUTPUT_DIR"
+
+        npx playwright test \
+          --config=playwright.visual.config.ts \
+          --project="${{ matrix.project }}" \
+          --reporter=line \
+          --grep "@visual" \
+          --output="$OUTPUT_DIR"
+
+        if [ ! -e "$OUTPUT_DIR/summary.md" ]; then
+          {
+            echo "# Visual diff run";
+            echo "- Surface: ${{ matrix.title }}";
+            if [ -n "${{ inputs.environment }}" ]; then
+              echo "- Environment: ${{ inputs.environment }}";
+            fi
+          } >> "$OUTPUT_DIR/summary.md"
+        fi
+      summary-title: Visual diff ${{ matrix.title }}
+      install-playwright: true
+      artifact-name: visual-diff-${{ matrix.id }}
+      artifact-path: |
+        playwright-visual/${{ matrix.id }}
+
+  summary:
+    name: Summary
+    needs: visual-diff
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post run summary
+        run: |
+          REF_INPUT="${{ github.event.inputs.target-ref }}"
+          if [ -z "$REF_INPUT" ]; then
+            REF_INPUT="${{ github.ref }}"
+          fi
+
+          ENV_INPUT="${{ github.event.inputs.environment }}"
+          if [ -z "$ENV_INPUT" ]; then
+            ENV_INPUT="(not specified)"
+          fi
+
+          {
+            echo "## Visual regression run";
+            echo "- Overall status: ${{ needs.visual-diff.result }}";
+            echo "- Ref: $REF_INPUT";
+            echo "- Environment tag: $ENV_INPUT";
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${{ needs.visual-diff.result }}" != "success" ]; then
+            echo "At least one browser/device target reported differences." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "No diffs detected across the configured targets." >> "$GITHUB_STEP_SUMMARY"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,26 @@
+# Continuous integration guidance
+
+## Visual regression workflow
+
+Use the **Visual Regression** workflow when you need a manual snapshot of the UI before promoting a build. The job reuses our Node base workflow, installs dependencies, and runs the Playwright visual diff suite across Chromium, Firefox, and WebKit desktop profiles.
+
+### Triggering a run
+
+1. Open the repository’s **Actions** tab and select **Visual Regression** from the workflow list.
+2. Choose the branch, tag, or commit to test in the **Run workflow** drawer. Leave the field blank to use the branch you selected in the UI.
+3. Optionally set the environment label (e.g., `staging`, `preview`) so the summary records where the screenshots originated.
+4. Start the run and wait for the matrix jobs to finish.
+
+### What the workflow executes
+
+- For each surface in the matrix (`Chromium · Desktop`, `Firefox · Desktop`, `WebKit · Desktop`) the runner:
+  - Fetches and checks out the requested ref.
+  - Installs Playwright browsers via the Node base reusable workflow.
+  - Runs `npx playwright test --config=playwright.visual.config.ts --project=<target> --grep "@visual" --output=playwright-visual/<target>` to produce fresh baselines and diffs.
+  - Uploads `visual-diff-<target>` artifacts that include the Playwright traces, screenshots, and a short summary file.
+
+### Reading the results
+
+- The workflow summary lists the ref, environment label, and whether any target reported differences.
+- A failing Playwright run marks its matrix job as failed, but the workflow is manual-only and therefore optional—production deployments continue to rely on the standard CI gate.
+- Download the relevant `visual-diff-<target>` artifact to review `*.png` diffs, traces, or the generated `summary.md` file when you need to investigate a regression.


### PR DESCRIPTION
## Summary
- add a Visual Regression workflow that reuses the node-base reusable workflow, supports optional ref/environment inputs, runs the Playwright visual diff matrix, and publishes artifacts
- document how to trigger and interpret the manual visual regression run in `docs/ci.md`

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d8267b254c832cbf06887645eda66d