### PR TITLE
fix: allow planner display capture

### DIFF
--- a/security-headers.mjs
+++ b/security-headers.mjs
@@ -8,7 +8,7 @@ export const baseSecurityHeadersMap = Object.freeze({
   "Referrer-Policy": "strict-origin-when-cross-origin",
   "X-Frame-Options": "DENY",
   "X-Content-Type-Options": "nosniff",
-  "Permissions-Policy": "accelerometer=(), autoplay=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), usb=(), xr-spatial-tracking=()",
+  "Permissions-Policy": "accelerometer=(), autoplay=(), camera=(), display-capture=(self), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), usb=(), xr-spatial-tracking=()",
 });
 
 /** @type {ReadonlyArray<SecurityHeader>} */


### PR DESCRIPTION
## Summary
- allow the Planner origin to use display capture by permitting `self` in the permissions policy header

## Testing
- `npm run verify-prompts` *(fails: `tsx` not found in environment)*
- `npm run check` *(fails: `concurrently` not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9707e4450832cac9595ae2a3b941b