### PR TITLE
Update CI concurrency group to include workflow context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:

--- a/src/components/gallery/usage.json
+++ b/src/components/gallery/usage.json
@@ -1,7 +1,8 @@
 {
   "badge": [],
   "button": [
-    "/"
+    "/",
+    "/preview/pages-check"
   ],
   "icon-button": [],
   "segmented-button": [],
@@ -25,6 +26,7 @@
     "/components",
     "/goals",
     "/planner",
+    "/preview/pages-check",
     "/prompts",
     "/reviews",
     "/team"
@@ -70,7 +72,10 @@
   "hero-planner-cards": [
     "/"
   ],
-  "hero-portrait-frame": [],
+  "hero-portrait-frame": [
+    "/",
+    "/preview/pages-check"
+  ],
   "welcome-hero-figure": [],
   "review-surface": [],
   "review-slider-track": [],


### PR DESCRIPTION
## Summary
- expand the CI workflow concurrency group to include the workflow name, event, and ref
- rebuild gallery usage metadata so preview coverage includes the pages-check route

## Testing
- npm run check
- npm run build-gallery-usage

------
https://chatgpt.com/codex/tasks/task_e_68d93b37f078832cb8c537300c022dd2