### PR TITLE
fix: move brand wordmark glow to css module

### DIFF
--- a/src/components/chrome/BrandWordmark.module.css
+++ b/src/components/chrome/BrandWordmark.module.css
@@ -1,0 +1,33 @@
+.root {
+  text-shadow: 0 0 var(--space-2) hsl(var(--accent) / 0.35);
+}
+
+.root::after {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  inset: calc(-1 * var(--space-1));
+  z-index: -1;
+  border-radius: var(--radius-full);
+  background: radial-gradient(
+    120% 120% at 50% 50%,
+    hsl(var(--accent) / 0.22),
+    transparent 70%
+  );
+  opacity: 0.75;
+}
+
+@supports ((background-clip: text) or (-webkit-background-clip: text)) {
+  .root {
+    background-image: linear-gradient(120deg, hsl(var(--accent)), hsl(var(--accent-2)));
+    background-clip: text;
+    -webkit-background-clip: text;
+    color: transparent;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .root::after {
+    display: none;
+  }
+}

--- a/src/components/chrome/BrandWordmark.tsx
+++ b/src/components/chrome/BrandWordmark.tsx
@@ -2,33 +2,24 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
+import styles from "./BrandWordmark.module.css";
 
 type BrandWordmarkProps = React.ComponentPropsWithoutRef<"span">;
-
-const glowStyle = {
-  textShadow: "0 0 var(--space-2) hsl(var(--accent) / 0.35)",
-} as const;
 
 export default function BrandWordmark({
   className,
   children = "noxi",
-  style,
   ...props
 }: BrandWordmarkProps) {
   return (
     <span
       {...props}
       className={cn(
+        styles.root,
         "relative inline-flex items-center font-semibold leading-none text-ui md:text-title",
         "tracking-[0.08em] text-foreground",
-        "supports-[background-clip:text]:bg-[linear-gradient(120deg,hsl(var(--accent)),hsl(var(--accent-2)))] supports-[background-clip:text]:bg-clip-text supports-[background-clip:text]:text-transparent",
-        "after:pointer-events-none after:absolute after:-inset-[var(--space-1)] after:-z-10 after:rounded-full after:bg-[radial-gradient(120%_120%_at_50%_50%,hsl(var(--accent)/0.22),transparent_70%)] after:opacity-75 after:content-[''] motion-reduce:after:hidden",
         className,
       )}
-      style={{
-        ...glowStyle,
-        ...style,
-      }}
     >
       {children}
     </span>

--- a/types/postcss-import.d.ts
+++ b/types/postcss-import.d.ts
@@ -1,0 +1,1 @@
+declare module "postcss-import";


### PR DESCRIPTION
## Summary
- move the BrandWordmark glow/gradient rules into a CSS module backed by accent tokens
- leave the React component using the module while still honouring external className/style props
- add a stub type declaration for `postcss-import` so the nonce/typecheck pipeline stays green

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d990fb5dc8832c838b26867799e6bf