### PR TITLE
feat(home): share dashboard section header

### DIFF
--- a/src/components/home/DashboardCard.tsx
+++ b/src/components/home/DashboardCard.tsx
@@ -4,11 +4,17 @@ import * as React from "react";
 import Link from "next/link";
 import { Button, NeoCard } from "@/components/ui";
 
+import DashboardSectionHeader, {
+  type DashboardSectionHeaderShowCodeProps,
+} from "./DashboardSectionHeader";
+
 interface DashboardCardProps {
   title: string;
   children?: React.ReactNode;
   cta?: { label: string; href: string };
   actions?: React.ReactNode;
+  headerLoading?: boolean;
+  showCode?: DashboardSectionHeaderShowCodeProps;
 }
 
 export default function DashboardCard({
@@ -16,13 +22,17 @@ export default function DashboardCard({
   children,
   cta,
   actions,
+  headerLoading,
+  showCode,
 }: DashboardCardProps) {
   return (
-    <NeoCard className="p-[var(--space-4)] md:p-[var(--space-6)] space-y-[var(--space-4)]">
-      <div className="flex items-center justify-between">
-        <h2 className="text-title font-semibold tracking-[-0.01em] text-card-foreground">{title}</h2>
-        {actions}
-      </div>
+    <NeoCard className="space-y-[var(--space-4)] p-[var(--space-4)] sm:p-[var(--space-5)] lg:p-[var(--space-6)]">
+      <DashboardSectionHeader
+        title={title}
+        actions={actions}
+        loading={headerLoading}
+        showCode={showCode}
+      />
       {children && (
         <div
           className="border-t border-card-hairline-60 pt-[var(--space-4)] space-y-[var(--space-4)]"

--- a/src/components/home/DashboardList.tsx
+++ b/src/components/home/DashboardList.tsx
@@ -101,7 +101,7 @@ export default function DashboardList<T>({
             return (
               <li
                 key={key}
-                className={cn("py-[var(--space-2)]", itemCls)}
+                className={cn("py-[var(--space-3)]", itemCls)}
               >
                 {renderItem(item, index)}
               </li>
@@ -110,7 +110,7 @@ export default function DashboardList<T>({
         : (
             <li
               className={cn(
-                "py-[var(--space-2)] text-ui text-muted-foreground",
+                "py-[var(--space-3)] text-ui text-muted-foreground",
                 cta ? "flex items-center justify-between" : "flex items-center",
               )}
             >
@@ -121,7 +121,7 @@ export default function DashboardList<T>({
               {cta ? (
                 <Link
                   href={cta.href}
-                  className="inline-flex items-center text-label font-medium text-accent-3 underline underline-offset-4 transition-colors hover:text-on-accent active:text-on-accent active:bg-interaction-accent-tintActive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] focus-visible:ring-offset-0 motion-reduce:transition-none"
+                  className="inline-flex items-center text-label font-medium text-accent-3 underline underline-offset-4 transition-colors hover:text-on-accent active:text-on-accent active:bg-interaction-accent-tintActive focus-visible:outline-none focus-visible:ring-[var(--ring-size-1)] focus-visible:ring-offset-0 ring-[var(--theme-ring)] motion-reduce:transition-none"
                 >
                   {cta.label}
                 </Link>

--- a/src/components/home/DashboardSectionHeader.tsx
+++ b/src/components/home/DashboardSectionHeader.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { Skeleton } from "@/components/ui";
+
+export interface DashboardSectionHeaderShowCodeProps {
+  id?: string;
+  controls?: string;
+  expanded?: boolean;
+  disabled?: boolean;
+  onToggle?: () => void;
+  label?: string;
+  expandedLabel?: string;
+}
+
+export interface DashboardSectionHeaderProps {
+  title: string;
+  actions?: React.ReactNode;
+  loading?: boolean;
+  className?: string;
+  showCode?: DashboardSectionHeaderShowCodeProps;
+}
+
+const baseActionGap =
+  "flex items-center gap-[var(--space-2)] sm:gap-[var(--space-3)]";
+
+function renderTitle(title: string, loading?: boolean) {
+  if (loading) {
+    return (
+      <Skeleton
+        ariaHidden={false}
+        role="status"
+        aria-label="Loading section title"
+        radius="sm"
+        className="!h-[var(--space-5)] !w-[min(60%,var(--space-16))]"
+      />
+    );
+  }
+
+  return (
+    <h2 className="text-title font-semibold tracking-[-0.01em] text-card-foreground">
+      {title}
+    </h2>
+  );
+}
+
+function renderShowCode(
+  showCode: DashboardSectionHeaderShowCodeProps | undefined,
+  loading?: boolean,
+) {
+  if (!showCode && !loading) {
+    return null;
+  }
+
+  if (loading) {
+    return (
+      <Skeleton
+        ariaHidden={false}
+        role="status"
+        aria-label="Loading Show code action"
+        radius="full"
+        className="!h-[var(--control-h-sm)] !w-[calc(var(--space-8)*2)]"
+      />
+    );
+  }
+
+  if (!showCode) {
+    return null;
+  }
+
+  const {
+    id,
+    controls,
+    expanded,
+    disabled,
+    onToggle,
+    label = "Show code",
+    expandedLabel = "Hide code",
+  } = showCode;
+
+  return (
+    <button
+      type="button"
+      id={id}
+      onClick={onToggle}
+      aria-controls={controls}
+      aria-expanded={expanded}
+      disabled={disabled}
+      data-state={expanded ? "expanded" : undefined}
+      className={cn(
+        "inline-flex items-center gap-[var(--space-1)] rounded-[var(--radius-sm)] px-[var(--space-2)] py-[var(--space-1)]",
+        "text-label font-medium text-accent-3 underline underline-offset-[var(--space-1)]",
+        "transition-colors focus-visible:outline-none focus-visible:ring-[var(--ring-size-1)]",
+        "focus-visible:ring-offset-0 ring-[var(--theme-ring)]",
+        "disabled:cursor-not-allowed disabled:opacity-disabled",
+      )}
+    >
+      {expanded ? expandedLabel : label}
+    </button>
+  );
+}
+
+export default function DashboardSectionHeader({
+  title,
+  actions,
+  loading,
+  className,
+  showCode,
+}: DashboardSectionHeaderProps) {
+  const shouldRenderActions = Boolean(actions) || Boolean(showCode) || loading;
+
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center justify-between gap-y-[var(--space-2)] gap-x-[var(--space-3)]",
+        className,
+      )}
+    >
+      {renderTitle(title, loading)}
+      {shouldRenderActions ? (
+        <div
+          className={cn(
+            baseActionGap,
+            "sm:justify-end",
+            loading ? "w-full sm:w-auto" : undefined,
+          )}
+        >
+          {actions}
+          {renderShowCode(showCode, loading)}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -1,6 +1,7 @@
 // src/components/home/index.ts
 export { default as DashboardCard } from "./DashboardCard";
 export { default as DashboardList } from "./DashboardList";
+export { default as DashboardSectionHeader } from "./DashboardSectionHeader";
 export { default as TodayCard } from "./TodayCard";
 export { default as GoalsCard } from "./GoalsCard";
 export { default as ReviewsCard } from "./ReviewsCard";

--- a/tests/home/DashboardList.test.tsx
+++ b/tests/home/DashboardList.test.tsx
@@ -116,5 +116,9 @@ describe("DashboardList", () => {
     const link = screen.getByRole("link", { name: cta.label });
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute("href", cta.href);
+    expect(link).toHaveClass(
+      "focus-visible:ring-[var(--ring-size-1)]",
+    );
+    expect(link).toHaveClass("ring-[var(--theme-ring)]");
   });
 });

--- a/tests/home/DashboardSectionHeader.test.tsx
+++ b/tests/home/DashboardSectionHeader.test.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import DashboardSectionHeader from "@/components/home/DashboardSectionHeader";
+
+describe("DashboardSectionHeader", () => {
+  it("renders the title layout with actions and show code button", () => {
+    const toggleSpy = vi.fn();
+    const { container } = render(
+      <DashboardSectionHeader
+        title="Planner"
+        actions={<button type="button">Refresh</button>}
+        showCode={{
+          controls: "planner-code",
+          onToggle: toggleSpy,
+          expanded: false,
+        }}
+      />,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("renders skeleton placeholders while loading", () => {
+    const { container } = render(
+      <DashboardSectionHeader title="Loading state" loading />,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/tests/home/__snapshots__/DashboardSectionHeader.test.tsx.snap
+++ b/tests/home/__snapshots__/DashboardSectionHeader.test.tsx.snap
@@ -1,0 +1,53 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`DashboardSectionHeader > renders skeleton placeholders while loading 1`] = `
+<div
+  class="flex flex-wrap items-center justify-between gap-y-[var(--space-2)] gap-x-[var(--space-3)]"
+>
+  <div
+    aria-hidden="false"
+    aria-label="Loading section title"
+    class="skeleton h-[var(--space-4)] w-full rounded-[var(--radius-sm,var(--radius-md))] !h-[var(--space-5)] !w-[min(60%,var(--space-16))]"
+    role="status"
+  />
+  <div
+    class="flex items-center gap-[var(--space-2)] sm:gap-[var(--space-3)] sm:justify-end w-full sm:w-auto"
+  >
+    <div
+      aria-hidden="false"
+      aria-label="Loading Show code action"
+      class="skeleton h-[var(--space-4)] w-full rounded-[var(--radius-full)] !h-[var(--control-h-sm)] !w-[calc(var(--space-8)*2)]"
+      role="status"
+    />
+  </div>
+</div>
+`;
+
+exports[`DashboardSectionHeader > renders the title layout with actions and show code button 1`] = `
+<div
+  class="flex flex-wrap items-center justify-between gap-y-[var(--space-2)] gap-x-[var(--space-3)]"
+>
+  <h2
+    class="text-title font-semibold tracking-[-0.01em] text-card-foreground"
+  >
+    Planner
+  </h2>
+  <div
+    class="flex items-center gap-[var(--space-2)] sm:gap-[var(--space-3)] sm:justify-end"
+  >
+    <button
+      type="button"
+    >
+      Refresh
+    </button>
+    <button
+      aria-controls="planner-code"
+      aria-expanded="false"
+      class="inline-flex items-center gap-[var(--space-1)] rounded-[var(--radius-sm)] px-[var(--space-2)] py-[var(--space-1)] text-label font-medium text-accent-3 underline underline-offset-[var(--space-1)] transition-colors focus-visible:outline-none focus-visible:ring-[var(--ring-size-1)] focus-visible:ring-offset-0 ring-[var(--theme-ring)] disabled:cursor-not-allowed disabled:opacity-disabled"
+      type="button"
+    >
+      Show code
+    </button>
+  </div>
+</div>
+`;


### PR DESCRIPTION
## Summary
- add a shared DashboardSectionHeader component with loading skeletons and show code action support
- migrate DashboardCard and DashboardList to the new spacing/ring tokens and export the header helper
- expand unit coverage with dashboard header snapshots and CTA focus ring assertions

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d89e929518832c93f3a69c0e77151c