### PR TITLE
Fix GitHub Pages routing

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -33,7 +33,12 @@ jobs:
         run: |
           set -euo pipefail
           export DEPLOY_ARTIFACT_ONLY=true
-          export NEXT_PUBLIC_BASE_PATH="/Planner"
+          REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          if [[ "${REPO_NAME}" == *.github.io ]]; then
+            export NEXT_PUBLIC_BASE_PATH=""
+          else
+            export NEXT_PUBLIC_BASE_PATH="/${REPO_NAME}"
+          fi
           npm run deploy
 
       - name: Upload static artifact

--- a/app/preview/pages-check/page.tsx
+++ b/app/preview/pages-check/page.tsx
@@ -1,0 +1,4 @@
+import Page, { metadata } from "../../../src/app/preview/pages-check/page";
+
+export { metadata };
+export default Page;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,19 +8,20 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const normalizeBasePath = (value) => {
   const trimmed = value?.trim();
   if (!trimmed) {
-    return "/";
+    return "";
   }
 
   const cleaned = trimmed.replace(/^\/+|\/+$/gu, "");
-  return cleaned ? `/${cleaned}` : "/";
+  return cleaned ? `/${cleaned}` : "";
 };
 
-const repo = process.env.NEXT_PUBLIC_BASE_PATH ?? "/Planner";
-const normalizedRepo = normalizeBasePath(repo);
+const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+const normalizedBasePathValue = normalizeBasePath(rawBasePath);
 const isExportStatic = process.env.EXPORT_STATIC === "true";
 const isProduction = process.env.NODE_ENV === "production";
