### PR TITLE
Fix: grant cache permissions for deploy pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   build:
@@ -23,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: write
     env:
       NEXT_TELEMETRY_DISABLED: '1'
     steps:


### PR DESCRIPTION
## Summary
- allow the Deploy Pages workflow and its build job to write actions data for caches

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d970a46c70832c9396030b44e1b912