### PR TITLE
feat: add semantic ring tone for input

### DIFF
--- a/src/components/prompts/PromptsDemos.tsx
+++ b/src/components/prompts/PromptsDemos.tsx
@@ -60,10 +60,7 @@ export default function PromptsDemos() {
           <Input className="rounded-full" placeholder="Rounded" />
           <Input placeholder="Disabled" disabled />
           <Input placeholder="Error" aria-invalid="true" />
-          <Input
-            placeholder="Custom ring"
-            className="[--theme-ring:hsl(var(--danger))]"
-          />
+          <Input placeholder="Custom ring" ringTone="danger" />
           <Input placeholder="With action">
             <IconButton
               size="sm"

--- a/src/components/ui/primitives/Input.gallery.tsx
+++ b/src/components/ui/primitives/Input.gallery.tsx
@@ -54,6 +54,12 @@ const INPUT_STATES: readonly InputStateSpec[] = [
     props: { placeholder: "Loading", "data-loading": true },
     code: "<Input placeholder=\"Loading\" data-loading />",
   },
+  {
+    id: "custom-ring",
+    name: "Custom ring",
+    props: { placeholder: "Custom ring", ringTone: "danger" },
+    code: "<Input placeholder=\"Custom ring\" ringTone=\"danger\" />",
+  },
 ];
 
 function InputStatePreview({ state }: { state: InputStateSpec }) {
@@ -85,6 +91,11 @@ export default defineGallerySection({
         { name: "height", type: '"sm" | "md" | "lg" | "xl"', defaultValue: '"md"' },
         { name: "disabled", type: "boolean", defaultValue: "false" },
         { name: "data-loading", type: "boolean", defaultValue: "false" },
+        {
+          name: "ringTone",
+          type: '"accent" | "danger" | "primary" | "success" | "warning"',
+          defaultValue: "undefined",
+        },
       ],
       axes: [
         {
@@ -114,6 +125,7 @@ export default defineGallerySection({
   <Input placeholder="Active" className="bg-[--active]" />
   <Input placeholder="Disabled" disabled />
   <Input placeholder="Loading" data-loading />
+  <Input placeholder="Custom ring" ringTone="danger" />
 </div>`,
     },
   ],

--- a/src/components/ui/primitives/Input.module.css
+++ b/src/components/ui/primitives/Input.module.css
@@ -1,0 +1,21 @@
+.root {}
+
+.ringToneAccent {
+  --theme-ring: hsl(var(--accent));
+}
+
+.ringToneDanger {
+  --theme-ring: hsl(var(--danger));
+}
+
+.ringTonePrimary {
+  --theme-ring: hsl(var(--primary));
+}
+
+.ringToneSuccess {
+  --theme-ring: hsl(var(--success));
+}
+
+.ringToneWarning {
+  --theme-ring: hsl(var(--warning));
+}

--- a/src/components/ui/primitives/Input.tsx
+++ b/src/components/ui/primitives/Input.tsx
@@ -5,6 +5,22 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 import { useFieldIds } from "@/lib/useFieldIds";
 import Field from "./Field";
+import styles from "./Input.module.css";
+
+export type InputRingTone =
+  | "accent"
+  | "danger"
+  | "primary"
+  | "success"
+  | "warning";
+
+const RING_TONE_CLASS_MAP: Record<InputRingTone, string> = {
+  accent: styles.ringToneAccent,
+  danger: styles.ringToneDanger,
+  primary: styles.ringTonePrimary,
+  success: styles.ringToneSuccess,
+  warning: styles.ringToneWarning,
+};
 
 export type InputSize = "sm" | "md" | "lg" | "xl";
 
@@ -22,6 +38,8 @@ export type InputProps = Omit<
   hasEndSlot?: boolean;
   /** Optional loading state forwarded via `data-loading` */
   "data-loading"?: string | boolean | number;
+  /** Overrides the focus ring tone by mapping to semantic tokens */
+  ringTone?: InputRingTone;
 };
 
 /**
@@ -42,6 +60,7 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
     indent = false,
     children,
     hasEndSlot = false,
+    ringTone,
     ...props
   },
   ref,
@@ -73,7 +92,7 @@ export default React.forwardRef<HTMLInputElement, InputProps>(function Input(
       disabled={disabled}
       readOnly={readOnly}
       loading={loading}
-      className={className}
+      className={cn(ringTone ? RING_TONE_CLASS_MAP[ringTone] : undefined, className)}
     >
       <Field.Input
         ref={ref}


### PR DESCRIPTION
## Summary
- add a `ringTone` prop to the Input primitive that maps to theme tokens via CSS modules
- update the Prompts demos and Input gallery to showcase the semantic ring option

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68da38b76634832ca457bde6c6f7b1f8