### PR TITLE
feat: support legacy prompt verification mode

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -31,6 +31,21 @@ This project standardises Node-based automation through the reusable workflow de
 - The accessibility job downloads the `next-build` artefact, verifies it before starting the server, and then exercises any tests tagged `@axe` (or the full suite when none are tagged).
 - The `Deploy Pages` workflow builds the static export on pushes to `main`, verifying prompts before the export, uploading the artefact for traceability, and executing the [`actions/deploy-pages`](https://github.com/actions/deploy-pages) step to publish the site.
 
+## Prompt verification modes
+
+Prompt checks default to the consolidated matcher that scans every prompt file for references, but some teams still rely on the legacy behaviour that only inspects `src/app/prompts/page.tsx` and `src/components/prompts/PromptsDemos.tsx`. Opt in to the legacy pass by setting `PROMPT_CHECK_MODE=legacy` for any invocation (for example, `PROMPT_CHECK_MODE=legacy npm run verify-prompts`). When the variable is unset or holds another value the modern path runs.
+
+In GitHub Actions jobs, add the flag within the step that runs the verifier:
+
+```yaml
+- name: Verify prompt coverage (legacy)
+  run: npm run verify-prompts
+  env:
+    PROMPT_CHECK_MODE: legacy
+```
+
+The same environment variable applies to `npm run check-prompts` and downstream deployments, so Pages or custom CD pipelines can toggle modes without modifying the script itself.
+
 ## Manual visual regression workflow
 
 - Trigger the `Visual Regression` workflow from the GitHub Actions tab when you need an on-demand screenshot comparison. Provide the branch or commit you want to exercise (defaults to `main`) and, optionally, a short environment label to capture which backend or deployment you are validating.

--- a/scripts/verify-prompts-legacy.ts
+++ b/scripts/verify-prompts-legacy.ts
@@ -1,0 +1,118 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import fg from "fast-glob";
+import { MultiBar, Presets } from "cli-progress";
+
+const toFilePath =
+  typeof fileURLToPath === "function"
+    ? fileURLToPath
+    : (value: string | URL): string => {
+        const url = value instanceof URL ? value : new URL(value);
+        return decodeURIComponent(url.pathname);
+      };
+
+const __filename = toFilePath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const promptsDir = path.resolve(__dirname, "../src/components/prompts");
+const appPromptsDir = path.resolve(__dirname, "../src/app/prompts");
+const promptsPageFile = path.resolve(
+  __dirname,
+  "../src/app/prompts/page.tsx",
+);
+const promptsDemosFile = path.resolve(
+  __dirname,
+  "../src/components/prompts/PromptsDemos.tsx",
+);
+
+type LegacyOptions = {
+  readonly components: readonly string[];
+  readonly shouldVerify: boolean;
+};
+
+async function loadPromptContents(): Promise<string[]> {
+  const [appFiles, componentFiles] = await Promise.all([
+    fg("**/*.tsx", { cwd: appPromptsDir, absolute: true }),
+    fg("**/*.tsx", { cwd: promptsDir, absolute: true }),
+  ]);
+  const targets = [...appFiles, ...componentFiles];
+  return Promise.all(targets.map((file) => fs.readFile(file, "utf8")));
+}
+
+async function verifyDemos(components: readonly string[]): Promise<void> {
+  const [pageContent, demosContent] = await Promise.all([
+    fs.readFile(promptsPageFile, "utf8"),
+    fs.readFile(promptsDemosFile, "utf8"),
+  ]);
+
+  const bars = new MultiBar(
+    { clearOnComplete: false, hideCursor: true },
+    Presets.shades_grey,
+  );
+  const bar = bars.create(components.length, 0);
+  const missing: string[] = [];
+
+  components.forEach((name, index) => {
+    if (!pageContent.includes(name) && !demosContent.includes(name)) {
+      missing.push(name);
+    }
+    bar.update(index + 1);
+  });
+
+  bars.stop();
+
+  if (missing.length > 0) {
+    console.error("Missing prompt demos for components:\n" + missing.join("\n"));
+    process.exit(1);
+  }
+
+  console.log("All components have prompt demos.");
+}
+
+async function listUnreferencedComponents(
+  components: readonly string[],
+): Promise<void> {
+  const contents = await loadPromptContents();
+
+  const bars = new MultiBar(
+    { clearOnComplete: false, hideCursor: true },
+    Presets.shades_grey,
+  );
+  const bar = bars.create(components.length, 0);
+  const missing: string[] = [];
+
+  components.forEach((name, index) => {
+    if (!contents.some((content) => content.includes(name))) {
+      missing.push(name);
+    }
+    bar.update(index + 1);
+  });
+
+  bars.stop();
+
+  if (missing.length > 0) {
+    console.log("Unreferenced UI components:\n" + missing.join("\n"));
+    return;
+  }
+
+  console.log("All UI components are referenced in prompts.");
+}
+
+export async function runLegacyPromptVerification(
+  options: LegacyOptions,
+): Promise<void> {
+  const { components, shouldVerify } = options;
+
+  if (components.length === 0) {
+    console.log("No UI components found to verify.");
+    return;
+  }
+
+  if (shouldVerify) {
+    await verifyDemos(components);
+    return;
+  }
+
+  await listUnreferencedComponents(components);
+}

--- a/tests/scripts/verify-prompts.test.ts
+++ b/tests/scripts/verify-prompts.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { runPromptVerification } from "../../scripts/verify-prompts.ts";
+
+describe("verify-prompts modes", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("modern mode executes without throwing", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      runPromptVerification({ mode: "modern", argv: [] }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("legacy mode executes without throwing", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      runPromptVerification({ mode: "legacy", argv: [] }),
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- restore the historical prompt verification logic in a dedicated `scripts/verify-prompts-legacy.ts` helper and gate it behind a `PROMPT_CHECK_MODE` toggle
- update `scripts/verify-prompts.ts` to choose between modern and legacy paths, export `runPromptVerification`, and add coverage for both modes
- document the environment flag for CI/deploy workflows in `docs/ci.md`

## Testing
- npm test -- --run
- npm run lint
- npm run lint:design
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d94b71f97c832cb4ab5e8e12c333a5