### PR TITLE
Add checkout to deploy pages workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -26,6 +26,7 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: '1'
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4.1.4
       - uses: ./.github/actions/setup-node-project
 
       - name: Export static site


### PR DESCRIPTION
## Summary
- run the Pages deployment build job against the checked-out repository

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d9262ed7bc832ca5802a8ffea3e7ef