### PR TITLE
Add repository checkout before local setup action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
+        with:
+          fetch-depth: 2
+
       - id: setup
         uses: ./.github/actions/setup-node-project
 
@@ -42,6 +47,11 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
+        with:
+          fetch-depth: 2
+
       - uses: ./.github/actions/setup-node-project
 
       - name: Run ESLint
@@ -71,6 +81,11 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
+        with:
+          fetch-depth: 2
+
       - uses: ./.github/actions/setup-node-project
 
       - name: Verify tokens
@@ -84,6 +99,11 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
+        with:
+          fetch-depth: 2
+
       - uses: ./.github/actions/setup-node-project
 
       - name: Run TypeScript compiler
@@ -97,6 +117,11 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
+        with:
+          fetch-depth: 2
+
       - uses: ./.github/actions/setup-node-project
 
       - name: Run Vitest suite
@@ -129,6 +154,11 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: "1"
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
+        with:
+          fetch-depth: 2
+
       - uses: ./.github/actions/setup-node-project
 
       - name: Build Next.js application
@@ -155,6 +185,11 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: "1"
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
+        with:
+          fetch-depth: 2
+
       - uses: ./.github/actions/setup-node-project
 
       - name: Download Next.js build artifact

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -29,6 +29,11 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: '1'
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
+        with:
+          fetch-depth: 2
+
       - uses: ./.github/actions/setup-node-project
 
       - name: Export static preview

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -25,6 +25,11 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: '1'
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
+        with:
+          fetch-depth: 2
+
       - uses: ./.github/actions/setup-node-project
         with:
           checkout-ref: ${{ inputs.branch != '' && inputs.branch || '' }}
@@ -56,6 +61,11 @@ jobs:
           - webkit
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
+        with:
+          fetch-depth: 2
+
       - uses: ./.github/actions/setup-node-project
         with:
           checkout-ref: ${{ inputs.branch != '' && inputs.branch || '' }}


### PR DESCRIPTION
## Summary
- ensure each workflow checks out the repository before invoking the local setup action
- keep the composite action usage unchanged while preventing missing action failures across CI, deploy, and visual jobs

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d8971abd28832c91e3ba55cff214da