### PR TITLE
fix: replace inline planner styles with token classes

### DIFF
--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -98,8 +98,6 @@ const GROUP_TABS: Array<{ key: Group | "all"; label: string }> = [
   { key: "review", label: "Review" },
 ];
 
-export const REMINDERS_SEARCH_MIN_WIDTH = "calc(var(--space-8)*3.5)";
-
 /* ---------- component ---------- */
 
 export default function Reminders() {
@@ -221,10 +219,7 @@ export default function Reminders() {
           {/* header row (no Quick Add here anymore) */}
           <div className="flex flex-wrap items-center gap-[var(--space-2)] sm:gap-[var(--space-3)] w-full">
             {/* search */}
-            <div
-              className="relative flex-1"
-              style={{ minWidth: REMINDERS_SEARCH_MIN_WIDTH }}
-            >
+            <div className="relative flex-1 min-w-[calc(var(--space-8)*3.5)]">
               <Search
                 aria-hidden
                 className="icon-md pointer-events-none absolute left-[var(--space-4)] top-1/2 -translate-y-1/2 text-muted-foreground opacity-70"

--- a/src/components/home/TeamPromptsCard.module.css
+++ b/src/components/home/TeamPromptsCard.module.css
@@ -1,0 +1,9 @@
+.promptsOverlay {
+  --seg-active-grad: linear-gradient(
+    90deg,
+    hsl(var(--primary-soft) / 0.45),
+    hsl(var(--accent-soft) / 0.45),
+    hsl(var(--accent-2) / 0.4)
+  );
+  background: var(--seg-active-grad);
+}

--- a/src/components/home/TeamPromptsCard.tsx
+++ b/src/components/home/TeamPromptsCard.tsx
@@ -4,6 +4,8 @@ import * as React from "react";
 import DashboardCard from "./DashboardCard";
 import QuickActionGrid from "./QuickActionGrid";
 import { layoutGridClassName } from "@/components/ui/layout/PageShell";
+import { cn } from "@/lib/utils";
+import styles from "./TeamPromptsCard.module.css";
 
 const teamQuickActions = [
   {
@@ -25,11 +27,6 @@ const teamQuickActions = [
     asChild: true,
   },
 ];
-
-const promptsOverlayGradient = {
-  "--seg-active-grad":
-    "linear-gradient(90deg, hsl(var(--primary-soft) / 0.45), hsl(var(--accent-soft) / 0.45), hsl(var(--accent-2) / 0.4))",
-} as React.CSSProperties;
 
 export default function TeamPromptsCard() {
   return (
@@ -53,8 +50,10 @@ export default function TeamPromptsCard() {
           <div className="relative overflow-hidden rounded-card r-card-md bg-card p-[var(--space-4)] text-center text-ui text-foreground">
             <div
               aria-hidden="true"
-              className="pointer-events-none absolute inset-0 -z-10 rounded-[inherit] bg-[var(--seg-active-grad)]"
-              style={promptsOverlayGradient}
+              className={cn(
+                "pointer-events-none absolute inset-0 -z-10 rounded-[inherit]",
+                styles.promptsOverlay,
+              )}
             />
             <span className="relative z-10 block">Get inspired with curated prompts</span>
           </div>

--- a/src/components/planner/PlannerListPanel.css
+++ b/src/components/planner/PlannerListPanel.css
@@ -1,13 +1,13 @@
 @layer components {
-  .planner-viewport[data-viewport-size~="minHTasks"] {
+  .planner-viewport--minHTasks {
     min-height: calc(var(--space-8) * 2);
   }
 
-  .planner-viewport[data-viewport-size~="maxHTasks"] {
+  .planner-viewport--maxHTasks {
     max-height: calc(var(--space-8) * 5);
   }
 
-  .planner-viewport[data-viewport-size~="maxHProjects"] {
+  .planner-viewport--maxHProjects {
     max-height: calc(var(--space-8) * 4 + var(--space-1));
   }
 }

--- a/src/components/planner/PlannerListPanel.tsx
+++ b/src/components/planner/PlannerListPanel.tsx
@@ -7,6 +7,12 @@ import "./PlannerListPanel.css";
 
 type PlannerViewportSizeToken = "minHTasks" | "maxHTasks" | "maxHProjects";
 
+const VIEWPORT_SIZE_CLASS_NAMES: Record<PlannerViewportSizeToken, string> = {
+  minHTasks: "planner-viewport--minHTasks",
+  maxHTasks: "planner-viewport--maxHTasks",
+  maxHProjects: "planner-viewport--maxHProjects",
+};
+
 type PlannerListPanelProps = {
   renderComposer?: () => React.ReactNode;
   renderEmpty: () => React.ReactNode;
@@ -24,7 +30,7 @@ type PlannerListPanelProps = {
   viewportSize?:
     | PlannerViewportSizeToken
     | PlannerViewportSizeToken[];
-  viewportProps?: React.HTMLAttributes<HTMLDivElement>;
+  viewportProps?: Omit<React.HTMLAttributes<HTMLDivElement>, "style">;
 };
 
 export default function PlannerListPanel({
@@ -38,15 +44,17 @@ export default function PlannerListPanel({
   viewportSize,
   viewportProps,
 }: PlannerListPanelProps) {
-  const {
-    className: viewportPropsClassName,
-    style: viewportPropsStyle,
-    ...restViewportProps
-  } = viewportProps ?? {};
+  const { className: viewportPropsClassName, ...restViewportProps } = viewportProps ?? {};
 
-  const viewportSizeValue = Array.isArray(viewportSize)
-    ? viewportSize.join(" ")
-    : viewportSize;
+  const viewportSizeTokens = Array.isArray(viewportSize)
+    ? viewportSize
+    : viewportSize
+      ? [viewportSize]
+      : [];
+
+  const viewportSizeClasses = viewportSizeTokens.map(
+    (token) => VIEWPORT_SIZE_CLASS_NAMES[token],
+  );
 
   const composer = renderComposer?.();
   const content = isEmpty ? renderEmpty() : renderList();
@@ -61,14 +69,13 @@ export default function PlannerListPanel({
       {composer}
       <div
         {...restViewportProps}
-        data-viewport-size={viewportSizeValue}
         className={cn(
           "planner-viewport w-full overflow-y-auto",
           viewportInsetClassName,
           viewportPropsClassName,
           viewportClassName,
+          viewportSizeClasses,
         )}
-        style={viewportPropsStyle}
       >
         {content}
       </div>

--- a/src/components/ui/league/pillars/PillarSelector.module.css
+++ b/src/components/ui/league/pillars/PillarSelector.module.css
@@ -1,0 +1,22 @@
+.indicator {
+  transition: background-color 160ms ease;
+}
+
+.button[data-active="true"] {
+  --pillar-indicator-gradient: linear-gradient(
+    90deg,
+    hsl(var(--primary) / 0.18),
+    hsl(var(--accent) / 0.18)
+  );
+  background: var(--pillar-indicator-gradient);
+}
+
+.button[data-active="true"] .indicator {
+  background: var(--accent-overlay);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .indicator {
+    transition: none;
+  }
+}

--- a/src/components/ui/league/pillars/PillarSelector.tsx
+++ b/src/components/ui/league/pillars/PillarSelector.tsx
@@ -4,12 +4,9 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 import type { Pillar } from "@/lib/types";
+import styles from "./PillarSelector.module.css";
 
 const ORDER: Pillar[] = ["Wave", "Trading", "Vision", "Tempo", "Positioning", "Comms"];
-
-type PillarHighlightStyle = React.CSSProperties & {
-  "--pillar-indicator-gradient"?: string;
-};
 
 export default function PillarSelector({
   value = [],
@@ -44,12 +41,6 @@ export default function PillarSelector({
       <div className="flex flex-wrap gap-[var(--space-2)]">
         {ORDER.map((p) => {
           const active = set.has(p);
-          const activeStyle: PillarHighlightStyle | undefined = active
-            ? {
-                "--pillar-indicator-gradient":
-                  "linear-gradient(90deg, hsl(var(--primary)/0.18), hsl(var(--accent)/0.18))",
-              }
-            : undefined;
           return (
             <button
               key={p}
@@ -59,18 +50,19 @@ export default function PillarSelector({
               onKeyDown={(event) => handleKeyDown(p, event)}
               className={cn(
                 "pill transition",
+                styles.button,
                 active &&
-                  "pill--medium text-foreground shadow-[var(--shadow-neo-soft)] [background:var(--pillar-indicator-gradient)]",
+                  "pill--medium text-foreground shadow-[var(--shadow-neo-soft)]",
               )}
-              style={activeStyle}
+              data-active={active ? "true" : undefined}
             >
               <span
                 aria-hidden
                 className={cn(
                   "h-[var(--space-2)] w-[var(--space-2)] rounded-full",
-                  active ? "" : "bg-muted-foreground"
+                  active ? "" : "bg-muted-foreground",
+                  styles.indicator,
                 )}
-                style={active ? { background: "var(--accent-overlay)" } : undefined}
               />
               {p}
             </button>


### PR DESCRIPTION
## Summary
- swap the reminders search width inline style for the matching tailwind utility token
- move PillarSelector highlight gradient and indicator fill into a css module and apply via data attributes
- define dashboard prompts overlay and planner viewport sizing tokens via stylesheet classes instead of inline styles

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68da8086a5d4832ca49d6ae78383749d