### PR TITLE
fix(ci): update cache action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           corepack enable
           corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
       - name: Restore Next.js cache
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
+        uses: actions/cache@v4
         with:
           path: .next/cache
           key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
## Summary
- update the CI workflow to use actions/cache v4 so the Next.js cache restore no longer relies on a deprecated revision

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d96ae70d30832caccdd7c39e5b3d6e