### PR TITLE
Ensure workflow creates .nojekyll marker before Pages upload

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,6 +35,7 @@ jobs:
           export DEPLOY_ARTIFACT_ONLY=true
           export NEXT_PUBLIC_BASE_PATH="/Planner"
           npm run deploy
+          npm run ensure:nojekyll -- out
 
       - name: Upload static artifact
         uses: actions/upload-pages-artifact@6b4985b4d81eed21dc8e42f6e28eaf41b0c9fb3d # v3.0.1

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "prepare": "husky",
     "launch": "tsx scripts/launcher.ts",
     "deploy": "tsx scripts/deploy-gh-pages.ts",
+    "ensure:nojekyll": "tsx scripts/create-nojekyll.ts",
     "report:summary": "node scripts/report-summary.mjs"
   },
   "dependencies": {

--- a/scripts/create-nojekyll.ts
+++ b/scripts/create-nojekyll.ts
@@ -1,0 +1,23 @@
+import "./check-node-version.js";
+import path from "node:path";
+import process from "node:process";
+import { ensureNoJekyll } from "./utils/nojekyll.js";
+
+function main(): void {
+  const targetArg = process.argv[2] ?? "out";
+  const targetDirectory = path.resolve(targetArg);
+  ensureNoJekyll(targetDirectory);
+}
+
+if (process.env.VITEST !== "true") {
+  try {
+    main();
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(error.message);
+    } else {
+      console.error(error);
+    }
+    process.exit(1);
+  }
+}

--- a/scripts/deploy-gh-pages.ts
+++ b/scripts/deploy-gh-pages.ts
@@ -175,15 +175,6 @@ export function flattenBasePathDirectory(outDir: string, slug: string): void {
   fs.rmSync(temporaryDir, { recursive: true, force: true });
 }
 
-function ensureNoJekyll(outDir: string): void {
-  const markerPath = path.join(outDir, ".nojekyll");
-  if (fs.existsSync(markerPath)) {
-    return;
-  }
-
-  fs.writeFileSync(markerPath, "");
-}
-
 function main(): void {
   const publish = shouldPublishSite(process.env);
   assertOriginRemote(process.env, publish);
@@ -206,8 +197,6 @@ function main(): void {
   if (shouldUseBasePath) {
     flattenBasePathDirectory(outDir, slug);
   }
-  ensureNoJekyll(outDir);
-
   if (!publish) {
     console.log("Skipping gh-pages publish step");
     return;

--- a/scripts/utils/nojekyll.ts
+++ b/scripts/utils/nojekyll.ts
@@ -1,0 +1,11 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export function ensureNoJekyll(directory: string): void {
+  const markerPath = path.join(directory, ".nojekyll");
+  if (fs.existsSync(markerPath)) {
+    return;
+  }
+
+  fs.writeFileSync(markerPath, "");
+}


### PR DESCRIPTION
## Summary
- extract the .nojekyll helper into a shared utility and lightweight CLI
- call the CLI after exporting the static site so the artifact always contains the marker
- remove the redundant marker handling from the legacy deploy script

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d8b020d7e0832c9af9186b709f61f9