### PR TITLE
Fix ScrollTopFloatingButton target change detection

### DIFF
--- a/src/components/planner/ScrollTopFloatingButton.tsx
+++ b/src/components/planner/ScrollTopFloatingButton.tsx
@@ -21,14 +21,16 @@ export default function ScrollTopFloatingButton({
     () => watchRef.current,
   );
 
+  const watchedElement = watchRef.current;
+
   const supportsIntersectionObserver =
     typeof window !== "undefined" && "IntersectionObserver" in window;
 
   React.useEffect(() => {
-    if (watchRef.current !== target) {
-      setTarget(watchRef.current ?? null);
+    if (watchedElement !== target) {
+      setTarget(watchedElement ?? null);
     }
-  }, [watchRef, target]);
+  }, [watchedElement, target]);
 
   React.useEffect(() => {
     if (!supportsIntersectionObserver) {


### PR DESCRIPTION
## Summary
- capture the watched element during render so the syncing effect sees ref updates
- keep the target state effect keyed to the captured element to trigger observer updates

## Testing
- npm run lint
- npm run typecheck
- npm test -- ScrollTopFloatingButton

------
https://chatgpt.com/codex/tasks/task_e_68d88af67f68832c92853147cffad516