### PR TITLE
Fix: restore workflow lint action

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 2
 
       - name: actionlint
-        uses: reviewdog/action-actionlint@6b010412dd19bd4a70f7ee4b8df3966d08512a87 # v1.47.0
+        uses: reviewdog/action-actionlint@93dc1f9bc10856298b6cc1a3b3239cfbbb87fe4b # v1.60.1
         with:
           github_token: ${{ github.token }}
           fail_on_error: true


### PR DESCRIPTION
## Summary
- update reviewdog/action-actionlint to the latest supported commit ref (v1.60.1)

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d970269418832c92822ae8d527e351