### PR TITLE
fix: align reviews empty state typography token

### DIFF
--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -176,7 +176,7 @@ export default function ReviewsPage({
                 />
                 <p
                   id={emptySearchDescriptionId}
-                  className="text-sm text-muted-foreground md:col-span-8"
+                  className="text-ui text-muted-foreground md:col-span-8"
                 >
                   Once you create your first review, you can filter by title, tag combinations, specific opponents, or patch history.
                 </p>


### PR DESCRIPTION
## Summary
- replace the reviews empty-state helper text to use the sanctioned `text-ui` token while keeping the muted color treatment
- verified the view no longer references the raw `text-sm` utility

## Testing
- npm run check
- npm run e2e:ci *(fails: required Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d991db6f68832cb889750b4ba74bfb