### PR TITLE
Add checkout step before using setup composite action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: actions/checkout@v4
       - id: setup
         uses: ./.github/actions/setup-node-project
 
@@ -42,6 +43,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node-project
 
       - name: Run ESLint
@@ -71,6 +73,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node-project
 
       - name: Verify tokens
@@ -84,6 +87,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node-project
 
       - name: Run TypeScript compiler
@@ -97,6 +101,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node-project
 
       - name: Run Vitest suite
@@ -129,6 +134,7 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: "1"
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node-project
 
       - name: Build Next.js application
@@ -155,6 +161,7 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: "1"
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node-project
 
       - name: Download Next.js build artifact

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -29,6 +29,7 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: '1'
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node-project
 
       - name: Export static preview

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -25,6 +25,7 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: '1'
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node-project
         with:
           checkout-ref: ${{ inputs.branch != '' && inputs.branch || '' }}
@@ -56,6 +57,7 @@ jobs:
           - webkit
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node-project
         with:
           checkout-ref: ${{ inputs.branch != '' && inputs.branch || '' }}


### PR DESCRIPTION
## Summary
- ensure each workflow job checks out the repository before invoking the setup-node-project composite action
- keep deploy preview and visual regression workflows aligned while preserving existing checkout-ref usage

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d8980b51d0832cb3276c91e3884459