### PR TITLE
Add design token guard CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
       summary-title: Lint
 
   token-guard:
-    name: Token Guard
+    name: Design Token Guard
     uses: ./.github/workflows/node-base.yml
     with:
-      run: npm run token-guard
-      summary-title: Token Guard
+      run: npm run lint:design
+      summary-title: Design Token Guard
 
   typecheck:
     name: Typecheck

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -25,5 +25,7 @@ This project standardises Node-based automation through the reusable workflow de
 
 ## Workflow usage
 
-- `ci.yml` runs linting, type-checking, unit tests, a build (with audit reporting and cached `.next/cache`), and E2E suites that opt into Playwright installation and per-browser artefacts.
+- `ci.yml` runs linting, the design token guard (`npm run lint:design`), type-checking, unit tests, a build (with audit reporting and cached `.next/cache`), and E2E suites that opt into Playwright installation and per-browser artefacts.
 - `nextjs.yml` first calls the reusable workflow with the deployment ref to produce the static export and upload it as an artefact, then a follow-up job configures GitHub Pages and deploys the downloaded export.
+
+The design token guard job is enforced as a required status check for protected branches so design regressions block merges alongside linting, type-checking, and unit tests.


### PR DESCRIPTION
## Summary
- switch the CI token guard job to run the design lint script via the shared node-base workflow
- document the new design token guard job and note that it is a required status check

## Testing
- npm run lint
- npm run typecheck
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d82c3a46c8832c827efad9ef884ff7