### PR TITLE
feat: add glitch hover overlays

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,6 +11,7 @@
     --danger-tint-foreground: var(--danger-foreground);
     --asset-noise-url: url("/noise.svg");
     --asset-glitch-gif-url: url("/glitch-gif.gif");
+    --glitch-gif-url: var(--asset-glitch-gif-url);
     --settings-column-width: calc(var(--space-4) * 14);
     --surface-overlay-soft: 0.12;
     --surface-overlay-strong: 0.2;
@@ -108,6 +109,15 @@
     position: absolute;
     inset: 0;
     pointer-events: none;
+    background-image: var(
+      --glitch-gif-url,
+      var(--asset-glitch-gif-url, url("/glitch-gif.gif"))
+    );
+    background-repeat: repeat;
+    background-size: cover;
+    background-position: center;
+    mix-blend-mode: lighten;
+    opacity: var(--glitch-overlay-opacity, 0.08);
   }
 
   /* Optional global overlays */
@@ -806,6 +816,28 @@ html.bg-intense body::after {
     transition:
       transform var(--dur-quick) var(--ease-out),
       filter var(--dur-quick);
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
+  }
+  .btn-glitch::before {
+    content: attr(data-text);
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: inherit;
+    mix-blend-mode: lighten;
+    opacity: 0;
+    pointer-events: none;
+    clip-path: inset(0 0 0 0);
+    transform: translate3d(0, 0, 0);
+    filter: none;
+    transition: opacity var(--dur-quick) var(--ease-out);
+    will-change: transform, filter;
+  }
+  .btn-glitch:hover::before,
+  .btn-glitch:focus-visible::before {
+    opacity: 0.8;
   }
   .btn-glitch:hover {
     filter: brightness(1.05);
@@ -1496,6 +1528,44 @@ textarea:-webkit-autofill {
       hsl(var(--accent) / 0.18);
 }
 
+@keyframes glitch {
+  0% {
+    clip-path: inset(0 0 0 0);
+    transform: translate3d(0, 0, 0);
+    filter: none;
+  }
+  18% {
+    clip-path: inset(12% 0 68% 0);
+    transform: translate3d(-2px, -1px, 0);
+    filter: hue-rotate(-4deg);
+  }
+  34% {
+    clip-path: inset(44% 0 38% 0);
+    transform: translate3d(2px, 1px, 0);
+    filter: hue-rotate(9deg);
+  }
+  52% {
+    clip-path: inset(72% 0 9% 0);
+    transform: translate3d(-1px, 2px, 0);
+    filter: hue-rotate(-8deg);
+  }
+  68% {
+    clip-path: inset(6% 0 80% 0);
+    transform: translate3d(1px, -2px, 0);
+    filter: hue-rotate(6deg);
+  }
+  82% {
+    clip-path: inset(28% 0 52% 0);
+    transform: translate3d(2px, -1px, 0);
+    filter: hue-rotate(12deg);
+  }
+  100% {
+    clip-path: inset(0 0 0 0);
+    transform: translate3d(0, 0, 0);
+    filter: none;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .glitch-rail {
     animation: none;
@@ -1508,6 +1578,8 @@ textarea:-webkit-autofill {
   border: var(--hairline-w) solid hsl(var(--card-hairline));
   background: hsl(var(--card) / 0.7);
   box-shadow: var(--shadow);
+  isolation: isolate;
+  overflow: hidden;
   transition:
     transform 0.12s ease,
     box-shadow 0.2s ease,
@@ -1562,6 +1634,15 @@ textarea:-webkit-autofill {
   );
   mix-blend-mode: overlay;
   opacity: 0.2;
+  clip-path: inset(0 0 0 0);
+  transform: translate3d(0, 0, 0);
+  filter: none;
+  will-change: transform, filter, clip-path;
+  transition: opacity var(--dur-quick) var(--ease-out);
+}
+.glitch-card:hover::before,
+.glitch-card:focus-within::before {
+  opacity: 0.32;
 }
 .glitch-title {
   position: relative;
@@ -1581,6 +1662,16 @@ textarea:-webkit-autofill {
   }
   .glitch-card::before {
     animation: lg-scan 11s linear infinite;
+  }
+  .glitch-card:hover::before,
+  .glitch-card:focus-within::before {
+    animation:
+      lg-scan 11s linear infinite,
+      glitch 0.55s steps(2, end) infinite;
+  }
+  .btn-glitch:hover::before,
+  .btn-glitch:focus-visible::before {
+    animation: glitch 0.45s steps(2, end) infinite;
   }
   .glitch-title:hover,
   .glitch-title:focus-visible {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -136,6 +136,7 @@ export default async function RootLayout({
     ":root {",
     `  --asset-noise-url: url(\"${withBasePath("/noise.svg")}\");`,
     `  --asset-glitch-gif-url: url(\"${withBasePath("/glitch-gif.gif")}\");`,
+    `  --glitch-gif-url: url(\"${withBasePath("/glitch-gif.gif")}\");`,
     "}",
   ].join("\n");
   const renderLayout = (nonce?: string) => {

--- a/src/components/chrome/PageTabs.tsx
+++ b/src/components/chrome/PageTabs.tsx
@@ -140,6 +140,7 @@ export default function PageTabs({
             href={item.href}
             scroll={false}
             className={mergedClassName}
+            data-text={typeof item.label === "string" ? item.label : undefined}
             onClick={(event) => {
               if (disabled) {
                 event.preventDefault();
@@ -161,6 +162,7 @@ export default function PageTabs({
           ref={ref as React.Ref<HTMLButtonElement>}
           disabled={disabled}
           className={mergedClassName}
+          data-text={typeof item.label === "string" ? item.label : undefined}
           onClick={(event) => {
             if (disabled) {
               event.preventDefault();

--- a/src/components/prompts/DemoHeader.tsx
+++ b/src/components/prompts/DemoHeader.tsx
@@ -71,6 +71,7 @@ export default function DemoHeader({
           aria-label="Timer demo"
           defaultValue="25:00"
           className="btn-like-segmented btn-glitch w-[5ch]"
+          data-text="25:00"
           inputClassName="text-center"
           type="text"
         />

--- a/src/components/prompts/component-gallery/ButtonsPanel.tsx
+++ b/src/components/prompts/component-gallery/ButtonsPanel.tsx
@@ -234,6 +234,9 @@ export default function ButtonsPanel({ data }: ButtonsPanelProps) {
                     {...restProps}
                     ref={ref as React.Ref<HTMLButtonElement>}
                     className={className}
+                    data-text={
+                      typeof item.label === "string" ? item.label : undefined
+                    }
                     disabled={disabled}
                     onClick={(event) => {
                       if (disabled) {

--- a/src/components/reviews/ReviewList.tsx
+++ b/src/components/reviews/ReviewList.tsx
@@ -107,6 +107,7 @@ export default function ReviewList({
             size="md"
             onClick={onCreate}
             className={cn("btn-glitch")}
+            data-text="Create review"
           >
             Create review
           </Button>

--- a/src/components/reviews/ReviewsPage.tsx
+++ b/src/components/reviews/ReviewsPage.tsx
@@ -155,6 +155,7 @@ export default function ReviewsPage({
                     "btn-glitch",
                     "w-full whitespace-nowrap md:col-span-2 md:justify-self-end",
                   )}
+                  data-text="New Review"
                   onClick={handleCreateReview}
                 >
                   <Plus />
@@ -188,6 +189,7 @@ export default function ReviewsPage({
                     "btn-glitch",
                     "w-full whitespace-nowrap md:col-span-4 md:justify-self-end",
                   )}
+                  data-text="New Review"
                   onClick={handleCreateReview}
                 >
                   <Plus />

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -46,6 +46,7 @@ export type TabElementProps = React.HTMLAttributes<HTMLElement> & {
   "aria-busy"?: boolean;
   "data-active"?: boolean;
   "data-loading"?: boolean;
+  "data-text"?: string;
 };
 
 export type TabRenderContext<
@@ -306,6 +307,10 @@ export default function TabBar<
               "data-active": active || undefined,
               "data-loading": isLoading || undefined,
               className: baseClass,
+              "data-text":
+                isGlitch && typeof item.label === "string"
+                  ? item.label
+                  : undefined,
               onClick: (event) => {
                 if (isDisabled) {
                   event.preventDefault();

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -275,6 +275,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                       </div>
                       <button
                         class="_root_2452a7 relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-quick ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:ring-2 focus-visible:ring-[var(--ring-contrast)] focus-visible:shadow-[var(--shadow-glow-md)] focus-visible:[outline:var(--spacing-0-5)_solid_var(--ring-contrast)] focus-visible:[outline-offset:var(--spacing-0-5)] disabled:opacity-disabled disabled:pointer-events-none data-[loading=true]:opacity-loading data-[disabled=true]:opacity-disabled data-[disabled=true]:pointer-events-none h-[var(--control-h-md)] px-[var(--space-4)] text-ui gap-[var(--space-2)] [&_svg]:size-[var(--space-5)] btn-glitch w-full whitespace-nowrap md:col-span-2 md:justify-self-end shadow-[var(--btn-primary-shadow-rest)] hover:shadow-[var(--btn-primary-shadow-hover)] active:shadow-[var(--btn-primary-shadow-active)] active:translate-y-[var(--spacing-0-25)] bg-primary-soft border-[hsl(var(--primary)/0.35)] text-[hsl(var(--primary-foreground))] [--hover:theme('colors.interaction.primary.hover')] [--active:theme('colors.interaction.primary.active')]"
+                        data-text="New Review"
                         data-tone="primary"
                         data-variant="primary"
                         tabindex="0"


### PR DESCRIPTION
## Summary
- add a reusable glitch animation overlay with hue-shifted keyframes and wire it into the global glitch background asset
- propagate `data-text` for glitch buttons and tabs so the overlay pseudo-element animates on hover/focus states

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dab70c6d1c832c8deb6faac474a15f