### PR TITLE
Fix duplicate main landmarks in route components

### DIFF
--- a/src/app/components/[section]/redirect-client.tsx
+++ b/src/app/components/[section]/redirect-client.tsx
@@ -14,10 +14,10 @@ export function ComponentsSectionRedirect({
   }, [target]);
 
   return (
-    <main aria-busy="true">
-      <p aria-live="polite" role="status">
+    <div aria-busy="true" role="status">
+      <p aria-live="polite">
         Redirecting to the selected components section…
       </p>
-    </main>
+    </div>
   );
 }

--- a/src/app/page-client.tsx
+++ b/src/app/page-client.tsx
@@ -84,7 +84,7 @@ function HomePageContent() {
       {isSplashMounted ? (
         <HomeSplash active={isSplashVisible} onExited={handleSplashExit} />
       ) : null}
-      <main
+      <section
         tabIndex={-1}
         className={styles.content}
         data-state={isSplashVisible ? "splash" : "ready"}
@@ -96,7 +96,7 @@ function HomePageContent() {
             onClientReady={handleClientReady}
           />
         </PlannerProvider>
-      </main>
+      </section>
     </div>
   );
 }

--- a/src/app/preview/[slug]/page.tsx
+++ b/src/app/preview/[slug]/page.tsx
@@ -82,7 +82,7 @@ interface PreviewContentProps {
   readonly route: GalleryPreviewRoute;
 }
 
-function PreviewContent({ route }: PreviewContentProps) {
+export function PreviewContent({ route }: PreviewContentProps) {
   const themeLabel = VARIANT_LABELS[route.themeVariant];
   const stateLabel = route.stateName ?? null;
   const axisSummary = route.axisParams
@@ -90,7 +90,7 @@ function PreviewContent({ route }: PreviewContentProps) {
     .join(" · ");
 
   return (
-    <main
+    <div
       className="min-h-screen bg-background text-foreground"
       data-preview-entry={route.entryId}
       data-preview-slug={route.slug}
@@ -118,11 +118,11 @@ function PreviewContent({ route }: PreviewContentProps) {
           <PreviewSurface previewId={route.previewId} />
         </Suspense>
       </div>
-    </main>
+    </div>
   );
 }
 
-function PreviewUnavailable({ route }: { readonly route: GalleryPreviewRoute }) {
+export function PreviewUnavailable({ route }: { readonly route: GalleryPreviewRoute }) {
   const themeLabel = VARIANT_LABELS[route.themeVariant];
   const stateLabel = route.stateName ?? null;
   const axisSummary = route.axisParams
@@ -130,7 +130,7 @@ function PreviewUnavailable({ route }: { readonly route: GalleryPreviewRoute }) 
     .join(" · ");
 
   return (
-    <main
+    <div
       className="min-h-screen bg-background text-foreground"
       data-preview-entry={route.entryId}
       data-preview-slug={route.slug}
@@ -161,7 +161,7 @@ function PreviewUnavailable({ route }: { readonly route: GalleryPreviewRoute }) 
           </div>
         </PreviewSurfaceContainer>
       </div>
-    </main>
+    </div>
   );
 }
 

--- a/tests/home/HomePage.test.tsx
+++ b/tests/home/HomePage.test.tsx
@@ -41,4 +41,19 @@ describe("Home page", () => {
       expectLink("Prompts", "/prompts");
     },
   );
+
+  it("renders a single main landmark", () => {
+    const { container } = render(
+      <ThemeProvider>
+        <main id="main-content">
+          <Suspense fallback="loading">
+            <Page />
+          </Suspense>
+        </main>
+      </ThemeProvider>,
+    );
+
+    const landmarks = container.querySelectorAll("main, [role=\"main\"]");
+    expect(landmarks).toHaveLength(1);
+  });
 });

--- a/tests/preview/PreviewPage.test.tsx
+++ b/tests/preview/PreviewPage.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import type { GalleryPreviewRoute } from "@/components/gallery";
+import { describe, expect, it, vi } from "vitest";
+import { PreviewContent, PreviewUnavailable } from "@/app/preview/[slug]/page";
+
+(globalThis as { React?: typeof React }).React = React;
+
+vi.mock("@/components/gallery/PreviewSurfaceClient", () => ({
+  default: () => <div data-testid="preview-surface" />,
+}));
+
+vi.mock("@/components/gallery/PreviewThemeClient", () => ({
+  default: () => null,
+}));
+
+const baseRoute: GalleryPreviewRoute = {
+  slug: "sample",
+  previewId: "preview-id",
+  entryId: "entry-id",
+  entryName: "Sample preview",
+  sectionId: "components",
+  stateId: null,
+  stateName: null,
+  themeVariant: "lg",
+  themeBackground: 0,
+  axisParams: [],
+};
+
+describe("Preview page landmarks", () => {
+  it("renders a single main landmark when the preview loads", () => {
+    const { container } = render(
+      <main id="main-content">
+        <PreviewContent route={baseRoute} />
+      </main>,
+    );
+
+    const landmarks = container.querySelectorAll("main, [role=\"main\"]");
+    expect(landmarks).toHaveLength(1);
+  });
+
+  it("renders a single main landmark when the preview is unavailable", () => {
+    const { container } = render(
+      <main id="main-content">
+        <PreviewUnavailable route={baseRoute} />
+      </main>,
+    );
+
+    const landmarks = container.querySelectorAll("main, [role=\"main\"]");
+    expect(landmarks).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- replace nested `<main>` usage in home, preview, and redirect route components with neutral containers while preserving accessibility attributes
- export preview page renderers so they can be unit tested and add coverage that enforces a single main landmark per render
- extend the home page test to assert only one main landmark is produced when mounted inside the layout shell

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dace5988e4832c8bf77271f65ea3f5