### PR TITLE
Align preview deploy base path setup

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -36,6 +36,12 @@ jobs:
         run: |
           set -euo pipefail
           export DEPLOY_ARTIFACT_ONLY=true
+          REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          if [[ "${REPO_NAME}" == *.github.io ]]; then
+            export NEXT_PUBLIC_BASE_PATH=""
+          else
+            export NEXT_PUBLIC_BASE_PATH="/${REPO_NAME}"
+          fi
           npm run deploy
 
       - name: Upload static artifact


### PR DESCRIPTION
## Summary
- add the repository-aware NEXT_PUBLIC_BASE_PATH export before running the preview deploy script so previews mirror pages deploys

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d924059724832cbb1cc60f7c5c6f8f