### PR TITLE
Fix: restore workflow permissions for cache and artifact jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
       - typecheck
       - unit
       - token-guard
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/node-base.yml
     with:
       run: |
@@ -83,6 +86,9 @@ jobs:
     name: Accessibility
     needs:
       - next-build
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/node-base.yml
     with:
       download-artifact-name: next-build
@@ -150,6 +156,9 @@ jobs:
     name: E2E (${{ matrix.project }})
     needs:
       - next-build
+    permissions:
+      contents: read
+      actions: write
     strategy:
       fail-fast: false
       matrix:
@@ -232,6 +241,9 @@ jobs:
     needs:
       - a11y
       - e2e
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/node-base.yml
     with:
       run: |


### PR DESCRIPTION
## Summary
- grant actions: write permissions to jobs that use caches or upload artifacts so cache and artifact actions succeed under read-all default

## Testing
- npm run check *(fails: npm not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d85882eb30832ca997f6451480be0e