### PR TITLE
Fix preview page config export

### DIFF
--- a/app/preview/[slug]/page.tsx
+++ b/app/preview/[slug]/page.tsx
@@ -7,7 +7,16 @@ import PreviewPage, {
 
 export default PreviewPage;
 
-export const dynamic = previewDynamic;
-export const dynamicParams = previewDynamicParams;
+export const dynamic = "force-static";
+export const dynamicParams = false;
 export const generateStaticParams = previewGenerateStaticParams;
 export const generateMetadata = previewGenerateMetadata;
+
+if (process.env.NODE_ENV !== "production") {
+  if (previewDynamic !== dynamic) {
+    throw new Error("Preview page dynamic config mismatch");
+  }
+  if (previewDynamicParams !== dynamicParams) {
+    throw new Error("Preview page dynamicParams config mismatch");
+  }
+}


### PR DESCRIPTION
## Summary
- inline the preview route dynamic settings so Next.js can statically analyze the config
- keep re-exported metadata/static params while asserting in development that they match the source page

## Testing
- npm run build
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d88a69f268832c830fdab5b1239416