### PR TITLE
Add concurrency guard to workflow lint job

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,5 +1,9 @@
 name: Workflow Lint
 
+concurrency:
+  group: workflow-lint-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
## Summary
- ensure workflow-lint workflow only runs one instance per ref by defining a concurrency group

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d93515835c832c9c0617d837ddcbcc