### PR TITLE
fix: reuse clipboard buffer class

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -159,6 +159,13 @@
   html.fx-overdrive .card-neo-soft.glitchy:hover .card-title {
     animation: chromaJitter 0.8s steps(3, end) infinite;
   }
+
+  .clipboard-copy-buffer {
+    position: fixed;
+    top: var(--visually-hidden-top);
+    opacity: var(--opacity-hidden, 0);
+    pointer-events: none;
+  }
   @supports (color: color-contrast(white vs black)) {
     :root {
       --danger-foreground: color-contrast(

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -45,11 +45,7 @@ export async function copyText(text: string): Promise<void> {
 
   const ta = document.createElement("textarea");
   ta.value = text;
-  Object.assign(ta.style, {
-    position: "fixed",
-    top: "var(--visually-hidden-top)",
-    opacity: "0",
-  });
+  ta.classList.add("clipboard-copy-buffer");
   document.body.appendChild(ta);
   ta.select();
 

--- a/tests/lib/clipboard.test.ts
+++ b/tests/lib/clipboard.test.ts
@@ -112,9 +112,11 @@ describe("copyText", () => {
     const select = vi.fn();
     const remove = vi.fn();
     const style = {} as CSSStyleDeclaration;
+    const classList = { add: vi.fn() } as unknown as DOMTokenList;
     const textarea = {
       value: "",
       style,
+      classList,
       select,
       remove,
     } as unknown as HTMLTextAreaElement;
@@ -144,9 +146,7 @@ describe("copyText", () => {
     expect(execCommand).toHaveBeenCalledWith("copy");
     expect(removeAllRanges).toHaveBeenCalledTimes(1);
     expect(remove).toHaveBeenCalledTimes(1);
-    expect((style as unknown as Record<string, string>).position).toBe("fixed");
-    expect((style as unknown as Record<string, string>).top).toBe("var(--visually-hidden-top)");
-    expect((style as unknown as Record<string, string>).opacity).toBe("0");
+    expect(classList.add).toHaveBeenCalledWith("clipboard-copy-buffer");
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
@@ -170,9 +170,11 @@ describe("copyText", () => {
 
     const select = vi.fn();
     const remove = vi.fn();
+    const classList = { add: vi.fn() } as unknown as DOMTokenList;
     const textarea = {
       value: "",
       style: {} as CSSStyleDeclaration,
+      classList,
       select,
       remove,
     } as unknown as HTMLTextAreaElement;
@@ -203,6 +205,7 @@ describe("copyText", () => {
     expect(select).toHaveBeenCalledTimes(1);
     expect(removeAllRanges).toHaveBeenCalledTimes(1);
     expect(remove).toHaveBeenCalledTimes(1);
+    expect(classList.add).toHaveBeenCalledWith("clipboard-copy-buffer");
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("[planner:clipboard] Failed to copy text"),
       execError,


### PR DESCRIPTION
## Summary
- add a reusable clipboard copy buffer helper class to the global stylesheet
- apply the helper class in the clipboard fallback implementation and update unit tests

## Testing
- npm run test -- tests/lib/clipboard.test.ts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68da90acd7d0832caff96e41143070cb