### PR TITLE
Rely on Next.js base path for internal navigation

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -6,7 +6,6 @@ import {
   PageHeader,
   PageShell,
 } from "@/components/ui";
-import { withBasePath } from "@/lib/utils";
 
 export const metadata: Metadata = {
   title: "Page Not Found",
@@ -33,7 +32,7 @@ export default function NotFound() {
           heading: "This page does not exist",
           actions: (
             <Button asChild>
-              <Link href={withBasePath("/")}>Go home</Link>
+              <Link href="/">Go home</Link>
             </Button>
           ),
           children: (

--- a/src/app/page-client.tsx
+++ b/src/app/page-client.tsx
@@ -13,7 +13,6 @@ import { PlannerProvider } from "@/components/planner";
 import { useTheme } from "@/lib/theme-context";
 import { useThemeQuerySync } from "@/lib/theme-hooks";
 import type { Variant } from "@/lib/theme";
-import useBasePath from "@/lib/useBasePath";
 
 const weeklyHighlights = [
   {
@@ -51,7 +50,6 @@ function HomePageBody({ themeVariant }: { themeVariant: Variant }) {
   const plannerOverviewProps = useHomePlannerOverview();
   const heroHeadingId = "home-hero-heading";
   const overviewHeadingId = "home-overview-heading";
-  const { withBasePath } = useBasePath();
   const heroActions = React.useMemo<React.ReactNode>(
     () => (
       <>
@@ -63,11 +61,11 @@ function HomePageBody({ themeVariant }: { themeVariant: Variant }) {
           tactile
           className="whitespace-nowrap"
         >
-          <Link href={withBasePath("/planner")}>Plan Week</Link>
+          <Link href="/planner">Plan Week</Link>
         </Button>
       </>
     ),
-    [withBasePath],
+    [],
   );
 
   return (

--- a/src/app/preview/pages-check/page.tsx
+++ b/src/app/preview/pages-check/page.tsx
@@ -41,7 +41,7 @@ export default function PagesCheckPage() {
             className="shadow-outline-subtle"
           />
           <Button asChild variant="secondary">
-            <Link href={withBasePath("/")}>Return home</Link>
+            <Link href="/">Return home</Link>
           </Button>
         </SectionCard.Body>
       </SectionCard>

--- a/src/components/chrome/BottomNav.tsx
+++ b/src/components/chrome/BottomNav.tsx
@@ -4,7 +4,6 @@ import * as React from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn, withoutBasePath } from "@/lib/utils";
-import useBasePath from "@/lib/useBasePath";
 import { NAV_ITEMS, type NavItem, isNavActive } from "./nav-items";
 import Spinner from "@/components/ui/feedback/Spinner";
 
@@ -33,8 +32,6 @@ export default function BottomNav({
 }: BottomNavProps = {}) {
   const rawPathname = usePathname() ?? "/";
   const pathname = withoutBasePath(rawPathname);
-  const { withBasePath } = useBasePath();
-
   return (
     <nav
       role="navigation"
@@ -73,7 +70,7 @@ export default function BottomNav({
           return (
             <li key={href}>
               <Link
-                href={withBasePath(href)}
+                href={href}
                 aria-current={active ? "page" : undefined}
                 role="button"
                 aria-pressed={pressed || undefined}

--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -11,7 +11,6 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { motion, useReducedMotion } from "framer-motion";
 import { cn, withoutBasePath } from "@/lib/utils";
-import useBasePath from "@/lib/useBasePath";
 import { NAV_ITEMS, NavItem, isNavActive } from "./nav-items";
 
 type NavBarProps = {
@@ -22,8 +21,6 @@ export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
   const rawPath = usePathname() ?? "/";
   const path = withoutBasePath(rawPath);
   const reduceMotion = useReducedMotion();
-  const { withBasePath } = useBasePath();
-
   return (
     <nav
       role="navigation"
@@ -37,7 +34,7 @@ export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
           return (
             <li key={href} className="relative">
               <Link
-                href={withBasePath(href)}
+                href={href}
                 aria-label={Icon ? label : undefined}
                 aria-current={active ? "page" : undefined}
                 data-active={active ? "true" : undefined}

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -9,7 +9,6 @@ import ThemeToggle from "@/components/ui/theme/ThemeToggle";
 import AnimationToggle from "@/components/ui/AnimationToggle";
 import { PageShell } from "@/components/ui";
 import Link from "next/link";
-import useBasePath from "@/lib/useBasePath";
 
 export type SiteChromeProps = {
   children?: React.ReactNode;
@@ -22,8 +21,6 @@ export type SiteChromeProps = {
  * - Z-index > heroes, so it stays above scrolling headers
  */
 export default function SiteChrome({ children }: SiteChromeProps) {
-  const { withBasePath } = useBasePath();
-
   return (
     <React.Fragment>
       <header
@@ -42,7 +39,7 @@ export default function SiteChrome({ children }: SiteChromeProps) {
           />
 
           <Link
-            href={withBasePath("/")}
+            href="/"
             aria-label="Home"
             className="col-span-full flex items-center gap-[var(--space-2)] md:col-span-3"
           >

--- a/src/components/home/QuickActionGrid.tsx
+++ b/src/components/home/QuickActionGrid.tsx
@@ -92,10 +92,11 @@ export default function QuickActionGrid({
         const trimmedHref = href.trim();
         const isHash = trimmedHref.startsWith("#");
         const isExternal = isExternalHref(trimmedHref);
-        const shouldPrefixBasePath = !isHash && !isExternal;
-        const resolvedHref = shouldPrefixBasePath
+        const shouldPrefixBasePathForAnchor = !isHash && !isExternal;
+        const anchorHref = shouldPrefixBasePathForAnchor
           ? withBasePath(trimmedHref)
           : trimmedHref;
+        const linkHref = trimmedHref;
         const {
           className: _omitClassName,
           target,
@@ -119,7 +120,7 @@ export default function QuickActionGrid({
 
         const childNode = isExternal || isHash ? (
           <a
-            href={resolvedHref}
+            href={anchorHref}
             target={target}
             rel={resolvedRel}
             {...(restLinkProps as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
@@ -128,7 +129,7 @@ export default function QuickActionGrid({
           </a>
         ) : (
           <Link
-            href={resolvedHref}
+            href={linkHref}
             target={target}
             rel={resolvedRel}
             {...restLinkProps}

--- a/tests/ui/ButtonBasePath.test.tsx
+++ b/tests/ui/ButtonBasePath.test.tsx
@@ -91,7 +91,7 @@ describe("Button anchor security defaults", () => {
 });
 
 describe("QuickActions base path integration", () => {
-  it("uses the base path for its internal shortcuts", async () => {
+  it("passes raw routes to Link components", async () => {
     process.env.NEXT_PUBLIC_BASE_PATH = "/beta";
     vi.resetModules();
     const { default: QuickActions } = await import(
@@ -101,14 +101,14 @@ describe("QuickActions base path integration", () => {
 
     expect(
       screen.getByRole("link", { name: "Planner Today" }),
-    ).toHaveAttribute("href", "/beta/planner");
+    ).toHaveAttribute("href", "/planner");
     expect(screen.getByRole("link", { name: "New Goal" })).toHaveAttribute(
       "href",
-      "/beta/goals?tab=goals&intent=create-goal#goal-form",
+      "/goals?tab=goals&intent=create-goal#goal-form",
     );
     expect(screen.getByRole("link", { name: "New Review" })).toHaveAttribute(
       "href",
-      "/beta/reviews?intent=create-review",
+      "/reviews?intent=create-review",
     );
   });
 });


### PR DESCRIPTION
## Summary
- stop manually prefixing internal `next/link` hrefs across navigation components and CTAs so Next.js can inject the configured `basePath`
- keep `withBasePath` for plain anchors and assets while updating unit coverage for QuickActions to assert raw routes

## Testing
- npm run check
- GITHUB_PAGES=true NEXT_PUBLIC_BASE_PATH=/Planner npm run build *(fails: Next.js export worker aborts while prerendering /preview/pages-check)*

------
https://chatgpt.com/codex/tasks/task_e_68d92351e760832ca9aabd742e4456f5