### PR TITLE
fix: default welcome hero image to lazy load

### DIFF
--- a/src/components/home/WelcomeHeroFigure.tsx
+++ b/src/components/home/WelcomeHeroFigure.tsx
@@ -21,6 +21,7 @@ export interface WelcomeHeroFigureProps {
   haloTone?: WelcomeHeroFigureTone;
   showGlitchRail?: boolean;
   framed?: boolean;
+  eager?: boolean;
 }
 
 export default function WelcomeHeroFigure({
@@ -29,6 +30,7 @@ export default function WelcomeHeroFigure({
   haloTone = "default",
   showGlitchRail,
   framed = true,
+  eager = false,
 }: WelcomeHeroFigureProps) {
   const shouldShowGlitchRail = framed && (showGlitchRail ?? haloTone === "default");
   const imageClassName = cn(
@@ -38,11 +40,15 @@ export default function WelcomeHeroFigure({
   const imageAlt = "Planner assistant sharing a colorful dashboard scene";
   const resolvedHeroImageSrc = withBasePath(heroImageSrc);
   const sharedImageProps = {
-    priority: true,
-    loading: "eager" as const,
     decoding: "async" as const,
     sizes: imageSizes,
     className: imageClassName,
+    ...(eager
+      ? ({
+          priority: true,
+          loading: "eager" as const,
+        } satisfies Pick<ComponentProps<typeof Image>, "priority" | "loading">)
+      : {}),
   } satisfies Partial<ComponentProps<typeof Image>>;
 
   return (


### PR DESCRIPTION
## Summary
- default the welcome hero figure to lazy-load its artwork while preserving async decoding
- add an optional `eager` prop so above-the-fold usages can still request eager loading with priority hints

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dabdaf0438832c815e26908517550a