### PR TITLE
Tighten visual regression workflow permissions

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -13,9 +13,15 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build application
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/node-base.yml
     with:
       checkout-ref: ${{ inputs.branch != '' && inputs.branch || github.ref }}
@@ -31,6 +37,9 @@ jobs:
   visual:
     name: Visual Regression (${{ matrix.project }})
     needs: build
+    permissions:
+      contents: read
+      actions: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- add a top-level permissions block to restrict default access for the visual regression workflow
- grant build and visual jobs the explicit permissions needed to upload and download artifacts

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d8582ef1c0832c94bd230539bcb78c