### PR TITLE
Restrict deploy preview workflow to main PRs

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -6,6 +6,8 @@ concurrency:
 
 on:
   pull_request:
+    branches:
+      - main
     types:
       - opened
       - synchronize


### PR DESCRIPTION
## Summary
- limit the deploy-preview workflow to pull requests targeting the main branch to avoid previews on other refs

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d92cdfe074832ca145876c99dd8d02