### PR TITLE
fix: enforce neomorphic styling for NeoCard

### DIFF
--- a/src/components/ui/primitives/NeoCard.tsx
+++ b/src/components/ui/primitives/NeoCard.tsx
@@ -7,7 +7,7 @@ export type NeoCardProps = CardProps & {
 };
 
 const NEO_CARD_BASE_CLASSNAME =
-  "relative overflow-hidden card-neo-soft [--neo-card-overlay-inset:0px] [--neo-card-overlay-opacity:var(--surface-overlay-strong,0.2)]";
+  "relative overflow-hidden card-neo-soft border border-card-hairline [box-shadow:var(--shadow-neo-soft)] [--neo-card-overlay-inset:0px] [--neo-card-overlay-opacity:var(--surface-overlay-strong,0.2)]";
 
 export const neoCardOverlayClassName = "neo-card__overlay";
 


### PR DESCRIPTION
## Summary
- ensure NeoCard always layers neomorphic border and shadow tokens after the base Card utilities so gradient, overlay, and state styles stay intact

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dac6989fd4832cbef6cbdde4612c76