### PR TITLE
Fix error boundary heading token

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -41,7 +41,7 @@ export function RouteErrorContent({
     >
       <div className="flex max-w-prose flex-col gap-[var(--space-4)]">
         <div className="space-y-[var(--space-2)]">
-          <h1 className="text-display-sm font-semibold text-foreground">
+          <h1 className="text-title-lg font-semibold text-foreground">
             {title}
           </h1>
           <p className="text-body text-muted-foreground">{description}</p>


### PR DESCRIPTION
## Summary
- replace the route error heading typography class with the supported `text-title-lg` token

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d99547ed28832cadee67c7c0aee5aa