### PR TITLE
Fix Next.js build by replacing icon text and wrapping global CSS selectors

### DIFF
--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -21,17 +21,14 @@ export default function Icon() {
           height="100%"
           fill={resolveTokenColor(tokens.background)}
         />
-        <text
-          x="50%"
-          y="50%"
+        <path
+          d="M11 8h4v16h-4z"
           fill={resolveTokenColor(tokens.iconFg)}
-          fontSize={tokens.fontBody}
-          fontWeight={tokens.fontWeightBold}
-          textAnchor="middle"
-          dominantBaseline="middle"
-        >
-          13
-        </text>
+        />
+        <path
+          d="M18 8h6a4 4 0 0 1 0 8a4 4 0 0 1 0 8h-6v-4h4a2 2 0 0 0 0-4h-4v-4h4a2 2 0 1 0 0-4h-4z"
+          fill={resolveTokenColor(tokens.iconFg)}
+        />
       </svg>
     ),
     size,

--- a/src/components/goals/reminders/ReminderQuickAddForm.module.css
+++ b/src/components/goals/reminders/ReminderQuickAddForm.module.css
@@ -1,9 +1,11 @@
-:global(.neon-primary) {
-  --neon: var(--primary);
-}
+:global {
+  .neon-primary {
+    --neon: var(--primary);
+  }
 
-:global(.neon-life) {
-  --neon: var(--accent);
+  .neon-life {
+    --neon: var(--accent);
+  }
 }
 
 .neonNote {

--- a/src/components/ui/layout/NeomorphicFrameStyles.module.css
+++ b/src/components/ui/layout/NeomorphicFrameStyles.module.css
@@ -1,81 +1,83 @@
-:global(.hero2-neomorph) {
-  background: linear-gradient(145deg, hsl(var(--card)), hsl(var(--panel)));
-  --hero2-shadow-key: var(--shadow);
-  --hero2-shadow-ambient: inset 0 0 0 calc(var(--hairline-w) * 1.5)
-    hsl(var(--shadow-color) / 0.18);
-  box-shadow: var(--hero2-shadow-ambient), var(--hero2-shadow-key);
-  position: relative;
-  --hero2-focus-ring-rest: 0 0 0 0 hsl(var(--ring) / 0),
-    0 0 0 0 hsl(var(--ring) / 0);
-  --hero2-focus-ring-active: 0 0 0 calc(var(--hairline-w) * 1)
-    hsl(var(--ring)),
-    var(--shadow-glow-lg);
-  --hero2-focus-ring: var(--hero2-focus-ring-rest);
-  --hero2-glow-top-left-color: hsl(var(--highlight) / 0.55);
-  --hero2-glow-top-left-soft: hsl(var(--highlight) / 0.08);
-  --hero2-glow-bottom-right-color: hsl(var(--shadow-color) / 0.42);
-  --hero2-glow-bottom-right-soft: hsl(var(--shadow-color) / 0.14);
-  --hero2-glow-top-left: radial-gradient(
-    140% 140% at 0% 0%,
-    var(--hero2-glow-top-left-color) 0%,
-    var(--hero2-glow-top-left-soft) 45%,
-    transparent 75%
-  );
-  --hero2-glow-bottom-right: radial-gradient(
-    160% 160% at 100% 100%,
-    var(--hero2-glow-bottom-right-color) 0%,
-    var(--hero2-glow-bottom-right-soft) 55%,
-    transparent 82%
-  );
-}
+:global {
+  .hero2-neomorph {
+    background: linear-gradient(145deg, hsl(var(--card)), hsl(var(--panel)));
+    --hero2-shadow-key: var(--shadow);
+    --hero2-shadow-ambient: inset 0 0 0 calc(var(--hairline-w) * 1.5)
+      hsl(var(--shadow-color) / 0.18);
+    box-shadow: var(--hero2-shadow-ambient), var(--hero2-shadow-key);
+    position: relative;
+    --hero2-focus-ring-rest: 0 0 0 0 hsl(var(--ring) / 0),
+      0 0 0 0 hsl(var(--ring) / 0);
+    --hero2-focus-ring-active: 0 0 0 calc(var(--hairline-w) * 1)
+      hsl(var(--ring)),
+      var(--shadow-glow-lg);
+    --hero2-focus-ring: var(--hero2-focus-ring-rest);
+    --hero2-glow-top-left-color: hsl(var(--highlight) / 0.55);
+    --hero2-glow-top-left-soft: hsl(var(--highlight) / 0.08);
+    --hero2-glow-bottom-right-color: hsl(var(--shadow-color) / 0.42);
+    --hero2-glow-bottom-right-soft: hsl(var(--shadow-color) / 0.14);
+    --hero2-glow-top-left: radial-gradient(
+      140% 140% at 0% 0%,
+      var(--hero2-glow-top-left-color) 0%,
+      var(--hero2-glow-top-left-soft) 45%,
+      transparent 75%
+    );
+    --hero2-glow-bottom-right: radial-gradient(
+      160% 160% at 100% 100%,
+      var(--hero2-glow-bottom-right-color) 0%,
+      var(--hero2-glow-bottom-right-soft) 55%,
+      transparent 82%
+    );
+  }
 
-:global(.hero2-neomorph::before),
-:global(.hero2-neomorph::after) {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  pointer-events: none;
-  z-index: -1;
-  opacity: 1;
-}
+  .hero2-neomorph::before,
+  .hero2-neomorph::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    z-index: -1;
+    opacity: 1;
+  }
 
-:global(.hero2-neomorph::before) {
-  background: var(--hero2-glow-top-left);
-  box-shadow: var(--hero2-focus-ring);
-  transition: box-shadow var(--dur-quick, 160ms) ease-out;
-}
+  .hero2-neomorph::before {
+    background: var(--hero2-glow-top-left);
+    box-shadow: var(--hero2-focus-ring);
+    transition: box-shadow var(--dur-quick, 160ms) ease-out;
+  }
 
-:global(.hero2-neomorph::after) {
-  background: var(--hero2-glow-bottom-right);
-}
+  .hero2-neomorph::after {
+    background: var(--hero2-glow-bottom-right);
+  }
 
-:global(.hero2-frame) {
-  --hero-slot-shadow: var(--shadow-neo-soft);
-}
+  .hero2-frame {
+    --hero-slot-shadow: var(--shadow-neo-soft);
+  }
 
-:global(.hero2-frame[data-hero-slot-shadow="soft"]) {
-  --hero-slot-shadow: var(--shadow-neo-soft);
-}
+  .hero2-frame[data-hero-slot-shadow="soft"] {
+    --hero-slot-shadow: var(--shadow-neo-soft);
+  }
 
-:global(.hero2-frame[data-hero-slot-shadow="strong"]) {
-  --hero-slot-shadow: var(--shadow-neo-strong);
-}
+  .hero2-frame[data-hero-slot-shadow="strong"] {
+    --hero-slot-shadow: var(--shadow-neo-strong);
+  }
 
-:global(.hero2-frame[data-hero-slot-shadow="none"]) {
-  --hero-slot-shadow: none;
-}
+  .hero2-frame[data-hero-slot-shadow="none"] {
+    --hero-slot-shadow: none;
+  }
 
-:global(.hero2-frame[data-hero-divider-tint="primary"]) {
-  --hero-slot-divider: var(--ring);
-  --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
-    hsl(var(--ring) / 0.45);
-}
+  .hero2-frame[data-hero-divider-tint="primary"] {
+    --hero-slot-divider: var(--ring);
+    --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
+      hsl(var(--ring) / 0.45);
+  }
 
-:global(.hero2-frame[data-hero-divider-tint="life"]) {
-  --hero-slot-divider: var(--accent-3);
-  --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
-    hsl(var(--accent-3) / 0.42);
+  .hero2-frame[data-hero-divider-tint="life"] {
+    --hero-slot-divider: var(--accent-3);
+    --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
+      hsl(var(--accent-3) / 0.42);
+  }
 }
 
 @supports (
@@ -85,75 +87,83 @@
     hsl(var(--background))
   )
 ) {
-  :global(.hero2-neomorph) {
-    --hero2-shadow-ambient: inset 0 0 0 calc(var(--hairline-w) * 1.5)
-      color-mix(in oklab, hsl(var(--shadow-color)) 28%, hsl(var(--highlight)));
-    --hero2-glow-top-left-color: color-mix(
-      in oklab,
-      hsl(var(--highlight)) 72%,
-      hsl(var(--shadow-color))
-    );
-    --hero2-glow-top-left-soft: color-mix(
-      in oklab,
-      hsl(var(--highlight)) 22%,
-      hsl(var(--background) / 0)
-    );
-    --hero2-glow-bottom-right-color: color-mix(
-      in oklab,
-      hsl(var(--shadow-color)) 82%,
-      hsl(var(--highlight))
-    );
-    --hero2-glow-bottom-right-soft: color-mix(
-      in oklab,
-      hsl(var(--shadow-color)) 28%,
-      hsl(var(--background) / 0)
-    );
-  }
-
-  :global(.hero2-frame[data-hero-divider-tint="primary"]) {
-    --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
-      color-mix(
+  :global {
+    .hero2-neomorph {
+      --hero2-shadow-ambient: inset 0 0 0 calc(var(--hairline-w) * 1.5)
+        color-mix(in oklab, hsl(var(--shadow-color)) 28%, hsl(var(--highlight)));
+      --hero2-glow-top-left-color: color-mix(
         in oklab,
-        hsl(var(--ring)) 68%,
-        hsl(var(--background))
+        hsl(var(--highlight)) 72%,
+        hsl(var(--shadow-color))
       );
-  }
-
-  :global(.hero2-frame[data-hero-divider-tint="life"]) {
-    --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
-      color-mix(
+      --hero2-glow-top-left-soft: color-mix(
         in oklab,
-        hsl(var(--accent-3)) 78%,
-        hsl(var(--background))
+        hsl(var(--highlight)) 22%,
+        hsl(var(--background) / 0)
       );
+      --hero2-glow-bottom-right-color: color-mix(
+        in oklab,
+        hsl(var(--shadow-color)) 82%,
+        hsl(var(--highlight))
+      );
+      --hero2-glow-bottom-right-soft: color-mix(
+        in oklab,
+        hsl(var(--shadow-color)) 28%,
+        hsl(var(--background) / 0)
+      );
+    }
+
+    .hero2-frame[data-hero-divider-tint="primary"] {
+      --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
+        color-mix(
+          in oklab,
+          hsl(var(--ring)) 68%,
+          hsl(var(--background))
+        );
+    }
+
+    .hero2-frame[data-hero-divider-tint="life"] {
+      --hero-slot-divider-shadow: 0 0 0 calc(var(--hairline-w) * 3)
+        color-mix(
+          in oklab,
+          hsl(var(--accent-3)) 78%,
+          hsl(var(--background))
+        );
+    }
   }
 }
 
 @media (prefers-contrast: more) {
-  :global(.hero2-frame) {
-    border-color: hsl(var(--foreground) / 0.7) !important;
-  }
-  :global(.hero2-neomorph) {
-    --hero2-shadow-key: 0 0 var(--space-4) hsl(var(--foreground) / 0.75);
-    --hero2-shadow-ambient: inset 0 0 0 calc(var(--hairline-w) * 2)
-      hsl(var(--foreground) / 0.7);
-    box-shadow: var(--hero2-shadow-ambient), var(--hero2-shadow-key);
-    --hero2-glow-top-left: none;
-    --hero2-glow-bottom-right: none;
-    --hero2-focus-ring-rest: 0 0 0 0 hsl(var(--foreground) / 0),
-      0 0 0 0 hsl(var(--foreground) / 0);
-    --hero2-focus-ring-active: 0 0 0 calc(var(--hairline-w) * 2)
-      hsl(var(--foreground) / 0.9),
-      0 0 0 0 hsl(var(--foreground) / 0.6);
+  :global {
+    .hero2-frame {
+      border-color: hsl(var(--foreground) / 0.7) !important;
+    }
+
+    .hero2-neomorph {
+      --hero2-shadow-key: 0 0 var(--space-4) hsl(var(--foreground) / 0.75);
+      --hero2-shadow-ambient: inset 0 0 0 calc(var(--hairline-w) * 2)
+        hsl(var(--foreground) / 0.7);
+      box-shadow: var(--hero2-shadow-ambient), var(--hero2-shadow-key);
+      --hero2-glow-top-left: none;
+      --hero2-glow-bottom-right: none;
+      --hero2-focus-ring-rest: 0 0 0 0 hsl(var(--foreground) / 0),
+        0 0 0 0 hsl(var(--foreground) / 0);
+      --hero2-focus-ring-active: 0 0 0 calc(var(--hairline-w) * 2)
+        hsl(var(--foreground) / 0.9),
+        0 0 0 0 hsl(var(--foreground) / 0.6);
+    }
   }
 }
 
 @media (forced-colors: active) {
-  :global(.hero2-frame) {
-    border-color: CanvasText !important;
-    background: Canvas !important;
-  }
-  :global(.hero2-neomorph) {
-    background: Canvas !important;
+  :global {
+    .hero2-frame {
+      border-color: CanvasText !important;
+      background: Canvas !important;
+    }
+
+    .hero2-neomorph {
+      background: Canvas !important;
+    }
   }
 }

--- a/src/components/ui/layout/hero/HeroGlitchStyles.module.css
+++ b/src/components/ui/layout/hero/HeroGlitchStyles.module.css
@@ -1,49 +1,73 @@
-:global(.hero2-title) {
-  position: relative;
-}
+:global {
+  .hero2-title {
+    position: relative;
+  }
 
-:global(.hero2-title::before),
-:global(.hero2-title::after) {
-  content: attr(data-text);
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  clip-path: inset(0 0 0 0);
-  opacity: 0.75;
-}
+  .hero2-title::before,
+  .hero2-title::after {
+    content: attr(data-text);
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    clip-path: inset(0 0 0 0);
+    opacity: 0.75;
+  }
 
-:global(.hero2-title::before) {
-  transform: translate(
-    calc(var(--hairline-w) / 2),
-    calc(-1 * var(--hairline-w) / 2)
-  );
-  color: hsl(var(--accent-2) / 0.85);
-  mix-blend-mode: screen;
-}
+  .hero2-title::before {
+    transform: translate(
+      calc(var(--hairline-w) / 2),
+      calc(-1 * var(--hairline-w) / 2)
+    );
+    color: hsl(var(--accent-2) / 0.85);
+    mix-blend-mode: screen;
+  }
 
-:global(.hero2-title::after) {
-  transform: translate(
-    calc(-1 * var(--hairline-w) / 2),
-    calc(var(--hairline-w) / 2)
-  );
-  color: hsl(var(--lav-deep) / 0.85);
-  mix-blend-mode: screen;
+  .hero2-title::after {
+    transform: translate(
+      calc(-1 * var(--hairline-w) / 2),
+      calc(var(--hairline-w) / 2)
+    );
+    color: hsl(var(--lav-deep) / 0.85);
+    mix-blend-mode: screen;
+  }
+
+  .tabs-hud {
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .hero2-divider-glow {
+    filter: blur(var(--hero-divider-blur, calc(var(--spacing-1) * 1.5)));
+  }
+
+  .neon-primary {
+    --neon: var(--primary);
+  }
+
+  .neon-life {
+    --neon: var(--accent);
+  }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  :global(.hero2-title::before) {
-    animation: hero2-glitch-a 2.4s infinite steps(8, end);
-  }
-  :global(.hero2-title::after) {
-    animation: hero2-glitch-b 2.4s infinite steps(9, end);
+  :global {
+    .hero2-title::before {
+      animation: hero2-glitch-a 2.4s infinite steps(8, end);
+    }
+
+    .hero2-title::after {
+      animation: hero2-glitch-b 2.4s infinite steps(9, end);
+    }
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  :global(.hero2-title::before),
-  :global(.hero2-title::after) {
-    animation: none;
-    transition-duration: 0s;
+  :global {
+    .hero2-title::before,
+    .hero2-title::after {
+      animation: none;
+      transition-duration: 0s;
+    }
   }
 }
 
@@ -86,41 +110,30 @@
   }
 }
 
-:global(.tabs-hud) {
-  background: transparent;
-  box-shadow: none;
-}
-
-:global(.hero2-divider-glow) {
-  filter: blur(var(--hero-divider-blur, calc(var(--spacing-1) * 1.5)));
-}
-
-:global(.neon-primary) {
-  --neon: var(--primary);
-}
-
-:global(.neon-life) {
-  --neon: var(--accent);
-}
-
 @media (prefers-contrast: more) {
-  :global(.hero2-divider-line) {
-    background-color: hsl(var(--foreground));
-    opacity: 0.85;
-  }
-  :global(.hero2-divider-glow) {
-    background-color: hsl(var(--foreground));
-    opacity: 0.9;
-    filter: none;
+  :global {
+    .hero2-divider-line {
+      background-color: hsl(var(--foreground));
+      opacity: 0.85;
+    }
+
+    .hero2-divider-glow {
+      background-color: hsl(var(--foreground));
+      opacity: 0.9;
+      filter: none;
+    }
   }
 }
 
 @media (forced-colors: active) {
-  :global(.hero2-divider-line) {
-    background-color: CanvasText;
-    opacity: 1;
-  }
-  :global(.hero2-divider-glow) {
-    display: none;
+  :global {
+    .hero2-divider-line {
+      background-color: CanvasText;
+      opacity: 1;
+    }
+
+    .hero2-divider-glow {
+      display: none;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- replace the favicon text node with vector paths so Next.js image prerendering succeeds
- wrap global utility selectors in CSS modules inside :global blocks to satisfy Next.js 15 purity checks
- keep neumorphic hero styling tokens intact across high contrast and reduced motion variants

## Testing
- npm run verify-prompts
- npm run check
- CI=1 npx --no-install next build

------
https://chatgpt.com/codex/tasks/task_e_68dab5f84214832cb311440cc7c3a9dd