### PR TITLE
Support GitHub Pages base path exports

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -32,6 +32,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          repo_name="${GITHUB_REPOSITORY#*/}"
+          if [[ "${repo_name}" == *.github.io ]]; then
+            export NEXT_PUBLIC_BASE_PATH=""
+          else
+            export NEXT_PUBLIC_BASE_PATH="/${repo_name}"
+          fi
           export DEPLOY_ARTIFACT_ONLY=true
           npm run deploy
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## GitHub Pages Deployment
 
-Run `npm run deploy` from the project root whenever you're ready to publish. The script rebuilds the site with the correct GitHub Pages base path (`GITHUB_PAGES=true` and `BASE_PATH=<repo>`), then calls the [`gh-pages`](https://github.com/tschaub/gh-pages) CLI with `--nojekyll` so the `.nojekyll` marker is always published. Set `GH_PAGES_BRANCH` (or `GITHUB_PAGES_BRANCH`) if your site publishes from a branch other than `gh-pages` so the deploy script targets the same branch you serve from.
+Run `npm run deploy` from the project root whenever you're ready to publish. The script rebuilds the site with the correct GitHub Pages base path (`GITHUB_PAGES=true` and `NEXT_PUBLIC_BASE_PATH=/&lt;repo&gt;`), then calls the [`gh-pages`](https://github.com/tschaub/gh-pages) CLI with `--nojekyll` so the `.nojekyll` marker is always published. Set `GH_PAGES_BRANCH` (or `GITHUB_PAGES_BRANCH`) if your site publishes from a branch other than `gh-pages` so the deploy script targets the same branch you serve from.
 
 Before building, the script verifies that a Git push target is configured. If `git remote get-url origin` fails and both `GITHUB_REPOSITORY` and `GITHUB_TOKEN` are missing, the deploy exits early and asks you to add an `origin` remote or supply those environment variables before re-running `npm run deploy`.
 
@@ -49,12 +49,12 @@ When the static files are published to `https://<username>.github.io/<repo>/`, t
 
 For CI (or any environment that should push automatically), export `GITHUB_TOKEN`, `GITHUB_REPOSITORY`, and (optionally) `CI=true` before running the deploy script. When those values are present, the script adds an authenticated remote URL so the push succeeds without additional setup.
 
-Running locally is zero-config in most cases as long as an `origin` remote exists—the script can infer the repository slug from `BASE_PATH`, `GITHUB_REPOSITORY`, your Git remote, or even the folder name if needed. You only need to set `BASE_PATH` manually if none of those sources are available.
+Running locally is zero-config in most cases as long as an `origin` remote exists—the script can infer the repository slug from `NEXT_PUBLIC_BASE_PATH`, `GITHUB_REPOSITORY`, your Git remote, or even the folder name if needed. You only need to set `NEXT_PUBLIC_BASE_PATH` manually if none of those sources are available.
 
-To mirror the GitHub Pages behavior in development, provide the repository slug with `BASE_PATH` while enabling the GitHub Pages flag. For example:
+To mirror the GitHub Pages behavior in development, provide the repository slug with `NEXT_PUBLIC_BASE_PATH` while enabling the GitHub Pages flag. For example:
 
 ```bash
-GITHUB_PAGES=true BASE_PATH=<repo> npm run dev
+GITHUB_PAGES=true NEXT_PUBLIC_BASE_PATH=/<repo> npm run dev
 ```
 
 Then open `http://localhost:3000/<repo>/` to load the home page under the same base path.

--- a/app/preview/pages-check/page.tsx
+++ b/app/preview/pages-check/page.tsx
@@ -1,0 +1,7 @@
+import PagesCheckClient from "./pages-check-client";
+
+export const dynamic = "force-static";
+
+export default function PagesCheckPage() {
+  return <PagesCheckClient />;
+}

