### PR TITLE
fix: persist neo surface tokens in theme generator

### DIFF
--- a/scripts/generate-themes.ts
+++ b/scripts/generate-themes.ts
@@ -80,36 +80,47 @@ function ensureSemicolon(value: string): string {
 }
 
 function renderVariableDefinition(
-  name: string,
-  tokenValue: TokenValue,
+  variable: VariableDefinition,
   indent = 2,
 ): string {
+  const { name, value, comment } = variable;
   const baseIndent = " ".repeat(indent);
-  if (typeof tokenValue === "string") {
-    return `${baseIndent}--${name}: ${ensureSemicolon(tokenValue)}`;
+  const lines: string[] = [];
+
+  if (comment) {
+    const comments = Array.isArray(comment) ? comment : [comment];
+    for (const entry of comments) {
+      lines.push(`${baseIndent}/* ${entry} */`);
+    }
   }
 
-  const values = [...tokenValue];
+  if (typeof value === "string") {
+    lines.push(`${baseIndent}--${name}: ${ensureSemicolon(value)}`);
+    return lines.join("\n");
+  }
+
+  const values = [...value];
   const hasLeadingEmpty = values[0] === "";
   if (hasLeadingEmpty) {
     values.shift();
   }
 
   if (!hasLeadingEmpty && values.length === 1) {
-    return `${baseIndent}--${name}: ${ensureSemicolon(values[0] ?? "")}`;
+    lines.push(`${baseIndent}--${name}: ${ensureSemicolon(values[0] ?? "")}`);
+    return lines.join("\n");
   }
 
-  const lines: string[] = [];
   const innerIndent = `${baseIndent}  `;
+  const variableLines: string[] = [];
 
   if (hasLeadingEmpty) {
-    lines.push(`${baseIndent}--${name}:`);
+    variableLines.push(`${baseIndent}--${name}:`);
   } else {
     const first = values.shift();
     if (first !== undefined) {
-      lines.push(`${baseIndent}--${name}: ${first}`);
+      variableLines.push(`${baseIndent}--${name}: ${first}`);
     } else {
-      lines.push(`${baseIndent}--${name}:`);
+      variableLines.push(`${baseIndent}--${name}:`);
     }
   }
 
@@ -117,21 +128,22 @@ function renderVariableDefinition(
     const isLast = index === values.length - 1;
     const nextIndent = isLast && line.trim() === ")" ? baseIndent : innerIndent;
     const text = isLast ? ensureSemicolon(line) : line;
-    lines.push(`${nextIndent}${text}`);
+    variableLines.push(`${nextIndent}${text}`);
   });
 
   if (values.length === 0) {
-    const lastIndex = lines.length - 1;
-    lines[lastIndex] = ensureSemicolon(lines[lastIndex]);
+    const lastIndex = variableLines.length - 1;
+    variableLines[lastIndex] = ensureSemicolon(variableLines[lastIndex]);
   }
 
+  lines.push(...variableLines);
   return lines.join("\n");
 }
 
 function renderRootBlock(definitions: VariableDefinition[]): string {
   const lines = [":root {"];
   for (const variable of definitions) {
-    lines.push(renderVariableDefinition(variable.name, variable.value));
+    lines.push(renderVariableDefinition(variable));
   }
   lines.push("}");
   return lines.join("\n");
@@ -178,7 +190,7 @@ function renderTheme(theme: ThemeDefinition): string {
     }
   }
   for (const variable of theme.variables) {
-    lines.push(renderVariableDefinition(variable.name, variable.value));
+    lines.push(renderVariableDefinition(variable));
   }
   lines.push("}");
   return lines.join("\n");

