### PR TITLE
Fix CI cache keys for reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,10 @@ jobs:
         npm run build
       cache-paths: |
         .next/cache
-      cache-key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}', 'app/**/*.{js,jsx,ts,tsx,mdx}') }}
+      cache-key: ubuntu-latest-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}', 'app/**/*.{js,jsx,ts,tsx,mdx}') }}
       cache-restore-keys: |
-        ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}', 'app/**/*.{js,jsx,ts,tsx,mdx}') }}-
-        ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+        ubuntu-latest-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}', 'app/**/*.{js,jsx,ts,tsx,mdx}') }}-
+        ubuntu-latest-nextjs-${{ hashFiles('**/package-lock.json') }}-
       artifact-name: next-build
       artifact-path: |
         .next
@@ -252,10 +252,10 @@ jobs:
         npm run deploy
       cache-paths: |
         .next/cache
-      cache-key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}', 'app/**/*.{js,jsx,ts,tsx,mdx}') }}
+      cache-key: ubuntu-latest-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}', 'app/**/*.{js,jsx,ts,tsx,mdx}') }}
       cache-restore-keys: |
-        ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}', 'app/**/*.{js,jsx,ts,tsx,mdx}') }}-
-        ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+        ubuntu-latest-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('next.config.*', 'src/**/*.{js,jsx,ts,tsx,mdx}', 'app/**/*.{js,jsx,ts,tsx,mdx}') }}-
+        ubuntu-latest-nextjs-${{ hashFiles('**/package-lock.json') }}-
       artifact-name: nextjs-static
       artifact-path: |
         out


### PR DESCRIPTION
## Summary
- replace runner.os references in cache inputs with the ubuntu label used by the reusable workflow to avoid undefined context errors

## Testing
- npm run check


------
https://chatgpt.com/codex/tasks/task_e_68d865b6b734832c95b909ff9de14d8d