### PR TITLE
Fix goals ring sizing to use scoped styled-jsx overrides

### DIFF
--- a/src/components/goals/GoalsProgress.tsx
+++ b/src/components/goals/GoalsProgress.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+
 import ProgressRingIcon from "@/icons/ProgressRingIcon";
 
 interface GoalsProgressProps {
@@ -15,36 +16,51 @@ export default function GoalsProgress({
   maxWidth,
 }: GoalsProgressProps) {
   const v = Math.max(0, Math.min(100, Math.round(pct)));
-  const customSize =
-    maxWidth == null
-      ? undefined
-      : typeof maxWidth === "number"
-        ? `${maxWidth}px`
-        : maxWidth;
-  const ringSize = typeof maxWidth === "number" ? maxWidth : undefined;
+  const reactId = React.useId();
+  const ringInstanceId = React.useMemo(
+    () => reactId.replace(/[:]/g, "_"),
+    [reactId],
+  );
+  const customSizeValue = React.useMemo(() => {
+    if (maxWidth == null) {
+      return null;
+    }
+    if (typeof maxWidth === "number") {
+      return Number.isFinite(maxWidth) ? `${maxWidth}px` : null;
+    }
+
+    return maxWidth;
+  }, [maxWidth]);
+  const ringSize =
+    typeof maxWidth === "number" && Number.isFinite(maxWidth)
+      ? maxWidth
+      : undefined;
   const ariaLabel =
     total === 0
       ? "Goals progress: no goals yet"
       : `Goals progress: ${v}% complete`;
   return (
-    <div
-      className="relative inline-flex size-[var(--goals-progress-size,var(--ring-diameter-m))] items-center justify-center"
-      style={
-        customSize
-          ? ({
-              "--goals-progress-size": customSize,
-            } as React.CSSProperties)
-          : undefined
-      }
-      aria-label={ariaLabel}
-    >
-      <ProgressRingIcon pct={v} size={ringSize} />
-      <span
-        aria-live="polite"
-        className="absolute inset-0 flex items-center justify-center text-label font-medium tracking-[0.02em] tabular-nums"
+    <>
+      <div
+        className="relative inline-flex size-[var(--goals-progress-size,var(--ring-diameter-m))] items-center justify-center"
+        data-ring-instance={customSizeValue ? ringInstanceId : undefined}
+        aria-label={ariaLabel}
       >
-        {v}%
-      </span>
-    </div>
+        <ProgressRingIcon pct={v} size={ringSize} />
+        <span
+          aria-live="polite"
+          className="absolute inset-0 flex items-center justify-center text-label font-medium tracking-[0.02em] tabular-nums"
+        >
+          {v}%
+        </span>
+      </div>
+      {customSizeValue ? (
+        <style jsx global>{`
+          [data-ring-instance="${ringInstanceId}"] {
+            --goals-progress-size: ${customSizeValue};
+          }
+        `}</style>
+      ) : null}
+    </>
   );
 }

--- a/src/components/goals/TimerRing.tsx
+++ b/src/components/goals/TimerRing.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+
 import TimerRingIcon from "@/icons/TimerRingIcon";
 import type { RingSize } from "@/lib/tokens";
 import { cn } from "@/lib/utils";
@@ -16,25 +17,47 @@ export default function TimerRing({
   className,
   size,
 }: TimerRingProps) {
-  const style =
-    size == null
-      ? undefined
-      : ({
-          "--timer-ring-size":
-            typeof size === "number"
-              ? `${size}px`
-              : `var(--ring-diameter-${size})`,
-        } as React.CSSProperties);
+  const reactId = React.useId();
+  const ringInstanceId = React.useMemo(
+    () => reactId.replace(/[:]/g, "_"),
+    [reactId],
+  );
+  const customSizeValue = React.useMemo(() => {
+    if (size == null) {
+      return null;
+    }
+    if (typeof size === "number") {
+      return Number.isFinite(size) ? `${size}px` : null;
+    }
+
+    return `var(--ring-diameter-${size})`;
+  }, [size]);
+  const hasCustomSize = customSizeValue !== null;
+  const ringIconSize =
+    typeof size === "number"
+      ? Number.isFinite(size)
+        ? size
+        : undefined
+      : size;
 
   return (
-    <div
-      className={cn(
-        "relative aspect-square",
-        className ?? "size-[var(--timer-ring-size,var(--ring-diameter-l))]",
-      )}
-      style={style}
-    >
-      <TimerRingIcon pct={pct} size={size} />
-    </div>
+    <>
+      <div
+        className={cn(
+          "relative aspect-square",
+          className ?? "size-[var(--timer-ring-size,var(--ring-diameter-l))]",
+        )}
+        data-ring-instance={hasCustomSize ? ringInstanceId : undefined}
+      >
+        <TimerRingIcon pct={pct} size={ringIconSize} />
+      </div>
+      {hasCustomSize ? (
+        <style jsx global>{`
+          [data-ring-instance="${ringInstanceId}"] {
+            --timer-ring-size: ${customSizeValue};
+          }
+        `}</style>
+      ) : null}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- scope timer and goals progress ring sizing overrides with nonce-aware styled-jsx tied to unique `data-ring-instance` ids
- preserve token-based defaults while only emitting scoped custom property overrides for provided numeric or token sizes

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68da291c88b8832c99bf465aae40e6b9