### PR TITLE
Show review list glitch empty state

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -165,6 +165,12 @@ Following these guidelines keeps the interface consistent and lets theme updates
 - `subTabs` adds a secondary segmented tab row; legacy `tabs` prop remains.
 - A neon divider forms a neon search row that can host a pill `SearchBar` and optional actions.
 
+## Reviews module
+
+- `ReviewList` swaps to the glitch ghost empty state when no reviews exist. Pair the create action with that prompt instead of leaving an inert list.
+- Keep the hero search, sort, and filter controls disabled until a review exists so the locked state communicates that nothing is available yet.
+- Respect reduced-motion preferences: the ghost avatar holds still while the button and copy remain available, matching the Storybook coverage for accessibility sign-off.
+
 ## SearchBar
 
 - Wraps its input in a `<form role="search">` for accessibility.

--- a/storybook/src/components/reviews/ReviewList.stories.tsx
+++ b/storybook/src/components/reviews/ReviewList.stories.tsx
@@ -55,7 +55,7 @@ const meta: Meta<typeof ReviewList> = {
     docs: {
       description: {
         component:
-          "`ReviewList` renders a vertical stack of `ReviewListItem` shells. Provide the current review collection, the selected id, and callbacks for row selection and creation so QA can confirm sidebar flows.",
+          "`ReviewList` renders a vertical stack of `ReviewListItem` shells. Provide the current review collection, the selected id, and callbacks for row selection and creation so QA can confirm sidebar flows. When the collection is empty, the component swaps to the glitch ghost call to action while the hero search and sort controls remain disabled until data exists.",
       },
     },
     chromatic: { pauseAnimationAtEnd: true },
@@ -109,6 +109,26 @@ export const Default: Story = {
           "Default list with the most recent review selected. The status pulse uses semantic motion tokens while spacing respects the review rail grid.",
       },
     },
+  },
+  render: (args) => (
+    <StorySurface>
+      <ReviewList {...args} className={cn("w-full", args.className)} />
+    </StorySurface>
+  ),
+};
+
+export const Empty: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Empty state showcasing the glitch ghost treatment. The create action remains primary and the page-level search controls stay disabled until at least one review lands.",
+      },
+    },
+  },
+  args: {
+    reviews: [],
+    selectedId: null,
   },
   render: (args) => (
     <StorySurface>
@@ -215,14 +235,18 @@ export const ReducedMotion: Story = {
     docs: {
       description: {
         story:
-          "Reduced-motion mode removes the status dot blink while keeping spacing, shadows, and selection rings intact for accessibility sign-off.",
+          "Reduced-motion mode removes the glitch shimmer, falling back to the static ghost avatar while keeping spacing, shadows, and focus treatment intact for accessibility sign-off.",
       },
     },
+  },
+  args: {
+    reviews: [],
+    selectedId: null,
   },
   render: (args) => (
     <ReducedMotionPreview>
       <StorySurface>
-        <ReviewList {...args} />
+        <ReviewList {...args} className={cn("w-full", args.className)} />
       </StorySurface>
     </ReducedMotionPreview>
   ),


### PR DESCRIPTION
## Summary
- add Storybook coverage for the review list ghost-town empty state and include a reduced-motion example
- refresh the design-system docs so designers know the hero controls stay disabled until data exists and that the ghost respects reduced motion

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d8a3833abc832cab22352b9e8bc909