### PR TITLE
feat: add planner view modes

### DIFF
--- a/src/components/planner/plannerContext.tsx
+++ b/src/components/planner/plannerContext.tsx
@@ -26,6 +26,26 @@ import {
   setNotes as applyNotesToDay,
 } from "./plannerCrud";
 
+export const PLANNER_VIEW_MODES = [
+  "day",
+  "week",
+  "month",
+  "agenda",
+] as const;
+
+export type PlannerViewMode = (typeof PLANNER_VIEW_MODES)[number];
+
+function decodePlannerViewMode(value: unknown): PlannerViewMode | null {
+  if (typeof value !== "string") return null;
+  return PLANNER_VIEW_MODES.includes(value as PlannerViewMode)
+    ? (value as PlannerViewMode)
+    : null;
+}
+
+export function isPlannerViewMode(value: unknown): value is PlannerViewMode {
+  return decodePlannerViewMode(value) !== null;
+}
+
 type DaysUpdateMetadata = {
   days: Record<ISODate, DayRecord>;
   changed?: Iterable<ISODate>;
@@ -184,6 +204,8 @@ type PlannerState = {
   today: ISODate;
   setIso: React.Dispatch<React.SetStateAction<ISODate>>;
   week: PlannerWeek;
+  viewMode: PlannerViewMode;
+  setViewMode: React.Dispatch<React.SetStateAction<PlannerViewMode>>;
   goals: PlannerGoalsState;
   getFocus: (iso: ISODate) => string;
   updateFocus: (iso: ISODate, value: string) => void;
@@ -210,6 +232,11 @@ export function PlannerProvider({ children }: { children: React.ReactNode }) {
   const [selectedState, setSelectedState] = usePersistentState<
     Record<ISODate, Selection>
   >("planner:selected", {});
+  const [viewMode, setViewMode] = usePersistentState<PlannerViewMode>(
+    "planner:view-mode",
+    "week",
+    { decode: decodePlannerViewMode },
+  );
   const [today, setToday] = React.useState(() => todayISO());
   const [goalList, setGoalList] = usePersistentState<Goal[]>("goals.v2", [], {
     decode: decodeGoals,
@@ -682,6 +709,8 @@ export function PlannerProvider({ children }: { children: React.ReactNode }) {
       iso,
       today,
       setIso: setFocus,
+      viewMode,
+      setViewMode,
       week,
       goals: goalsValue,
       getFocus: getDayFocus,
@@ -693,6 +722,8 @@ export function PlannerProvider({ children }: { children: React.ReactNode }) {
       iso,
       today,
       setFocus,
+      viewMode,
+      setViewMode,
       week,
       goalsValue,
       getDayFocus,

--- a/src/components/planner/views/AgendaView.tsx
+++ b/src/components/planner/views/AgendaView.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import * as React from "react";
+import PageShell, {
+  layoutGridClassName,
+} from "@/components/ui/layout/PageShell";
+import { addDays, fromISODate, toISODate } from "@/lib/date";
+import TodayHero from "../TodayHero";
+import WeekNotes from "../WeekNotes";
+import DayRow from "../DayRow";
+import ScrollTopFloatingButton from "../ScrollTopFloatingButton";
+import { useFocusDate } from "../useFocusDate";
+import type { ISODate } from "../plannerTypes";
+import { usePreloadedDays } from "./usePreloadedDays";
+
+const AGENDA_LENGTH = 14;
+
+export default function AgendaView() {
+  const { iso, today } = useFocusDate();
+  const heroRef = React.useRef<HTMLDivElement>(null);
+
+  const agendaDays = React.useMemo<ISODate[]>(() => {
+    const start = fromISODate(iso) ?? new Date();
+    start.setHours(0, 0, 0, 0);
+    return Array.from({ length: AGENDA_LENGTH }, (_, index) =>
+      toISODate(addDays(start, index)),
+    );
+  }, [iso]);
+
+  usePreloadedDays(agendaDays);
+
+  return (
+    <>
+      <PageShell
+        as="section"
+        grid
+        className="py-[var(--space-6)]"
+        contentClassName="gap-y-[var(--space-6)]"
+        aria-label="Planner agenda view"
+      >
+        <section
+          aria-label="Today and weekly panels"
+          className={`${layoutGridClassName} col-span-full lg:grid-cols-12`}
+        >
+          <div className="col-span-full lg:col-span-8" ref={heroRef}>
+            <TodayHero iso={iso} />
+          </div>
+
+          <aside
+            aria-label="Day notes"
+            className="col-span-full space-y-[var(--space-6)] lg:col-span-4 lg:sticky lg:top-[var(--header-stack)]"
+          >
+            <WeekNotes iso={iso} />
+          </aside>
+        </section>
+
+        <ul
+          aria-label="Agenda (next 14 days)"
+          className="col-span-full flex flex-col gap-[var(--space-4)]"
+        >
+          {agendaDays.map((day) => (
+            <DayRow key={day} iso={day} isToday={day === today} />
+          ))}
+        </ul>
+      </PageShell>
+      <ScrollTopFloatingButton watchRef={heroRef} />
+    </>
+  );
+}
+

--- a/src/components/planner/views/DayView.tsx
+++ b/src/components/planner/views/DayView.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import * as React from "react";
+import PageShell, {
+  layoutGridClassName,
+} from "@/components/ui/layout/PageShell";
+import TodayHero from "../TodayHero";
+import WeekNotes from "../WeekNotes";
+import DayRow from "../DayRow";
+import ScrollTopFloatingButton from "../ScrollTopFloatingButton";
+import { useFocusDate } from "../useFocusDate";
+import type { ISODate } from "../plannerTypes";
+import { usePreloadedDays } from "./usePreloadedDays";
+
+export default function DayView() {
+  const { iso, today } = useFocusDate();
+  const heroRef = React.useRef<HTMLDivElement>(null);
+  const dayList = React.useMemo<ISODate[]>(() => [iso], [iso]);
+  usePreloadedDays(dayList);
+
+  return (
+    <>
+      <PageShell
+        as="section"
+        grid
+        className="py-[var(--space-6)]"
+        contentClassName="gap-y-[var(--space-6)]"
+        aria-label="Planner day view"
+      >
+        <section
+          aria-label="Today and weekly panels"
+          className={`${layoutGridClassName} col-span-full lg:grid-cols-12`}
+        >
+          <div className="col-span-full lg:col-span-8" ref={heroRef}>
+            <TodayHero iso={iso} />
+          </div>
+
+          <aside
+            aria-label="Day notes"
+            className="col-span-full space-y-[var(--space-6)] lg:col-span-4 lg:sticky lg:top-[var(--header-stack)]"
+          >
+            <WeekNotes iso={iso} />
+          </aside>
+        </section>
+
+        <ul
+          aria-label="Selected day"
+          className="col-span-full flex flex-col gap-[var(--space-4)]"
+        >
+          <DayRow iso={iso} isToday={iso === today} />
+        </ul>
+      </PageShell>
+      <ScrollTopFloatingButton watchRef={heroRef} />
+    </>
+  );
+}
+

--- a/src/components/planner/views/MonthView.tsx
+++ b/src/components/planner/views/MonthView.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import * as React from "react";
+import PageShell, {
+  layoutGridClassName,
+} from "@/components/ui/layout/PageShell";
+import { addDays, fromISODate, mondayStartOfWeek, toISODate } from "@/lib/date";
+import { LOCALE } from "@/lib/utils";
+import TodayHero from "../TodayHero";
+import WeekNotes from "../WeekNotes";
+import WeekSummary from "../WeekSummary";
+import ScrollTopFloatingButton from "../ScrollTopFloatingButton";
+import { useFocusDate } from "../useFocusDate";
+import type { ISODate } from "../plannerTypes";
+import { usePreloadedDays } from "./usePreloadedDays";
+
+const monthFormatter = new Intl.DateTimeFormat(LOCALE, {
+  month: "long",
+  year: "numeric",
+});
+
+export default function MonthView() {
+  const { iso } = useFocusDate();
+  const heroRef = React.useRef<HTMLDivElement>(null);
+
+  const { monthLabel, monthDays, weekStarts } = React.useMemo(() => {
+    const focusDate = fromISODate(iso) ?? new Date();
+    const startOfMonth = new Date(
+      focusDate.getFullYear(),
+      focusDate.getMonth(),
+      1,
+      0,
+      0,
+      0,
+      0,
+    );
+    const firstWeekStart = mondayStartOfWeek(startOfMonth);
+    const endOfMonth = new Date(
+      focusDate.getFullYear(),
+      focusDate.getMonth() + 1,
+      0,
+      23,
+      59,
+      59,
+      999,
+    );
+    const weekStartsAccumulator: ISODate[] = [];
+    const dayAccumulator: ISODate[] = [];
+
+    for (
+      let cursor = new Date(firstWeekStart);
+      cursor <= endOfMonth;
+      cursor = addDays(cursor, 7)
+    ) {
+      weekStartsAccumulator.push(toISODate(cursor));
+    }
+
+    const lastWeekStartIso = weekStartsAccumulator.at(-1) ?? toISODate(firstWeekStart);
+    const lastWeekStart = fromISODate(lastWeekStartIso) ?? new Date(firstWeekStart);
+    const lastWeekEnd = addDays(lastWeekStart, 6);
+
+    for (
+      let cursor = new Date(firstWeekStart);
+      cursor <= lastWeekEnd;
+      cursor = addDays(cursor, 1)
+    ) {
+      dayAccumulator.push(toISODate(cursor));
+    }
+
+    return {
+      monthLabel: monthFormatter.format(focusDate),
+      monthDays: dayAccumulator,
+      weekStarts: weekStartsAccumulator,
+    };
+  }, [iso]);
+
+  usePreloadedDays(monthDays);
+
+  return (
+    <>
+      <PageShell
+        as="section"
+        grid
+        className="py-[var(--space-6)]"
+        contentClassName="gap-y-[var(--space-6)]"
+        aria-label="Planner month view"
+      >
+        <section
+          aria-label="Today and weekly panels"
+          className={`${layoutGridClassName} col-span-full lg:grid-cols-12`}
+        >
+          <div className="col-span-full lg:col-span-8" ref={heroRef}>
+            <TodayHero iso={iso} />
+          </div>
+
+          <aside
+            aria-label="Day notes"
+            className="col-span-full space-y-[var(--space-6)] lg:col-span-4 lg:sticky lg:top-[var(--header-stack)]"
+          >
+            <WeekNotes iso={iso} />
+          </aside>
+        </section>
+      </PageShell>
+
+      <PageShell
+        as="section"
+        grid
+        className="pb-[var(--space-8)]"
+        contentClassName="gap-y-[var(--space-4)]"
+        aria-label="Month overview"
+      >
+        <header className="col-span-full flex flex-col gap-[var(--space-2)] sm:flex-row sm:items-center sm:justify-between">
+          <h2 className="text-title font-semibold tracking-[-0.01em]">
+            {monthLabel}
+          </h2>
+          <p className="text-body text-muted-foreground">
+            Weekly summaries keep progress visible at a glance.
+          </p>
+        </header>
+        <div className="col-span-full grid gap-[var(--space-4)] md:grid-cols-2 xl:grid-cols-3">
+          {weekStarts.map((weekIso) => (
+            <WeekSummary key={weekIso} iso={weekIso} />
+          ))}
+        </div>
+      </PageShell>
+      <ScrollTopFloatingButton watchRef={heroRef} />
+    </>
+  );
+}
+

--- a/src/components/planner/views/WeekView.tsx
+++ b/src/components/planner/views/WeekView.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import * as React from "react";
+import PageShell, {
+  layoutGridClassName,
+} from "@/components/ui/layout/PageShell";
+import TodayHero from "../TodayHero";
+import WeekNotes from "../WeekNotes";
+import DayRow from "../DayRow";
+import ScrollTopFloatingButton from "../ScrollTopFloatingButton";
+import { useFocusDate, useWeek } from "../useFocusDate";
+import type { ISODate } from "../plannerTypes";
+import { usePreloadedDays } from "./usePreloadedDays";
+
+const PLANNER_SCROLL_STORAGE_KEY = "planner:scroll-position";
+
+export default function WeekView() {
+  const { iso, today } = useFocusDate();
+  const { days } = useWeek(iso);
+  const heroRef = React.useRef<HTMLDivElement>(null);
+
+  usePreloadedDays(days);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+
+    const stored = sessionStorage.getItem(PLANNER_SCROLL_STORAGE_KEY);
+    if (stored) {
+      const parsed = Number.parseInt(stored, 10);
+      if (!Number.isNaN(parsed)) {
+        window.scrollTo({ top: parsed });
+      }
+    }
+
+    let frame = 0;
+    const handleScroll = () => {
+      if (frame) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        sessionStorage.setItem(
+          PLANNER_SCROLL_STORAGE_KEY,
+          Math.round(window.scrollY).toString(),
+        );
+      });
+    };
+
+    const handlePageHide = () => {
+      sessionStorage.setItem(
+        PLANNER_SCROLL_STORAGE_KEY,
+        Math.round(window.scrollY).toString(),
+      );
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("pagehide", handlePageHide);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("pagehide", handlePageHide);
+      if (frame) {
+        window.cancelAnimationFrame(frame);
+      }
+      sessionStorage.setItem(
+        PLANNER_SCROLL_STORAGE_KEY,
+        Math.round(window.scrollY).toString(),
+      );
+    };
+  }, []);
+
+  const dayItems = React.useMemo<Array<{ iso: ISODate; isToday: boolean }>>(
+    () => days.map((d) => ({ iso: d, isToday: d === today })),
+    [days, today],
+  );
+
+  return (
+    <>
+      <PageShell
+        as="section"
+        grid
+        className="py-[var(--space-6)]"
+        contentClassName="gap-y-[var(--space-6)]"
+        aria-label="Planner week view"
+      >
+        <section
+          aria-label="Today and weekly panels"
+          className={`${layoutGridClassName} col-span-full lg:grid-cols-12`}
+        >
+          <div className="col-span-full lg:col-span-8" ref={heroRef}>
+            <TodayHero iso={iso} />
+          </div>
+
+          <aside
+            aria-label="Day notes"
+            className="col-span-full space-y-[var(--space-6)] lg:col-span-4 lg:sticky lg:top-[var(--header-stack)]"
+          >
+            <WeekNotes iso={iso} />
+          </aside>
+        </section>
+
+        <ul
+          aria-label="Week days (Monday to Sunday)"
+          className="col-span-full flex flex-col gap-[var(--space-4)]"
+        >
+          {dayItems.map((item) => (
+            <DayRow key={item.iso} iso={item.iso} isToday={item.isToday} />
+          ))}
+        </ul>
+      </PageShell>
+      <ScrollTopFloatingButton watchRef={heroRef} />
+    </>
+  );
+}
+

--- a/src/components/planner/views/usePreloadedDays.ts
+++ b/src/components/planner/views/usePreloadedDays.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import * as React from "react";
+import type { ISODate, DayRecord } from "../plannerTypes";
+import { usePlannerStore } from "../usePlannerStore";
+
+export function usePreloadedDays(days: readonly ISODate[]): DayRecord[] {
+  const { getDay } = usePlannerStore();
+  return React.useMemo(
+    () => days.map((iso) => getDay(iso)),
+    [days, getDay],
+  );
+}
+

--- a/tests/planner/PlannerPage.test.tsx
+++ b/tests/planner/PlannerPage.test.tsx
@@ -1,0 +1,65 @@
+import * as React from "react";
+import { describe, it, expect, beforeEach, beforeAll, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import PlannerPage from "@/components/planner/PlannerPage";
+import { createStorageKey } from "@/lib/db";
+import { resetLocalStorage } from "../setup";
+
+const { createElement } = React;
+
+beforeAll(() => {
+  (globalThis as typeof globalThis & { React?: typeof React }).React = React;
+});
+
+describe("PlannerPage view modes", () => {
+  beforeEach(() => {
+    resetLocalStorage();
+    window.scrollTo = vi.fn();
+  });
+
+  it("switches view modes without remounting planner data", async () => {
+    const user = userEvent.setup();
+    render(createElement(PlannerPage));
+
+    const weekList = await screen.findByRole("list", {
+      name: /week days/i,
+    });
+    expect(weekList).toBeInTheDocument();
+
+    const agendaTab = screen.getByRole("tab", { name: /agenda/i });
+    await user.click(agendaTab);
+
+    expect(
+      await screen.findByRole("list", { name: /agenda \(next 14 days\)/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("list", { name: /week days/i })).toBeNull();
+
+    const dayTab = screen.getByRole("tab", { name: /day/i });
+    await user.click(dayTab);
+
+    expect(
+      await screen.findByRole("list", { name: /selected day/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("restores the persisted view mode preference", async () => {
+    const key = createStorageKey("planner:view-mode");
+    window.localStorage.setItem(key, JSON.stringify("agenda"));
+
+    render(createElement(PlannerPage));
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /agenda/i })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+
+    expect(
+      await screen.findByRole("list", { name: /agenda \(next 14 days\)/i }),
+    ).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add a persisted planner view mode and expose it via the segmented control on the planner header
- implement day, week, month, and agenda planner views that reuse existing hooks and layout tokens
- cover view mode switching and persistence with dedicated planner page tests

## Testing
- npm run verify-prompts
- npm run check
- npm run e2e:ci *(fails: Playwright browsers not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68dabc8272a8832cb8fa1a47ed14afcf