### PR TITLE
Refactor hero hero frames to CSS modules

### DIFF
--- a/src/components/home/HeroPortraitFrame.module.css
+++ b/src/components/home/HeroPortraitFrame.module.css
@@ -1,0 +1,49 @@
+.framed,
+.frameless {
+  --portrait-size: clamp(
+    calc(var(--space-7) + var(--space-1)),
+    calc(var(--space-7) + var(--space-1) + 4vw),
+    calc(var(--space-8) + var(--space-4))
+  );
+  --portrait-rim: calc(var(--space-2) / 2);
+  --portrait-glow: calc(var(--space-4) + var(--space-1));
+  --portrait-rim-gradient: conic-gradient(
+    from 140deg at 50% 50%,
+    hsl(var(--accent) / 0.88),
+    hsl(var(--accent-2) / 0.9),
+    hsl(var(--ring) / 0.85),
+    hsl(var(--accent) / 0.88)
+  );
+  --portrait-surface: hsl(var(--card) / 0.92);
+  --portrait-outline: 0 0 0 var(--hairline-w) hsl(var(--card-hairline) / 0.65);
+  --portrait-glow-gradient: radial-gradient(
+    circle at 50% 32%,
+    hsl(var(--lav-deep) / 0.55),
+    transparent 70%
+  );
+}
+
+.frameless {
+  width: var(--portrait-size);
+  height: var(--portrait-size);
+  background: var(--portrait-surface);
+  box-shadow: var(--portrait-outline);
+}
+
+.rim {
+  width: calc(var(--portrait-size) + var(--portrait-rim) * 2);
+  height: calc(var(--portrait-size) + var(--portrait-rim) * 2);
+  padding: var(--portrait-rim);
+  background: var(--portrait-rim-gradient);
+}
+
+.inner {
+  width: var(--portrait-size);
+  height: var(--portrait-size);
+  background: var(--portrait-surface);
+  box-shadow: var(--portrait-outline);
+}
+
+.glow {
+  background: var(--portrait-glow-gradient);
+}

--- a/src/components/home/HeroPortraitFrame.tsx
+++ b/src/components/home/HeroPortraitFrame.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import Image from "next/image";
 import { cn, withBasePath } from "@/lib/utils";
