### PR TITLE
Use client redirect for component section pages

### DIFF
--- a/src/app/components/[section]/page.tsx
+++ b/src/app/components/[section]/page.tsx
@@ -1,10 +1,12 @@
-import { notFound, redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 
 import {
   DEFAULT_COMPONENTS_VIEW,
   getAllComponentSlugs,
   resolveComponentsSlug,
 } from "@/components/gallery-page/slug";
+
+import { ComponentsSectionRedirect } from "./redirect-client";
 
 export { metadata } from "../page";
 
@@ -47,5 +49,5 @@ export default async function ComponentsSectionPage({
   const query = searchParams.toString();
   const target = query ? `/components?${query}` : "/components";
 
-  redirect(target);
+  return <ComponentsSectionRedirect target={target} />;
 }

--- a/src/app/components/[section]/redirect-client.tsx
+++ b/src/app/components/[section]/redirect-client.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface ComponentsSectionRedirectProps {
+  target: string;
+}
+
+export function ComponentsSectionRedirect({
+  target,
+}: ComponentsSectionRedirectProps) {
+  useEffect(() => {
+    window.location.replace(target);
+  }, [target]);
+
+  return (
+    <main aria-busy="true">
+      <p aria-live="polite" role="status">
+        Redirecting to the selected components section…
+      </p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- replace the server-side redirect in the components section route with a client redirect helper
- add an accessible fallback message while the client navigation takes effect

## Testing
- npm run check
- CI=1 npm run build *(fails: existing static export still errors when layouts read headers without `GITHUB_PAGES=true`; static preview route `/preview/pages-check` also fails outside its expected environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d929fe8b08832c9bb00bf9ae80a1d2