### PR TITLE
Update CI docs for GitHub Pages workflow

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,6 +1,6 @@
 # Continuous integration workflows
 
-This project standardises Node-based automation through the reusable workflow defined at `.github/workflows/node-base.yml`. Jobs in `ci.yml` and deployment flows call into that workflow so dependency management, caching, and Playwright bootstrapping stay consistent.
+This project standardises Node-based automation through the reusable workflow defined at `.github/workflows/node-base.yml`. Jobs in `ci.yml`—including the build, test, and GitHub Pages publishing steps—call into that workflow so dependency management, caching, and Playwright bootstrapping stay consistent across CI and deployment runs.
 
 ## `node-base` workflow inputs
 
@@ -26,7 +26,7 @@ This project standardises Node-based automation through the reusable workflow de
 ## Workflow usage
 
 - `ci.yml` runs linting, the design token guard (`npm run lint:design`), type-checking, unit tests, a build (with audit reporting and cached `.next/cache`), and E2E suites that opt into Playwright installation and per-browser artefacts.
-- `nextjs.yml` first calls the reusable workflow with the deployment ref to produce the static export and upload it as an artefact, then a follow-up job configures GitHub Pages and deploys the downloaded export.
+- The `pages-build` job inside `ci.yml` reuses `node-base` to create the static export for GitHub Pages, while `pages-deploy` consumes that artefact and executes the [`actions/deploy-pages`](https://github.com/actions/deploy-pages) step to publish the site.
 
 ## Manual visual regression workflow
 

--- a/docs/github-actions-shas.md
+++ b/docs/github-actions-shas.md
@@ -4,12 +4,12 @@ The workflows in this repository pin third-party GitHub Actions to exact commit 
 
 | Action | Upstream tag | Commit SHA | Referenced in workflows |
 | --- | --- | --- | --- |
-| `actions/checkout` | `v5` | `08c6903cd8c0fde910a37f88322edcfb5dd907a8` | `ci.yml`, `nextjs.yml` |
-| `actions/setup-node` | `v5` | `a0853c24544627f65ddf259abe73b1d18a591444` | `ci.yml`, `nextjs.yml` |
-| `actions/configure-pages` | `v5` | `983d7736d9b0ae728b81ab479565c72886d7745b` | `nextjs.yml` |
-| `actions/cache` | `v4` | `0400d5f644dc74513175e3cd8d07132dd4860809` | `nextjs.yml` |
-| `actions/upload-pages-artifact` | `v4` | `7b1f4a764d45c48632c6b24a0339c27f5614fb0b` | `nextjs.yml` |
-| `actions/deploy-pages` | `v4` | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` | `nextjs.yml` |
+| `actions/checkout` | `v5` | `08c6903cd8c0fde910a37f88322edcfb5dd907a8` | `ci.yml`, `visual-regression.yml` |
+| `actions/setup-node` | `v5` | `a0853c24544627f65ddf259abe73b1d18a591444` | `ci.yml`, `visual-regression.yml` |
+| `actions/configure-pages` | `v5` | `983d7736d9b0ae728b81ab479565c72886d7745b` | `ci.yml` (`pages-deploy`) |
+| `actions/cache` | `v4` | `0400d5f644dc74513175e3cd8d07132dd4860809` | `ci.yml`, `visual-regression.yml` |
+| `actions/upload-pages-artifact` | `v4` | `56afc609e74202658d3ffba0e8f6dda462b719fa` | `ci.yml` (`pages-deploy`) |
+| `actions/deploy-pages` | `v4` | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` | `ci.yml` (`pages-deploy`) |
 
 ## Updating the pins
 


### PR DESCRIPTION
## Summary
- document that the reusable node-base workflow powers CI and the GitHub Pages deployment
- update the CI guide to mention the `pages-build` and `pages-deploy` jobs in `ci.yml`
- refresh the GitHub Actions SHA table to reference the current workflows and pinned commits

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d8370a5cc0832ca451866673b43f7d