### PR TITLE
fix: move timer progress fill to css module

### DIFF
--- a/src/components/goals/TimerTab.module.css
+++ b/src/components/goals/TimerTab.module.css
@@ -1,0 +1,7 @@
+.progressFill {
+  --timer-progress: calc(attr(data-progress number, 0) / 100);
+  width: 100%;
+  transform-origin: left center;
+  transform: scaleX(var(--timer-progress));
+  will-change: transform;
+}

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -8,6 +8,7 @@ import Hero from "@/components/ui/layout/Hero";
 import SegmentedButton from "@/components/ui/primitives/SegmentedButton";
 import TimerRing from "./TimerRing";
 import DurationSelector from "./DurationSelector";
+import styles from "./TimerTab.module.css";
 import {
   Play,
   Pause,
@@ -401,7 +402,7 @@ export default function TimerTab() {
     return () => window.removeEventListener("keydown", onKey);
   }, [running, isCustom, pause, start, reset, setTimer]);
 
-  const pct = Math.round(progress * 100);
+  const pct = clamp(Math.round(progress * 100), 0, 100);
 
   return (
     <>
@@ -485,8 +486,8 @@ export default function TimerTab() {
               <div className="relative h-[var(--space-2)] w-full rounded-full bg-background/20 shadow-neo-inset">
                 <div className="absolute inset-0 bg-[repeating-linear-gradient(to_right,transparent,transparent_9%,hsl(var(--foreground)/0.15)_9%,hsl(var(--foreground)/0.15)_10%)]" />
                 <div
-                  className="h-full rounded-full bg-[linear-gradient(90deg,hsl(var(--accent)),hsl(var(--accent-2)))] shadow-[var(--shadow-glow-md)] transition-[width] duration-quick ease-linear"
-                  style={{ width: `${pct}%` }}
+                  className={`${styles.progressFill} h-full rounded-full bg-[linear-gradient(90deg,hsl(var(--accent)),hsl(var(--accent-2)))] shadow-[var(--shadow-glow-md)] transition-transform duration-quick ease-linear motion-reduce:transition-none`}
+                  data-progress={pct}
                 />
               </div>
               <div className="mt-[var(--space-1)] text-right text-label font-medium tracking-[0.02em] text-muted-foreground tabular-nums">


### PR DESCRIPTION
## Summary
- move the timer tab progress fill styling into a CSS module driven by data-progress
- clamp the displayed percent and drive the fill scale with a transform so gradients and glow tokens stay intact

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68da291c35e0832c9fddd9685f3478e3