### PR TITLE
feat: integrate planner reminders

### DIFF
--- a/src/components/goals/reminders/useReminders.tsx
+++ b/src/components/goals/reminders/useReminders.tsx
@@ -145,9 +145,7 @@ const SOURCE_TABS = SOURCE_FILTERS.map((s) => ({
   label: s === "all" ? "All" : s,
 }));
 
-const RemindersContext = React.createContext<RemindersContextValue | null>(null);
-
-type RemindersContextValue = {
+export type RemindersContextValue = {
   items: Reminder[];
   filtered: Reminder[];
   counts: Record<Group, number>;
@@ -176,6 +174,10 @@ type RemindersContextValue = {
   sourceTabs: typeof SOURCE_TABS;
   groups: typeof GROUPS;
 };
+
+export const RemindersContext = React.createContext<RemindersContextValue | null>(
+  null,
+);
 
 function inferDomain(reminder: Reminder): Domain {
   if (reminder.domain) return reminder.domain;

--- a/src/components/planner/DayCard.tsx
+++ b/src/components/planner/DayCard.tsx
@@ -10,13 +10,14 @@
 import "./style.css";
 import * as React from "react";
 import { useSelectedProject, useSelectedTask } from "./useSelection";
-import type { ISODate } from "./plannerTypes";
+import type { ISODate, TaskReminder } from "./plannerTypes";
 import { useDay } from "./useDay";
 import { cn } from "@/lib/utils";
 import DayCardHeader from "./DayCardHeader";
 import ProjectList from "./ProjectList";
 import TaskList from "./TaskList";
 import { usePlannerActions } from "./usePlannerStore";
+import TaskReminderSettings from "./TaskReminderSettings";
 
 type Props = { iso: ISODate; isToday?: boolean };
 
@@ -35,11 +36,14 @@ export default function DayCard({ iso, isToday }: Props) {
     removeTaskImage: removeTaskImageForDay,
     doneCount,
     totalCount,
+    updateTaskReminder,
   } = useDay(iso);
 
   const [selectedProjectId, setSelectedProjectId] = useSelectedProject(iso);
-  const [, setSelectedTaskId] = useSelectedTask(iso);
+  const [selectedTaskId, setSelectedTaskId] = useSelectedTask(iso);
   const { createProject, createTask } = usePlannerActions();
+
+  const selectedTask = selectedTaskId ? tasksById[selectedTaskId] : undefined;
 
   const handleCreateProject = React.useCallback(
     (name: string) =>
@@ -56,6 +60,14 @@ export default function DayCard({ iso, isToday }: Props) {
         select: setSelectedTaskId,
       }),
     [createTask, iso, selectedProjectId, setSelectedTaskId],
+  );
+
+  const handleReminderChange = React.useCallback(
+    (partial: Partial<TaskReminder> | null) => {
+      if (!selectedTaskId) return;
+      updateTaskReminder(selectedTaskId, partial);
+    },
+    [selectedTaskId, updateTaskReminder],
   );
 
   return (
@@ -117,6 +129,10 @@ export default function DayCard({ iso, isToday }: Props) {
           </div>
         </React.Fragment>
       )}
+
+      <div className="col-span-full">
+        <TaskReminderSettings task={selectedTask} onChange={handleReminderChange} />
+      </div>
     </section>
   );
 }

--- a/src/components/planner/PlannerPage.tsx
+++ b/src/components/planner/PlannerPage.tsx
@@ -23,6 +23,7 @@ import { PageHeader } from "@/components/ui";
 import PageShell, { layoutGridClassName } from "@/components/ui/layout/PageShell";
 import { CalendarDays } from "lucide-react";
 import { formatWeekRangeLabel } from "@/lib/date";
+import { RemindersProvider } from "@/components/goals/reminders/useReminders";
 
 const PLANNER_SCROLL_STORAGE_KEY = "planner:scroll-position";
 
