### PR TITLE
Set SKIP_PREVIEW_STATIC for GitHub Pages export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,7 @@ jobs:
       run: |
         set -euo pipefail
         export DEPLOY_ARTIFACT_ONLY=true
+        export SKIP_PREVIEW_STATIC=true
         npm run deploy
       cache-paths: |
         .next/cache

--- a/src/app/preview/[slug]/page.tsx
+++ b/src/app/preview/[slug]/page.tsx
@@ -13,6 +13,9 @@ import PreviewThemeClient from "@/components/gallery/PreviewThemeClient";
 import { Spinner } from "@/components/ui";
 import { VARIANT_LABELS } from "@/lib/theme";
 
+const SKIP_PREVIEW_RENDER =
+  process.env.GITHUB_PAGES === "true" || process.env.SKIP_PREVIEW_STATIC === "true";
+
 export const dynamic = "force-static";
 export const dynamicParams = false;
 
@@ -127,6 +130,49 @@ function PreviewContent({ route, renderer }: PreviewContentProps) {
   );
 }
 
+function PreviewUnavailable({ route }: { readonly route: GalleryPreviewRoute }) {
+  const themeLabel = VARIANT_LABELS[route.themeVariant];
+  const stateLabel = route.stateName ?? null;
+  const axisSummary = route.axisParams
+    .map((axis) => `${axis.label}: ${axis.options.map((option) => option.label).join(", ")}`)
+    .join(" · ");
+
+  return (
+    <main
+      className="min-h-screen bg-background text-foreground"
+      data-preview-entry={route.entryId}
+      data-preview-slug={route.slug}
+      data-preview-state={route.stateId ?? undefined}
+    >
+      <PreviewThemeClient variant={route.themeVariant} background={route.themeBackground} />
+      <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-[var(--space-5)] px-[var(--space-5)] py-[var(--space-6)]">
+        <header className="space-y-[var(--space-2)]">
+          <p className="text-caption font-medium uppercase tracking-[0.2em] text-muted-foreground">
+            Gallery preview
+          </p>
+          <h1 className="text-title font-semibold tracking-[-0.01em]">
+            {route.entryName}
+            {stateLabel ? <span className="text-muted-foreground"> · {stateLabel}</span> : null}
+          </h1>
+          <p className="text-label text-muted-foreground">
+            {themeLabel}
+            {route.themeBackground > 0 ? ` background ${route.themeBackground}` : " theme"}
+          </p>
+          {axisSummary ? (
+            <p className="text-caption text-muted-foreground">{axisSummary}</p>
+          ) : null}
+        </header>
+        <PreviewSurfaceContainer status="loading">
+          <div className="space-y-[var(--space-2)] text-label text-muted-foreground">
+            <p>Preview unavailable in the static export.</p>
+            <p>Clone the repository and run the development server to view this preview.</p>
+          </div>
+        </PreviewSurfaceContainer>
+      </div>
+    </main>
+  );
+}
+
 export default async function PreviewPage({ params }: PreviewPageParams) {
   const { slug } = await params;
   const route = getGalleryPreviewRoute(slug);
@@ -137,6 +183,10 @@ export default async function PreviewPage({ params }: PreviewPageParams) {
   const renderer = getGalleryPreviewRenderer(route.previewId);
   if (!renderer) {
     notFound();
+  }
+
+  if (SKIP_PREVIEW_RENDER) {
+    return <PreviewUnavailable route={route} />;
   }
 
   return <PreviewContent route={route} renderer={renderer} />;

--- a/src/components/gallery/PreviewRendererClient.tsx
+++ b/src/components/gallery/PreviewRendererClient.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  getPreviewManifest,
+  loadModulePreviews,
+} from "./preview-engine";
+import TokenPreviewBoundary from "./TokenPreviewBoundary";
+import type { GalleryPreviewRenderer } from "./registry";
+
+const rendererCache = new Map<string, GalleryPreviewRenderer>();
+
+async function resolveRenderer(previewId: string): Promise<GalleryPreviewRenderer> {
+  const cached = rendererCache.get(previewId);
+  if (cached) {
+    return cached;
+  }
+
+  const manifest = getPreviewManifest(previewId);
+  if (!manifest) {
+    throw new Error(`Gallery preview "${previewId}" is not registered`);
+  }
+
+  const previews = await loadModulePreviews(manifest);
+  const render = previews.get(previewId);
+  if (!render) {
+    throw new Error(`Gallery preview "${previewId}" not found in module`);
+  }
+
+  rendererCache.set(previewId, render);
+  return render;
+}
+
+interface PreviewRendererClientProps {
+  readonly previewId: string;
+  readonly onReady?: () => void;
+  readonly onError?: (error: Error) => void;
+}
+
+export default function PreviewRendererClient({
+  previewId,
+  onReady,
+  onError,
+}: PreviewRendererClientProps) {
+  const [renderer, setRenderer] = React.useState<GalleryPreviewRenderer | null>(() => {
+    return rendererCache.get(previewId) ?? null;
+  });
+  const [error, setError] = React.useState<Error | null>(null);
+
+  React.useEffect(() => {
+    const cached = rendererCache.get(previewId);
+    if (cached) {
+      setRenderer(() => cached);
+      setError(null);
+      onReady?.();
+      return undefined;
+    }
+
+    let cancelled = false;
+    resolveRenderer(previewId)
+      .then((resolved) => {
+        if (cancelled) {
+          return;
+        }
+        rendererCache.set(previewId, resolved);
+        setRenderer(() => resolved);
+        setError(null);
+        onReady?.();
+      })
+      .catch((cause) => {
+        if (cancelled) {
+          return;
+        }
+        const nextError = cause instanceof Error ? cause : new Error(String(cause));
+        setError(nextError);
+        onError?.(nextError);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [previewId, onError, onReady]);
+
+  if (error) {
+    return (
+      <div className="text-label text-danger" role="alert">
+        {error.message}
+      </div>
+    );
+  }
+
+  if (!renderer) {
+    return null;
+  }
+
+  return React.createElement(TokenPreviewBoundary, undefined, renderer());
+}

--- a/src/components/gallery/TokenPreviewBoundary.tsx
+++ b/src/components/gallery/TokenPreviewBoundary.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 
 import { useTokenOverrides } from "./token-overrides-store";

--- a/src/components/gallery/preview-engine.ts
+++ b/src/components/gallery/preview-engine.ts
@@ -1,0 +1,132 @@
+import {
+  galleryPayload,
+  galleryPreviewModules,
+  galleryPreviewRoutes,
+  type GalleryPreviewModuleManifest,
+} from "./generated-manifest";
+import type {
+  GalleryPreviewRenderer,
+  GalleryPreviewRoute,
+  GallerySection,
+} from "./registry";
+
+export { galleryPayload, galleryPreviewModules, galleryPreviewRoutes };
+export type { GalleryPreviewModuleManifest, GalleryPreviewRenderer, GalleryPreviewRoute };
+
+export type GalleryModuleExport = {
+  readonly default: unknown;
+};
+
+const previewModuleIndex = new Map<string, GalleryPreviewModuleManifest>();
+for (const manifest of galleryPreviewModules) {
+  for (const previewId of manifest.previewIds) {
+    previewModuleIndex.set(previewId, manifest);
+  }
+}
+
+const previewRouteIndex = new Map<string, GalleryPreviewRoute>();
+for (const route of galleryPreviewRoutes) {
+  previewRouteIndex.set(route.slug, route);
+}
+
+const modulePreviewCache = new WeakMap<
+  GalleryPreviewModuleManifest,
+  Map<string, GalleryPreviewRenderer>
+>();
+
+const moduleLoadCache = new WeakMap<
+  GalleryPreviewModuleManifest,
+  Promise<Map<string, GalleryPreviewRenderer>>
+>();
+
+const isGallerySection = (value: unknown): value is GallerySection => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as { entries?: unknown };
+  return Array.isArray(candidate.entries);
+};
+
+const normalizeSections = (
+  exported: GalleryModuleExport["default"],
+): readonly GallerySection[] => {
+  if (Array.isArray(exported)) {
+    return exported.filter(isGallerySection);
+  }
+
+  if (isGallerySection(exported)) {
+    return [exported];
+  }
+
+  return [];
+};
+
+const collectModulePreviews = (
+  sections: readonly GallerySection[],
+): Map<string, GalleryPreviewRenderer> => {
+  const map = new Map<string, GalleryPreviewRenderer>();
+  for (const section of sections) {
+    if (!Array.isArray(section.entries)) {
+      continue;
+    }
+
+    for (const entry of section.entries) {
+      const preview = entry?.preview;
+      if (preview && typeof preview.id === "string" && typeof preview.render === "function") {
+        map.set(preview.id, preview.render);
+      }
+
+      if (!Array.isArray(entry?.states)) {
+        continue;
+      }
+
+      for (const state of entry.states) {
+        const statePreview = state?.preview;
+        if (
+          statePreview &&
+          typeof statePreview.id === "string" &&
+          typeof statePreview.render === "function"
+        ) {
+          map.set(statePreview.id, statePreview.render);
+        }
+      }
+    }
+  }
+  return map;
+};
+
+export const loadModulePreviews = (
+  manifest: GalleryPreviewModuleManifest,
+): Promise<Map<string, GalleryPreviewRenderer>> => {
+  const cached = modulePreviewCache.get(manifest);
+  if (cached) {
+    return Promise.resolve(cached);
+  }
+
+  const pending = moduleLoadCache.get(manifest);
+  if (pending) {
+    return pending;
+  }
+
+  const promise = manifest
+    .loader()
+    .then((module: GalleryModuleExport) => {
+      const sections = normalizeSections(module.default);
+      const previews = collectModulePreviews(sections);
+      modulePreviewCache.set(manifest, previews);
+      return previews;
+    })
+    .catch((error) => {
+      modulePreviewCache.delete(manifest);
+      moduleLoadCache.delete(manifest);
+      throw error;
+    });
+
+  moduleLoadCache.set(manifest, promise);
+  return promise;
+};
+
+export const getPreviewManifest = (id: string) => previewModuleIndex.get(id) ?? null;
+export const getPreviewRoute = (slug: string) => previewRouteIndex.get(slug) ?? null;
+export const getAllPreviewRoutes = () => galleryPreviewRoutes;

--- a/src/components/gallery/runtime.ts
+++ b/src/components/gallery/runtime.ts
@@ -2,151 +2,35 @@ import * as React from "react";
 
 import {
   galleryPayload,
-  galleryPreviewModules,
-  galleryPreviewRoutes,
-  type GalleryPreviewModuleManifest,
-} from "./generated-manifest";
-import TokenPreviewBoundary from "./TokenPreviewBoundary";
+  getAllPreviewRoutes,
+  getPreviewManifest,
+  getPreviewRoute,
+} from "./preview-engine";
+import PreviewRendererClient from "./PreviewRendererClient";
 import type {
   GalleryEntryKind,
   GalleryPreviewRenderer,
-  GallerySection,
   GallerySectionId,
-  GalleryPreviewRoute,
 } from "./registry";
 
-type GalleryModuleExport = {
-  readonly default: GallerySection | readonly GallerySection[];
-};
-
-const previewModuleIndex = new Map<string, GalleryPreviewModuleManifest>();
-
-for (const manifest of galleryPreviewModules) {
-  for (const previewId of manifest.previewIds) {
-    previewModuleIndex.set(previewId, manifest);
-  }
-}
-
-const modulePreviewCache = new WeakMap<
-  GalleryPreviewModuleManifest,
-  Map<string, GalleryPreviewRenderer>
->();
-
-const moduleLoadCache = new WeakMap<
-  GalleryPreviewModuleManifest,
-  Promise<Map<string, GalleryPreviewRenderer>>
->();
-
-const previewComponentCache = new Map<
-  string,
-  React.LazyExoticComponent<React.ComponentType>
->();
-
 const previewRendererCache = new Map<string, GalleryPreviewRenderer>();
-const previewRouteIndex = new Map<string, GalleryPreviewRoute>();
-
-for (const route of galleryPreviewRoutes) {
-  previewRouteIndex.set(route.slug, route);
-}
-
-const normalizeSections = (
-  exported: GalleryModuleExport["default"],
-): readonly GallerySection[] => {
-  return (Array.isArray(exported) ? exported : [exported]) as readonly GallerySection[];
-};
-
-const collectModulePreviews = (
-  sections: readonly GallerySection[],
-): Map<string, GalleryPreviewRenderer> => {
-  const map = new Map<string, GalleryPreviewRenderer>();
-  for (const section of sections) {
-    for (const entry of section.entries) {
-      map.set(entry.preview.id, entry.preview.render);
-      if (entry.states) {
-        for (const state of entry.states) {
-          map.set(state.preview.id, state.preview.render);
-        }
-      }
-    }
-  }
-  return map;
-};
-
-const loadModulePreviews = (
-  manifest: GalleryPreviewModuleManifest,
-): Promise<Map<string, GalleryPreviewRenderer>> => {
-  const cached = modulePreviewCache.get(manifest);
-  if (cached) {
-    return Promise.resolve(cached);
-  }
-  const pending = moduleLoadCache.get(manifest);
-  if (pending) {
-    return pending;
-  }
-  const promise = manifest
-    .loader()
-    .then((module: GalleryModuleExport) => {
-      const sections = normalizeSections(module.default);
-      const previews = collectModulePreviews(sections);
-      modulePreviewCache.set(manifest, previews);
-      return previews;
-    })
-    .catch((error) => {
-      modulePreviewCache.delete(manifest);
-      moduleLoadCache.delete(manifest);
-      throw error;
-    });
-  moduleLoadCache.set(manifest, promise);
-  return promise;
-};
-
-const getLazyPreviewComponent = (
-  id: string,
-  manifest: GalleryPreviewModuleManifest,
-) => {
-  let component = previewComponentCache.get(id);
-  if (component) {
-    return component;
-  }
-
-  component = React.lazy(async () => {
-    const previews = await loadModulePreviews(manifest);
-    const render = previews.get(id);
-    if (!render) {
-      throw new Error(`Gallery preview \"${id}\" not found in module`);
-    }
-    const PreviewComponent: React.FC = () =>
-      React.createElement(React.Fragment, undefined, render());
-    PreviewComponent.displayName = `GalleryPreview(${id})`;
-    return { default: PreviewComponent };
-  });
-
-  previewComponentCache.set(id, component);
-  return component;
-};
 
 export { galleryPayload };
 
 export const getGalleryPreviewRenderer = (
   id: string,
 ): GalleryPreviewRenderer | null => {
+  if (!getPreviewManifest(id)) {
+    return null;
+  }
+
   const cached = previewRendererCache.get(id);
   if (cached) {
     return cached;
   }
 
-  const manifest = previewModuleIndex.get(id);
-  if (!manifest) {
-    return null;
-  }
-
-  const LazyComponent = getLazyPreviewComponent(id, manifest);
   const renderer: GalleryPreviewRenderer = () =>
-    React.createElement(
-      TokenPreviewBoundary,
-      undefined,
-      React.createElement(LazyComponent),
-    );
+    React.createElement(PreviewRendererClient, { previewId: id });
 
   previewRendererCache.set(id, renderer);
   return renderer;
@@ -159,7 +43,6 @@ export const getGalleryEntriesByKind = (
 export const getGallerySection = (id: GallerySectionId) =>
   galleryPayload.sections.find((section) => section.id === id) ?? null;
 
-export const getGalleryPreviewRoute = (slug: string) =>
-  previewRouteIndex.get(slug) ?? null;
+export const getGalleryPreviewRoute = getPreviewRoute;
 
-export const getGalleryPreviewRoutes = () => galleryPreviewRoutes;
+export const getGalleryPreviewRoutes = () => getAllPreviewRoutes();


### PR DESCRIPTION
## Summary
- export SKIP_PREVIEW_STATIC during the Pages build job so preview routes serve the static fallback when deploying

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d868ff934c832caa32e47a0153cb25