### PR TITLE
Fix node-base workflow artifact action pin

### DIFF
--- a/.github/workflows/node-base.yml
+++ b/.github/workflows/node-base.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Download artifact
         if: inputs.download-artifact-name != ''
-        uses: actions/download-artifact@89f3d9d3dc0f01c4eb82c0dec28181581b88a8d0
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         with:
           name: ${{ inputs.download-artifact-name }}
           path: ${{ inputs.download-artifact-path }}


### PR DESCRIPTION
## Summary
- update the node-base reusable workflow to pin actions/download-artifact to the latest stable commit so CI jobs can download cached artifacts again

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d8808c3380832c8430ce2ab1796e3b