@@ -164,8 +165,10 @@ function Inner() {
 
 export default function PlannerPage() {
   return (
-    <PlannerProvider>
-      <Inner />
-    </PlannerProvider>
+    <RemindersProvider>
+      <PlannerProvider>
+        <Inner />
+      </PlannerProvider>
+    </RemindersProvider>
   );
 }

--- a/src/components/planner/TaskReminderSettings.tsx
+++ b/src/components/planner/TaskReminderSettings.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import * as React from "react";
+import NeoCard from "@/components/ui/primitives/NeoCard";
+import Label from "@/components/ui/Label";
+import Input from "@/components/ui/primitives/Input";
+import Select from "@/components/ui/Select";
+import Toggle from "@/components/ui/toggles/Toggle";
+import { AnimatedSelect } from "@/components/ui";
+import { usePersistentState } from "@/lib/db";
+import { usePlannerReminders } from "./plannerContext";
+import type { DayTask, TaskReminder } from "./plannerTypes";
+
+const LEAD_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "0", label: "At start" },
+  { value: "5", label: "5 minutes before" },
+  { value: "10", label: "10 minutes before" },
+  { value: "15", label: "15 minutes before" },
+  { value: "30", label: "30 minutes before" },
+  { value: "60", label: "1 hour before" },
+];
+
+const DEFAULT_TIME = "09:00";
+
+type TaskReminderSettingsProps = {
+  task?: DayTask;
+  onChange: (partial: Partial<TaskReminder> | null) => void;
+};
+
+export default function TaskReminderSettings({
+  task,
+  onChange,
+}: TaskReminderSettingsProps) {
+  const { filtered, items } = usePlannerReminders();
+  const [defaultReminderId, setDefaultReminderId] =
+    usePersistentState<string | null>("planner:reminder-default-id.v1", null);
+  const [defaultTime, setDefaultTime] = usePersistentState<string>(
+    "planner:reminder-default-time.v1",
+    DEFAULT_TIME,
+  );
+  const [defaultLeadMinutes, setDefaultLeadMinutes] = usePersistentState<number>(
+    "planner:reminder-default-lead.v1",
+    0,
+  );
+
+  const availableReminders = React.useMemo(() => {
+    const source = filtered.length > 0 ? filtered : items;
+    return source
+      .slice()
+      .sort((a, b) => {
+        if (!!b.pinned === !!a.pinned) return a.title.localeCompare(b.title);
+        return Number(b.pinned) - Number(a.pinned);
+      })
+      .map((reminder) => ({
+        value: reminder.id,
+        label: reminder.title,
+      }));
+  }, [filtered, items]);
+
+  const activeReminder = task?.reminder;
+  const isEnabled = Boolean(activeReminder?.enabled);
+  const reminderId =
+    activeReminder?.reminderId ??
+    defaultReminderId ??
+    availableReminders[0]?.value ??
+    "";
+  const reminderTime = activeReminder?.time ?? defaultTime ?? DEFAULT_TIME;
+  const leadMinutes =
+    activeReminder?.leadMinutes ?? defaultLeadMinutes ?? 0;
+
+  const selectedTaskLabel = React.useMemo(() => {
+    if (!task) return "No task selected";
+    const trimmed = task.title.trim();
+    return trimmed ? `Reminder for “${trimmed}”` : "Reminder for untitled task";
+  }, [task]);
+
+  const handleToggle = React.useCallback(
+    (side: "Left" | "Right") => {
+      if (!task) return;
+      const enable = side === "Right";
+      const fallbackId =
+        activeReminder?.reminderId ??
+        reminderId ??
+        availableReminders[0]?.value ??
+        "";
+      const fallbackTime =
+        activeReminder?.time ?? reminderTime ?? DEFAULT_TIME;
+      const fallbackLead =
+        activeReminder?.leadMinutes ?? leadMinutes ?? 0;
+
+      if (!enable) {
+        onChange({
+          enabled: false,
+          ...(fallbackId ? { reminderId: fallbackId } : {}),
+          ...(fallbackTime ? { time: fallbackTime } : {}),
+          leadMinutes: fallbackLead,
+        });
+        return;
+      }
+
+      onChange({
+        enabled: true,
+        ...(fallbackId ? { reminderId: fallbackId } : {}),
+        ...(fallbackTime ? { time: fallbackTime } : {}),
+        leadMinutes: fallbackLead,
+      });
+      if (fallbackId) setDefaultReminderId(fallbackId);
+      if (fallbackTime) setDefaultTime(fallbackTime);
+      setDefaultLeadMinutes(fallbackLead);
+    },
+    [
+      task,
+      activeReminder?.reminderId,
+      activeReminder?.time,
+      activeReminder?.leadMinutes,
+      reminderId,
+      reminderTime,
+      leadMinutes,
+      availableReminders,
+      onChange,
+      setDefaultReminderId,
+      setDefaultTime,
+      setDefaultLeadMinutes,
+    ],
+  );
+
+  const handleReminderSelect = React.useCallback(
+    (value: string) => {
+      if (!task) return;
+      onChange({ reminderId: value || undefined });
+      if (value) setDefaultReminderId(value);
+    },
+    [onChange, setDefaultReminderId, task],
+  );
+
+  const handleTimeChange = React.useCallback(
+    (value: string) => {
+      if (!task) return;
+      onChange({ time: value || undefined });
+      if (value) setDefaultTime(value);
+    },
+    [onChange, setDefaultTime, task],
+  );
+
+  const handleLeadChange = React.useCallback(
+    (value: string) => {
+      if (!task) return;
+      const minutes = Number.parseInt(value, 10);
+      const normalized = Number.isFinite(minutes) ? Math.max(0, minutes) : 0;
+      onChange({ leadMinutes: normalized });
+      setDefaultLeadMinutes(normalized);
+    },
+    [onChange, setDefaultLeadMinutes, task],
+  );
+
+  const noReminders = availableReminders.length === 0;
+
+  return (
+    <NeoCard className="col-span-full card-pad space-y-[var(--space-4)]">
+      <header className="flex flex-col gap-[var(--space-1)]">
+        <h3 className="text-title-sm font-semibold">Task reminders</h3>
+        <p className="text-ui text-muted-foreground">{selectedTaskLabel}</p>
+      </header>
+
+      {!task ? (
+        <p className="text-ui text-muted-foreground">
+          Select a task to attach a reminder.
+        </p>
+      ) : noReminders ? (
+        <p className="text-ui text-muted-foreground">
+          Add reminders in Goals → Reminders to make them available here.
+        </p>
+      ) : (
+        <div className="grid gap-[var(--space-4)] md:grid-cols-2">
+          <div className="flex flex-col gap-[var(--space-2)]">
+            <span className="text-ui font-medium">
+              Reminder state
+            </span>
+            <Toggle
+              leftLabel="Off"
+              rightLabel="On"
+              value={isEnabled ? "Right" : "Left"}
+              onChange={handleToggle}
+              disabled={!task}
+              className="w-full"
+            />
+          </div>
+
+          <div className="flex flex-col gap-[var(--space-2)]">
+            <Label htmlFor={`reminder-select-${task.id}`}>Reminder</Label>
+            <AnimatedSelect
+              id={`reminder-select-${task.id}`}
+              items={availableReminders}
+              value={reminderId}
+              onChange={handleReminderSelect}
+              placeholder="Choose reminder"
+              ariaLabel="Select reminder template"
+              disabled={!isEnabled}
+              size="md"
+            />
+          </div>
+
+          <div className="flex flex-col gap-[var(--space-2)]">
+            <Label htmlFor={`reminder-time-${task.id}`}>Time</Label>
+            <Input
+              id={`reminder-time-${task.id}`}
+              type="time"
+              step={60}
+              value={reminderTime}
+              onChange={(event) => handleTimeChange(event.target.value)}
+              disabled={!isEnabled}
+            />
+          </div>
+
+          <div className="flex flex-col gap-[var(--space-2)]">
+            <Label htmlFor={`reminder-lead-${task.id}`}>Lead time</Label>
+            <Select
+              variant="native"
+              id={`reminder-lead-${task.id}`}
+              items={LEAD_OPTIONS}
+              value={String(leadMinutes)}
+              onChange={handleLeadChange}
+              disabled={!isEnabled}
+            />
+          </div>
+        </div>
+      )}
+    </NeoCard>
+  );
+}