--- a/app/preview/pages-check/pages-check-client.tsx
+++ b/app/preview/pages-check/pages-check-client.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import * as React from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { PageShell, SectionCard } from "@/components/ui";
+import { useBasePath } from "@/lib/base-path";
+
+export default function PagesCheckClient() {
+  const { basePath, resolveHref, resolveAsset } = useBasePath();
+  const [ready, setReady] = React.useState(false);
+
+  React.useEffect(() => {
+    setReady(true);
+  }, []);
+
+  const plannerHref = resolveHref("/planner");
+  const componentsHref = resolveHref("/components");
+  const logoSrc = resolveAsset("/planner-logo.svg");
+  const statusLabelId = "pages-check-heading";
+  const readiness = ready ? "ready" : "loading";
+
+  return (
+    <PageShell
+      as="main"
+      grid
+      aria-labelledby={statusLabelId}
+      className="min-h-screen py-[var(--space-6)] md:py-[var(--space-8)]"
+      data-pages-check={readiness}
+      data-testid="pages-check-container"
+    >
+      <SectionCard className="col-span-full">
+        <SectionCard.Header
+          id={statusLabelId}
+          title={
+            <>
+              Pages export smoke check
+              <span className="mt-[var(--spacing-0-5)] block text-label text-muted-foreground">
+                {basePath
+                  ? `Serving from \"${basePath}\"`
+                  : "Serving from the root path"}
+              </span>
+            </>
+          }
+          titleClassName="text-title font-semibold tracking-tight"
+          titleAs="h1"
+          sticky={false}
+        />
+        <SectionCard.Body className="space-y-[var(--space-4)]">
+          <p className="text-ui text-muted-foreground">
+            This route confirms that a static export works when the site lives
+            under a prefixed directory.
+          </p>
+          <dl className="grid gap-[var(--space-3)] sm:grid-cols-2">
+            <div className="space-y-[var(--space-1)]">
+              <dt className="text-label font-medium text-muted-foreground">
+                Base path
+              </dt>
+              <dd
+                className="text-ui font-semibold"
+                data-testid="pages-check-base-path"
+              >
+                {basePath || "/"}
+              </dd>
+            </div>
+            <div className="space-y-[var(--space-1)]">
+              <dt className="text-label font-medium text-muted-foreground">
+                Sample links
+              </dt>
+              <dd className="flex flex-wrap gap-[var(--space-2)] text-ui">
+                <Link
+                  href={plannerHref}
+                  className="underline decoration-dotted underline-offset-4 hover:text-foreground focus-visible:text-foreground"
+                >
+                  Planner
+                </Link>
+                <Link
+                  href={componentsHref}
+                  className="underline decoration-dotted underline-offset-4 hover:text-foreground focus-visible:text-foreground"
+                >
+                  Components
+                </Link>
+              </dd>
+            </div>
+          </dl>
+          <figure className="flex flex-wrap items-center gap-[var(--space-3)]">
+            <Image
+              src={logoSrc}
+              alt="Planner wordmark"
+              width={120}
+              height={40}
+              className="h-auto rounded-card border border-border bg-surface/80 p-[var(--space-1)] shadow-neo"
+              data-testid="pages-check-logo"
+            />
+            <figcaption className="text-label text-muted-foreground">
+              Static assets resolve through the detected base path.
+            </figcaption>
+          </figure>
+        </SectionCard.Body>
+      </SectionCard>
+    </PageShell>
+  );
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,11 +1,9 @@
 import path from "path";
 import { fileURLToPath } from "url";
+import { PHASE_EXPORT } from "next/constants";
 import { baseSecurityHeaders } from "./security-headers.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-/** @type {import('next').NextConfig} */
-const isGitHubPages = process.env.GITHUB_PAGES === "true";
 
 const sanitizeSlug = (value) => {
   const trimmed = value?.trim();
@@ -17,12 +15,10 @@ const sanitizeSlug = (value) => {
   return cleaned.length > 0 ? cleaned : undefined;
 };
 
-const envSlug = sanitizeSlug(process.env.BASE_PATH);
-const repositorySlug = sanitizeSlug(process.env.GITHUB_REPOSITORY?.split("/")[1]);
-const slug = envSlug ?? repositorySlug;
-const normalizedBasePath = slug ? `/${slug}` : undefined;
-const isUserOrOrgGitHubPage = (repositorySlug ?? slug)?.endsWith(".github.io") ?? false;
-const shouldApplyBasePath = Boolean(isGitHubPages && normalizedBasePath && !isUserOrOrgGitHubPage);
+const normalizedBasePath = (() => {
+  const slug = sanitizeSlug(process.env.NEXT_PUBLIC_BASE_PATH);
+  return slug ? `/${slug}` : "";
+})();
 
 const securityHeaders = async () => {
   return [
@@ -33,35 +29,45 @@ const securityHeaders = async () => {
   ];
 };
 
-const nextConfig = {
-  reactStrictMode: true,
-  output: isGitHubPages ? "export" : undefined,
-  basePath: shouldApplyBasePath ? normalizedBasePath : undefined,
-  assetPrefix: shouldApplyBasePath ? normalizedBasePath : undefined,
-  images: {
-    unoptimized: isGitHubPages,
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "**",
-      },
-      {
-        protocol: "http",
-        hostname: "**",
-      },
-    ],
-  },
-  env: {
-    NEXT_PUBLIC_BASE_PATH: shouldApplyBasePath ? normalizedBasePath : "",
-  },
-  webpack: (config) => {
-    config.resolve.alias["@"] = path.resolve(__dirname, "src");
-    return config;
-  },
+const resolveBasePath = () => (normalizedBasePath ? normalizedBasePath : undefined);
+
+/** @type {import('next').NextConfig} */
+const createConfig = (phase) => {
+  const isExportPhase = phase === PHASE_EXPORT;
+
+  const config = {
+    reactStrictMode: true,
+    output: "export",
+    trailingSlash: true,
+    basePath: resolveBasePath(),
+    assetPrefix: resolveBasePath(),
+    images: {
+      unoptimized: true,
+      remotePatterns: [
+        {
+          protocol: "https",
+          hostname: "**",
+        },
+        {
+          protocol: "http",
+          hostname: "**",
+        },
+      ],
+    },
+    env: {
+      NEXT_PUBLIC_BASE_PATH: normalizedBasePath,
+    },
+    webpack: (config) => {
+      config.resolve.alias["@"] = path.resolve(__dirname, "src");
+      return config;
+    },
+  };
+
+  if (!isExportPhase) {
+    config.headers = securityHeaders;
+  }
+
+  return config;
 };
 
-if (!isGitHubPages) {
-  nextConfig.headers = securityHeaders;
-}
-
-export default nextConfig;
+export default createConfig;

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Redirecting…</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      body {
+        margin: 0;
+        display: flex;
+        min-height: 100vh;
+        align-items: center;
+        justify-content: center;
+        background: #090909;
+        color: #f5f5f5;
+        padding: 2rem;
+        text-align: center;
+      }
+      main {
+        max-width: 28rem;
+      }
+      h1 {
+        font-size: 1.375rem;
+        margin-bottom: 0.75rem;
+      }
+      p {
+        margin: 0.5rem 0;
+      }
+      a {
+        color: inherit;
+        font-weight: 600;
+      }
+    </style>
+  </head>
+  <body>
+    <main role="status" aria-live="polite">
+      <h1>Redirecting you to Planner…</h1>
+      <p>If the page does not refresh, return to the Planner home.</p>
+      <p>
+        <noscript>
+          JavaScript is required for the automatic redirect. Reload the page or
+          navigate back to the home screen.
+        </noscript>
+      </p>
+    </main>
+    <script>
+      (function () {
+        try {
+          var path = window.location.pathname.replace(/404\.html$/i, "");
+          var segments = path.split("/").filter(Boolean);
+          var isUserSite = /\.github\.io$/i.test(window.location.hostname);
+          var baseSegments = isUserSite ? [] : segments.slice(0, 1);
+          var basePath = baseSegments.length ? "/" + baseSegments.join("/") : "";
+          var target = basePath + "/index.html";
+          window.location.replace(target);
+        } catch (error) {
+          console.error("Planner redirect failed", error);
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/scripts/deploy-gh-pages.ts
+++ b/scripts/deploy-gh-pages.ts
@@ -87,7 +87,7 @@ function parseRemoteSlug(remoteUrl: string): string | undefined {
 }
 
 function detectRepositorySlug(): string {
-  const basePathEnv = process.env.BASE_PATH;
+  const basePathEnv = process.env.NEXT_PUBLIC_BASE_PATH;
   if (basePathEnv !== undefined) {
     const fromEnv = sanitizeSlug(basePathEnv);
     return fromEnv ?? "";
@@ -117,7 +117,7 @@ function detectRepositorySlug(): string {
   }
 
   throw new Error(
-    "Unable to determine repository slug. Set BASE_PATH to your repository name before running this script.",
+    "Unable to determine repository slug. Set NEXT_PUBLIC_BASE_PATH to your repository name before running this script.",
   );
 }
 
@@ -197,7 +197,7 @@ function main(): void {
   const buildEnv: NodeJS.ProcessEnv = {
     ...process.env,
     GITHUB_PAGES: "true",
-    BASE_PATH: shouldUseBasePath ? slug : "",
+    NEXT_PUBLIC_BASE_PATH: basePath,
   };
 
   runCommand(npmCommand, ["run", "build"], buildEnv);

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -6,6 +6,7 @@ import {
   PageHeader,
   PageShell,
 } from "@/components/ui";
+import { withBasePath } from "@/lib/utils";
 
 export const metadata: Metadata = {
   title: "Page Not Found",
@@ -14,6 +15,7 @@ export const metadata: Metadata = {
 
 export default function NotFound() {
   const headerId = "not-found-header";
+  const homeHref = withBasePath("/");
 
   return (
     <PageShell
@@ -28,13 +30,13 @@ export default function NotFound() {
           heading: "Page not found",
           icon: <AlertCircle className="opacity-80" />,
         }}
-        hero={{
-          heading: "This page does not exist",
-          actions: (
-            <Button asChild>
-              <Link href="/">Go home</Link>
-            </Button>
-          ),
+          hero={{
+            heading: "This page does not exist",
+            actions: (
+              <Button asChild>
+                <Link href={homeHref}>Go home</Link>
+              </Button>
+            ),
           children: (
             <p className="text-ui text-muted-foreground">
               The page you are looking for does not exist.

--- a/src/app/page-client.tsx
+++ b/src/app/page-client.tsx
@@ -13,6 +13,7 @@ import { PlannerProvider } from "@/components/planner";
 import { useTheme } from "@/lib/theme-context";
 import { useThemeQuerySync } from "@/lib/theme-hooks";
 import type { Variant } from "@/lib/theme";
+import { useBasePath } from "@/lib/base-path";
 
 const weeklyHighlights = [
   {
@@ -50,6 +51,8 @@ function HomePageBody({ themeVariant }: { themeVariant: Variant }) {
   const plannerOverviewProps = useHomePlannerOverview();
   const heroHeadingId = "home-hero-heading";
   const overviewHeadingId = "home-overview-heading";
+  const { resolveHref } = useBasePath();
+  const plannerHref = resolveHref("/planner");
   const heroActions = React.useMemo<React.ReactNode>(
     () => (
       <>
@@ -61,11 +64,11 @@ function HomePageBody({ themeVariant }: { themeVariant: Variant }) {
           tactile
           className="whitespace-nowrap"
         >
-          <Link href="/planner">Plan Week</Link>
+          <Link href={plannerHref}>Plan Week</Link>
         </Button>
       </>
     ),
-    [],
+    [plannerHref],
   );
 
   return (

--- a/src/components/chrome/BottomNav.tsx
+++ b/src/components/chrome/BottomNav.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useBasePath } from "@/lib/base-path";
 import { cn, withoutBasePath } from "@/lib/utils";
 import { NAV_ITEMS, type NavItem, isNavActive } from "./nav-items";
 import Spinner from "@/components/ui/feedback/Spinner";
@@ -32,6 +33,7 @@ export default function BottomNav({
 }: BottomNavProps = {}) {
   const rawPathname = usePathname() ?? "/";
   const pathname = withoutBasePath(rawPathname);
+  const { resolveHref } = useBasePath();
 
   return (
     <nav
@@ -50,6 +52,7 @@ export default function BottomNav({
           }
 
           const active = isNavActive(pathname, href);
+          const resolvedHref = resolveHref(href);
           const disabled = Boolean(item.disabled);
           const busy = Boolean(item.busy);
           const providedState = item.state;
@@ -71,7 +74,7 @@ export default function BottomNav({
           return (
             <li key={href}>
               <Link
-                href={href}
+                href={resolvedHref}
                 aria-current={active ? "page" : undefined}
                 role="button"
                 aria-pressed={pressed || undefined}

--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -10,6 +10,7 @@ import * as React from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { motion, useReducedMotion } from "framer-motion";
+import { useBasePath } from "@/lib/base-path";
 import { cn, withoutBasePath } from "@/lib/utils";
 import { NAV_ITEMS, NavItem, isNavActive } from "./nav-items";
 
@@ -21,6 +22,7 @@ export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
   const rawPath = usePathname() ?? "/";
   const path = withoutBasePath(rawPath);
   const reduceMotion = useReducedMotion();
+  const { resolveHref } = useBasePath();
 
   return (
     <nav
@@ -31,11 +33,12 @@ export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
       <ul className="flex list-none flex-nowrap items-center justify-center gap-[var(--space-1)] md:gap-[var(--space-2)]">
         {items.map(({ href, label, mobileIcon: Icon }) => {
           const active = isNavActive(path, href);
+          const resolvedHref = resolveHref(href);
 
           return (
             <li key={href} className="relative">
               <Link
-                href={href}
+                href={resolvedHref}
                 aria-label={Icon ? label : undefined}
                 aria-current={active ? "page" : undefined}
                 data-active={active ? "true" : undefined}

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -9,6 +9,7 @@ import ThemeToggle from "@/components/ui/theme/ThemeToggle";
 import AnimationToggle from "@/components/ui/AnimationToggle";
 import { PageShell } from "@/components/ui";
 import Link from "next/link";
+import { useBasePath } from "@/lib/base-path";
 
 export type SiteChromeProps = {
   children?: React.ReactNode;
@@ -21,6 +22,9 @@ export type SiteChromeProps = {
  * - Z-index > heroes, so it stays above scrolling headers
  */
 export default function SiteChrome({ children }: SiteChromeProps) {
+  const { resolveHref } = useBasePath();
+  const homeHref = resolveHref("/");
+
   return (
     <React.Fragment>
       <header
@@ -39,7 +43,7 @@ export default function SiteChrome({ children }: SiteChromeProps) {
           />
 
           <Link
-            href="/"
+            href={homeHref}
             aria-label="Home"
             className="col-span-full flex items-center gap-[var(--space-2)] md:col-span-3"
           >

--- a/src/components/home/QuickActionGrid.tsx
+++ b/src/components/home/QuickActionGrid.tsx
@@ -3,7 +3,8 @@
 import * as React from "react";
 import Link from "next/link";
 import Button, { type ButtonProps } from "@/components/ui/primitives/Button";
-import { cn, withBasePath } from "@/lib/utils";
+import { useBasePath } from "@/lib/base-path";
+import { cn } from "@/lib/utils";
 
 type QuickActionLayout = "stacked" | "grid" | "twelveColumn" | "inline";
 
@@ -64,6 +65,8 @@ export default function QuickActionGrid({
   buttonVariant = "secondary",
   hoverLift = false,
 }: QuickActionGridProps) {
+  const { resolveHref } = useBasePath();
+
   return (
     <div className={cn(ROOT_CLASSNAME, layoutClassNames[layout], className)}>
       {actions.map((action) => {
@@ -94,7 +97,7 @@ export default function QuickActionGrid({
         const isExternal = isExternalHref(trimmedHref);
         const shouldPrefixBasePath = !isHash && !isExternal;
         const resolvedHref = shouldPrefixBasePath
-          ? withBasePath(trimmedHref)
+          ? resolveHref(trimmedHref)
           : trimmedHref;
         const {
           className: _omitClassName,

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -5,7 +5,8 @@ import type { CSSProperties } from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { motion, useReducedMotion } from "framer-motion";
 import type { HTMLMotionProps } from "framer-motion";
-import { cn, withBasePath } from "@/lib/utils";
+import { useBasePath } from "@/lib/base-path";
+import { cn } from "@/lib/utils";
 import Spinner, { type SpinnerTone, type SpinnerSize } from "../feedback/Spinner";
 import { neuRaised, neuInset } from "./Neu";
 
@@ -223,6 +224,7 @@ export const Button = React.forwardRef<
   } = props;
   const asChild = props.asChild ?? false;
   const reduceMotion = useReducedMotion();
+  const { resolveHref } = useBasePath();
   const disabledProp =
     "disabled" in props && typeof props.disabled !== "undefined"
       ? props.disabled
@@ -485,7 +487,7 @@ export const Button = React.forwardRef<
         (trimmedHref.startsWith("/") || (!hasScheme && !isProtocolRelative));
 
       resolvedHref = shouldPrefixBasePath
-        ? withBasePath(trimmedHref)
+        ? resolveHref(trimmedHref)
         : trimmedHref;
     }
 

--- a/src/lib/base-path.ts
+++ b/src/lib/base-path.ts
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { withBasePath } from "@/lib/utils";
+
+type BasePathResolvers = {
+  basePath: string;
+  resolveHref: (href: string) => string;
+  resolveAsset: (path: string) => string;
+};
+
+const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+
+const resolveWithBasePath = (value: string): string => withBasePath(value);
+
+export function useBasePath(): BasePathResolvers {
+  const basePath = React.useMemo(() => BASE_PATH, []);
+
+  const resolveHref = React.useCallback(resolveWithBasePath, [basePath]);
+  const resolveAsset = React.useCallback(resolveWithBasePath, [basePath]);
+
+  return React.useMemo(
+    () => ({
+      basePath,
+      resolveHref,
+      resolveAsset,
+    }),
+    [basePath, resolveHref, resolveAsset],
+  );
+}

--- a/tests/e2e/pages-check.spec.ts
+++ b/tests/e2e/pages-check.spec.ts
@@ -1,0 +1,74 @@
+import { test } from "@playwright/test";
+
+type CorePage = import("playwright-core").Page;
+
+const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+
+const PAGES_CHECK_ROUTE = `${BASE_PATH}/preview/pages-check`;
+const isNextAsset = (url: string) => url.includes("/_next/");
+
+test.describe("pages export smoke check", () => {
+  test("loads without 404 responses for Next.js assets", async ({ page }) => {
+    const playwrightPage = page as unknown as CorePage;
+    const navigationResponse = await playwrightPage.goto(PAGES_CHECK_ROUTE);
+    if (!navigationResponse) {
+      throw new Error("Navigation to the pages-check route failed.");
+    }
+    const navigationStatus = navigationResponse.status();
+    if (navigationStatus >= 400) {
+      throw new Error(`Navigation responded with status ${navigationStatus}.`);
+    }
+
+    await playwrightPage.waitForFunction(() => {
+      const container = document.querySelector(
+        '[data-testid="pages-check-container"]',
+      );
+      return container?.getAttribute("data-pages-check") === "ready";
+    });
+
+    const resourceUrls = await playwrightPage.evaluate(() => {
+      const scripts = Array.from(
+        document.querySelectorAll<HTMLScriptElement>("script[src]"),
+        (node) => node.getAttribute("src"),
+      );
+      const styles = Array.from(
+        document.querySelectorAll<HTMLLinkElement>(
+          'link[rel="stylesheet"][href]'
+        ),
+        (node) => node.getAttribute("href"),
+      );
+      return [...scripts, ...styles].filter(
+        (value): value is string => Boolean(value),
+      );
+    });
+
+    const nextResourceUrls = resourceUrls.filter(isNextAsset);
+    if (nextResourceUrls.length === 0) {
+      throw new Error("No Next.js resources were detected on the page.");
+    }
+
+    const request = playwrightPage.context().request;
+    const currentUrl = playwrightPage.url();
+
+    for (const href of nextResourceUrls) {
+      const absoluteUrl = new URL(href, currentUrl).toString();
+      const response = await request.get(absoluteUrl);
+      if (response.status() === 404) {
+        throw new Error(`Next.js asset returned 404: ${absoluteUrl}`);
+      }
+    }
+
+    const logoSrc = await playwrightPage
+      .locator('[data-testid="pages-check-logo"]')
+      .getAttribute("src");
+    if (!logoSrc) {
+      throw new Error("Pages check logo did not render a source attribute.");
+    }
+
+    const logoUrl = new URL(logoSrc, currentUrl).toString();
+    const logoResponse = await request.get(logoUrl);
+    if (logoResponse.status() === 404) {
+      throw new Error(`Static asset returned 404: ${logoUrl}`);
+    }
+  });
+});

--- a/tests/lib/useBasePath.test.tsx
+++ b/tests/lib/useBasePath.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH;
+
+afterEach(() => {
+  cleanup();
+  if (ORIGINAL_BASE_PATH === undefined) {
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+  } else {
+    process.env.NEXT_PUBLIC_BASE_PATH = ORIGINAL_BASE_PATH;
+  }
+  vi.resetModules();
+});
+
+describe("useBasePath", () => {
+  it("returns the root base path by default", async () => {
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+    vi.resetModules();
+    const { useBasePath } = await import("@/lib/base-path");
+    const { result } = renderHook(() => useBasePath());
+
+    expect(result.current.basePath).toBe("");
+    expect(result.current.resolveHref("/planner")).toBe("/planner");
+    expect(result.current.resolveAsset("planner-logo.svg")).toBe(
+      "/planner-logo.svg",
+    );
+  });
+
+  it("prefixes the configured base path", async () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "/beta";
+    vi.resetModules();
+    const { useBasePath } = await import("@/lib/base-path");
+    const { result } = renderHook(() => useBasePath());
+
+    expect(result.current.basePath).toBe("/beta");
+    expect(result.current.resolveHref("/planner")).toBe("/beta/planner");
+    expect(result.current.resolveAsset("planner-logo.svg")).toBe(
+      "/beta/planner-logo.svg",
+    );
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
     },
     "types": [
       "vitest/globals",
+      "@playwright/test",
       "react",
       "node"
     ],


### PR DESCRIPTION
## Summary
- normalize static exports around `NEXT_PUBLIC_BASE_PATH`, including the GitHub Pages workflow, deploy script, docs, and SPA 404 fallback
- add a shared `useBasePath` helper and migrate navigation, chrome, and call-to-action components to resolve URLs via the configured prefix
- expose a `/preview/pages-check` route with Playwright coverage plus a unit test for the base-path hook to guard prefixed assets

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68d8a67060e8832c905e6568b0d83a6f