### PR TITLE
fix: support data-driven hero divider tint

### DIFF
--- a/src/components/ui/layout/NeomorphicFrameStyles.tsx
+++ b/src/components/ui/layout/NeomorphicFrameStyles.tsx
@@ -58,6 +58,16 @@ export function NeomorphicFrameStyles() {
       .hero2-neomorph::after {
         background: var(--hero2-glow-bottom-right);
       }
+      .hero2-frame[data-hero-divider-tint="primary"] {
+        --hero-slot-divider: var(--ring);
+        --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
+          hsl(var(--ring) / 0.45);
+      }
+      .hero2-frame[data-hero-divider-tint="life"] {
+        --hero-slot-divider: var(--accent-3);
+        --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
+          hsl(var(--accent-3) / 0.42);
+      }
       @supports (
         color: color-mix(
           in oklab,
@@ -92,6 +102,22 @@ export function NeomorphicFrameStyles() {
             hsl(var(--shadow-color)) 28%,
             hsl(var(--background) / 0)
           );
+        }
+        .hero2-frame[data-hero-divider-tint="primary"] {
+          --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
+            color-mix(
+              in oklab,
+              hsl(var(--ring)) 68%,
+              hsl(var(--background))
+            );
+        }
+        .hero2-frame[data-hero-divider-tint="life"] {
+          --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
+            color-mix(
+              in oklab,
+              hsl(var(--accent-3)) 78%,
+              hsl(var(--background))
+            );
         }
       }
       @media (prefers-contrast: more) {
@@ -128,6 +154,10 @@ export function NeomorphicFrameStyles() {
           --hero2-focus-ring-active: 0 0 0 calc(var(--hairline-w) * 2)
             CanvasText,
             0 0 0 0 CanvasText;
+        }
+        .hero2-frame[data-hero-divider-tint] {
+          --hero-slot-divider: CanvasText !important;
+          --hero-slot-divider-shadow: none !important;
         }
       }
     `}</style>

--- a/src/components/ui/layout/NeomorphicHeroFrame.tsx
+++ b/src/components/ui/layout/NeomorphicHeroFrame.tsx
@@ -40,6 +40,7 @@ export interface NeomorphicHeroFrameProps
   labelledById?: string;
   slots?: HeroSlots | null;
   children?: React.ReactNode;
+  "data-hero-divider-tint"?: "primary" | "life";
 }
 
 type VariantSlotConfig = {
@@ -335,6 +336,17 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
   ) => {
     const Component = (as ?? "div") as FrameElement;
     const Comp = Component as React.ElementType;
+    const {
+      ["data-hero-divider-tint"]: heroDividerTintAttr,
+      ...restWithoutDividerTint
+    } = rest;
+    const sanitizedFrameDividerTint =
+      heroDividerTintAttr === "life"
+        ? "life"
+        : heroDividerTintAttr === "primary"
+        ? "primary"
+        : undefined;
+    const frameDividerTint = sanitizedFrameDividerTint ?? "primary";
     const variantStyles =
       variant !== "unstyled" ? variantMap[variant] : undefined;
     const [hasFocus, setHasFocus] = React.useState(false);
@@ -436,7 +448,7 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
           variantStyles?.slot.gapMd,
           "md:grid-cols-12",
           "before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-[hsl(var(--hero-slot-divider,var(--ring)))] before:opacity-60 before:content-['']",
-          "after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-px after:bg-[hsl(var(--hero-slot-divider,var(--ring)))] after:opacity-40 after:[filter:blur(var(--hero-divider-blur,calc(var(--spacing-1)*1.5)))] after:content-['']",
+          "after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-px after:bg-[hsl(var(--hero-slot-divider,var(--ring)))] after:opacity-40 after:[filter:blur(var(--hero-divider-blur,calc(var(--spacing-1)*1.5)))] after:shadow-[var(--hero-slot-divider-shadow,0_0_0_calc(var(--hairline-w)*3)_hsl(var(--ring)/0.45))] after:content-['']",
         )}
         data-align={align}
       >
@@ -481,7 +493,7 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
         {variant !== "unstyled" ? <NeomorphicFrameStyles /> : null}
         <Comp
           ref={ref}
-          {...rest}
+          {...restWithoutDividerTint}
           className={cn(
             "group/hero-frame relative z-0 isolate flex flex-col overflow-visible hero-focus",
             variantStyles
@@ -504,6 +516,7 @@ const NeomorphicHeroFrame = React.forwardRef<HTMLElement, NeomorphicHeroFramePro
           tabIndex={tabIndex ?? -1}
           onFocusCapture={handleFocusCapture}
           onBlurCapture={handleBlurCapture}
+          data-hero-divider-tint={frameDividerTint}
         >
           {resolvedChildren}
           {slotArea}

--- a/src/components/ui/layout/PageHeader.tsx
+++ b/src/components/ui/layout/PageHeader.tsx
@@ -121,7 +121,12 @@ export interface PageHeaderBaseProps<
   className?: string;
   /** Optional className for the semantic wrapper */
   containerClassName?: string;
-  /** Additional props for the outer frame */
+  /**
+   * Additional props for the outer frame.
+   *
+   * To override the hero divider tint without relying on inline styles,
+   * supply a `data-hero-divider-tint` attribute.
+   */
   frameProps?: NeomorphicHeroFrameProps;
   /** Optional className for the inner content wrapper */
   contentClassName?: string;
@@ -256,17 +261,18 @@ const PageHeaderInner = <
     label: frameLabel,
     labelledById: frameLabelledById,
     style: frameStyle,
+    ["data-hero-divider-tint"]: frameDividerTintAttr,
     ...restFrameProps
   } = frameProps ?? {};
 
-  const frameStyleWithDivider = React.useMemo<React.CSSProperties>(() => {
-    const heroSlotDividerColor =
-      heroDividerTint === "life" ? "var(--accent-3)" : "var(--ring)";
-    return {
-      ...(frameStyle ?? {}),
-      "--hero-slot-divider": heroSlotDividerColor,
-    } as React.CSSProperties;
-  }, [frameStyle, heroDividerTint]);
+  const normalizedFrameDividerTint =
+    frameDividerTintAttr === "life"
+      ? "life"
+      : frameDividerTintAttr === "primary"
+      ? "primary"
+      : undefined;
+
+  const resolvedFrameDividerTint = normalizedFrameDividerTint ?? heroDividerTint;
 
   const heroShouldRenderActionArea = frameSlotsProp === null;
   const heroShouldRenderTabs = heroShouldRenderActionArea || tabsInHero;
@@ -603,8 +609,9 @@ const PageHeaderInner = <
           : {})}
         label={frameLabel}
         labelledById={frameLabelledById}
-        style={frameStyleWithDivider}
+        data-hero-divider-tint={resolvedFrameDividerTint}
         {...restFrameProps}
+        style={frameStyle}
         className={cn(className, frameClassName)}
       >
         <div

--- a/tests/components/PageHeader.test.tsx
+++ b/tests/components/PageHeader.test.tsx
@@ -139,9 +139,7 @@ describe("PageHeader", () => {
     ) as HTMLElement | null;
 
     expect(frame).not.toBeNull();
-    expect(
-      (frame as HTMLElement).style.getPropertyValue("--hero-slot-divider"),
-    ).toBe("var(--ring)");
+    expect(frame).toHaveAttribute("data-hero-divider-tint", "primary");
   });
 
   it("switches the hero slot divider tint when the life palette is active", () => {
@@ -160,10 +158,94 @@ describe("PageHeader", () => {
     ) as HTMLElement | null;
 
     expect(frame).not.toBeNull();
-    expect(
-      (frame as HTMLElement).style.getPropertyValue("--hero-slot-divider"),
-    ).toBe("var(--accent-3)");
+    expect(frame).toHaveAttribute("data-hero-divider-tint", "life");
   });
+
+  it("preserves caller-provided frameProps.style overrides", () => {
+    const { container } = render(
+      <PageHeader
+        header={baseHeader}
+        hero={baseHero}
+        frameProps={{ style: { outline: "1px solid rgb(255, 0, 0)" } }}
+      />,
+    );
+
+    const frame = container.querySelector(
+      "[data-variant='default']",
+    ) as HTMLElement | null;
+
+    expect(frame).not.toBeNull();
+    expect(frame?.style.outline).toBe("1px solid rgb(255, 0, 0)");
+    expect(frame).toHaveAttribute("data-hero-divider-tint", "primary");
+  });
+
+  it("allows frameProps to override the hero divider tint attribute", () => {
+    const { container } = render(
+      <PageHeader
+        header={baseHeader}
+        hero={{
+          ...baseHero,
+          dividerTint: "life",
+        }}
+        frameProps={{ "data-hero-divider-tint": "primary" }}
+      />,
+    );
+
+    const frame = container.querySelector(
+      "[data-variant='default']",
+    ) as HTMLElement | null;
+
+    expect(frame).not.toBeNull();
+    expect(frame).toHaveAttribute("data-hero-divider-tint", "primary");
+  });
+
+  it.each([
+    ["default"],
+    ["compact"],
+    ["dense"],
+  ] as const)(
+    "keeps divider tint attributes when hero slots render for %s variant",
+    (variant) => {
+      const { container } = render(
+        <PageHeader
+          header={baseHeader}
+          hero={{
+            ...baseHero,
+            dividerTint: "life",
+            subTabs: {
+              items: [
+                { key: "roadmap", label: "Roadmap" },
+                { key: "updates", label: "Updates" },
+              ],
+              value: "roadmap",
+              onChange: vi.fn(),
+              ariaLabel: "Hero filters",
+            },
+            search: {
+              value: "",
+              onValueChange: () => {},
+              "aria-label": "Search hero content",
+            },
+            actions: <button type="button">Primary action</button>,
+          }}
+          frameProps={{ variant }}
+        />,
+      );
+
+      const frame = container.querySelector(
+        `[data-variant='${variant}']`,
+      ) as HTMLElement | null;
+      const slotGroup = container.querySelector(
+        "div[data-align]",
+      ) as HTMLElement | null;
+
+      expect(frame).not.toBeNull();
+      expect(frame).toHaveAttribute("data-hero-divider-tint", "life");
+      expect(slotGroup).not.toBeNull();
+      const slots = (slotGroup as HTMLElement).querySelectorAll("[data-slot]");
+      expect(slots).toHaveLength(3);
+    },
+  );
 
   it("balances header text when titles span multiple lines", () => {
     const wrappingHeading =

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -63,6 +63,16 @@ exports[`ReviewsPage > renders default state 1`] = `
       .hero2-neomorph::after {
         background: var(--hero2-glow-bottom-right);
       }
+      .hero2-frame[data-hero-divider-tint="primary"] {
+        --hero-slot-divider: var(--ring);
+        --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
+          hsl(var(--ring) / 0.45);
+      }
+      .hero2-frame[data-hero-divider-tint="life"] {
+        --hero-slot-divider: var(--accent-3);
+        --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
+          hsl(var(--accent-3) / 0.42);
+      }
       @supports (
         color: color-mix(
           in oklab,
@@ -97,6 +107,22 @@ exports[`ReviewsPage > renders default state 1`] = `
             hsl(var(--shadow-color)) 28%,
             hsl(var(--background) / 0)
           );
+        }
+        .hero2-frame[data-hero-divider-tint="primary"] {
+          --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
+            color-mix(
+              in oklab,
+              hsl(var(--ring)) 68%,
+              hsl(var(--background))
+            );
+        }
+        .hero2-frame[data-hero-divider-tint="life"] {
+          --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
+            color-mix(
+              in oklab,
+              hsl(var(--accent-3)) 78%,
+              hsl(var(--background))
+            );
         }
       }
       @media (prefers-contrast: more) {
@@ -134,13 +160,17 @@ exports[`ReviewsPage > renders default state 1`] = `
             CanvasText,
             0 0 0 0 CanvasText;
         }
+        .hero2-frame[data-hero-divider-tint] {
+          --hero-slot-divider: CanvasText !important;
+          --hero-slot-divider-shadow: none !important;
+        }
       }
     
       </style>
       <div
         class="group/hero-frame relative z-0 isolate flex flex-col overflow-visible hero-focus border border-border/55 bg-card/70 text-foreground shadow-outline-subtle hero2-frame hero2-neomorph before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:rounded-[inherit] before:transition before:duration-slow before:ease-out before:content-[''] motion-reduce:before:transition-none has-[:focus-visible]:before:[--hero2-focus-ring:var(--hero2-focus-ring-active)] data-[has-focus=true]:before:[--hero2-focus-ring:var(--hero2-focus-ring-active)] rounded-card r-card-lg px-[var(--space-6)] py-[var(--space-6)] md:px-[var(--space-7)] md:py-[var(--space-7)] lg:px-[var(--space-8)] lg:py-[var(--space-8)]"
+        data-hero-divider-tint="primary"
         data-variant="default"
-        style="--hero-slot-divider: var(--ring);"
         tabindex="-1"
       >
         <div
@@ -261,6 +291,16 @@ exports[`ReviewsPage > renders default state 1`] = `
       .hero2-neomorph::after {
         background: var(--hero2-glow-bottom-right);
       }
+      .hero2-frame[data-hero-divider-tint="primary"] {
+        --hero-slot-divider: var(--ring);
+        --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
+          hsl(var(--ring) / 0.45);
+      }
+      .hero2-frame[data-hero-divider-tint="life"] {
+        --hero-slot-divider: var(--accent-3);
+        --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
+          hsl(var(--accent-3) / 0.42);
+      }
       @supports (
         color: color-mix(
           in oklab,
@@ -295,6 +335,22 @@ exports[`ReviewsPage > renders default state 1`] = `
             hsl(var(--shadow-color)) 28%,
             hsl(var(--background) / 0)
           );
