### PR TITLE
Fix animation toggle cleanup

### DIFF
--- a/src/components/ui/AnimationToggle.tsx
+++ b/src/components/ui/AnimationToggle.tsx
@@ -38,7 +38,7 @@ export default function AnimationToggle({
     }
 
     return () => {
-      if (latestEnabledRef.current && appliedByToggleRef.current) {
+      if (appliedByToggleRef.current) {
         root.classList.remove("no-animations");
         appliedByToggleRef.current = false;
       }

--- a/tests/ui/AnimationToggle.test.tsx
+++ b/tests/ui/AnimationToggle.test.tsx
@@ -49,7 +49,7 @@ describe("AnimationToggle", () => {
     });
   });
 
-  it("leaves reduced motion class in place when unmounted while disabled", async () => {
+  it("removes reduced motion class when unmounted while disabled", async () => {
     const { getByRole, unmount } = render(<AnimationToggle />);
     const button = getByRole("button");
 
@@ -63,7 +63,9 @@ describe("AnimationToggle", () => {
 
     unmount();
 
-    expect(document.documentElement.classList.contains("no-animations")).toBe(true);
+    expect(document.documentElement.classList.contains("no-animations")).toBe(
+      false,
+    );
   });
 
   it("is focusable for keyboard users", () => {


### PR DESCRIPTION
## Summary
- ensure the animation toggle cleanup removes the no-animations class when it was applied by the toggle
- update the animation toggle unit test to reflect the cleanup behavior

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d89f64e014832ca95f352dad75beb3