### PR TITLE
fix: render favicon via svg tokens

### DIFF
--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -10,21 +10,29 @@ export const dynamic = "force-static";
 export default function Icon() {
   return new ImageResponse(
     (
-      <div
-        style={{
-          alignItems: "center",
-          backgroundColor: resolveTokenColor(tokens.background),
-          color: resolveTokenColor(tokens.iconFg),
-          display: "flex",
-          fontSize: tokens.fontBody,
-          fontWeight: tokens.fontWeightBold,
-          height: "100%",
-          justifyContent: "center",
-          width: "100%",
-        }}
+      <svg
+        width="100%"
+        height="100%"
+        viewBox={`0 0 ${size.width} ${size.height}`}
+        xmlns="http://www.w3.org/2000/svg"
       >
-        13
-      </div>
+        <rect
+          width="100%"
+          height="100%"
+          fill={resolveTokenColor(tokens.background)}
+        />
+        <text
+          x="50%"
+          y="50%"
+          fill={resolveTokenColor(tokens.iconFg)}
+          fontSize={tokens.fontBody}
+          fontWeight={tokens.fontWeightBold}
+          textAnchor="middle"
+          dominantBaseline="middle"
+        >
+          13
+        </text>
+      </svg>
     ),
     size,
   );


### PR DESCRIPTION
## Summary
- replace the favicon div layout with an SVG that uses design tokens for colors and typography
- ensure the text remains centered via SVG attributes so the icon renders consistently across themes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68da9536f4b0832cb8d55eb2134ad785