### PR TITLE
fix: preserve nonce when enabling feedback

### DIFF
--- a/security-headers.mjs
+++ b/security-headers.mjs
@@ -38,14 +38,10 @@ export const createContentSecurityPolicy = (nonce, options) => {
 
   const nonceSource = `'nonce-${nonce}'`;
   const styleSrcBase = ["'self'"];
-  const styleSrc = [...styleSrcBase];
-  const styleSrcElem = [...styleSrcBase];
+  const styleSrc = [...styleSrcBase, nonceSource];
+  const styleSrcElem = [...styleSrcBase, nonceSource];
   const imgSrcBase = ["'self'", "data:", "https:"];
 
-  if (!allowVercelFeedback) {
-    styleSrc.push(nonceSource);
-    styleSrcElem.push(nonceSource);
-  }
   const imgSrc = [...imgSrcBase];
   const connectSrc = ["'self'"];
 


### PR DESCRIPTION
## Summary
- always append the CSP nonce to style-src and style-src-elem before applying feedback options
- keep Vercel feedback origins additive so the nonce is preserved when feedback is enabled

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d99536b128832c9618e68f2d83c1c1