### PR TITLE
Use build artifact for e2e workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
           - webkit
     uses: ./.github/workflows/node-base.yml
     with:
+      download-artifact-name: next-build
       run: |
         set -euo pipefail
         case "${{ matrix.project }}" in
@@ -163,7 +164,10 @@ jobs:
         export PLAYWRIGHT_HOST="$HOST"
         export PLAYWRIGHT_PORT="$PORT"
 
-        npm run build
+        if [ ! -d ".next" ]; then
+          echo "Downloaded build artifact missing .next directory" >&2
+          exit 1
+        fi
 
         npm run start -- --hostname "$HOST" --port "$PORT" &
         SERVER_PID=$!

--- a/.github/workflows/node-base.yml
+++ b/.github/workflows/node-base.yml
@@ -52,6 +52,16 @@ on:
         required: false
         default: false
         type: boolean
+      download-artifact-name:
+        description: Optional artifact name to download before running commands
+        required: false
+        default: ""
+        type: string
+      download-artifact-path:
+        description: Destination directory for the downloaded artifact contents
+        required: false
+        default: "."
+        type: string
       checkout-ref:
         description: Optional git ref to checkout instead of the default
         required: false
@@ -82,6 +92,13 @@ jobs:
         run: |
           corepack enable
           corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+
+      - name: Download artifact
+        if: inputs.download-artifact-name != ''
+        uses: actions/download-artifact@89f3d9d3dc0f01c4eb82c0dec28181581b88a8d0
+        with:
+          name: ${{ inputs.download-artifact-name }}
+          path: ${{ inputs.download-artifact-path }}
 
       - name: Restore project cache
         if: inputs.cache-paths != ''


### PR DESCRIPTION
## Summary
- download the build job's Next.js artifact before running Playwright e2e suites
- extend the reusable node workflow with optional artifact download support and reuse the .next output

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d84bc428f8832cb7475438844b05bb