### PR TITLE
Add soft card surface variant

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -363,7 +363,8 @@ html.bg-intense body::after {
 @layer components {
   /* Cards: glossy neon with crisp hairlines */
   .card-neo,
-  .card-neo-soft {
+  .card-neo-soft,
+  .card-soft {
     --_r: var(--radius-card);
     border-radius: var(--_r);
     border: 0;
@@ -395,6 +396,15 @@ html.bg-intense body::after {
     backdrop-filter: blur(6px);
     border: var(--hairline-w) solid hsl(var(--card-hairline));
     box-shadow: var(--shadow-neo-soft);
+  }
+  .card-soft {
+    background: linear-gradient(
+      180deg,
+      hsl(var(--card)),
+      hsl(var(--background))
+    );
+    border: var(--hairline-w) solid hsl(var(--card-hairline));
+    box-shadow: var(--shadow-outline-subtle);
   }
   .card-neo::before,
   .card-neo-soft::before {


### PR DESCRIPTION
## Summary
- add `.card-soft` surface styling alongside existing neon card variants
- apply the card gradient, hairline border, and outline shadow for SectionCard plain surfaces

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d921c44808832c8f879ed32a0ad9f4