### PR TITLE
chore(ci): bump cache actions to maintained v4 release

### DIFF
--- a/.github/actions/setup-node-project/action.yml
+++ b/.github/actions/setup-node-project/action.yml
@@ -160,7 +160,7 @@ runs:
     - name: Restore node_modules cache
       id: restore-node-modules
       if: ${{ inputs.cache-node-modules == 'true' }}
-      uses: actions/cache/restore@v4.1.2
+      uses: actions/cache/restore@v4
       with:
         path: node_modules
         key: ${{ steps.cache-key.outputs.primary }}
@@ -174,7 +174,7 @@ runs:
 
     - name: Save node_modules cache
       if: ${{ inputs.cache-node-modules == 'true' && steps.restore-node-modules.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4.1.2
+      uses: actions/cache/save@v4
       with:
         path: node_modules
         key: ${{ steps.cache-key.outputs.primary }}

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Restore Playwright cache
         id: playwright-cache
-        uses: actions/cache/restore@v4.1.2
+        uses: actions/cache/restore@v4
         with:
           path: ~/.cache/ms-playwright
           key: visual-playwright-${{ steps.playwright-version.outputs.value }}-${{ hashFiles('package-lock.json') }}
@@ -156,7 +156,7 @@ jobs:
 
       - name: Save Playwright cache
         if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4.1.2
+        uses: actions/cache/save@v4
         with:
           path: ~/.cache/ms-playwright
           key: visual-playwright-${{ steps.playwright-version.outputs.value }}-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
## Summary
- update the setup-node-project composite action to use actions/cache@v4 for restore/save steps
- align the visual regression workflow to the maintained actions/cache@v4 steps for Playwright caches

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d92d488b98832cb3b491497f0c100e