### PR TITLE
feat: add shared planner surface gradients

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2214,6 +2214,46 @@ a:active .lucide {
 }
 
 @layer utilities {
+  :root {
+    --surface-card-soft: linear-gradient(
+      180deg,
+      hsl(var(--card) / 0.65),
+      hsl(var(--card) / 0.45)
+    );
+    --surface-card-strong: linear-gradient(
+      180deg,
+      hsl(var(--card) / 0.85),
+      hsl(var(--card) / 0.65)
+    );
+    --surface-card-strong-hover: linear-gradient(
+      180deg,
+      hsl(var(--card) / 0.95),
+      hsl(var(--card) / 0.75)
+    );
+    --surface-card-strong-active: linear-gradient(
+      180deg,
+      hsl(var(--card) / 0.8),
+      hsl(var(--card) / 0.6)
+    );
+    --surface-card-strong-today: linear-gradient(
+      180deg,
+      hsl(var(--card) / 0.9),
+      hsl(var(--card) / 0.7)
+    );
+    --surface-card-strong-empty: linear-gradient(
+      180deg,
+      hsl(var(--card) / 0.6),
+      hsl(var(--card) / 0.5)
+    );
+    --surface-rail-accent: linear-gradient(
+      180deg,
+      hsl(var(--accent)),
+      hsl(var(--primary))
+    );
+  }
+}
+
+@layer utilities {
   .icon-xs {
     width: var(--icon-size-xs);
     height: var(--icon-size-xs);

--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -207,11 +207,7 @@
   border: var(--hairline-w) dashed hsl(var(--card-hairline) / 0.7);
   border-radius: var(--radius-lg);
   color: hsl(var(--muted-foreground));
-  background: linear-gradient(
-    180deg,
-    hsl(var(--card) / 0.65),
-    hsl(var(--card) / 0.45)
-  );
+  @apply surface-card-soft;
   text-align: center;
 }
 
@@ -229,11 +225,7 @@
   gap: var(--space-2);
   border: var(--hairline-w) solid hsl(var(--card-hairline));
   border-radius: inherit;
-  background: linear-gradient(
-    180deg,
-    hsl(var(--card) / 0.85),
-    hsl(var(--card) / 0.65)
-  );
+  @apply surface-card-strong;
   color: hsl(var(--foreground));
   cursor: pointer;
   outline: none;
@@ -249,11 +241,7 @@
     transform var(--dur-quick) var(--ease-out);
 }
 .ws-tile:hover {
-  background: linear-gradient(
-    180deg,
-    hsl(var(--card) / 0.95),
-    hsl(var(--card) / 0.75)
-  );
+  background: var(--surface-card-strong-hover);
   border-color: hsl(var(--ring) / 0.45);
   --ws-shadow-inner: 0 0 0 calc(var(--hairline-w) * 1.5)
     hsl(var(--ring) / 0.35) inset;
@@ -270,11 +258,7 @@
     0 calc(var(--space-2)) calc(var(--space-5)) hsl(var(--shadow-color) / 0.24);
 }
 .ws-tile:active {
-  background: linear-gradient(
-    180deg,
-    hsl(var(--card) / 0.8),
-    hsl(var(--card) / 0.6)
-  );
+  background: var(--surface-card-strong-active);
   border-color: hsl(var(--ring) / 0.6);
   --ws-shadow-inner: 0 0 0 calc(var(--hairline-w) * 2) hsl(var(--ring) / 0.4)
     inset;
@@ -285,11 +269,7 @@
 
 .ws-tile--today {
   border-color: hsl(var(--ring) / 0.55);
-  background: linear-gradient(
-    180deg,
-    hsl(var(--card) / 0.9),
-    hsl(var(--card) / 0.7)
-  );
+  background: var(--surface-card-strong-today);
   --ws-shadow-inner: 0 0 0 calc(var(--hairline-w) * 1.5) hsl(var(--ring) / 0.4)
     inset;
   --ws-shadow-outer: 0 calc(var(--space-2)) calc(var(--space-5))
@@ -301,11 +281,7 @@
 }
 
 .ws-tile--empty {
-  background: linear-gradient(
-    180deg,
-    hsl(var(--card) / 0.6),
-    hsl(var(--card) / 0.5)
-  );
+  background: var(--surface-card-strong-empty);
   color: hsl(var(--muted-foreground));
   --ws-shadow-inner: 0 0 0 var(--hairline-w) hsl(var(--card-hairline) / 0.35)
     inset;
@@ -326,11 +302,7 @@
   left: var(--space-1);
   width: calc(var(--spacing-0-5) + var(--hairline-w));
   border-radius: var(--radius-xl);
-  background: linear-gradient(
-    180deg,
-    hsl(var(--accent)),
-    hsl(var(--primary))
-  );
+  @apply surface-rail-accent;
   box-shadow: 0 0 var(--space-2) hsl(var(--ring) / 0.45);
   pointer-events: none;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,6 +5,20 @@ import type { Config } from "tailwindcss";
 import plugin from "tailwindcss/plugin";
 import { spacingTokens, radiusScale } from "./src/lib/tokens";
 
+const plannerSurfaces = plugin(({ addUtilities }) => {
+  addUtilities({
+    ".surface-card-soft": {
+      background: "var(--surface-card-soft)",
+    },
+    ".surface-card-strong": {
+      background: "var(--surface-card-strong)",
+    },
+    ".surface-rail-accent": {
+      background: "var(--surface-rail-accent)",
+    },
+  });
+});
+
 const borderRadiusTokens = Object.entries(radiusScale).reduce(
   (acc, [token, value]) => {
     acc[token] = `${value}px`;
@@ -259,6 +273,7 @@ const config: Config = {
     },
   },
   plugins: [
+    plannerSurfaces,
     plugin(({ matchUtilities }) => {
       matchUtilities(
         {


### PR DESCRIPTION
## Summary
- register planner-specific surface gradient utilities in Tailwind so components can share the same tokens
- expose matching CSS variables for gradient reuse outside Tailwind contexts
- refactor planner styles to consume the shared surface tokens for cards, rails, and state variations

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dab1d5cee4832c8c3cc3c08ce42152