### PR TITLE
Fix spacing token regeneration collisions

### DIFF
--- a/scripts/generate-tokens.ts
+++ b/scripts/generate-tokens.ts
@@ -132,7 +132,13 @@ async function buildTokens(): Promise<void> {
   let match: RegExpExecArray | null;
   while ((match = colorRegex.exec(themeBase))) {
     const name = match[1];
-    if (name.startsWith("radius-") || isDeprecatedToken(name)) continue;
+    if (
+      name.startsWith("radius-") ||
+      name.startsWith("spacing-") ||
+      isDeprecatedToken(name)
+    ) {
+      continue;
+    }
     colors[name] = { value: match[2].trim() };
   }
   const globalsPath = path.resolve(__dirname, "../src/app/globals.css");


### PR DESCRIPTION
## Summary
- skip spacing tokens when harvesting :root variables from themes so the generator no longer re-adds duplicate spacing definitions
- regenerate the token bundle to confirm every spacing variable is emitted once

## Testing
- npm run check
- npm run verify-prompts

------
https://chatgpt.com/codex/tasks/task_e_68dac86f12c0832c9984355e10d74114