### PR TITLE
Add checkout step to deploy preview workflow

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -29,6 +29,9 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: '1'
     steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
       - uses: ./.github/actions/setup-node-project
 
       - name: Export static preview


### PR DESCRIPTION
## Summary
- add the pinned checkout step to the deploy preview build job before initializing the Node project

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d9263039c0832cadf51825a8e11962