-const shouldApplyBasePath = (isProduction || isExportStatic) && normalizedRepo !== "/";
-const normalizedBasePath = shouldApplyBasePath ? normalizedRepo : undefined;
+const shouldApplyBasePath = normalizedBasePathValue.length > 0;
+const nextBasePath = shouldApplyBasePath ? normalizedBasePathValue : undefined;
+const nextAssetPrefix = shouldApplyBasePath ? normalizedBasePathValue : undefined;
 
 const securityHeaders = async () => {
   return [
@@ -35,8 +36,8 @@ const nextConfig = {
   reactStrictMode: true,
   output: "export",
   trailingSlash: true,
-  basePath: normalizedBasePath,
-  assetPrefix: normalizedBasePath,
+  basePath: nextBasePath,
+  assetPrefix: nextAssetPrefix,
   images: {
     unoptimized: true,
     remotePatterns: [
@@ -51,7 +52,7 @@ const nextConfig = {
     ],
   },
   env: {
-    NEXT_PUBLIC_BASE_PATH: shouldApplyBasePath ? normalizedRepo : "",
+    NEXT_PUBLIC_BASE_PATH: normalizedBasePathValue,
   },
   webpack: (config) => {
     config.resolve.alias["@"] = path.resolve(__dirname, "src");

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Redirecting…</title>
+  </head>
+  <body>
+    <main>
+      <h1>Redirecting…</h1>
+      <p>This route falls back to the Planner single-page app.</p>
+      <p>
+        If the redirect does not start automatically,
+        <a id="pages-redirect-link" href="__BASE_PATH__/index.html">return to Planner</a>.
+      </p>
+    </main>
+    <script>
+      (function () {
+        var placeholder = "__BASE_PATH__";
+        var basePath = placeholder === "__BASE_PATH__" ? "" : placeholder;
+        if (basePath && basePath !== "/") {
+          basePath = "/" + basePath.replace(/^\/+|\/+$/g, "");
+        }
+        if (basePath === "/") {
+          basePath = "";
+        }
+        var target = (basePath || "") + "/index.html";
+        var search = window.location.search || "";
+        var hash = window.location.hash || "";
+        var fallbackLink = document.getElementById("pages-redirect-link");
+        if (fallbackLink) {
+          fallbackLink.setAttribute("href", target + search + hash);
+        }
+        window.location.replace(target + search + hash);
+      })();
+    </script>
+  </body>
+</html>

--- a/scripts/deploy-gh-pages.ts
+++ b/scripts/deploy-gh-pages.ts
@@ -184,6 +184,17 @@ function ensureNoJekyll(outDir: string): void {
   fs.writeFileSync(markerPath, "");
 }
 
+function injectBasePathIntoSpaFallback(outDir: string, basePath: string): void {
+  const fallbackPath = path.join(outDir, "404.html");
+  if (!fs.existsSync(fallbackPath)) {
+    return;
+  }
+
+  const html = fs.readFileSync(fallbackPath, "utf8");
+  const updated = html.replace(/__BASE_PATH__/gu, basePath);
+  fs.writeFileSync(fallbackPath, updated);
+}
+
 function main(): void {
   const publish = shouldPublishSite(process.env);
   assertOriginRemote(process.env, publish);
@@ -206,6 +217,7 @@ function main(): void {
   if (shouldUseBasePath) {
     flattenBasePathDirectory(outDir, slug);
   }
+  injectBasePathIntoSpaFallback(outDir, basePath);
   ensureNoJekyll(outDir);
 
   if (!publish) {

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -6,6 +6,7 @@ import {
   PageHeader,
   PageShell,
 } from "@/components/ui";
+import { withBasePath } from "@/lib/utils";
 
 export const metadata: Metadata = {
   title: "Page Not Found",
@@ -32,7 +33,7 @@ export default function NotFound() {
           heading: "This page does not exist",
           actions: (
             <Button asChild>
-              <Link href="/">Go home</Link>
+              <Link href={withBasePath("/")}>Go home</Link>
             </Button>
           ),
           children: (

--- a/src/app/page-client.tsx
+++ b/src/app/page-client.tsx
@@ -13,6 +13,7 @@ import { PlannerProvider } from "@/components/planner";
 import { useTheme } from "@/lib/theme-context";
 import { useThemeQuerySync } from "@/lib/theme-hooks";
 import type { Variant } from "@/lib/theme";
+import useBasePath from "@/lib/useBasePath";
 
 const weeklyHighlights = [
   {
@@ -50,6 +51,7 @@ function HomePageBody({ themeVariant }: { themeVariant: Variant }) {
   const plannerOverviewProps = useHomePlannerOverview();
   const heroHeadingId = "home-hero-heading";
   const overviewHeadingId = "home-overview-heading";
+  const { withBasePath } = useBasePath();
   const heroActions = React.useMemo<React.ReactNode>(
     () => (
       <>
@@ -61,11 +63,11 @@ function HomePageBody({ themeVariant }: { themeVariant: Variant }) {
           tactile
           className="whitespace-nowrap"
         >
-          <Link href="/planner">Plan Week</Link>
+          <Link href={withBasePath("/planner")}>Plan Week</Link>
         </Button>
       </>
     ),
-    [],
+    [withBasePath],
   );
 
   return (

--- a/src/app/preview/pages-check/page.tsx
+++ b/src/app/preview/pages-check/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Button, PageShell, SectionCard } from "@/components/ui";
+import HeroPortraitFrame from "@/components/home/HeroPortraitFrame";
+import { getBasePath, withBasePath } from "@/lib/utils";
+
+const basePath = getBasePath();
+const basePathLabel = basePath || "/";
+
+export const metadata: Metadata = {
+  title: "GitHub Pages routing check",
+  description: "Verifies static assets resolve correctly when the site is served from a base path.",
+};
+
+export default function PagesCheckPage() {
+  const heroImageSrc = withBasePath("/hero_image.png");
+
+  return (
+    <PageShell
+      as="section"
+      grid
+      aria-labelledby="pages-check-heading"
+      className="py-[var(--space-6)] md:py-[var(--space-8)]"
+    >
+      <SectionCard className="col-span-full md:col-span-10 md:col-start-2 lg:col-span-8 lg:col-start-3">
+        <SectionCard.Header
+          id="pages-check-heading"
+          title="GitHub Pages routing check"
+          titleAs="h1"
+          sticky={false}
+          titleClassName="text-title font-semibold tracking-[-0.01em]"
+        />
+        <SectionCard.Body className="flex flex-col items-center gap-[var(--space-4)] text-center">
+          <p className="text-ui text-muted-foreground" data-testid="base-path-value">
+            Base path resolved to <span className="font-mono text-foreground">{basePathLabel}</span>
+          </p>
+          <HeroPortraitFrame
+            frame={false}
+            imageSrc={heroImageSrc}
+            imageAlt="Illustration used to confirm static asset routing."
+            className="shadow-outline-subtle"
+          />
+          <Button asChild variant="secondary">
+            <Link href={withBasePath("/")}>Return home</Link>
+          </Button>
+        </SectionCard.Body>
+      </SectionCard>
+    </PageShell>
+  );
+}

--- a/src/components/chrome/BottomNav.tsx
+++ b/src/components/chrome/BottomNav.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn, withoutBasePath } from "@/lib/utils";
+import useBasePath from "@/lib/useBasePath";
 import { NAV_ITEMS, type NavItem, isNavActive } from "./nav-items";
 import Spinner from "@/components/ui/feedback/Spinner";
 
@@ -32,6 +33,7 @@ export default function BottomNav({
 }: BottomNavProps = {}) {
   const rawPathname = usePathname() ?? "/";
   const pathname = withoutBasePath(rawPathname);
+  const { withBasePath } = useBasePath();
 
   return (
     <nav
@@ -71,7 +73,7 @@ export default function BottomNav({
           return (
             <li key={href}>
               <Link
-                href={href}
+                href={withBasePath(href)}
                 aria-current={active ? "page" : undefined}
                 role="button"
                 aria-pressed={pressed || undefined}

--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -11,6 +11,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { motion, useReducedMotion } from "framer-motion";
 import { cn, withoutBasePath } from "@/lib/utils";
+import useBasePath from "@/lib/useBasePath";
 import { NAV_ITEMS, NavItem, isNavActive } from "./nav-items";
 
 type NavBarProps = {
@@ -21,6 +22,7 @@ export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
   const rawPath = usePathname() ?? "/";
   const path = withoutBasePath(rawPath);
   const reduceMotion = useReducedMotion();
+  const { withBasePath } = useBasePath();
 
   return (
     <nav
@@ -35,7 +37,7 @@ export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
           return (
             <li key={href} className="relative">
               <Link
-                href={href}
+                href={withBasePath(href)}
                 aria-label={Icon ? label : undefined}
                 aria-current={active ? "page" : undefined}
                 data-active={active ? "true" : undefined}

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -9,6 +9,7 @@ import ThemeToggle from "@/components/ui/theme/ThemeToggle";
 import AnimationToggle from "@/components/ui/AnimationToggle";
 import { PageShell } from "@/components/ui";
 import Link from "next/link";
+import useBasePath from "@/lib/useBasePath";
 
 export type SiteChromeProps = {
   children?: React.ReactNode;
@@ -21,6 +22,8 @@ export type SiteChromeProps = {
  * - Z-index > heroes, so it stays above scrolling headers
  */
 export default function SiteChrome({ children }: SiteChromeProps) {
+  const { withBasePath } = useBasePath();
+
   return (
     <React.Fragment>
       <header
@@ -39,7 +42,7 @@ export default function SiteChrome({ children }: SiteChromeProps) {
           />
 
           <Link
-            href="/"
+            href={withBasePath("/")}
             aria-label="Home"
             className="col-span-full flex items-center gap-[var(--space-2)] md:col-span-3"
           >

--- a/src/lib/useBasePath.ts
+++ b/src/lib/useBasePath.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import * as React from "react";
+import { getBasePath, withBasePath as resolveWithBasePath } from "@/lib/utils";
+
+type BasePathHelpers = {
+  readonly basePath: string;
+  readonly withBasePath: (path: string) => string;
+};
+
+export default function useBasePath(): BasePathHelpers {
+  const basePath = React.useMemo(() => getBasePath(), []);
+
+  const prefixWithBasePath = React.useCallback((path: string) => {
+    return resolveWithBasePath(path);
+  }, []);
+
+  return React.useMemo(
+    () => ({
+      basePath,
+      withBasePath: prefixWithBasePath,
+    }),
+    [basePath, prefixWithBasePath],
+  );
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -36,6 +36,10 @@ function normalizeBasePath(raw: string | undefined): string {
 
 const NORMALIZED_BASE = normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH);
 
+export function getBasePath(): string {
+  return NORMALIZED_BASE;
+}
+
 const ABSOLUTE_URL_PATTERN = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
 
 function isAbsoluteUrl(path: string): boolean {

--- a/tests/e2e/pages-prefix.spec.ts
+++ b/tests/e2e/pages-prefix.spec.ts
@@ -1,0 +1,81 @@
+// @ts-nocheck
+/// <reference types="@playwright/test" />
+import { test } from "playwright/test";
+
+type ResponseLike = {
+  url(): string;
+  status(): number;
+};
+
+type ResponseListeningPage = {
+  on(event: "response", listener: (response: ResponseLike) => void): void;
+  off(event: "response", listener: (response: ResponseLike) => void): void;
+};
+
+test.describe("GitHub Pages base path", () => {
+  test("serves Next.js chunks and static assets without 404s", async ({ page }) => {
+    const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+    const targetPath = `${basePath || ""}/preview/pages-check`;
+    const nextAssetStatuses: Array<{ url: string; status: number }> = [];
+    const staticAssetStatuses: Array<{ url: string; status: number }> = [];
+
+    const playwrightPage = page as unknown as any;
+    const pageWithEvents = page as unknown as ResponseListeningPage;
+    const handleResponse = (response: ResponseLike) => {
+      const url = response.url();
+      if (url.includes("/_next/")) {
+        nextAssetStatuses.push({ url, status: response.status() });
+      } else if (url.includes("/hero_image.png")) {
+        staticAssetStatuses.push({ url, status: response.status() });
+      }
+    };
+
+    pageWithEvents.on("response", handleResponse);
+
+    const response = await playwrightPage.goto(targetPath);
+    await playwrightPage.waitForLoadState("networkidle");
+
+    pageWithEvents.off("response", handleResponse);
+
+    if (!response) {
+      throw new Error(`Navigation to ${targetPath} failed`);
+    }
+
+    const responseStatus = response.status();
+    if (responseStatus !== 200 && responseStatus !== 304) {
+      throw new Error(
+        `Expected a successful navigation response but received status ${responseStatus}`,
+      );
+    }
+    if (nextAssetStatuses.length === 0) {
+      throw new Error("No Next.js chunk responses were captured");
+    }
+    if (staticAssetStatuses.length === 0) {
+      throw new Error("No static asset responses were captured");
+    }
+
+    for (const { url, status } of [...nextAssetStatuses, ...staticAssetStatuses]) {
+      if (status >= 400) {
+        throw new Error(`${url} returned ${status}`);
+      }
+    }
+
+    const basePathValue = await playwrightPage.evaluate(() => {
+      const marker = document.querySelector('[data-testid="base-path-value"]');
+      return marker ? marker.textContent : null;
+    });
+    if (!basePathValue) {
+      throw new Error("Base path marker was not rendered");
+    }
+    const normalizedValue = basePathValue;
+    if (basePath) {
+      if (!normalizedValue.includes(basePath)) {
+        throw new Error(`Expected base path marker to include ${basePath}`);
+      }
+    } else {
+      if (!normalizedValue.includes("/")) {
+        throw new Error("Expected base path marker to include root slash");
+      }
+    }
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,8 @@
     "types": [
       "vitest/globals",
       "react",
-      "node"
+      "node",
+      "@playwright/test"
     ],
     "plugins": [
       {


### PR DESCRIPTION
## Summary
- normalize the Next.js base path and asset prefix from NEXT_PUBLIC_BASE_PATH and ship an SPA-friendly 404 fallback for static exports
- add a reusable useBasePath helper and update navigation, home, and error routes to respect repository prefixes
- add a GitHub Pages preview page plus Playwright coverage, inject the base path at export time, and auto-configure the workflow base path

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d8b03f0920832c860311741350eeb3