### PR TITLE
chore: ensure deploy preview checkout uses head sha

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -34,8 +34,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.1
         with:
-          fetch-depth: 2
-          ref: ${{ github.ref }}
+          fetch-depth: 0
+          # Use the head SHA for PRs; fall back to the workflow ref for other events.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
 
       - uses: ./.github/actions/setup-node-project
 


### PR DESCRIPTION
## Summary
- ensure the deploy preview workflow checks out the pull request head SHA when available
- fetch the full history so the head commit remains reachable on reruns

## Testing
- `npm run verify-prompts`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68d97f4af35c832ca2719536a42767b4