### PR TITLE
ci: run eslint as dedicated workflow step

### DIFF
--- a/.github/matchers/eslint-stylish.json
+++ b/.github/matchers/eslint-stylish.json
@@ -1,0 +1,22 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "eslint-stylish",
+      "pattern": [
+        {
+          "regexp": "^([^\\s].*)$",
+          "file": 1
+        },
+        {
+          "regexp": "^\\s+(\\d+):(\\d+)\\s+(error|warning|info)\\s+(.*)\\s\\s+(.*)$",
+          "line": 1,
+          "column": 2,
+          "severity": 3,
+          "message": 4,
+          "code": 5,
+          "loop": true
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
           fi
       - name: Verify prompts registry
         run: npm run verify-prompts
+      - name: Lint
+        run: |
+          echo "::add-matcher::.github/matchers/eslint-stylish.json"
+          npm run lint:ci
       - name: Type check
         run: |
           echo "::add-matcher::.github/matchers/typescript.json"


### PR DESCRIPTION
## Summary
- add the GitHub ESLint stylish problem matcher so lint annotations appear in Actions
- run npm run lint:ci in its own workflow step to fail on warnings before type checking

## Testing
- npm run lint:ci
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d96aaa54b0832ca8bd80f8332a2c16