### PR TITLE
Add documentation paths-ignore to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,18 @@ concurrency:
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'CHANGELOG.md'
   push:
     branches:
       - main
       - work
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'CHANGELOG.md'
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- add paths-ignore filters for documentation-only changes on pull_request and push triggers in the CI workflow

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d851303888832c86566c91897335e2