### PR TITLE
fix: guard deploy preview workflow expressions

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,7 +1,7 @@
 name: Deploy Preview
 
 concurrency:
-  group: deploy-preview-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.event_name == 'pull_request' && format('deploy-preview-{0}', github.event.pull_request.number) || format('deploy-preview-{0}', github.ref) }}
   cancel-in-progress: true
 
 on:
@@ -24,7 +24,7 @@ permissions:
 jobs:
   build:
     name: Build static preview
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- gate the deploy-preview concurrency group on pull_request events before reading pull_request metadata
- guard the build job condition to avoid referencing pull_request data during other event types

## Testing
- actionlint

------
https://chatgpt.com/codex/tasks/task_e_68d93bb19a10832c84ce90353692c130