### PR TITLE
chore: run deploy build and sync Next type config

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,7 +40,9 @@
         "name": "next"
       }
     ],
-    "incremental": true
+    "incremental": true,
+    "allowJs": true,
+    "skipLibCheck": true
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Summary
- run the GitHub Pages deploy script in artifact-only mode so the static export is rebuilt with the repository base path and `.nojekyll`
- accept Next.js updates to the generated TypeScript config files so future deploy runs stay clean

## Testing
- DEPLOY_ARTIFACT_ONLY=1 npm run deploy
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d897117c60832cad4183db6e8994ef