### PR TITLE
fix: align noir and hardstuck previews with theme tokens

### DIFF
--- a/src/components/prompts/component-gallery/MiscPanel.module.css
+++ b/src/components/prompts/component-gallery/MiscPanel.module.css
@@ -1,0 +1,11 @@
+.chipNoir {
+  background-color: hsl(var(--noir-background));
+  color: hsl(var(--noir-foreground));
+  border: var(--hairline-w) solid hsl(var(--noir-border));
+}
+
+.chipHardstuck {
+  background-color: hsl(var(--hardstuck-background));
+  color: hsl(var(--hardstuck-foreground));
+  border: var(--hairline-w) solid hsl(var(--hardstuck-border));
+}

--- a/src/components/prompts/component-gallery/MiscPanel.tsx
+++ b/src/components/prompts/component-gallery/MiscPanel.tsx
@@ -38,6 +38,7 @@ import { layoutGridClassName } from "@/components/ui/layout/PageShell";
 import { cn } from "@/lib/utils";
 import { demoReview } from "./ComponentGallery.demoData";
 import type { MiscPanelData } from "./useComponentGalleryState";
+import styles from "./MiscPanel.module.css";
 
 const GRID_CLASS = cn(layoutGridClassName, "sm:grid-cols-2 md:grid-cols-12");
 const ROW_HEIGHT: number = spacingTokens[5] ?? 32;
@@ -318,12 +319,10 @@ export default function MiscPanel({ data }: MiscPanelProps) {
           label: "Noir Background",
           element: (
             <div
-              className="w-56 h-24 rounded-[var(--radius-md)] flex items-center justify-center"
-              style={{
-                backgroundColor: "hsl(var(--noir-background))",
-                color: "hsl(var(--noir-foreground))",
-                border: "var(--hairline-w) solid hsl(var(--noir-border))",
-              }}
+              className={cn(
+                "w-56 h-24 rounded-[var(--radius-md)] flex items-center justify-center",
+                styles.chipNoir,
+              )}
             >
               Noir
             </div>
@@ -333,12 +332,10 @@ export default function MiscPanel({ data }: MiscPanelProps) {
           label: "Hardstuck Background",
           element: (
             <div
-              className="w-56 h-24 rounded-[var(--radius-md)] flex items-center justify-center"
-              style={{
-                backgroundColor: "hsl(var(--hardstuck-background))",
-                color: "hsl(var(--hardstuck-foreground))",
-                border: "var(--hairline-w) solid hsl(var(--hardstuck-border))",
-              }}
+              className={cn(
+                "w-56 h-24 rounded-[var(--radius-md)] flex items-center justify-center",
+                styles.chipHardstuck,
+              )}
             >
               Hardstuck
             </div>


### PR DESCRIPTION
## Summary
- move the Noir and Hardstuck preview styling into a scoped CSS module that uses theme tokens
- apply the new theme-specific classes in the misc gallery panel and drop inline styles

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68da38b8cbe8832cb1a7dfca15662ebf