### PR TITLE
Fix planner list panel viewport sizing tokens

### DIFF
--- a/src/components/planner/PlannerListPanel.css
+++ b/src/components/planner/PlannerListPanel.css
@@ -1,0 +1,13 @@
+@layer components {
+  .planner-viewport[data-viewport-size~="minHTasks"] {
+    min-height: calc(var(--space-8) * 2);
+  }
+
+  .planner-viewport[data-viewport-size~="maxHTasks"] {
+    max-height: calc(var(--space-8) * 5);
+  }
+
+  .planner-viewport[data-viewport-size~="maxHProjects"] {
+    max-height: calc(var(--space-8) * 4 + var(--space-1));
+  }
+}

--- a/src/components/planner/PlannerListPanel.tsx
+++ b/src/components/planner/PlannerListPanel.tsx
@@ -3,6 +3,10 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
+import "./PlannerListPanel.css";
+
+type PlannerViewportSizeToken = "minHTasks" | "maxHTasks" | "maxHProjects";
+
 type PlannerListPanelProps = {
   renderComposer?: () => React.ReactNode;
   renderEmpty: () => React.ReactNode;
@@ -11,7 +15,15 @@ type PlannerListPanelProps = {
   className?: string;
   viewportClassName?: string;
   viewportInsetClassName?: string;
-  viewportStyle?: React.CSSProperties;
+  /**
+   * Applies predefined viewport sizing tokens. Tokens map to utilities defined
+   * in PlannerListPanel.css: `minHTasks` enforces the task list minimum height,
+   * `maxHTasks` caps the task viewport, and `maxHProjects` aligns the project
+   * list with its design-system max height.
+   */
+  viewportSize?:
+    | PlannerViewportSizeToken
+    | PlannerViewportSizeToken[];
   viewportProps?: React.HTMLAttributes<HTMLDivElement>;
 };
 
@@ -23,7 +35,7 @@ export default function PlannerListPanel({
   className,
   viewportClassName,
   viewportInsetClassName = "card-pad",
-  viewportStyle,
+  viewportSize,
   viewportProps,
 }: PlannerListPanelProps) {
   const {
@@ -31,6 +43,10 @@ export default function PlannerListPanel({
     style: viewportPropsStyle,
     ...restViewportProps
   } = viewportProps ?? {};
+
+  const viewportSizeValue = Array.isArray(viewportSize)
+    ? viewportSize.join(" ")
+    : viewportSize;
 
   const composer = renderComposer?.();
   const content = isEmpty ? renderEmpty() : renderList();
@@ -45,13 +61,14 @@ export default function PlannerListPanel({
       {composer}
       <div
         {...restViewportProps}
+        data-viewport-size={viewportSizeValue}
         className={cn(
-          "w-full overflow-y-auto",
+          "planner-viewport w-full overflow-y-auto",
           viewportInsetClassName,
           viewportPropsClassName,
           viewportClassName,
         )}
-        style={{ ...viewportPropsStyle, ...viewportStyle }}
+        style={viewportPropsStyle}
       >
         {content}
       </div>

--- a/src/components/planner/ProjectList.tsx
+++ b/src/components/planner/ProjectList.tsx
@@ -288,11 +288,7 @@ export default function ProjectList({
       viewportClassName={cn(
         projectsScrollable ? undefined : "overflow-visible",
       )}
-      viewportStyle={
-        projectsScrollable
-          ? { maxHeight: "calc(var(--space-8) * 4 + var(--space-1))" }
-          : undefined
-      }
+      viewportSize={projectsScrollable ? "maxHProjects" : undefined}
     />
   );
 }

--- a/src/components/planner/TaskList.tsx
+++ b/src/components/planner/TaskList.tsx
@@ -112,10 +112,7 @@ export default function TaskList({
           ))}
         </ul>
       )}
-      viewportStyle={{
-        minHeight: "calc(var(--space-8) * 2)",
-        maxHeight: "calc(var(--space-8) * 5)",
-      }}
+      viewportSize={["minHTasks", "maxHTasks"]}
     />
   );
 }


### PR DESCRIPTION
## Summary
- add viewport sizing tokens for planner lists and expose them via PlannerListPanel
- move task and project panels to data-attribute driven viewport sizing utilities
- codify the task and project viewport heights in a dedicated PlannerListPanel stylesheet

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68da33b314fc832cab1e9601951b5beb