### PR TITLE
Add checkout to visual regression workflow

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -25,6 +25,9 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: '1'
     steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
       - uses: ./.github/actions/setup-node-project
         with:
           checkout-ref: ${{ inputs.branch != '' && inputs.branch || '' }}
@@ -56,6 +59,9 @@ jobs:
           - webkit
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
       - uses: ./.github/actions/setup-node-project
         with:
           checkout-ref: ${{ inputs.branch != '' && inputs.branch || '' }}


### PR DESCRIPTION
## Summary
- add the pinned actions/checkout step to the visual regression build job
- check out the repository before running the visual matrix job setup

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d926356af0832cacda90085c650d9b