### PR TITLE
fix: remove unsupported upload pages input

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -56,7 +56,6 @@ jobs:
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: ./out
-          if-no-files-found: error
 
   deploy:
     name: Deploy to GitHub Pages


### PR DESCRIPTION
## Summary
- remove the unsupported `if-no-files-found` input from the upload-pages-artifact step

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d97e3fb77c832c802cc342146aec8f