### PR TITLE
fix: scope hero divider tint utilities

### DIFF
--- a/src/components/ui/layout/hero/Hero.module.css
+++ b/src/components/ui/layout/hero/Hero.module.css
@@ -1,0 +1,11 @@
+.divider {
+  --divider: var(--ring);
+}
+
+.divider[data-divider-tint="life"] {
+  --divider: var(--accent-3);
+}
+
+.divider[data-divider-tint="primary"] {
+  --divider: var(--ring);
+}

--- a/src/components/ui/layout/hero/Hero.tsx
+++ b/src/components/ui/layout/hero/Hero.tsx
@@ -114,7 +114,6 @@ function Hero<Key extends string = string>({
     shouldRenderGlitchStyles,
     isRaisedBar,
     showDividerGlow,
-    dividerStyle,
     classes,
   } = useHeroStyles({
     frame,
@@ -124,7 +123,6 @@ function Hero<Key extends string = string>({
     barVariant,
     tone,
     glitch,
-    dividerTint,
   });
 
   const iconNode = icon ? (
@@ -244,7 +242,10 @@ function Hero<Key extends string = string>({
           <div className={classes.body}>
             {children ? <div className={cn(bodyClassName)}>{children}</div> : null}
             {searchProps || actions ? (
-              <div className="relative" style={dividerStyle}>
+              <div
+                className={cn("relative", classes.divider)}
+                data-divider-tint={dividerTint}
+              >
                 <span aria-hidden className={classes.dividerLine} />
                 {showDividerGlow ? (
                   <span aria-hidden className={classes.dividerGlow} />

--- a/src/components/ui/layout/hero/useHeroStyles.ts
+++ b/src/components/ui/layout/hero/useHeroStyles.ts
@@ -5,6 +5,7 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 import type { TabBarProps } from "../TabBar";
+import styles from "./Hero.module.css";
 
 type HeroTabVariant = Extract<TabBarProps["variant"], "neo">;
 
@@ -16,7 +17,6 @@ export interface HeroStyleOptions {
   barVariant: "flat" | "raised";
   tone: "heroic" | "supportive";
   glitch: "default" | "subtle" | "off";
-  dividerTint: "primary" | "life";
 }
 
 export interface HeroStyleResult {
@@ -25,7 +25,6 @@ export interface HeroStyleResult {
   isRaisedBar: boolean;
   showRail: boolean;
   showDividerGlow: boolean;
-  dividerStyle: React.CSSProperties;
   classes: {
     shell: string;
     bar: string;
@@ -42,6 +41,7 @@ export interface HeroStyleResult {
     rail: string;
     dividerLine: string;
     dividerGlow: string;
+    divider: string;
   };
 }
 
@@ -54,7 +54,6 @@ export function useHeroStyles(options: HeroStyleOptions): HeroStyleResult {
     barVariant,
     tone,
     glitch,
-    dividerTint,
   } = options;
 
   return React.useMemo(() => {
@@ -67,10 +66,6 @@ export function useHeroStyles(options: HeroStyleOptions): HeroStyleResult {
     const isRaisedBar = barVariant === "raised";
     const showRail = false;
     const showDividerGlow = frame && !isGlitchOff;
-    const dividerStyle = {
-      "--divider": dividerTint === "life" ? "var(--accent-3)" : "var(--ring)",
-    } as React.CSSProperties;
-
     const stickyClasses = sticky ? cn("sticky sticky-blur", topClassName) : "";
 
     const shellPadding =
@@ -192,7 +187,6 @@ export function useHeroStyles(options: HeroStyleOptions): HeroStyleResult {
       isRaisedBar,
       showRail,
       showDividerGlow,
-      dividerStyle,
       classes: {
         shell,
         bar,
@@ -209,6 +203,7 @@ export function useHeroStyles(options: HeroStyleOptions): HeroStyleResult {
         rail: railClassName,
         dividerLine,
         dividerGlow,
+        divider: styles.divider,
       },
     } satisfies HeroStyleResult;
   }, [
@@ -219,7 +214,6 @@ export function useHeroStyles(options: HeroStyleOptions): HeroStyleResult {
     barVariant,
     tone,
     glitch,
-    dividerTint,
   ]);
 }
 

--- a/tests/components/PageHeader.test.tsx
+++ b/tests/components/PageHeader.test.tsx
@@ -121,12 +121,10 @@ describe("PageHeader", () => {
     const actionButton = screen.getByRole("button", {
       name: "Primary action",
     });
-    const dividerContainer = actionButton.closest("div[style]");
+    const dividerContainer = actionButton.closest("div[data-divider-tint]");
 
     expect(dividerContainer).not.toBeNull();
-    expect(
-      (dividerContainer as HTMLElement).style.getPropertyValue("--divider"),
-    ).toBe("var(--accent-3)");
+    expect((dividerContainer as HTMLElement).dataset.dividerTint).toBe("life");
   });
 
   it("applies the primary tint to the hero slot divider by default", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,9 @@
       ],
       "ast-types/*": [
         "types/ast-types/*"
+      ],
+      "postcss-import": [
+        "types/postcss-import"
       ]
     },
     "types": [

--- a/types/postcss-import/index.d.ts
+++ b/types/postcss-import/index.d.ts
@@ -1,0 +1,31 @@
+import type { AcceptedPlugin, PluginCreator } from "postcss";
+
+declare module "postcss-import" {
+  interface PostcssImportOptions {
+    root?: string;
+    path?: string | string[];
+    skipDuplicates?: boolean;
+    addModulesDirectories?: string[];
+    plugins?: AcceptedPlugin[];
+    filter?: (id: string) => boolean;
+    load?: (
+      filename: string,
+      options?: { root: string; from: string }
+    ) => string | Promise<string>;
+    resolve?: (
+      id: string,
+      basedir: string,
+      options: { root: string; from: string }
+    ) =>
+      | string
+      | string[]
+      | Promise<string>
+      | Promise<string[]>;
+    onImport?: (sources: string[]) => void;
+  }
+
+  const postcssImport: PluginCreator<PostcssImportOptions>;
+
+  export type { PostcssImportOptions };
+  export default postcssImport;
+}


### PR DESCRIPTION
## Summary
- replace inline hero divider tint styles with a data attribute and module-scoped class so glow colors stay on tokens
- add hero divider tint utilities and update tests to assert the new attribute pipeline
- expose the divider scope class through useHeroStyles and provide local typings for postcss-import

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d990fd4cdc832ca46c2850828364be