+        }
+        .hero2-frame[data-hero-divider-tint="primary"] {
+          --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
+            color-mix(
+              in oklab,
+              hsl(var(--ring)) 68%,
+              hsl(var(--background))
+            );
+        }
+        .hero2-frame[data-hero-divider-tint="life"] {
+          --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
+            color-mix(
+              in oklab,
+              hsl(var(--accent-3)) 78%,
+              hsl(var(--background))
+            );
         }
       }
       @media (prefers-contrast: more) {
@@ -331,6 +387,10 @@ exports[`ReviewsPage > renders default state 1`] = `
           --hero2-focus-ring-active: 0 0 0 calc(var(--hairline-w) * 2)
             CanvasText,
             0 0 0 0 CanvasText;
+        }
+        .hero2-frame[data-hero-divider-tint] {
+          --hero-slot-divider: CanvasText !important;
+          --hero-slot-divider-shadow: none !important;
         }
       }
     

--- a/tests/ui/NeomorphicHeroFrame.test.tsx
+++ b/tests/ui/NeomorphicHeroFrame.test.tsx
@@ -44,6 +44,38 @@ describe("NeomorphicHeroFrame", () => {
     expect(frame).toHaveAttribute("data-variant", variant);
   });
 
+  it("defaults the divider tint attribute to the primary palette", () => {
+    const { container } = render(
+      <NeomorphicHeroFrame>
+        <span>Content</span>
+      </NeomorphicHeroFrame>,
+    );
+
+    const frame = container.querySelector("[data-variant]") as HTMLElement | null;
+
+    expect(frame).not.toBeNull();
+    if (!frame) {
+      throw new Error("Hero frame not found");
+    }
+    expect(frame).toHaveAttribute("data-hero-divider-tint", "primary");
+  });
+
+  it("respects an explicit divider tint attribute", () => {
+    const { container } = render(
+      <NeomorphicHeroFrame data-hero-divider-tint="life">
+        <span>Content</span>
+      </NeomorphicHeroFrame>,
+    );
+
+    const frame = container.querySelector("[data-variant]") as HTMLElement | null;
+
+    expect(frame).not.toBeNull();
+    if (!frame) {
+      throw new Error("Hero frame not found");
+    }
+    expect(frame).toHaveAttribute("data-hero-divider-tint", "life");
+  });
+
   it("toggles focus halo data attribute when focus enters and leaves", async () => {
     const user = userEvent.setup();
     const { container } = render(

--- a/types/postcss-import.d.ts
+++ b/types/postcss-import.d.ts
@@ -1,0 +1,1 @@
+declare module "postcss-import";


### PR DESCRIPTION
## Summary
- drive hero slot divider styling via data-hero-divider-tint instead of inline CSS
- add global tokens for primary/life divider shadows and document frameProps override path
- extend tests to cover new tint attribute defaults, overrides, and CSP-safe hero stacks

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d990fdda54832c922a8410590a6aab