### PR TITLE
ci: streamline GitHub Pages workflows

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,62 @@
+name: Deploy Pages
+
+concurrency:
+  group: deploy-pages-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'CHANGELOG.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build static site
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      NEXT_TELEMETRY_DISABLED: '1'
+    steps:
+      - uses: ./.github/actions/setup-node-project
+
+      - name: Export static site
+        shell: bash
+        run: |
+          set -euo pipefail
+          export DEPLOY_ARTIFACT_ONLY=true
+          npm run deploy
+
+      - name: Upload static artifact
+        uses: actions/upload-pages-artifact@6b4985b4d81eed21dc8e42f6e28eaf41b0c9fb3d # v3.0.1
+        with:
+          path: ./out
+          if-no-files-found: error
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    if: needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: Production
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@f65c7f0a20510b02fd348436de4b0bd711c4d7f9 # v5.0.1
+
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@af48c8d784fbb3eccd0f19f41da3b3c25c2ba234 # v4.0.7

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -23,9 +23,9 @@ jobs:
   build:
     name: Build static preview
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-    runs-on: ubuntu-latest
     env:
       NEXT_TELEMETRY_DISABLED: '1'
     steps:
@@ -38,41 +38,29 @@ jobs:
           export DEPLOY_ARTIFACT_ONLY=true
           npm run deploy
 
-      - name: Upload static output
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v4.4.3
+      - name: Upload static artifact
+        uses: actions/upload-pages-artifact@6b4985b4d81eed21dc8e42f6e28eaf41b0c9fb3d # v3.0.1
         with:
-          name: preview-static
-          path: out
+          path: ./out
           if-no-files-found: error
 
   deploy:
     name: Deploy preview
-    needs:
-      - build
+    needs: build
     if: needs.build.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pages: write
       id-token: write
-      pull-requests: write
     environment:
       name: Deploy Preview
       url: ${{ steps.deploy.outputs.page_url }}
+    outputs:
+      page_url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - name: Setup Pages
         uses: actions/configure-pages@f65c7f0a20510b02fd348436de4b0bd711c4d7f9 # v5.0.1
-
-      - name: Download static export
-        uses: actions/download-artifact@f0444e9ed1bc69c8f27d0fc1b60d26e867f49fc1 # v4.1.7
-        with:
-          name: preview-static
-          path: out
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@6b4985b4d81eed21dc8e42f6e28eaf41b0c9fb3d # v3.0.1
-        with:
-          path: ./out
 
       - name: Deploy to GitHub Pages
         id: deploy
@@ -80,8 +68,16 @@ jobs:
         with:
           preview: true
 
-      - name: Share preview URL
-        if: github.event_name == 'pull_request'
+  share:
+    name: Share preview URL
+    needs: deploy
+    if: github.event_name == 'pull_request' && needs.deploy.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Post preview comment
         uses: actions/github-script@d59a4d062958ca40b034b6f04da4898e95a1c18f # v7.0.1
         with:
           script: |
@@ -115,4 +111,4 @@ jobs:
               });
             }
         env:
-          PREVIEW_URL: ${{ steps.deploy.outputs.page_url }}
+          PREVIEW_URL: ${{ needs.deploy.outputs.page_url }}


### PR DESCRIPTION
## Summary
- streamline the deploy preview workflow to upload a single Pages artifact and separate the comment job
- add a dedicated GitHub Pages deployment workflow for pushes to main using the shared static export path

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d89abe071c832c844e699bd3ddfe61