### PR TITLE
Add manual visual regression workflow

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,0 +1,89 @@
+name: Visual Regression
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Git ref to check out before running the suite
+        required: false
+        default: main
+        type: string
+      environment:
+        description: Optional environment name to annotate the run
+        required: false
+        type: string
+
+jobs:
+  visual:
+    name: Visual Regression (${{ matrix.project }})
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - chromium
+          - firefox
+          - webkit
+    uses: ./.github/workflows/node-base.yml
+    with:
+      checkout-ref: ${{ inputs.branch != '' && inputs.branch || github.ref }}
+      install-playwright: true
+      summary-title: Visual Regression ${{ matrix.project }}
+      run: |
+        set -euo pipefail
+
+        PLAYWRIGHT_PORT=3100
+        export PLAYWRIGHT_PORT
+
+        if [ -n "${WORKFLOW_ENVIRONMENT:-}" ]; then
+          echo "Environment label: ${WORKFLOW_ENVIRONMENT}"
+        fi
+
+        npm run build
+
+        npm run start -- --hostname 127.0.0.1 --port "$PLAYWRIGHT_PORT" &
+        SERVER_PID=$!
+
+        cleanup() {
+          if kill -0 "$SERVER_PID" 2>/dev/null; then
+            kill "$SERVER_PID"
+            wait "$SERVER_PID" || true
+          fi
+        }
+
+        trap cleanup EXIT
+
+        for attempt in $(seq 1 30); do
+          if curl --fail --silent --head "http://127.0.0.1:${PLAYWRIGHT_PORT}" >/dev/null; then
+            READY=1
+            break
+          fi
+          sleep 2
+        done
+
+        if [ -z "${READY:-}" ]; then
+          echo "Server failed to start" >&2
+          exit 1
+        fi
+
+        OUTPUT_DIR="playwright-results/visual/${{ matrix.project }}"
+        mkdir -p "$OUTPUT_DIR"
+
+        LIST_OUTPUT=$(npx playwright test --list --project=${{ matrix.project }} --grep "@visual") || true
+
+        if ! echo "$LIST_OUTPUT" | grep -q "@visual"; then
+          echo "No @visual-tagged tests detected; skipping Playwright execution." >&2
+          exit 0
+        fi
+
+        npx playwright test \
+          --project=${{ matrix.project }} \
+          --reporter=line \
+          --trace=retain-on-failure \
+          --output="$OUTPUT_DIR" \
+          --grep "@visual"
+      artifact-name: visual-diff-${{ matrix.project }}
+      artifact-path: |
+        playwright-results/visual/${{ matrix.project }}
+      artifact-on-failure: true
+    env:
+      WORKFLOW_ENVIRONMENT: ${{ inputs.environment }}

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -28,4 +28,10 @@ This project standardises Node-based automation through the reusable workflow de
 - `ci.yml` runs linting, the design token guard (`npm run lint:design`), type-checking, unit tests, a build (with audit reporting and cached `.next/cache`), and E2E suites that opt into Playwright installation and per-browser artefacts.
 - `nextjs.yml` first calls the reusable workflow with the deployment ref to produce the static export and upload it as an artefact, then a follow-up job configures GitHub Pages and deploys the downloaded export.
 
+## Manual visual regression workflow
+
+- Trigger the `Visual Regression` workflow from the GitHub Actions tab when you need an on-demand screenshot comparison. Provide the branch or commit you want to exercise (defaults to `main`) and, optionally, a short environment label to capture which backend or deployment you are validating.
+- The workflow reuses `node-base` with Playwright browsers installed, builds the app, launches the production server locally, then runs any Playwright tests tagged with `@visual` for each configured browser target. If no tests carry the tag the run exits early with a notice so routine checks stay fast.
+- Diff artefacts upload automatically when a comparison fails. Each browser matrix entry produces a zip named `visual-diff-<browser>` that contains the expected, actual, and diff images alongside the Playwright report output for that browser. Download the zip, extract it locally, and open the accompanying `index.html` to inspect failures interactively. Clean runs skip the upload so the manual workflow remains optional overhead rather than a required part of the release cadence.
+
 The design token guard job is enforced as a required status check for protected branches so design regressions block merges alongside linting, type-checking, and unit tests.


### PR DESCRIPTION
## Summary
- add a workflow_dispatch-only visual regression workflow that reuses node-base with Playwright browsers and uploads diff artefacts on failure
- document how to run the manual workflow and review its outputs in docs/ci.md

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d83085ad9c832c8b1b66fe32a676a0