### PR TITLE
Fix prompts barrel exports

### DIFF
--- a/src/components/prompts/index.ts
+++ b/src/components/prompts/index.ts
@@ -14,6 +14,7 @@ export { default as PromptsPanel } from "./component-gallery/PromptsPanel";
 export * from "./component-gallery/useComponentGalleryState";
 export { default as WeekPickerDemo } from "./component-gallery/WeekPickerDemo";
 export { default as ComponentsView } from "./ComponentsView";
+export * from "./ComponentsView";
 export * from "./constants";
 export * from "./demoData";
 export { default as DemoHeader } from "./DemoHeader";


### PR DESCRIPTION
## Summary
- expose ComponentsView named exports through the prompts barrel so downstream imports succeed

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d86315ebc0832c8592b38b1399c03f