### PR TITLE
Fix visual regression workflow artifact extraction

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -55,6 +55,12 @@ jobs:
           echo "Environment label: ${WORKFLOW_ENVIRONMENT}"
         fi
 
+        if [ -d "next-build/.next" ]; then
+          rm -rf .next
+          mv next-build/.next .next
+          rm -rf next-build
+        fi
+
         npm run start -- --hostname 127.0.0.1 --port "$PLAYWRIGHT_PORT" &
         SERVER_PID=$!
 


### PR DESCRIPTION
## Summary
- move the downloaded Next.js build output into `.next` before starting the server in the visual regression workflow
- clean up the temporary `next-build` directory after relocating the build output

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d8531ab9d4832c86fc60105e0fa9ec