+import styles from "./HeroPortraitFrame.module.css";
 
 export interface HeroPortraitFrameProps {
   imageSrc: string;
@@ -10,47 +11,6 @@ export interface HeroPortraitFrameProps {
   className?: string;
   frame?: boolean;
 }
-
-type CSSVarStyle = React.CSSProperties & Record<`--${string}`, string>;
-
-const frameVariables: CSSVarStyle = {
-  "--portrait-size":
-    "clamp(calc(var(--space-7) + var(--space-1)), calc(var(--space-7) + var(--space-1) + 4vw), calc(var(--space-8) + var(--space-4)))",
-  "--portrait-rim": "calc(var(--space-2) / 2)",
-  "--portrait-glow": "calc(var(--space-4) + var(--space-1))",
-  "--portrait-rim-gradient":
-    "conic-gradient(from 140deg at 50% 50%, hsl(var(--accent) / 0.88), hsl(var(--accent-2) / 0.9), hsl(var(--ring) / 0.85), hsl(var(--accent) / 0.88))",
-  "--portrait-surface": "hsl(var(--card) / 0.92)",
-  "--portrait-outline": "0 0 0 var(--hairline-w) hsl(var(--card-hairline) / 0.65)",
-  "--portrait-glow-gradient":
-    "radial-gradient(circle at 50% 32%, hsl(var(--lav-deep) / 0.55), transparent 70%)",
-};
-
-const rimStyle: React.CSSProperties = {
-  width: "calc(var(--portrait-size) + var(--portrait-rim) * 2)",
-  height: "calc(var(--portrait-size) + var(--portrait-rim) * 2)",
-  padding: "var(--portrait-rim)",
-  background: "var(--portrait-rim-gradient)",
-};
-
-const innerStyle: React.CSSProperties = {
-  width: "var(--portrait-size)",
-  height: "var(--portrait-size)",
-  background: "var(--portrait-surface)",
-  boxShadow: "var(--portrait-outline)",
-};
-
-const framelessContainerStyle: CSSVarStyle = {
-  ...frameVariables,
-  width: innerStyle.width,
-  height: innerStyle.height,
-  background: innerStyle.background,
-  boxShadow: innerStyle.boxShadow,
-};
-
-const glowStyle: React.CSSProperties = {
-  background: "var(--portrait-glow-gradient)",
-};
 
 const defaultSizes =
   "(max-width: 640px) 104px, (max-width: 1024px) 136px, 168px";
@@ -81,10 +41,10 @@ export default function HeroPortraitFrame({
       <div
         className={cn(
           baseClassName,
+          styles.frameless,
           "overflow-hidden rounded-full shadow-neo",
           className,
         )}
-        style={framelessContainerStyle}
       >
         {portraitImage}
       </div>
@@ -92,23 +52,31 @@ export default function HeroPortraitFrame({
   }
 
   return (
-    <div className={cn(baseClassName, className)} style={frameVariables}>
+    <div
+      className={cn(baseClassName, styles.framed, className)}
+    >
       <span
         aria-hidden
-        className="pointer-events-none absolute -inset-[calc(var(--portrait-rim)*1.6)] rounded-full blur-[var(--portrait-glow)] opacity-80"
-        style={glowStyle}
+        className={cn(
+          "pointer-events-none absolute -inset-[calc(var(--portrait-rim)*1.6)] rounded-full blur-[var(--portrait-glow)] opacity-80",
+          styles.glow,
+        )}
       />
       <span
         aria-hidden
         className="glitch-rail pointer-events-none absolute -inset-[calc(var(--portrait-rim)*1.1)] rounded-full mix-blend-screen opacity-70"
       />
       <div
-        className="relative flex items-center justify-center rounded-full shadow-neo"
-        style={rimStyle}
+        className={cn(
+          "relative flex items-center justify-center rounded-full shadow-neo",
+          styles.rim,
+        )}
       >
         <div
-          className="relative flex items-center justify-center overflow-hidden rounded-full"
-          style={innerStyle}
+          className={cn(
+            "relative flex items-center justify-center overflow-hidden rounded-full",
+            styles.inner,
+          )}
         >
           {portraitImage}
         </div>

--- a/src/components/home/WelcomeHeroFigure.module.css
+++ b/src/components/home/WelcomeHeroFigure.module.css
@@ -1,0 +1,74 @@
+.framed,
+.frameless {
+  --welcome-figure-rim: calc(var(--space-2) / 1.4);
+  --welcome-figure-rim-gradient: conic-gradient(
+    from 125deg at 50% 50%,
+    hsl(var(--accent) / 0.92),
+    hsl(var(--accent-2) / 0.88),
+    hsl(var(--ring) / 0.85),
+    hsl(var(--accent) / 0.92)
+  );
+  --welcome-figure-surface: hsl(var(--card) / 0.95);
+  --welcome-figure-inner: hsl(var(--surface) / 0.88);
+  --welcome-figure-outline: 0 0 0 var(--hairline-w) hsl(var(--card-hairline) / 0.65);
+}
+
+.toneDefault {
+  --welcome-figure-glow: calc(var(--space-4) + var(--space-1));
+  --welcome-figure-primary-halo: radial-gradient(
+    circle at 52% 36%,
+    hsl(var(--accent-2) / 0.34),
+    transparent 68%
+  );
+  --welcome-figure-secondary-halo: radial-gradient(
+    circle at 34% 70%,
+    hsl(var(--accent) / 0.28),
+    transparent 74%
+  );
+  --welcome-figure-primary-opacity: 0.35;
+  --welcome-figure-secondary-opacity: 0.3;
+  --welcome-figure-primary-blur: calc(var(--welcome-figure-glow) * 0.85);
+  --welcome-figure-secondary-blur: calc(var(--welcome-figure-glow) * 0.6);
+  --welcome-figure-glitch-opacity: 0.36;
+}
+
+.toneSubtle {
+  --welcome-figure-glow: calc(var(--space-3) + var(--space-1));
+  --welcome-figure-primary-halo: radial-gradient(
+    circle at 52% 36%,
+    hsl(var(--accent-2) / 0.28),
+    transparent 64%
+  );
+  --welcome-figure-secondary-halo: radial-gradient(
+    circle at 34% 70%,
+    hsl(var(--accent) / 0.22),
+    transparent 70%
+  );
+  --welcome-figure-primary-opacity: 0.3;
+  --welcome-figure-secondary-opacity: 0.26;
+  --welcome-figure-primary-blur: calc(var(--welcome-figure-glow) * 0.7);
+  --welcome-figure-secondary-blur: calc(var(--welcome-figure-glow) * 0.5);
+  --welcome-figure-glitch-opacity: 0.18;
+}
+
+.rim {
+  padding: var(--welcome-figure-rim);
+  background: var(--welcome-figure-rim-gradient);
+}
+
+.inner {
+  background: var(--welcome-figure-surface);
+  box-shadow: var(--welcome-figure-outline);
+}
+
+.overlay {
+  background: var(--welcome-figure-inner);
+}
+
+.haloPrimary {
+  background: var(--welcome-figure-primary-halo);
+}
+
+.haloSecondary {
+  background: var(--welcome-figure-secondary-halo);
+}

--- a/src/components/home/WelcomeHeroFigure.tsx
+++ b/src/components/home/WelcomeHeroFigure.tsx
@@ -1,73 +1,10 @@
 import * as React from "react";
+import type { ComponentProps } from "react";
 import Image from "next/image";
 import { cn, withBasePath } from "@/lib/utils";
-
-type CSSVarStyle = React.CSSProperties & Record<`--${string}`, string>;
+import styles from "./WelcomeHeroFigure.module.css";
 
 type WelcomeHeroFigureTone = "default" | "subtle";
-
-const figureBaseVariables: CSSVarStyle = {
-  "--welcome-figure-rim": "calc(var(--space-2) / 1.4)",
-  "--welcome-figure-rim-gradient":
-    "conic-gradient(from 125deg at 50% 50%, hsl(var(--accent) / 0.92), hsl(var(--accent-2) / 0.88), hsl(var(--ring) / 0.85), hsl(var(--accent) / 0.92))",
-  "--welcome-figure-surface": "hsl(var(--card) / 0.95)",
-  "--welcome-figure-inner": "hsl(var(--surface) / 0.88)",
-  "--welcome-figure-outline": "0 0 0 var(--hairline-w) hsl(var(--card-hairline) / 0.65)",
-};
-
-const haloToneVariables: Record<WelcomeHeroFigureTone, CSSVarStyle> = {
-  default: {
-    "--welcome-figure-glow": "calc(var(--space-4) + var(--space-1))",
-    "--welcome-figure-primary-halo":
-      "radial-gradient(circle at 52% 36%, hsl(var(--accent-2) / 0.34), transparent 68%)",
-    "--welcome-figure-secondary-halo":
-      "radial-gradient(circle at 34% 70%, hsl(var(--accent) / 0.28), transparent 74%)",
-    "--welcome-figure-primary-opacity": "0.35",
-    "--welcome-figure-secondary-opacity": "0.3",
-    "--welcome-figure-primary-blur": "calc(var(--welcome-figure-glow) * 0.85)",
-    "--welcome-figure-secondary-blur": "calc(var(--welcome-figure-glow) * 0.6)",
-    "--welcome-figure-glitch-opacity": "0.36",
-  },
-  subtle: {
-    "--welcome-figure-glow": "calc(var(--space-3) + var(--space-1))",
-    "--welcome-figure-primary-halo":
-      "radial-gradient(circle at 52% 36%, hsl(var(--accent-2) / 0.28), transparent 64%)",
-    "--welcome-figure-secondary-halo":
-      "radial-gradient(circle at 34% 70%, hsl(var(--accent) / 0.22), transparent 70%)",
-    "--welcome-figure-primary-opacity": "0.3",
-    "--welcome-figure-secondary-opacity": "0.26",
-    "--welcome-figure-primary-blur": "calc(var(--welcome-figure-glow) * 0.7)",
-    "--welcome-figure-secondary-blur": "calc(var(--welcome-figure-glow) * 0.5)",
-    "--welcome-figure-glitch-opacity": "0.18",
-  },
-};
-
-const defaultFigureVariables: CSSVarStyle = {
-  ...figureBaseVariables,
-  ...haloToneVariables.default,
-};
-
-const rimStyle: React.CSSProperties = {
-  padding: "var(--welcome-figure-rim)",
-  background: "var(--welcome-figure-rim-gradient)",
-};
-
-const innerStyle: React.CSSProperties = {
-  background: "var(--welcome-figure-surface)",
-  boxShadow: "var(--welcome-figure-outline)",
-};
-
-const overlayStyle: React.CSSProperties = {
-  background: "var(--welcome-figure-inner)",
-};
-
-const haloPrimaryStyle: React.CSSProperties = {
-  background: "var(--welcome-figure-primary-halo)",
-};
-
-const haloSecondaryStyle: React.CSSProperties = {
-  background: "var(--welcome-figure-secondary-halo)",
-};
 
 const defaultSizes =
   "(max-width: 767px) 100vw, (max-width: 1023px) calc(100vw / 3), calc(100vw * 5 / 12)";
@@ -93,7 +30,6 @@ export default function WelcomeHeroFigure({
   showGlitchRail,
   framed = true,
 }: WelcomeHeroFigureProps) {
-  const toneVariables = haloToneVariables[haloTone];
   const shouldShowGlitchRail = framed && (showGlitchRail ?? haloTone === "default");
   const imageClassName = cn(
     "relative z-[1] object-contain object-center",
@@ -107,28 +43,33 @@ export default function WelcomeHeroFigure({
     decoding: "async" as const,
     sizes: imageSizes,
     className: imageClassName,
-  } satisfies Partial<React.ComponentProps<typeof Image>>;
+  } satisfies Partial<ComponentProps<typeof Image>>;
 
   return (
     <figure
       className={cn(
         "relative z-10 flex w-full items-center justify-center",
         framed && "isolate aspect-square rounded-full",
+        framed ? styles.framed : styles.frameless,
+        framed ? (haloTone === "default" ? styles.toneDefault : styles.toneSubtle) : null,
         className,
       )}
-      style={framed ? { ...defaultFigureVariables, ...toneVariables } : undefined}
     >
       {framed ? (
         <>
           <span
             aria-hidden
-            className="pointer-events-none absolute -inset-[calc(var(--welcome-figure-rim)*2.3)] rounded-full opacity-[var(--welcome-figure-primary-opacity)] blur-[var(--welcome-figure-primary-blur)]"
-            style={haloPrimaryStyle}
+            className={cn(
+              "pointer-events-none absolute -inset-[calc(var(--welcome-figure-rim)*2.3)] rounded-full opacity-[var(--welcome-figure-primary-opacity)] blur-[var(--welcome-figure-primary-blur)]",
+              styles.haloPrimary,
+            )}
           />
           <span
             aria-hidden
-            className="pointer-events-none absolute -inset-[calc(var(--welcome-figure-rim)*1.6)] rounded-full opacity-[var(--welcome-figure-secondary-opacity)] blur-[var(--welcome-figure-secondary-blur)]"
-            style={haloSecondaryStyle}
+            className={cn(
+              "pointer-events-none absolute -inset-[calc(var(--welcome-figure-rim)*1.6)] rounded-full opacity-[var(--welcome-figure-secondary-opacity)] blur-[var(--welcome-figure-secondary-blur)]",
+              styles.haloSecondary,
+            )}
           />
           {shouldShowGlitchRail ? (
             <span
@@ -137,17 +78,23 @@ export default function WelcomeHeroFigure({
             />
           ) : null}
           <div
-            className="relative flex h-full w-full items-center justify-center rounded-full shadow-neoSoft ring-1 ring-border/50"
-            style={rimStyle}
+            className={cn(
+              "relative flex h-full w-full items-center justify-center rounded-full shadow-neoSoft ring-1 ring-border/50",
+              styles.rim,
+            )}
           >
             <div
-              className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-full shadow-neo-inset"
-              style={innerStyle}
+              className={cn(
+                "relative flex h-full w-full items-center justify-center overflow-hidden rounded-full shadow-neo-inset",
+                styles.inner,
+              )}
             >
               <span
                 aria-hidden
-                className="pointer-events-none absolute inset-0 rounded-full"
-                style={overlayStyle}
+                className={cn(
+                  "pointer-events-none absolute inset-0 rounded-full",
+                  styles.overlay,
+                )}
               />
               <Image {...sharedImageProps} alt={imageAlt} src={resolvedHeroImageSrc} fill />
             </div>


### PR DESCRIPTION
## Summary
- move HeroPortraitFrame styling into a CSS module that encapsulates frame variables, glow, and frameless sizing
- add a WelcomeHeroFigure CSS module with tone-specific variables and apply the classes from the components to replace inline styles

## Testing
- `npm run verify-prompts`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68d988b9b4f0832c9188c62138063b15