### PR TITLE
Fix pillar badge shadows

### DIFF
--- a/src/components/ui/league/pillars/PillarBadge.module.css
+++ b/src/components/ui/league/pillars/PillarBadge.module.css
@@ -76,35 +76,53 @@
 .root[data-pillar="Wave"] {
   --g1: hsl(var(--pillar-wave-start));
   --g2: hsl(var(--pillar-wave-end));
-  --shadow: hsl(var(--pillar-wave-shadow));
+  --shadow: calc(var(--spacing-3)) calc(var(--spacing-3)) var(--spacing-5)
+      hsl(var(--pillar-wave-shadow)),
+    calc(var(--spacing-3) * -1) calc(var(--spacing-3) * -1) var(--spacing-5)
+      hsl(var(--foreground) / 0.06);
 }
 
 .root[data-pillar="Trading"] {
   --g1: hsl(var(--pillar-trading-start));
   --g2: hsl(var(--pillar-trading-end));
-  --shadow: hsl(var(--pillar-trading-shadow));
+  --shadow: calc(var(--spacing-3)) calc(var(--spacing-3)) var(--spacing-5)
+      hsl(var(--pillar-trading-shadow)),
+    calc(var(--spacing-3) * -1) calc(var(--spacing-3) * -1) var(--spacing-5)
+      hsl(var(--foreground) / 0.06);
 }
 
 .root[data-pillar="Vision"] {
   --g1: hsl(var(--pillar-vision-start));
   --g2: hsl(var(--pillar-vision-end));
-  --shadow: hsl(var(--pillar-vision-shadow));
+  --shadow: calc(var(--spacing-3)) calc(var(--spacing-3)) var(--spacing-5)
+      hsl(var(--pillar-vision-shadow)),
+    calc(var(--spacing-3) * -1) calc(var(--spacing-3) * -1) var(--spacing-5)
+      hsl(var(--foreground) / 0.06);
 }
 
 .root[data-pillar="Tempo"] {
   --g1: hsl(var(--pillar-tempo-start));
   --g2: hsl(var(--pillar-tempo-end));
-  --shadow: hsl(var(--pillar-tempo-shadow));
+  --shadow: calc(var(--spacing-3)) calc(var(--spacing-3)) var(--spacing-5)
+      hsl(var(--pillar-tempo-shadow)),
+    calc(var(--spacing-3) * -1) calc(var(--spacing-3) * -1) var(--spacing-5)
+      hsl(var(--foreground) / 0.06);
 }
 
 .root[data-pillar="Positioning"] {
   --g1: hsl(var(--pillar-positioning-start));
   --g2: hsl(var(--pillar-positioning-end));
-  --shadow: hsl(var(--pillar-positioning-shadow));
+  --shadow: calc(var(--spacing-3)) calc(var(--spacing-3)) var(--spacing-5)
+      hsl(var(--pillar-positioning-shadow)),
+    calc(var(--spacing-3) * -1) calc(var(--spacing-3) * -1) var(--spacing-5)
+      hsl(var(--foreground) / 0.06);
 }
 
 .root[data-pillar="Comms"] {
   --g1: hsl(var(--pillar-comms-start));
   --g2: hsl(var(--pillar-comms-end));
-  --shadow: hsl(var(--pillar-comms-shadow));
+  --shadow: calc(var(--spacing-3)) calc(var(--spacing-3)) var(--spacing-5)
+      hsl(var(--pillar-comms-shadow)),
+    calc(var(--spacing-3) * -1) calc(var(--spacing-3) * -1) var(--spacing-5)
+      hsl(var(--foreground) / 0.06);
 }


### PR DESCRIPTION
## Summary
- ensure pillar badge shadows provide full box-shadow offsets so themed variants render depth

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d9ccd0d2a8832ca141ae127a760c05