### PR TITLE
Fix preview page exports for Next build

### DIFF
--- a/app/preview/[slug]/page.tsx
+++ b/app/preview/[slug]/page.tsx
@@ -1,8 +1,13 @@
-export {
-  dynamic,
-  dynamicParams,
-  generateStaticParams,
-  generateMetadata,
+import PreviewPage, {
+  dynamic as previewDynamic,
+  dynamicParams as previewDynamicParams,
+  generateMetadata as previewGenerateMetadata,
+  generateStaticParams as previewGenerateStaticParams,
 } from "../../../src/app/preview/[slug]/page";
 
-export { default } from "../../../src/app/preview/[slug]/page";
+export default PreviewPage;
+
+export const dynamic = previewDynamic;
+export const dynamicParams = previewDynamicParams;
+export const generateStaticParams = previewGenerateStaticParams;
+export const generateMetadata = previewGenerateMetadata;


### PR DESCRIPTION
## Summary
- ensure the preview route re-exports Next special fields as concrete bindings so the build recognises the static configuration

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d882cb4d24832caefd16cc3fd13c0c