### PR TITLE
Fix GitHub Pages base path fallback

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -15,7 +15,10 @@ const normalizeBasePath = (value) => {
   return cleaned ? `/${cleaned}` : "";
 };
 
-const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+// Allow deploy scripts to provide BASE_PATH while still letting explicit
+// NEXT_PUBLIC_BASE_PATH override it for local overrides or previews.
+const rawBasePath =
+  process.env.NEXT_PUBLIC_BASE_PATH ?? process.env.BASE_PATH ?? "";
 const normalizedBasePathValue = normalizeBasePath(rawBasePath);
 const isExportStatic = process.env.EXPORT_STATIC === "true";
 const isProduction = process.env.NODE_ENV === "production";


### PR DESCRIPTION
## Summary
- allow the Next.js config to fall back to BASE_PATH when NEXT_PUBLIC_BASE_PATH is not provided so GitHub Pages builds pick up the repository slug

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d939b65880832ca13b3788e9d17983