### PR TITLE
Normalize GitHub Pages base path slug

### DIFF
--- a/scripts/deploy-gh-pages.ts
+++ b/scripts/deploy-gh-pages.ts
@@ -202,13 +202,14 @@ function main(): void {
   const repositorySlug = sanitizeSlug(process.env.GITHUB_REPOSITORY?.split("/").pop());
   const isUserOrOrgGitHubPage = (repositorySlug ?? slug)?.endsWith(".github.io") ?? false;
   const shouldUseBasePath = slug.length > 0 && !isUserOrOrgGitHubPage;
-  const basePath = shouldUseBasePath ? `/${slug}` : "";
-  console.log(`Deploying with base path ${basePath || "/"}`);
+  const normalizedBasePath = shouldUseBasePath ? `/${slug}` : "";
+  console.log(`Deploying with base path ${normalizedBasePath || "/"}`);
 
   const buildEnv: NodeJS.ProcessEnv = {
     ...process.env,
     GITHUB_PAGES: "true",
     BASE_PATH: shouldUseBasePath ? slug : "",
+    NEXT_PUBLIC_BASE_PATH: normalizedBasePath,
   };
 
   runCommand(npmCommand, ["run", "build"], buildEnv);
@@ -217,7 +218,7 @@ function main(): void {
   if (shouldUseBasePath) {
     flattenBasePathDirectory(outDir, slug);
   }
-  injectBasePathIntoSpaFallback(outDir, basePath);
+  injectBasePathIntoSpaFallback(outDir, normalizedBasePath);
   ensureNoJekyll(outDir);
 
   if (!publish) {

--- a/src/app/preview/pages-check/page.tsx
+++ b/src/app/preview/pages-check/page.tsx
@@ -23,14 +23,10 @@ export default function PagesCheckPage() {
       className="py-[var(--space-6)] md:py-[var(--space-8)]"
     >
       <SectionCard className="col-span-full md:col-span-10 md:col-start-2 lg:col-span-8 lg:col-start-3">
-        <SectionCard.Header
-          id="pages-check-heading"
-          title="GitHub Pages routing check"
-          titleAs="h1"
-          sticky={false}
-          titleClassName="text-title font-semibold tracking-[-0.01em]"
-        />
-        <SectionCard.Body className="flex flex-col items-center gap-[var(--space-4)] text-center">
+        <div className="section-h" id="pages-check-heading">
+          <h1 className="text-title font-semibold tracking-[-0.01em]">GitHub Pages routing check</h1>
+        </div>
+        <div className="section-b flex flex-col items-center gap-[var(--space-4)] text-center text-ui">
           <p className="text-ui text-muted-foreground" data-testid="base-path-value">
             Base path resolved to <span className="font-mono text-foreground">{basePathLabel}</span>
           </p>
@@ -43,7 +39,7 @@ export default function PagesCheckPage() {
           <Button asChild variant="secondary">
             <Link href="/">Return home</Link>
           </Button>
-        </SectionCard.Body>
+        </div>
       </SectionCard>
     </PageShell>
   );


### PR DESCRIPTION
## Summary
- derive the base path slug for GitHub Pages builds from NEXT_PUBLIC_BASE_PATH, BASE_PATH, or the repository name and apply it to Next.js basePath, assetPrefix, and runtime env
- have the deploy script export the normalized slug via NEXT_PUBLIC_BASE_PATH when building and reuse it when updating the SPA fallback
- update the GitHub Pages preview check page to inline the SectionCard header/body markup while retaining the call-to-action button

## Testing
- `npm run check`
- `NEXT_PUBLIC_BASE_PATH=/foo GITHUB_PAGES=true DEPLOY_ARTIFACT_ONLY=true npm run deploy`


------
https://chatgpt.com/codex/tasks/task_e_68d941fc0a84832cb1b2639d958ca7e9