### PR TITLE
Fix components redirect to respect deployment base path

### DIFF
--- a/src/app/components/[section]/page.tsx
+++ b/src/app/components/[section]/page.tsx
@@ -5,6 +5,7 @@ import {
   getAllComponentSlugs,
   resolveComponentsSlug,
 } from "@/components/gallery-page/slug";
+import { withBasePath } from "@/lib/utils";
 
 import { ComponentsSectionRedirect } from "./redirect-client";
 
@@ -47,7 +48,7 @@ export default async function ComponentsSectionPage({
   }
 
   const query = searchParams.toString();
-  const target = query ? `/components?${query}` : "/components";
+  const target = withBasePath(query ? `/components?${query}` : "/components");
 
   return <ComponentsSectionRedirect target={target} />;
 }


### PR DESCRIPTION
## Summary
- prefix the components section redirect target with the deployment base path so exported builds keep working on sub-paths

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d96e4a762c832cb003bac714320a75