--- a/src/components/planner/index.ts
+++ b/src/components/planner/index.ts
@@ -18,6 +18,7 @@ export * from "./scheduleSavingReset";
 export { default as ScrollTopFloatingButton } from "./ScrollTopFloatingButton";
 export { default as TaskList } from "./TaskList";
 export { default as TaskRow } from "./TaskRow";
+export { default as TaskReminderSettings } from "./TaskReminderSettings";
 export { default as TodayHero } from "./TodayHero";
 export { default as TodayHeroHeader } from "./TodayHeroHeader";
 export { default as TodayHeroProjects } from "./TodayHeroProjects";

--- a/src/components/planner/plannerCrud.ts
+++ b/src/components/planner/plannerCrud.ts
@@ -10,8 +10,9 @@ import {
   removeTask as dayRemoveTask,
   addTaskImage as dayAddTaskImage,
   removeTaskImage as dayRemoveTaskImage,
+  updateTaskReminder as dayUpdateTaskReminder,
 } from "./dayCrud";
-import type { DayRecord, ISODate } from "./plannerTypes";
+import type { DayRecord, ISODate, TaskReminder } from "./plannerTypes";
 
 export type UpsertDay = (iso: ISODate, fn: (d: DayRecord) => DayRecord) => void;
 
@@ -64,6 +65,11 @@ export function makeCrud(iso: ISODate, upsertDay: UpsertDay) {
   const removeTaskImage = (id: string, url: string, index?: number) =>
     upsertDay(iso, (d) => dayRemoveTaskImage(d, id, url, index));
 
+  const updateTaskReminder = (
+    id: string,
+    partial: Partial<TaskReminder> | null,
+  ) => upsertDay(iso, (d) => dayUpdateTaskReminder(d, id, partial));
+
   const setNotesForDay = (notes: string) =>
     upsertDay(iso, (d) => setNotes(d, notes));
 
@@ -81,6 +87,7 @@ export function makeCrud(iso: ISODate, upsertDay: UpsertDay) {
     removeTask,
     addTaskImage,
     removeTaskImage,
+    updateTaskReminder,
     setNotes: setNotesForDay,
     setFocus: setFocusForDay,
   } as const;

--- a/src/components/planner/plannerTypes.ts
+++ b/src/components/planner/plannerTypes.ts
@@ -9,6 +9,13 @@ export type Project = {
   loading?: boolean;
 };
 
+export type TaskReminder = {
+  enabled: boolean;
+  reminderId?: string;
+  time?: string;
+  leadMinutes?: number;
+};
+
 export type DayTask = {
   id: string;
   title: string;
@@ -16,6 +23,7 @@ export type DayTask = {
   projectId?: string;
   createdAt: number;
   images: string[];
+  reminder?: TaskReminder;
 };
 
 export type DayRecord = {

--- a/src/components/planner/useDay.ts
+++ b/src/components/planner/useDay.ts
@@ -34,6 +34,7 @@ export function useDay(iso: ISODate) {
     toggleTask: crud.toggleTask,
     addTaskImage: crud.addTaskImage,
     removeTaskImage: crud.removeTaskImage,
+    updateTaskReminder: crud.updateTaskReminder,
     doneCount,
     totalCount,
   } as const;

--- a/src/components/planner/usePlannerStore.ts
+++ b/src/components/planner/usePlannerStore.ts
@@ -17,7 +17,7 @@ import type {
 import { makeCrud } from "./plannerCrud";
 import { readLocal, removeLocal } from "@/lib/db";
 
-export type { ISODate, DayRecord, Project, DayTask } from "./plannerTypes";
+export type { ISODate, DayRecord, Project, DayTask, TaskReminder } from "./plannerTypes";
 
 type LegacySnapshot = {
   projects: Project[] | null;

--- a/tests/planner/PlannerReminders.integration.test.tsx
+++ b/tests/planner/PlannerReminders.integration.test.tsx
@@ -1,0 +1,151 @@
+import * as React from "react";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+type PlannerModule = typeof import("@/components/planner");
+type DbModule = typeof import("@/lib/db");
+
+describe("Planner reminders integration", () => {
+  let PlannerProvider: PlannerModule["PlannerProvider"];
+  let usePlannerStore: PlannerModule["usePlannerStore"];
+  let usePlannerReminders: PlannerModule["usePlannerReminders"];
+
+  let flushWriteLocal: DbModule["flushWriteLocal"];
+  let setWriteLocalDelay: DbModule["setWriteLocalDelay"];
+  let originalWriteDelay: number;
+
+  let wrapper: React.FC<{ children: React.ReactNode }>;
+
+  beforeAll(async () => {
+    const plannerModule = await import("@/components/planner");
+    PlannerProvider = plannerModule.PlannerProvider;
+    usePlannerStore = plannerModule.usePlannerStore;
+    usePlannerReminders = plannerModule.usePlannerReminders;
+
+    const dbModule = await import("@/lib/db");
+    flushWriteLocal = dbModule.flushWriteLocal;
+    setWriteLocalDelay = dbModule.setWriteLocalDelay;
+    originalWriteDelay = dbModule.writeLocalDelay;
+
+    wrapper = ({ children }) => <PlannerProvider>{children}</PlannerProvider>;
+  });
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    setWriteLocalDelay(0);
+  });
+
+  afterEach(() => {
+    flushWriteLocal();
+    window.localStorage.clear();
+    setWriteLocalDelay(originalWriteDelay);
+  });
+
+  it("persists reminder attachments and rehydrates offline", async () => {
+    const hook = renderHook(
+      () => ({
+        planner: usePlannerStore(),
+        reminders: usePlannerReminders(),
+      }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(hook.result.current.planner.day.projects).toBeDefined();
+    });
+
+    let projectId: string | undefined;
+    act(() => {
+      projectId = hook.result.current.planner.addProject("Reminder Ready");
+    });
+    expect(projectId).toBeTruthy();
+
+    let taskId: string | undefined;
+    act(() => {
+      taskId = hook.result.current.planner.addTask(
+        "Attach reminder",
+        projectId,
+      );
+    });
+    expect(taskId).toBeTruthy();
+
+    const reminderId = hook.result.current.reminders.items[0]?.id;
+    expect(reminderId).toBeTruthy();
+
+    act(() => {
+      hook.result.current.planner.updateTaskReminder(taskId!, {
+        enabled: true,
+        reminderId: reminderId!,
+        time: "10:15",
+        leadMinutes: 15,
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        hook.result.current.planner.day.tasksById[taskId!]?.reminder,
+      ).toMatchObject({
+        enabled: true,
+        reminderId,
+        time: "10:15",
+        leadMinutes: 15,
+      });
+    });
+
+    flushWriteLocal();
+
+    const storedDaysRaw = window.localStorage.getItem(
+      "noxis-planner:planner:days",
+    );
+    expect(storedDaysRaw).toBeTruthy();
+
+    const storedDays = JSON.parse(storedDaysRaw ?? "{}") as Record<
+      string,
+      {
+        tasks?: Array<{
+          id?: string;
+          reminder?: {
+            enabled?: boolean;
+            reminderId?: string;
+            time?: string;
+            leadMinutes?: number;
+          };
+        }>;
+      }
+    >;
+
+    const focus = hook.result.current.planner.focus;
+    const storedReminder = storedDays[focus]?.tasks?.find(
+      (task) => task?.id === taskId,
+    )?.reminder;
+
+    expect(storedReminder).toMatchObject({
+      enabled: true,
+      reminderId,
+      time: "10:15",
+      leadMinutes: 15,
+    });
+
+    hook.unmount();
+
+    const rerender = renderHook(() => usePlannerStore(), { wrapper });
+
+    await waitFor(() => {
+      expect(rerender.result.current.day.tasksById[taskId!]?.reminder).toMatchObject({
+        enabled: true,
+        reminderId,
+        time: "10:15",
+        leadMinutes: 15,
+      });
+    });
+
+    rerender.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- wrap the planner stack with the reminders provider and surface reminder state via `usePlannerReminders`
- extend planner CRUD/types to persist task reminder preferences and add a neumorphic reminder settings card
- add an integration test that verifies reminder attachments persist across reloads and offline storage

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dabd8a6b38832cbbc5ee2006812161