### PR TITLE
Normalize GitHub Pages base path handling

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,28 +5,30 @@ import { baseSecurityHeaders } from "./security-headers.mjs";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /** @type {import('next').NextConfig} */
-const normalizeBasePath = (value) => {
+const collectPathSegments = (value) => {
   const trimmed = value?.trim();
-  if (!trimmed) {
-    return "";
+  if (!trimmed || trimmed === "/") {
+    return [];
   }
 
-  const cleaned = trimmed.replace(/^\/+|\/+$/gu, "");
-  return cleaned ? `/${cleaned}` : "";
+  return trimmed
+    .split("/")
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
 };
 
-const sanitizeSlug = (value) => {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
+const normalizeBasePath = (value) => {
+  const segments = collectPathSegments(value);
+  return segments.length > 0 ? `/${segments.join("/")}` : "";
+};
 
-  const cleaned = trimmed.replace(/^\/+|\/+$/gu, "");
-  return cleaned.length > 0 ? cleaned : undefined;
+const normalizeSlug = (value) => {
+  const segments = collectPathSegments(value);
+  return segments.length > 0 ? segments.join("/") : undefined;
 };
 
 const isGitHubPages = process.env.GITHUB_PAGES === "true";
-const repositorySlug = sanitizeSlug(process.env.GITHUB_REPOSITORY?.split("/").pop());
+const repositorySlug = normalizeSlug(process.env.GITHUB_REPOSITORY?.split("/").pop());
 
 const resolveGitHubPagesSlug = () => {
   const explicitSlugSources = [process.env.NEXT_PUBLIC_BASE_PATH, process.env.BASE_PATH];
@@ -39,10 +41,10 @@ const resolveGitHubPagesSlug = () => {
         return "";
       }
 
-      const sanitized = sanitizeSlug(candidate);
+      const normalized = normalizeSlug(candidate);
 
-      if (sanitized !== undefined) {
-        return sanitized;
+      if (normalized !== undefined) {
+        return normalized;
       }
 
       return "";


### PR DESCRIPTION
## Summary
- align the Next.js base path normalizer with the shared segment-based helper to collapse duplicate slashes
- normalize GitHub Pages slugs without leading slashes so derived paths stay consistent across deployments

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d983d3ec78832c9a6e8edd0b658335