### PR TITLE
Add prompt verification to CI and deployment workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
           if [ "$AUDIT_STATUS" -ne 0 ]; then
             echo "npm audit reported issues below the high severity threshold."
           fi
+      - name: Verify prompts registry
+        run: npm run verify-prompts
       - name: Run checks
         run: npm run check
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -34,6 +34,9 @@ jobs:
 
       - uses: ./.github/actions/setup-node-project
 
+      - name: Verify prompts registry
+        run: npm run verify-prompts
+
       - name: Export static site
         shell: bash
         run: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -39,6 +39,9 @@ jobs:
 
       - uses: ./.github/actions/setup-node-project
 
+      - name: Verify prompts registry
+        run: npm run verify-prompts
+
       - name: Export static preview
         shell: bash
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,6 @@ This file provides instructions for all contributors.
 - For long-running scripts, use the progress helpers in `src/utils/progress.ts` to display CLI progress bars.
 
 ## Testing
-- Run `npm run check` before committing; it runs `npm test`, `npm run lint`, and `npm run typecheck`.
+- Run `npm run verify-prompts` and `npm run check` before committing; `npm run check` runs `npm test`, `npm run lint`, and `npm run typecheck`.
 - Only commit when all checks pass.
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,6 @@ The script shows a progress bar and runs automatically before `npm run build`.
 
 ## Contributing
 
-- Before committing, run `npm run check` to execute tests, lint, and type checks.
+- Before committing, run `npm run verify-prompts` to confirm gallery coverage and `npm run check` to execute tests, lint, and type checks.
 - Run `npm run format` before committing to ensure code style consistency.
 - When introducing new styles or components, add them to the prompts page (`src/app/prompts/page.tsx`) so they can be previewed.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -27,9 +27,9 @@ This project standardises Node-based automation through the reusable workflow de
 
 ## Workflow usage
 
-- `ci.yml` runs linting, the design token guard (`npm run lint:design`), type-checking, and unit tests before the dedicated `next-build` job creates the production `.next` output (with audit reporting and cached `.next/cache`). That single build artefact feeds both the accessibility suite and the Playwright E2E matrix so we avoid redundant compiles.
+- `ci.yml` runs the prompt verifier (`npm run verify-prompts`), linting, the design token guard (`npm run lint:design`), type-checking, and unit tests before the dedicated `next-build` job creates the production `.next` output (with audit reporting and cached `.next/cache`). That single build artefact feeds both the accessibility suite and the Playwright E2E matrix so we avoid redundant compiles.
 - The accessibility job downloads the `next-build` artefact, verifies it before starting the server, and then exercises any tests tagged `@axe` (or the full suite when none are tagged).
-- The `Deploy Pages` workflow builds the static export on pushes to `main`, uploads the artefact for traceability, and executes the [`actions/deploy-pages`](https://github.com/actions/deploy-pages) step to publish the site.
+- The `Deploy Pages` workflow builds the static export on pushes to `main`, verifying prompts before the export, uploading the artefact for traceability, and executing the [`actions/deploy-pages`](https://github.com/actions/deploy-pages) step to publish the site.
 
 ## Manual visual regression workflow
 

--- a/docs/dependency-remediation.md
+++ b/docs/dependency-remediation.md
@@ -20,7 +20,7 @@ When the CI audit step flags vulnerable packages, follow this playbook to resolv
 
 ## 4. Verify locally
 - Run `npm audit --json` locally to ensure the vulnerability count drops to zero for high and critical severities.
-- Execute `npm run check` to confirm linting, tests, and type-checking still pass with the updated dependencies.
+- Execute `npm run verify-prompts` followed by `npm run check` to confirm gallery integrity, linting, tests, and type-checking still pass with the updated dependencies.
 
 ## 5. Document and ship
 - Capture the remediation notes (version bumps, mitigation steps, or acceptance of risk) in the pull request description.

--- a/docs/design-governance.md
+++ b/docs/design-governance.md
@@ -13,7 +13,7 @@ This guide codifies how we keep the Planner design system consistent across impl
 
 - **Cause**: Our current ESLint preset focuses on React correctness but does not guard design decisions. **Impact**: Subtle violations (e.g., manual spacing, inline colors) pass code review undetected.
 - Layer style-specific rules into `eslint.config.mjs` by composing `no-restricted-syntax` blocks that disallow literal color strings, pixel-based spacing, or importing CSS files outside the themes/tokens pipeline. Mirror the allowed vocabulary by loading the token names from `tokens/tokens.js` so the rule set evolves with the design system.
-- Keep the existing `npm run lint:design` command wired into `npm run check` (see `.github/workflows/ci.yml`). CI must continue running this task so the design lint gate always reports alongside the broader checks and blocks merges when it fails.
+- Keep the existing `npm run lint:design` command wired into `npm run check` (see `.github/workflows/ci.yml`, which now runs `npm run verify-prompts` ahead of the aggregate check). CI must continue running this task so the design lint gate always reports alongside the broader checks and blocks merges when it fails.
 - Surface actionable messages (e.g., "Use `space-5` instead of `20px`") to teach newcomers the preferred token. Pair the rule with a fixer where possible so migrations stay lightweight.
 
 ## Component gallery accountability

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -27,7 +27,7 @@ For governance and enforcement workflows, read [Design System Governance](./desi
 - Honour the shared component gallery by updating examples alongside implementation work.
 - Respect theme helpers, persistence, and reduced-motion preferences when adding interactions.
 - Preserve keyboard and screen reader affordances: semantic landmarks, labelled controls, and visible focus remain non-negotiable.
-- Keep contributions scoped and typed, running `npm run check` (tests, lint, design lint, typecheck) before requesting review.
+- Keep contributions scoped and typed, running `npm run verify-prompts` to ensure gallery entries are registered and `npm run check` (tests, lint, design lint, typecheck) before requesting review.
 
 ## Gallery previews
 

--- a/scripts/verify-prompts.ts
+++ b/scripts/verify-prompts.ts
@@ -11,15 +11,6 @@ const __dirname = path.dirname(__filename);
 const uiDir = path.resolve(__dirname, "../src/components/ui");
 const promptsDir = path.resolve(__dirname, "../src/components/prompts");
 const appPromptsDir = path.resolve(__dirname, "../src/app/prompts");
-const promptsPageFile = path.resolve(
-  __dirname,
-  "../src/app/prompts/page.tsx",
-);
-const promptsDemosFile = path.resolve(
-  __dirname,
-  "../src/components/prompts/PromptsDemos.tsx",
-);
-
 const ignoredComponents = new Set(["Split"]);
 
 type ProgressHandle = {
@@ -110,16 +101,14 @@ async function loadPromptContents(): Promise<string[]> {
 }
 
 async function verifyDemos(components: string[]): Promise<void> {
-  const [pageContent, demosContent] = await Promise.all([
-    fs.readFile(promptsPageFile, "utf8"),
-    fs.readFile(promptsDemosFile, "utf8"),
-  ]);
+  const contents = await loadPromptContents();
 
   const progress = createProgress(components.length);
   const missing: string[] = [];
 
   components.forEach((name, index) => {
-    if (!pageContent.includes(name) && !demosContent.includes(name)) {
+    const isReferenced = contents.some((content) => content.includes(name));
+    if (!isReferenced) {
       missing.push(name);
     }
     progress.update(index + 1);


### PR DESCRIPTION
## Summary
- add npm run verify-prompts to the CI checks and deployment workflows so demo coverage fails fast
- adjust the prompt verifier to scan the full prompts directory to reflect current gallery structure
- document the new verification requirement across contributor guides and repository instructions

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d93d2743fc832c8043c1491493f86e