### PR TITLE
Expand CI cache globs for app directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,9 +120,9 @@ jobs:
         npm run build
       cache-paths: |
         .next/cache
-      cache-key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}') }}
+      cache-key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}', 'app/**/*.{js,jsx,ts,tsx,mdx}') }}
       cache-restore-keys: |
-        ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}') }}-
+        ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}', 'app/**/*.{js,jsx,ts,tsx,mdx}') }}-
         ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
       artifact-name: next-build
       artifact-path: |
@@ -218,9 +218,9 @@ jobs:
         npm run deploy
       cache-paths: |
         .next/cache
-      cache-key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}') }}
+      cache-key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}', 'app/**/*.{js,jsx,ts,tsx,mdx}') }}
       cache-restore-keys: |
-        ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}') }}-
+        ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}', 'app/**/*.{js,jsx,ts,tsx,mdx}') }}-
         ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
       artifact-name: nextjs-static
       artifact-path: |

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -19,7 +19,7 @@ This project standardises Node-based automation through the reusable workflow de
 
 ## Cache guidance
 
-- Next.js builds cache `.next/cache`. Use the key pattern from `ci.yml` so changes to dependencies or source invalidate the cache while retaining fallbacks for dependency-only changes.
+- Next.js builds cache `.next/cache`. Use the key pattern from `ci.yml`—`hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}', 'app/**/*.{js,jsx,ts,tsx,mdx}')`—so changes to dependencies or source invalidate the cache while retaining fallbacks for dependency-only changes.
 - Playwright installs cache to `~/.cache/ms-playwright` automatically when `install-playwright` is enabled. The workflow derives the key from the detected Playwright version and lockfile hash.
 - Additional cache directories can be layered by listing each path within `cache-paths`.
 


### PR DESCRIPTION
## Summary
- update the build and pages export cache keys to track changes in the app directory
- document the updated cache hash pattern for Next.js builds

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d84bc88618832ca47ae365a0ecd485