### PR TITLE
fix: align glitch card depth tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,6 +26,17 @@
     --team-glitch-ring-color: hsl(var(--ring) / 0.55);
     --team-glitch-ring-blur: var(--space-2);
     --team-glitch-ring-shadow: 0 0 var(--team-glitch-ring-blur) var(--team-glitch-ring-color);
+    --glitch-card-surface-top: hsl(var(--card) / 0.78);
+    --glitch-card-surface-bottom: hsl(var(--panel) / 0.66);
+    --glitch-card-border-color: hsl(var(--card-hairline));
+    --shadow-glitch-card: var(--shadow-neo);
+    --shadow-glitch-card-hover: var(--shadow-neo-strong);
+    --glitch-card-spectrum-a: hsl(var(--primary) / 0.55);
+    --glitch-card-spectrum-b: hsl(var(--accent) / 0.45);
+    --glitch-card-spectrum-c: hsl(var(--ring) / 0.55);
+    --glitch-card-stripe-color: hsl(var(--foreground) / 0.035);
+    --glitch-card-stripe-opacity: var(--glitch-static-opacity, 0.18);
+    --glitch-card-halo-opacity: 0.28;
     --team-glitch-accent-color: hsl(var(--accent) / 0.35);
     --team-glitch-accent-blur: var(--spacing-0-5);
     --team-glitch-accent-shadow: 0 0 var(--team-glitch-accent-blur) var(--team-glitch-accent-color);
@@ -44,6 +55,41 @@
     --viewport-height: 100vh;
     --viewport-height: 100dvh;
     --select-menu-max-height: calc(var(--viewport-height) * 0.6);
+  }
+
+  @supports (color: color-mix(in oklab, white 50%, black)) {
+    :root {
+      --glitch-card-surface-top: color-mix(
+        in oklab,
+        hsl(var(--card)) 86%,
+        hsl(var(--accent)) 14%
+      );
+      --glitch-card-surface-bottom: color-mix(
+        in oklab,
+        hsl(var(--panel)) 88%,
+        hsl(var(--accent-2)) 12%
+      );
+      --glitch-card-spectrum-a: color-mix(
+        in oklab,
+        hsl(var(--accent)) 68%,
+        hsl(var(--primary))
+      );
+      --glitch-card-spectrum-b: color-mix(
+        in oklab,
+        hsl(var(--accent-2)) 64%,
+        hsl(var(--ring))
+      );
+      --glitch-card-spectrum-c: color-mix(
+        in oklab,
+        hsl(var(--ring)) 72%,
+        hsl(var(--accent-3))
+      );
+      --glitch-card-stripe-color: color-mix(
+        in oklab,
+        hsl(var(--foreground)) 16%,
+        transparent
+      );
+    }
   }
 
   body {
@@ -1617,22 +1663,29 @@ textarea:-webkit-autofill {
 .glitch-card {
   position: relative;
   border-radius: var(--radius-card);
-  border: var(--hairline-w) solid hsl(var(--card-hairline));
-  background: hsl(var(--card) / 0.7);
-  box-shadow: var(--shadow);
+  border: var(--hairline-w) solid var(--glitch-card-border-color);
+  background: linear-gradient(
+    180deg,
+    var(--glitch-card-surface-top),
+    var(--glitch-card-surface-bottom)
+  );
+  box-shadow: var(--shadow-glitch-card, var(--shadow-neo));
   transition:
     transform 0.12s ease,
     box-shadow 0.2s ease,
     background 0.2s ease;
 }
 .glitch-card:hover {
-  box-shadow: var(--shadow-dropdown);
+  box-shadow: var(--shadow-glitch-card-hover, var(--shadow-neo-strong));
 }
 .glitch-card:focus-within {
   outline: none;
   box-shadow:
-    0 0 0 var(--spacing-0-75) hsl(var(--ring) / 0.35),
-    var(--shadow-dropdown);
+    var(
+      --shadow-glitch-card-focus-ring,
+      0 0 0 var(--spacing-0-75) hsl(var(--ring) / 0.35)
+    ),
+    var(--shadow-glitch-card-hover, var(--shadow-neo-strong));
 }
 .glitch-card::after {
   content: "";
@@ -1643,11 +1696,11 @@ textarea:-webkit-autofill {
   padding: var(--spacing-0-25);
   background: linear-gradient(
     90deg,
-    hsl(var(--primary) / 0.55),
-    hsl(var(--accent) / 0.45),
-    hsl(var(--ring) / 0.55),
-    hsl(var(--accent) / 0.45),
-    hsl(var(--primary) / 0.55)
+    var(--glitch-card-spectrum-a),
+    var(--glitch-card-spectrum-b),
+    var(--glitch-card-spectrum-c),
+    var(--glitch-card-spectrum-b),
+    var(--glitch-card-spectrum-a)
   );
   background-size: 300% 100%;
   -webkit-mask:
@@ -1658,7 +1711,7 @@ textarea:-webkit-autofill {
     linear-gradient(hsl(var(--foreground)) 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
-  opacity: 0.28;
+  opacity: var(--glitch-card-halo-opacity);
 }
 .glitch-card::before {
   content: "";
@@ -1668,12 +1721,12 @@ textarea:-webkit-autofill {
   pointer-events: none;
   background: repeating-linear-gradient(
     to bottom,
-    hsl(var(--foreground) / 0.035) 0 var(--spacing-0-25),
+    var(--glitch-card-stripe-color) 0 var(--spacing-0-25),
     transparent var(--spacing-0-25)
       calc(var(--spacing-0-5) + var(--spacing-0-25))
   );
   mix-blend-mode: overlay;
-  opacity: 0.2;
+  opacity: var(--glitch-card-stripe-opacity);
 }
 .glitch-title {
   position: relative;

--- a/src/components/reviews/ReviewList.tsx
+++ b/src/components/reviews/ReviewList.tsx
@@ -180,7 +180,7 @@ export default function ReviewList({
   );
 
   const emptyContainerClass = cn(
-    "w-full mx-auto rounded-card r-card-lg text-card-foreground shadow-outline-subtle",
+    "w-full mx-auto rounded-card r-card-lg text-card-foreground",
     "ds-card-pad backdrop-blur-sm transition-colors transition-shadow duration-chill",
     "relative isolate overflow-hidden glitch-card",
     interactiveRingClass,


### PR DESCRIPTION
## Summary
- align glitch card surface, border, and depth tokens with the neumorphic container palette and color-mix fallbacks
- rebuild glitch overlays to use palette-driven gradients and scanlines while honoring theme tokens
- remove redundant ReviewList empty state shadow to keep glitch depth consistent across consumers

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dad28d9e78832cbf9f609cb55b83fa