--- a/scripts/themes.ts
+++ b/scripts/themes.ts
@@ -3,6 +3,7 @@ export type TokenValue = string | string[];
 export interface VariableDefinition {
   name: string;
   value: TokenValue;
+  comment?: string | string[];
 }
 
 export interface ThemeDefinition {
@@ -19,6 +20,52 @@ export const rootVariables: VariableDefinition[] = [
   { name: "lg-black", value: "var(--background)" },
   { name: "card-foreground", value: "var(--foreground)" },
   { name: "header-stack", value: "calc(var(--spacing-8) + var(--spacing-4))" },
+  {
+    comment: "Depth & surface spacing (neumorphism)",
+    name: "neo-depth-sm",
+    value: "var(--spacing-1)",
+  },
+  { name: "neo-depth-md", value: "var(--spacing-3)" },
+  { name: "neo-depth-lg", value: "var(--spacing-4)" },
+  {
+    name: "neo-surface",
+    value: "color-mix(in oklab, hsl(var(--card)) 88%, hsl(var(--panel)) 12%)",
+  },
+  {
+    name: "neo-surface-alt",
+    value: "color-mix(in oklab, hsl(var(--panel)) 82%, hsl(var(--card)) 18%)",
+  },
+  {
+    name: "neo-highlight",
+    value: "color-mix(in oklab, hsl(var(--ring)) 18%, hsl(var(--card)))",
+  },
+  {
+    comment: [
+      "Glow parity (retro-futurism)",
+      "neo-glow-strength multiplies --shadow-neon",
+    ],
+    name: "neo-glow-strength",
+    value: "0.45",
+  },
+  { name: "neon-outline-opacity", value: "0.35" },
+  {
+    comment: [
+      "Glitch normalization (identical amplitude & cadence)",
+      "0–1 scaling for transforms/opacity",
+    ],
+    name: "glitch-intensity",
+    value: "1.0",
+  },
+  { comment: "base animation length", name: "glitch-duration", value: "450ms" },
+  { comment: "hue-rotate magnitude", name: "glitch-fringe", value: "12deg" },
+  { comment: "overlay alpha", name: "glitch-static-opacity", value: "0.18" },
+  { comment: "Retro grid parity", name: "retro-grid-step", value: "24px" },
+  { name: "retro-grid-opacity", value: "0.15" },
+  {
+    comment: ["Accessibility clamps", "used in tests; not CSS-enforced"],
+    name: "aa-min-contrast",
+    value: "4.5",
+  },
   {
     name: "shadow-neon",
     value: [

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -260,26 +260,6 @@
   --radius-xl: 16px;
   --radius-2xl: 24px;
   --radius-full: 9999px;
-  /* Depth & surface spacing (neumorphism) */
-  --neo-depth-sm: var(--spacing-1);
-  --neo-depth-md: var(--spacing-3);
-  --neo-depth-lg: var(--spacing-4);
-  --neo-surface: color-mix(in oklab, hsl(var(--card)) 88%, hsl(var(--panel)) 12%);
-  --neo-surface-alt: color-mix(in oklab, hsl(var(--panel)) 82%, hsl(var(--card)) 18%);
-  --neo-highlight: color-mix(in oklab, hsl(var(--ring)) 18%, hsl(var(--card)));
-  /* Glow parity (retro-futurism) */
-  --neo-glow-strength: 0.45; /* used as multiplier on --shadow-neon */
-  --neon-outline-opacity: 0.35;
-  /* Glitch normalization (identical amplitude & cadence) */
-  --glitch-intensity: 1.0;        /* 0–1 scaling for transforms/opacity */
-  --glitch-duration: 450ms;       /* base animation length */
-  --glitch-fringe: 12deg;         /* hue-rotate magnitude */
-  --glitch-static-opacity: 0.18;  /* overlay alpha */
-  /* Retro grid parity */
-  --retro-grid-step: 24px;
-  --retro-grid-opacity: 0.15;
-  /* Accessibility clamps */
-  --aa-min-contrast: 4.5; /* used in tests; not CSS-enforced */
 }
 @supports (color: color-mix(in oklab, white, black)) {
   :root {
@@ -296,6 +276,32 @@
   --lg-black: var(--background);
   --card-foreground: var(--foreground);
   --header-stack: calc(var(--spacing-8) + var(--spacing-4));
+  /* Depth & surface spacing (neumorphism) */
+  --neo-depth-sm: var(--spacing-1);
+  --neo-depth-md: var(--spacing-3);
+  --neo-depth-lg: var(--spacing-4);
+  --neo-surface: color-mix(in oklab, hsl(var(--card)) 88%, hsl(var(--panel)) 12%);
+  --neo-surface-alt: color-mix(in oklab, hsl(var(--panel)) 82%, hsl(var(--card)) 18%);
+  --neo-highlight: color-mix(in oklab, hsl(var(--ring)) 18%, hsl(var(--card)));
+  /* Glow parity (retro-futurism) */
+  /* neo-glow-strength multiplies --shadow-neon */
+  --neo-glow-strength: 0.45;
+  --neon-outline-opacity: 0.35;
+  /* Glitch normalization (identical amplitude & cadence) */
+  /* 0–1 scaling for transforms/opacity */
+  --glitch-intensity: 1.0;
+  /* base animation length */
+  --glitch-duration: 450ms;
+  /* hue-rotate magnitude */
+  --glitch-fringe: 12deg;
+  /* overlay alpha */
+  --glitch-static-opacity: 0.18;
+  /* Retro grid parity */
+  --retro-grid-step: 24px;
+  --retro-grid-opacity: 0.15;
+  /* Accessibility clamps */
+  /* used in tests; not CSS-enforced */
+  --aa-min-contrast: 4.5;
   --shadow-neon:
     0 0 var(--space-1) hsl(var(--neon) / 0.55),
     0 0 calc(var(--space-3) - var(--space-1) / 2) hsl(var(--neon) / 0.35),
@@ -411,26 +417,6 @@ html.theme-aurora {
     hsl(var(--accent-2) / 0.3)
   );
   --shadow: 0 10px 30px hsl(var(--shadow-base) / 0.28);
-  /* Depth & surface spacing (neumorphism) */
-  --neo-depth-sm: var(--spacing-1);
-  --neo-depth-md: var(--spacing-3);
-  --neo-depth-lg: var(--spacing-4);
-  --neo-surface: color-mix(in oklab, hsl(var(--card)) 88%, hsl(var(--panel)) 12%);
-  --neo-surface-alt: color-mix(in oklab, hsl(var(--panel)) 82%, hsl(var(--card)) 18%);
-  --neo-highlight: color-mix(in oklab, hsl(var(--ring)) 18%, hsl(var(--card)));
-  /* Glow parity (retro-futurism) */
-  --neo-glow-strength: 0.45; /* used as multiplier on --shadow-neon */
-  --neon-outline-opacity: 0.35;
-  /* Glitch normalization (identical amplitude & cadence) */
-  --glitch-intensity: 1.0;        /* 0–1 scaling for transforms/opacity */
-  --glitch-duration: 450ms;       /* base animation length */
-  --glitch-fringe: 12deg;         /* hue-rotate magnitude */
-  --glitch-static-opacity: 0.18;  /* overlay alpha */
-  /* Retro grid parity */
-  --retro-grid-step: 24px;
-  --retro-grid-opacity: 0.15;
-  /* Accessibility clamps */
-  --aa-min-contrast: 4.5; /* used in tests; not CSS-enforced */
 }
 /* ---------- Citrus ---------- */
 html.theme-citrus {
@@ -459,26 +445,6 @@ html.theme-citrus {
   --success: 150 68% 46%;
   --success-glow: 150 68% 36% / 0.6;
   --citrus-teal: 168 72% 42%;
-  /* Depth & surface spacing (neumorphism) */
-  --neo-depth-sm: var(--spacing-1);
-  --neo-depth-md: var(--spacing-3);
-  --neo-depth-lg: var(--spacing-4);
-  --neo-surface: color-mix(in oklab, hsl(var(--card)) 88%, hsl(var(--panel)) 12%);
-  --neo-surface-alt: color-mix(in oklab, hsl(var(--panel)) 82%, hsl(var(--card)) 18%);
-  --neo-highlight: color-mix(in oklab, hsl(var(--ring)) 18%, hsl(var(--card)));
-  /* Glow parity (retro-futurism) */
-  --neo-glow-strength: 0.45; /* used as multiplier on --shadow-neon */
-  --neon-outline-opacity: 0.35;
-  /* Glitch normalization (identical amplitude & cadence) */
-  --glitch-intensity: 1.0;        /* 0–1 scaling for transforms/opacity */
-  --glitch-duration: 450ms;       /* base animation length */
-  --glitch-fringe: 12deg;         /* hue-rotate magnitude */
-  --glitch-static-opacity: 0.18;  /* overlay alpha */
-  /* Retro grid parity */
-  --retro-grid-step: 24px;
-  --retro-grid-opacity: 0.15;
-  /* Accessibility clamps */
-  --aa-min-contrast: 4.5; /* used in tests; not CSS-enforced */
 }
 /* ---------- Noir ---------- */
 html.theme-noir {
@@ -509,26 +475,6 @@ html.theme-noir {
   --noir-rose: 352 68% 54%;
   --noir-ink: 352 80% 6%;
   --noir-ruby: 12 76% 46%;
-  /* Depth & surface spacing (neumorphism) */
-  --neo-depth-sm: var(--spacing-1);
-  --neo-depth-md: var(--spacing-3);
-  --neo-depth-lg: var(--spacing-4);
-  --neo-surface: color-mix(in oklab, hsl(var(--card)) 88%, hsl(var(--panel)) 12%);
-  --neo-surface-alt: color-mix(in oklab, hsl(var(--panel)) 82%, hsl(var(--card)) 18%);
-  --neo-highlight: color-mix(in oklab, hsl(var(--ring)) 18%, hsl(var(--card)));
-  /* Glow parity (retro-futurism) */
-  --neo-glow-strength: 0.45; /* used as multiplier on --shadow-neon */
-  --neon-outline-opacity: 0.35;
-  /* Glitch normalization (identical amplitude & cadence) */
-  --glitch-intensity: 1.0;        /* 0–1 scaling for transforms/opacity */
-  --glitch-duration: 450ms;       /* base animation length */
-  --glitch-fringe: 12deg;         /* hue-rotate magnitude */
-  --glitch-static-opacity: 0.18;  /* overlay alpha */
-  /* Retro grid parity */
-  --retro-grid-step: 24px;
-  --retro-grid-opacity: 0.15;
-  /* Accessibility clamps */
-  --aa-min-contrast: 4.5; /* used in tests; not CSS-enforced */
 }
 /* ---------- Oceanic ---------- */
 html.theme-ocean {
@@ -557,26 +503,6 @@ html.theme-ocean {
   --success-glow: 158 72% 38% / 0.6;
   --ocean-cyan: 194 88% 52%;
   --ocean-indigo: 230 72% 62%;
-  /* Depth & surface spacing (neumorphism) */
-  --neo-depth-sm: var(--spacing-1);
-  --neo-depth-md: var(--spacing-3);
-  --neo-depth-lg: var(--spacing-4);
-  --neo-surface: color-mix(in oklab, hsl(var(--card)) 88%, hsl(var(--panel)) 12%);
-  --neo-surface-alt: color-mix(in oklab, hsl(var(--panel)) 82%, hsl(var(--card)) 18%);
-  --neo-highlight: color-mix(in oklab, hsl(var(--ring)) 18%, hsl(var(--card)));
-  /* Glow parity (retro-futurism) */
-  --neo-glow-strength: 0.45; /* used as multiplier on --shadow-neon */
-  --neon-outline-opacity: 0.35;
-  /* Glitch normalization (identical amplitude & cadence) */
-  --glitch-intensity: 1.0;        /* 0–1 scaling for transforms/opacity */
-  --glitch-duration: 450ms;       /* base animation length */
-  --glitch-fringe: 12deg;         /* hue-rotate magnitude */
-  --glitch-static-opacity: 0.18;  /* overlay alpha */
-  /* Retro grid parity */
-  --retro-grid-step: 24px;
-  --retro-grid-opacity: 0.15;
-  /* Accessibility clamps */
-  --aa-min-contrast: 4.5; /* used in tests; not CSS-enforced */
 }
 /* ---------- Kitten ---------- */
 html.theme-kitten {
@@ -606,26 +532,6 @@ html.theme-kitten {
   --kitten-rose: 346 94% 42%;
   --kitten-pink: 342 96% 48%;
   --kitten-blush: 348 88% 88%;
-  /* Depth & surface spacing (neumorphism) */
-  --neo-depth-sm: var(--spacing-1);
-  --neo-depth-md: var(--spacing-3);
-  --neo-depth-lg: var(--spacing-4);
-  --neo-surface: color-mix(in oklab, hsl(var(--card)) 88%, hsl(var(--panel)) 12%);
-  --neo-surface-alt: color-mix(in oklab, hsl(var(--panel)) 82%, hsl(var(--card)) 18%);
-  --neo-highlight: color-mix(in oklab, hsl(var(--ring)) 18%, hsl(var(--card)));
-  /* Glow parity (retro-futurism) */
-  --neo-glow-strength: 0.45; /* used as multiplier on --shadow-neon */
-  --neon-outline-opacity: 0.35;
-  /* Glitch normalization (identical amplitude & cadence) */
-  --glitch-intensity: 1.0;        /* 0–1 scaling for transforms/opacity */
-  --glitch-duration: 450ms;       /* base animation length */
-  --glitch-fringe: 12deg;         /* hue-rotate magnitude */
-  --glitch-static-opacity: 0.18;  /* overlay alpha */
-  /* Retro grid parity */
-  --retro-grid-step: 24px;
-  --retro-grid-opacity: 0.15;
-  /* Accessibility clamps */
-  --aa-min-contrast: 4.5; /* used in tests; not CSS-enforced */
 }
 /* ---------- Hardstuck ---------- */
 html.theme-hardstuck {
@@ -664,26 +570,6 @@ html.theme-hardstuck {
   --success-glow: 120 90% 42% / 0.6;
   --hardstuck-forest: 120 70% 42%;
   --hardstuck-deep: 120 82% 8%;
-  /* Depth & surface spacing (neumorphism) */
-  --neo-depth-sm: var(--spacing-1);
-  --neo-depth-md: var(--spacing-3);
-  --neo-depth-lg: var(--spacing-4);
-  --neo-surface: color-mix(in oklab, hsl(var(--card)) 88%, hsl(var(--panel)) 12%);
-  --neo-surface-alt: color-mix(in oklab, hsl(var(--panel)) 82%, hsl(var(--card)) 18%);
-  --neo-highlight: color-mix(in oklab, hsl(var(--ring)) 18%, hsl(var(--card)));
-  /* Glow parity (retro-futurism) */
-  --neo-glow-strength: 0.45; /* used as multiplier on --shadow-neon */
-  --neon-outline-opacity: 0.35;
-  /* Glitch normalization (identical amplitude & cadence) */
-  --glitch-intensity: 1.0;        /* 0–1 scaling for transforms/opacity */
-  --glitch-duration: 450ms;       /* base animation length */
-  --glitch-fringe: 12deg;         /* hue-rotate magnitude */
-  --glitch-static-opacity: 0.18;  /* overlay alpha */
-  /* Retro grid parity */
-  --retro-grid-step: 24px;
-  --retro-grid-opacity: 0.15;
-  /* Accessibility clamps */
-  --aa-min-contrast: 4.5; /* used in tests; not CSS-enforced */
 }
 /* ---------- Retro ---------- */
 html.theme-retro {
@@ -743,26 +629,6 @@ html.theme-retro {
       hsl(var(--accent-3) / 0.12) 14px 15px,
       transparent 15px 28px
   );
-  /* Depth & surface spacing (neumorphism) */
-  --neo-depth-sm: var(--spacing-1);
-  --neo-depth-md: var(--spacing-3);
-  --neo-depth-lg: var(--spacing-4);
-  --neo-surface: color-mix(in oklab, hsl(var(--card)) 88%, hsl(var(--panel)) 12%);
-  --neo-surface-alt: color-mix(in oklab, hsl(var(--panel)) 82%, hsl(var(--card)) 18%);
-  --neo-highlight: color-mix(in oklab, hsl(var(--ring)) 18%, hsl(var(--card)));
-  /* Glow parity (retro-futurism) */
-  --neo-glow-strength: 0.45; /* used as multiplier on --shadow-neon */
-  --neon-outline-opacity: 0.35;
-  /* Glitch normalization (identical amplitude & cadence) */
-  --glitch-intensity: 1.0;        /* 0–1 scaling for transforms/opacity */
-  --glitch-duration: 450ms;       /* base animation length */
-  --glitch-fringe: 12deg;         /* hue-rotate magnitude */
-  --glitch-static-opacity: 0.18;  /* overlay alpha */
-  /* Retro grid parity */
-  --retro-grid-step: 24px;
-  --retro-grid-opacity: 0.15;
-  /* Accessibility clamps */
-  --aa-min-contrast: 4.5; /* used in tests; not CSS-enforced */
 }
 /* =========================================================
    Per-theme glitch backdrops


### PR DESCRIPTION
## Summary
- allow the theme generator to emit inline documentation comments for tokens
- register the neumorphic depth, glow, glitch, and accessibility tokens in the generator source
- regenerate the generated themes.css to include the new root-level tokens once

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dad2103170832c8b484df7c1ad2c81