### PR TITLE
chore: skip docs-only changes in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,17 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'CHANGELOG.md'
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'CHANGELOG.md'
 
 jobs:
   checks:


### PR DESCRIPTION
## Summary
- skip docs-only changes in the CI workflow to avoid redundant runs when only documentation updates are pushed

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d93eb45c80832cb745730344819094