### PR TITLE
ci: share Next.js build artifact across checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,16 +40,50 @@ jobs:
       run: npm test -- --run
       summary-title: Unit Tests
 
-  a11y:
-    name: Accessibility
+  next-build:
+    name: Next.js Build
+    needs:
+      - lint
+      - typecheck
+      - unit
+      - token-guard
     uses: ./.github/workflows/node-base.yml
     with:
+      run: |
+        set -euo pipefail
+        npm audit --audit-level=moderate --json > audit-report.json || AUDIT_STATUS=$?
+        if [ -n "${AUDIT_STATUS:-}" ] && [ "$AUDIT_STATUS" -ne 0 ]; then
+          echo "npm audit reported issues below the high severity threshold."
+        fi
+        node scripts/audit-ci-report.mjs audit-report.json
+        npm run build
+      cache-paths: |
+        .next/cache
+      cache-key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}', 'app/**/*.{js,jsx,ts,tsx,mdx}') }}
+      cache-restore-keys: |
+        ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}', 'app/**/*.{js,jsx,ts,tsx,mdx}') }}-
+        ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+      artifact-name: next-build
+      artifact-path: |
+        .next
+      summary-title: Next.js Build
+
+  a11y:
+    name: Accessibility
+    needs:
+      - next-build
+    uses: ./.github/workflows/node-base.yml
+    with:
+      download-artifact-name: next-build
       run: |
         set -euo pipefail
 
         LIST_OUTPUT=$(npx playwright test --list --project=chromium --grep "@axe") || true
 
-        npm run build
+        if [ ! -d ".next" ]; then
+          echo "Downloaded build artifact missing .next directory" >&2
+          exit 1
+        fi
 
         PORT=3000
         npm run start -- --hostname 127.0.0.1 --port "$PORT" &
@@ -64,6 +98,7 @@ jobs:
 
         trap cleanup EXIT
 
+        unset READY || true
         for attempt in $(seq 1 30); do
           if curl --fail --silent --head "http://127.0.0.1:${PORT}" >/dev/null; then
             READY=1
@@ -100,39 +135,10 @@ jobs:
         playwright-results/a11y
       artifact-on-failure: true
 
-  build:
-    name: Build
-    needs:
-      - lint
-      - typecheck
-      - unit
-      - token-guard
-      - a11y
-    uses: ./.github/workflows/node-base.yml
-    with:
-      run: |
-        set -euo pipefail
-        npm audit --audit-level=moderate --json > audit-report.json || AUDIT_STATUS=$?
-        if [ -n "${AUDIT_STATUS:-}" ] && [ "$AUDIT_STATUS" -ne 0 ]; then
-          echo "npm audit reported issues below the high severity threshold."
-        fi
-        node scripts/audit-ci-report.mjs audit-report.json
-        npm run build
-      cache-paths: |
-        .next/cache
-      cache-key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}', 'app/**/*.{js,jsx,ts,tsx,mdx}') }}
-      cache-restore-keys: |
-        ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}', 'app/**/*.{js,jsx,ts,tsx,mdx}') }}-
-        ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
-      artifact-name: next-build
-      artifact-path: |
-        .next
-      summary-title: Build
-
   e2e:
     name: E2E (${{ matrix.project }})
     needs:
-      - build
+      - next-build
     strategy:
       fail-fast: false
       matrix:
@@ -213,6 +219,7 @@ jobs:
       github.event_name == 'push' &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/work')
     needs:
+      - a11y
       - e2e
     uses: ./.github/workflows/node-base.yml
     with:


### PR DESCRIPTION
## Summary
- add a dedicated next-build job that runs after linting, type checking, unit tests, and the token guard to publish the .next artifact
- have the accessibility and e2e suites download the shared build (with readiness checks) and keep deployment waiting on both
- refresh docs/ci.md to describe the single-build flow and updated required checks

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d850c4f5ac832c96df76c6bfb30553