### PR TITLE
Fix ring noise filter slope token usage

### DIFF
--- a/src/icons/RingNoiseDefs.tsx
+++ b/src/icons/RingNoiseDefs.tsx
@@ -1,5 +1,13 @@
 import * as React from "react";
 
+import tokens from "../../tokens/tokens.js";
+
+const gradientNoiseOpacityToken = tokens.gradientNoiseOpacity;
+const parsedGradientNoiseOpacity = Number.parseFloat(gradientNoiseOpacityToken);
+const gradientNoiseOpacity = Number.isFinite(parsedGradientNoiseOpacity)
+  ? parsedGradientNoiseOpacity
+  : 0.1;
+
 interface RingNoiseDefsProps {
   id: string;
 }
@@ -24,7 +32,7 @@ export default function RingNoiseDefs({ id }: RingNoiseDefsProps) {
       />
       <feColorMatrix in="noise" type="saturate" values="0" result="monoNoise" />
       <feComponentTransfer in="monoNoise" result="noiseAlpha">
-        <feFuncA type="linear" slope="var(--gradient-noise-opacity, 0.1)" />
+        <feFuncA type="linear" slope={gradientNoiseOpacity} />
       </feComponentTransfer>
       <feBlend in="SourceGraphic" in2="noiseAlpha" mode="soft-light" />
     </filter>

--- a/tests/icons/__snapshots__/RingIcons.theme.test.tsx.snap
+++ b/tests/icons/__snapshots__/RingIcons.theme.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`Ring icons across themes > renders ring icons for the aurora theme 1`] 
           result="noiseAlpha"
         >
           <fefunca
-            slope="var(--gradient-noise-opacity, 0.1)"
+            slope="0.1"
             type="linear"
           />
         </fecomponenttransfer>
@@ -106,7 +106,7 @@ exports[`Ring icons across themes > renders ring icons for the aurora theme 1`] 
           result="noiseAlpha"
         >
           <fefunca
-            slope="var(--gradient-noise-opacity, 0.1)"
+            slope="0.1"
             type="linear"
           />
         </fecomponenttransfer>
@@ -196,7 +196,7 @@ exports[`Ring icons across themes > renders ring icons for the citrus theme 1`] 
           result="noiseAlpha"
         >
           <fefunca
-            slope="var(--gradient-noise-opacity, 0.1)"
+            slope="0.1"
             type="linear"
           />
         </fecomponenttransfer>
@@ -264,7 +264,7 @@ exports[`Ring icons across themes > renders ring icons for the citrus theme 1`] 
           result="noiseAlpha"
         >
           <fefunca
-            slope="var(--gradient-noise-opacity, 0.1)"
+            slope="0.1"
             type="linear"
           />
         </fecomponenttransfer>
@@ -354,7 +354,7 @@ exports[`Ring icons across themes > renders ring icons for the hardstuck theme 1
           result="noiseAlpha"
         >
           <fefunca
-            slope="var(--gradient-noise-opacity, 0.1)"
+            slope="0.1"
             type="linear"
           />
         </fecomponenttransfer>
@@ -422,7 +422,7 @@ exports[`Ring icons across themes > renders ring icons for the hardstuck theme 1
           result="noiseAlpha"
         >
           <fefunca
-            slope="var(--gradient-noise-opacity, 0.1)"
+            slope="0.1"
             type="linear"
           />
         </fecomponenttransfer>
@@ -512,7 +512,7 @@ exports[`Ring icons across themes > renders ring icons for the kitten theme 1`] 
           result="noiseAlpha"
         >
           <fefunca
-            slope="var(--gradient-noise-opacity, 0.1)"
+            slope="0.1"
             type="linear"
           />
         </fecomponenttransfer>
@@ -580,7 +580,7 @@ exports[`Ring icons across themes > renders ring icons for the kitten theme 1`] 
           result="noiseAlpha"
         >
           <fefunca
-            slope="var(--gradient-noise-opacity, 0.1)"
+            slope="0.1"
             type="linear"
           />
         </fecomponenttransfer>
@@ -670,7 +670,7 @@ exports[`Ring icons across themes > renders ring icons for the lg theme 1`] = `
           result="noiseAlpha"
         >
           <fefunca
-            slope="var(--gradient-noise-opacity, 0.1)"
+            slope="0.1"
             type="linear"
           />
         </fecomponenttransfer>
@@ -738,7 +738,7 @@ exports[`Ring icons across themes > renders ring icons for the lg theme 1`] = `
           result="noiseAlpha"
         >
           <fefunca
-            slope="var(--gradient-noise-opacity, 0.1)"
+            slope="0.1"
             type="linear"
           />
         </fecomponenttransfer>
@@ -828,7 +828,7 @@ exports[`Ring icons across themes > renders ring icons for the noir theme 1`] = 
           result="noiseAlpha"
         >
           <fefunca
-            slope="var(--gradient-noise-opacity, 0.1)"
+            slope="0.1"
             type="linear"
           />
         </fecomponenttransfer>
@@ -896,7 +896,7 @@ exports[`Ring icons across themes > renders ring icons for the noir theme 1`] = 
           result="noiseAlpha"
         >
           <fefunca
-            slope="var(--gradient-noise-opacity, 0.1)"
+            slope="0.1"
             type="linear"
           />
         </fecomponenttransfer>
@@ -986,7 +986,7 @@ exports[`Ring icons across themes > renders ring icons for the ocean theme 1`] =
           result="noiseAlpha"
         >
           <fefunca
-            slope="var(--gradient-noise-opacity, 0.1)"
+            slope="0.1"
             type="linear"
           />
         </fecomponenttransfer>
@@ -1054,7 +1054,7 @@ exports[`Ring icons across themes > renders ring icons for the ocean theme 1`] =
           result="noiseAlpha"
         >
           <fefunca
-            slope="var(--gradient-noise-opacity, 0.1)"
+            slope="0.1"
             type="linear"
           />
         </fecomponenttransfer>


### PR DESCRIPTION
## Summary
- import the gradient noise opacity design token into the ring noise filter and fall back safely when the token is invalid
- update ring icon snapshots to reflect the numeric slope value produced by the filter

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d8a5069988832c9bdb9f29953eea21