### PR TITLE
fix: allow https images in csp

### DIFF
--- a/security-headers.mjs
+++ b/security-headers.mjs
@@ -45,7 +45,7 @@ export const createContentSecurityPolicy = (nonce, options) => {
     styleSrc.push(nonceSource);
     styleSrcElem.push(nonceSource);
   }
-  const imgSrc = ["'self'", "data:"];
+  const imgSrc = ["'self'", "data:", "https:"];
   const connectSrc = ["'self'"];
 
   if (allowVercelFeedback) {


### PR DESCRIPTION
## Summary
- allow HTTPS-hosted images by adding the `https:` scheme to the CSP `img-src` directive while retaining existing self and data sources
- rely on the shared security header map so build- and runtime headers both emit the widened policy

## Testing
- npm run check
- npm run verify-prompts

------
https://chatgpt.com/codex/tasks/task_e_68d971dc15f4832c89a4a8965b0eccb7