### PR TITLE
chore: bump checkout pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -27,7 +27,7 @@ jobs:
       NEXT_TELEMETRY_DISABLED: '1'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
         with:
           fetch-depth: 2
           ref: ${{ github.ref }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -32,7 +32,7 @@ jobs:
       NEXT_TELEMETRY_DISABLED: '1'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
         with:
           fetch-depth: 2
           ref: ${{ github.ref }}

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -26,7 +26,7 @@ jobs:
       NEXT_TELEMETRY_DISABLED: '1'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
         with:
           fetch-depth: 2
           ref: ${{ inputs.branch != '' && inputs.branch || github.ref }}
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
         with:
           fetch-depth: 2
           ref: ${{ inputs.branch != '' && inputs.branch || github.ref }}


### PR DESCRIPTION
## Summary
- update all workflow checkout steps to the latest pinned SHA for actions/checkout v4.2.1

## Testing
- yamllint -d '{extends: default, rules: {line-length: {max: 200}, comments: disable, document-start: disable, truthy: disable}}' .github/workflows/ci.yml .github/workflows/deploy-pages.yml .github/workflows/deploy-preview.yml .github/workflows/visual-regression.yml
- /tmp/actionlint

------
https://chatgpt.com/codex/tasks/task_e_68d93504d80c832c84f1cd77a9a57104