### PR TITLE
Fix env passing in visual regression workflow

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -57,6 +57,9 @@ jobs:
       run: |
         set -euo pipefail
 
+        WORKFLOW_ENVIRONMENT="${{ inputs.environment }}"
+        export WORKFLOW_ENVIRONMENT
+
         PLAYWRIGHT_PORT=3100
         export PLAYWRIGHT_PORT
 
@@ -115,5 +118,3 @@ jobs:
       artifact-path: |
         playwright-results/visual/${{ matrix.project }}
       artifact-on-failure: true
-    env:
-      WORKFLOW_ENVIRONMENT: ${{ inputs.environment }}


### PR DESCRIPTION
## Summary
- export the optional environment label inside the visual regression job before launching Playwright
- remove the unsupported `env` block when invoking the reusable node-base workflow

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d8878f972c832c8094b0e159dd60b3