### PR TITLE
Add helper for numeric SVG filter tokens

### DIFF
--- a/src/lib/filter-tokens.ts
+++ b/src/lib/filter-tokens.ts
@@ -1,0 +1,114 @@
+import tokens from "../../tokens/tokens.js";
+
+const FILTER_SLOPE_TOKEN = "--gradient-noise-opacity";
+const FILTER_TABLE_TOKEN = "--gradient-noise-table";
+const FILTER_STD_DEVIATION_TOKEN = "--gradient-noise-std-deviation";
+
+const numberPattern = /-?\d*\.?\d+(?:e[+-]?\d+)?/gi;
+
+const parsedGradientNoiseOpacity = Number.parseFloat(
+  tokens.gradientNoiseOpacity,
+);
+const defaultSlope = Number.isFinite(parsedGradientNoiseOpacity)
+  ? parsedGradientNoiseOpacity
+  : 0.1;
+
+const defaultTable = Object.freeze([0, 1] as const);
+const defaultStdDeviation = 0;
+
+const clampNumber = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max);
+
+const parseNumbers = (value: string): number[] => {
+  if (!value) {
+    return [];
+  }
+
+  const matches = value.match(numberPattern);
+
+  if (!matches) {
+    return [];
+  }
+
+  return matches
+    .map((segment) => Number.parseFloat(segment))
+    .filter((segment): segment is number => Number.isFinite(segment));
+};
+
+const parseNumber = (value: string): number | null => {
+  const [first] = parseNumbers(value);
+
+  if (typeof first === "number") {
+    return first;
+  }
+
+  return null;
+};
+
+export interface FilterNumericValues {
+  slope: number;
+  table: readonly number[];
+  stdDeviation: number;
+}
+
+const cloneDefaultTable = (): number[] => [...defaultTable];
+
+const getComputedValue = (token: string): string => {
+  if (typeof document === "undefined") {
+    return "";
+  }
+
+  const { documentElement } = document;
+
+  if (!documentElement) {
+    return "";
+  }
+
+  return getComputedStyle(documentElement).getPropertyValue(token).trim();
+};
+
+const numericTable = (raw: string): number[] => {
+  const parsed = parseNumbers(raw).map((entry) =>
+    clampNumber(entry, 0, 1),
+  );
+
+  if (parsed.length === 0) {
+    return cloneDefaultTable();
+  }
+
+  return parsed;
+};
+
+const numericSlope = (raw: string): number => {
+  const parsed = parseNumber(raw);
+
+  if (parsed === null) {
+    return defaultSlope;
+  }
+
+  return clampNumber(parsed, 0, 1);
+};
+
+const numericStdDeviation = (raw: string): number => {
+  const parsed = parseNumber(raw);
+
+  if (parsed === null) {
+    return defaultStdDeviation;
+  }
+
+  return clampNumber(parsed, 0, 64);
+};
+
+export const tokensToFilter = (): FilterNumericValues => {
+  const slope = numericSlope(getComputedValue(FILTER_SLOPE_TOKEN));
+  const table = numericTable(getComputedValue(FILTER_TABLE_TOKEN));
+  const stdDeviation = numericStdDeviation(
+    getComputedValue(FILTER_STD_DEVIATION_TOKEN),
+  );
+
+  return {
+    slope,
+    table,
+    stdDeviation,
+  };
+};

--- a/tests/lib/filterTokens.test.ts
+++ b/tests/lib/filterTokens.test.ts
@@ -1,0 +1,62 @@
+import tokens from "../../tokens/tokens.js";
+import { tokensToFilter } from "@/lib/filter-tokens";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("tokensToFilter", () => {
+  const getDefaultSlope = () => {
+    const parsed = Number.parseFloat(tokens.gradientNoiseOpacity);
+    return Number.isFinite(parsed) ? parsed : 0.1;
+  };
+
+  const mockComputedStyle = (values: Record<string, string>) => {
+    vi.spyOn(window, "getComputedStyle").mockImplementation(() => ({
+      getPropertyValue: (property: string) => values[property] ?? "",
+    }) as unknown as CSSStyleDeclaration);
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns numeric values from the current theme tokens", () => {
+    mockComputedStyle({
+      "--gradient-noise-opacity": "0.45",
+      "--gradient-noise-table": "0 0.25 0.75 1",
+      "--gradient-noise-std-deviation": "2.5",
+    });
+
+    const result = tokensToFilter();
+
+    expect(result.slope).toBeCloseTo(0.45);
+    expect(result.table).toEqual([0, 0.25, 0.75, 1]);
+    expect(result.stdDeviation).toBeCloseTo(2.5);
+  });
+
+  it("clamps values outside the supported range", () => {
+    mockComputedStyle({
+      "--gradient-noise-opacity": "-0.5",
+      "--gradient-noise-table": "-1 0.5 3",
+      "--gradient-noise-std-deviation": "96",
+    });
+
+    const result = tokensToFilter();
+
+    expect(result.slope).toBe(0);
+    expect(result.table).toEqual([0, 0.5, 1]);
+    expect(result.stdDeviation).toBe(64);
+  });
+
+  it("falls back to the defaults when the tokens are missing or invalid", () => {
+    mockComputedStyle({
+      "--gradient-noise-opacity": "var(--missing, )",
+      "--gradient-noise-table": "inherit",
+      "--gradient-noise-std-deviation": "",
+    });
+
+    const result = tokensToFilter();
+
+    expect(result.slope).toBeCloseTo(getDefaultSlope());
+    expect(result.table).toEqual([0, 1]);
+    expect(result.stdDeviation).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a helper that resolves CSS custom properties to numeric filter values with range clamping
- update ring noise filter defs to read theme updates via the helper and respect the SVG numeric filters flag
- cover the token parsing logic with unit tests for valid, clamped, and fallback scenarios

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d8aeb1edf0832c9323a157813ff4ed