### PR TITLE
feat: add theme and container controls to gallery preview

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,6 +26,9 @@
     --team-glitch-ring-color: hsl(var(--ring) / 0.55);
     --team-glitch-ring-blur: var(--space-2);
     --team-glitch-ring-shadow: 0 0 var(--team-glitch-ring-blur) var(--team-glitch-ring-color);
+    --preview-cq-sm: calc(var(--space-8) * 5);
+    --preview-cq-md: calc(var(--space-8) * 12);
+    --preview-cq-lg: calc(var(--space-8) * 16);
     --glitch-card-surface-top: hsl(var(--card) / 0.78);
     --glitch-card-surface-bottom: hsl(var(--panel) / 0.66);
     --glitch-card-border-color: hsl(var(--card-hairline));
@@ -98,6 +101,11 @@
       var(--viewport-height) - var(--header-stack) - var(--space-6)
     );
     font-family: var(--font-sans), var(--font-sans-fallback);
+  }
+
+  [data-preview-container] {
+    container-type: inline-size;
+    container-name: preview;
   }
 
   body[data-dialog-lock="true"] {
@@ -202,6 +210,46 @@ body.fx-gifbars::before {
   background-position: center;
   mix-blend-mode: overlay;
   opacity: 0.08;
+}
+
+@layer utilities {
+  .cq-sm {
+    width: min(100%, var(--preview-cq-sm));
+    inline-size: min(100%, var(--preview-cq-sm));
+    max-inline-size: var(--preview-cq-sm);
+    margin-inline: auto;
+    transition: inline-size var(--dur-quick) var(--ease-out),
+      width var(--dur-quick) var(--ease-out),
+      max-inline-size var(--dur-quick) var(--ease-out);
+  }
+
+  .cq-md {
+    width: min(100%, var(--preview-cq-md));
+    inline-size: min(100%, var(--preview-cq-md));
+    max-inline-size: var(--preview-cq-md);
+    margin-inline: auto;
+    transition: inline-size var(--dur-quick) var(--ease-out),
+      width var(--dur-quick) var(--ease-out),
+      max-inline-size var(--dur-quick) var(--ease-out);
+  }
+
+  .cq-lg {
+    width: min(100%, var(--preview-cq-lg));
+    inline-size: min(100%, var(--preview-cq-lg));
+    max-inline-size: var(--preview-cq-lg);
+    margin-inline: auto;
+    transition: inline-size var(--dur-quick) var(--ease-out),
+      width var(--dur-quick) var(--ease-out),
+      max-inline-size var(--dur-quick) var(--ease-out);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cq-sm,
+  .cq-md,
+  .cq-lg {
+    transition: none;
+  }
 }
 
 @keyframes glitch {

--- a/src/app/preview/[slug]/PreviewContentClient.tsx
+++ b/src/app/preview/[slug]/PreviewContentClient.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import * as React from "react";
+import { Suspense } from "react";
+
+import PreviewSurface, {
+  PREVIEW_SURFACE_CONTAINER_CLASSNAME,
+} from "@/components/gallery/PreviewSurfaceClient";
+import PreviewThemeClient from "@/components/gallery/PreviewThemeClient";
+import type { GalleryPreviewRoute } from "@/components/gallery";
+import { BackgroundPicker, Card, Label, ThemePicker, Spinner } from "@/components/ui";
+import { usePersistentState } from "@/lib/db";
+import {
+  VARIANT_LABELS,
+  decodeThemeState,
+  type Background,
+  type Variant,
+} from "@/lib/theme";
+import { cn } from "@/lib/utils";
+
+const BACKGROUND_LABELS: Record<Background, string> = {
+  0: "Default",
+  1: "Alt 1",
+  2: "Alt 2",
+  3: "VHS",
+  4: "Streak",
+};
+
+const CONTAINER_OPTIONS = [
+  { id: "cq-sm", label: "Compact", width: "≤320px" },
+  { id: "cq-md", label: "Comfort", width: "≤768px" },
+  { id: "cq-lg", label: "Full", width: "≤1024px" },
+] as const;
+
+type ContainerSize = (typeof CONTAINER_OPTIONS)[number]["id"];
+
+type ControlState = {
+  variant: Variant;
+  bg: Background;
+  container: ContainerSize;
+};
+
+interface PreviewContentClientProps {
+  readonly route: GalleryPreviewRoute;
+  readonly axisSummary: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isContainerSize(value: unknown): value is ContainerSize {
+  if (typeof value !== "string") {
+    return false;
+  }
+  return CONTAINER_OPTIONS.some((option) => option.id === value);
+}
+
+function PreviewLoadingFallback({ containerSize }: { containerSize: ContainerSize }) {
+  return (
+    <section
+      aria-busy="true"
+      aria-live="polite"
+      className={cn(
+        PREVIEW_SURFACE_CONTAINER_CLASSNAME,
+        "transition-[inline-size] duration-quick ease-out motion-reduce:transition-none",
+        containerSize,
+      )}
+      data-container-size={containerSize}
+      data-preview-container=""
+      data-preview-ready="loading"
+    >
+      <div
+        className="flex items-center gap-[var(--space-2)] text-label text-muted-foreground"
+        role="status"
+      >
+        <Spinner />
+        <span>Loading preview…</span>
+      </div>
+    </section>
+  );
+}
+
+export default function PreviewContentClient({
+  route,
+  axisSummary,
+}: PreviewContentClientProps) {
+  const controlsHeadingId = React.useId();
+  const sliderId = React.useId();
+  const sliderDescriptionId = React.useId();
+  const sliderStatusId = React.useId();
+
+  const defaultState = React.useMemo<ControlState>(
+    () => ({
+      variant: route.themeVariant,
+      bg: route.themeBackground,
+      container: "cq-lg",
+    }),
+    [route.themeVariant, route.themeBackground],
+  );
+
+  const decodeControlState = React.useCallback(
+    (value: unknown): ControlState | null => {
+      if (!isRecord(value)) {
+        return null;
+      }
+
+      const themeState = decodeThemeState(value) ?? defaultState;
+      const rawContainer = value["container"];
+      const container = isContainerSize(rawContainer)
+        ? rawContainer
+        : defaultState.container;
+
+      return {
+        variant: themeState.variant,
+        bg: themeState.bg,
+        container,
+      };
+    },
+    [defaultState],
+  );
+
+  const persistenceOptions = React.useMemo(
+    () => ({ decode: decodeControlState }),
+    [decodeControlState],
+  );
+
+  const [controlState, setControlState] = usePersistentState<ControlState>(
+    `preview.controls:${route.slug}`,
+    defaultState,
+    persistenceOptions,
+  );
+
+  const handleVariantChange = React.useCallback(
+    (next: Variant) => {
+      setControlState((prev) => {
+        if (prev.variant === next) {
+          return prev;
+        }
+        return { ...prev, variant: next };
+      });
+    },
+    [setControlState],
+  );
+
+  const handleBackgroundChange = React.useCallback(
+    (next: Background) => {
+      setControlState((prev) => {
+        if (prev.bg === next) {
+          return prev;
+        }
+        return { ...prev, bg: next };
+      });
+    },
+    [setControlState],
+  );
+
+  const handleContainerChange = React.useCallback(
+    (nextIndex: number) => {
+      if (!Number.isFinite(nextIndex)) {
+        return;
+      }
+      const clampedIndex = Math.min(
+        Math.max(Math.trunc(nextIndex), 0),
+        CONTAINER_OPTIONS.length - 1,
+      );
+      const option = CONTAINER_OPTIONS[clampedIndex];
+      setControlState((prev) => {
+        if (prev.container === option.id) {
+          return prev;
+        }
+        return { ...prev, container: option.id };
+      });
+    },
+    [setControlState],
+  );
+
+  const currentContainerIndex = React.useMemo(() => {
+    const index = CONTAINER_OPTIONS.findIndex(
+      (option) => option.id === controlState.container,
+    );
+    if (index >= 0) {
+      return index;
+    }
+    return CONTAINER_OPTIONS.length - 1;
+  }, [controlState.container]);
+
+  const currentContainer = CONTAINER_OPTIONS[currentContainerIndex];
+  const containerProgress =
+    CONTAINER_OPTIONS.length > 1
+      ? (currentContainerIndex / (CONTAINER_OPTIONS.length - 1)) * 100
+      : 0;
+
+  const themeLabel = VARIANT_LABELS[controlState.variant];
+  const backgroundLabel = BACKGROUND_LABELS[controlState.bg] ?? BACKGROUND_LABELS[0];
+  const backgroundSummary =
+    controlState.bg === 0 ? "Default background" : `${backgroundLabel} background`;
+
+  const sliderDescribedBy = `${sliderDescriptionId} ${sliderStatusId}`;
+  const stateLabel = route.stateName ? ` · ${route.stateName}` : "";
+
+  return (
+    <div
+      className="min-h-screen bg-background text-foreground"
+      data-preview-entry={route.entryId}
+      data-preview-slug={route.slug}
+      data-preview-state={route.stateId ?? undefined}
+    >
+      <PreviewThemeClient
+        variant={controlState.variant}
+        background={controlState.bg}
+      />
+      <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-[var(--space-5)] px-[var(--space-5)] py-[var(--space-6)]">
+        <header className="space-y-[var(--space-2)]">
+          <p className="text-caption font-medium uppercase tracking-[0.2em] text-muted-foreground">
+            Gallery preview
+          </p>
+          <h1 className="text-title font-semibold tracking-[-0.01em]">
+            {route.entryName}
+            {stateLabel ? <span className="text-muted-foreground">{stateLabel}</span> : null}
+          </h1>
+          <p aria-live="polite" className="text-label text-muted-foreground">
+            {themeLabel} · {backgroundSummary}
+          </p>
+          {axisSummary ? (
+            <p className="text-caption text-muted-foreground">{axisSummary}</p>
+          ) : null}
+        </header>
+
+        <section aria-labelledby={controlsHeadingId} className="space-y-[var(--space-3)]">
+          <h2
+            id={controlsHeadingId}
+            className="text-caption font-semibold uppercase tracking-[0.2em] text-muted-foreground"
+          >
+            Preview controls
+          </h2>
+          <Card className="bg-[hsl(var(--surface)/0.75)] border border-[hsl(var(--card-hairline)/0.55)] shadow-outline-subtle backdrop-blur-sm">
+            <div className="flex flex-col gap-[var(--space-4)]">
+              <div className="grid gap-[var(--space-3)] md:grid-cols-2">
+                <ThemePicker
+                  variant={controlState.variant}
+                  onVariantChange={handleVariantChange}
+                  className="w-full"
+                />
+                <BackgroundPicker
+                  bg={controlState.bg}
+                  onBgChange={handleBackgroundChange}
+                  className="w-full"
+                />
+              </div>
+
+              <div className="space-y-[var(--space-2)]">
+                <Label htmlFor={sliderId}>Container width</Label>
+                <p
+                  id={sliderDescriptionId}
+                  className="text-caption text-muted-foreground"
+                >
+                  Snap the preview to the small, medium, or large container query breakpoints.
+                </p>
+                <div className="group/slider relative mt-[var(--space-1)] h-[var(--space-6)]">
+                  <div
+                    className="pointer-events-none absolute left-0 right-0 top-1/2 h-[var(--space-1)] -translate-y-1/2 rounded-full bg-[hsl(var(--card-hairline)/0.45)] shadow-[var(--shadow-inset-hairline)]"
+                    aria-hidden
+                  />
+                  <div
+                    className="pointer-events-none absolute left-0 top-1/2 h-[var(--space-1)] -translate-y-1/2 rounded-full bg-[hsl(var(--accent)/0.6)] shadow-[var(--shadow-glow-sm)] transition-[width] duration-quick ease-out motion-reduce:transition-none"
+                    style={{ width: `${containerProgress}%` }}
+                    aria-hidden
+                  />
+                  <div
+                    className="pointer-events-none absolute top-1/2 size-[var(--space-5)] -translate-y-1/2 -translate-x-1/2 rounded-full border border-[hsl(var(--card-hairline)/0.6)] bg-[hsl(var(--card)/0.9)] shadow-[var(--shadow-control)] transition-[left] duration-quick ease-out motion-reduce:transition-none group-focus-visible/slider:ring-2 group-focus-visible/slider:ring-[var(--ring-contrast)] group-focus-visible/slider:shadow-[var(--shadow-glow-md)]"
+                    style={{ left: `${containerProgress}%` }}
+                    aria-hidden
+                  />
+                  <input
+                    id={sliderId}
+                    type="range"
+                    min={0}
+                    max={CONTAINER_OPTIONS.length - 1}
+                    step={1}
+                    value={currentContainerIndex}
+                    aria-valuetext={`${currentContainer.label} width (${currentContainer.width})`}
+                    aria-describedby={sliderDescribedBy}
+                    onChange={(event) => {
+                      const nextValue = Number(event.target.value);
+                      handleContainerChange(nextValue);
+                    }}
+                    className="absolute inset-0 z-10 h-full w-full cursor-pointer appearance-none rounded-[var(--control-radius)] opacity-0 focus-visible:outline-none"
+                  />
+                </div>
+                <p
+                  id={sliderStatusId}
+                  aria-live="polite"
+                  className="text-caption text-muted-foreground"
+                >
+                  {currentContainer.label} width · {currentContainer.width}
+                </p>
+                <div className="flex items-center justify-between text-caption text-muted-foreground" aria-hidden>
+                  {CONTAINER_OPTIONS.map((option) => {
+                    const selected = option.id === currentContainer.id;
+                    return (
+                      <span
+                        key={option.id}
+                        className={cn(
+                          "flex-1 text-center",
+                          selected && "font-semibold text-foreground",
+                        )}
+                      >
+                        {option.label}
+                      </span>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          </Card>
+        </section>
+
+        <div className="flex flex-1 items-center justify-center">
+          <Suspense fallback={<PreviewLoadingFallback containerSize={controlState.container} />}>
+            <PreviewSurface
+              previewId={route.previewId}
+              containerSize={controlState.container}
+            />
+          </Suspense>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/preview/[slug]/page.tsx
+++ b/src/app/preview/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { Suspense } from "react";
 import type { ReactNode } from "react";
 
 import {
@@ -9,10 +8,12 @@ import {
   getGalleryPreviewRoutes,
   type GalleryPreviewRoute,
 } from "@/components/gallery";
-import PreviewSurface from "@/components/gallery/PreviewSurfaceClient";
+import PreviewContentClient from "./PreviewContentClient";
 import PreviewThemeClient from "@/components/gallery/PreviewThemeClient";
-import { Spinner } from "@/components/ui";
 import { VARIANT_LABELS } from "@/lib/theme";
+import { cn } from "@/lib/utils";
+
+import { PREVIEW_SURFACE_CONTAINER_CLASSNAME } from "@/components/gallery/PreviewSurfaceClient";
 
 const SKIP_PREVIEW_RENDER =
   process.env.GITHUB_PAGES === "true" || process.env.SKIP_PREVIEW_STATIC === "true";
@@ -59,22 +60,17 @@ function PreviewSurfaceContainer({
     <section
       aria-busy={status === "loading"}
       aria-live={status === "loading" ? "polite" : undefined}
-      className="relative flex w-full items-center justify-center rounded-card r-card-lg border border-[hsl(var(--card-hairline)/0.6)] bg-[hsl(var(--surface-2)/0.7)] p-[var(--space-5)] shadow-[var(--shadow-inset-hairline)]"
+      className={cn(
+        PREVIEW_SURFACE_CONTAINER_CLASSNAME,
+        "transition-[inline-size] duration-quick ease-out motion-reduce:transition-none",
+        "cq-lg",
+      )}
+      data-container-size="cq-lg"
+      data-preview-container=""
       data-preview-ready={status}
     >
       {children}
     </section>
-  );
-}
-
-function PreviewFallback() {
-  return (
-    <PreviewSurfaceContainer status="loading">
-      <div className="flex items-center gap-[var(--space-2)] text-label text-muted-foreground" role="status">
-        <Spinner />
-        <span>Loading preview…</span>
-      </div>
-    </PreviewSurfaceContainer>
   );
 }
 
@@ -83,43 +79,11 @@ interface PreviewContentProps {
 }
 
 export function PreviewContent({ route }: PreviewContentProps) {
-  const themeLabel = VARIANT_LABELS[route.themeVariant];
-  const stateLabel = route.stateName ?? null;
   const axisSummary = route.axisParams
     .map((axis) => `${axis.label}: ${axis.options.map((option) => option.label).join(", ")}`)
     .join(" · ");
 
-  return (
-    <div
-      className="min-h-screen bg-background text-foreground"
-      data-preview-entry={route.entryId}
-      data-preview-slug={route.slug}
-      data-preview-state={route.stateId ?? undefined}
-    >
-      <PreviewThemeClient variant={route.themeVariant} background={route.themeBackground} />
-      <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-[var(--space-5)] px-[var(--space-5)] py-[var(--space-6)]">
-        <header className="space-y-[var(--space-2)]">
-          <p className="text-caption font-medium uppercase tracking-[0.2em] text-muted-foreground">
-            Gallery preview
-          </p>
-          <h1 className="text-title font-semibold tracking-[-0.01em]">
-            {route.entryName}
-            {stateLabel ? <span className="text-muted-foreground"> · {stateLabel}</span> : null}
-          </h1>
-          <p className="text-label text-muted-foreground">
-            {themeLabel}
-            {route.themeBackground > 0 ? ` background ${route.themeBackground}` : " theme"}
-          </p>
-          {axisSummary ? (
-            <p className="text-caption text-muted-foreground">{axisSummary}</p>
-          ) : null}
-        </header>
-        <Suspense fallback={<PreviewFallback />}>
-          <PreviewSurface previewId={route.previewId} />
-        </Suspense>
-      </div>
-    </div>
-  );
+  return <PreviewContentClient route={route} axisSummary={axisSummary} />;
 }
 
 export function PreviewUnavailable({ route }: { readonly route: GalleryPreviewRoute }) {

--- a/src/components/gallery/PreviewSurfaceClient.tsx
+++ b/src/components/gallery/PreviewSurfaceClient.tsx
@@ -2,20 +2,36 @@
 
 import { useCallback, useState } from "react";
 
+import { cn } from "@/lib/utils";
+
 import PreviewRendererClient from "./PreviewRendererClient";
+
+export const PREVIEW_SURFACE_CONTAINER_CLASSNAME =
+  "relative flex w-full items-center justify-center rounded-card r-card-lg border border-[hsl(var(--card-hairline)/0.6)] bg-[hsl(var(--surface-2)/0.7)] p-[var(--space-5)] shadow-[var(--shadow-inset-hairline)]";
 
 function PreviewSurfaceContainer({
   children,
   status,
+  className,
+  containerSize,
 }: {
   readonly children?: React.ReactNode;
   readonly status: "loading" | "loaded";
+  readonly className?: string;
+  readonly containerSize?: string;
 }) {
   return (
     <section
       aria-busy={status === "loading"}
       aria-live={status === "loading" ? "polite" : undefined}
-      className="relative flex w-full items-center justify-center rounded-card r-card-lg border border-[hsl(var(--card-hairline)/0.6)] bg-[hsl(var(--surface-2)/0.7)] p-[var(--space-5)] shadow-[var(--shadow-inset-hairline)]"
+      className={cn(
+        PREVIEW_SURFACE_CONTAINER_CLASSNAME,
+        "transition-[inline-size] duration-quick ease-out motion-reduce:transition-none",
+        containerSize ?? "cq-lg",
+        className,
+      )}
+      data-container-size={containerSize ?? "cq-lg"}
+      data-preview-container=""
       data-preview-ready={status}
     >
       {children}
@@ -25,9 +41,15 @@ function PreviewSurfaceContainer({
 
 interface PreviewSurfaceProps {
   readonly previewId: string;
+  readonly className?: string;
+  readonly containerSize?: string;
 }
 
-export default function PreviewSurface({ previewId }: PreviewSurfaceProps) {
+export default function PreviewSurface({
+  previewId,
+  className,
+  containerSize,
+}: PreviewSurfaceProps) {
   const [status, setStatus] = useState<"loading" | "loaded">("loading");
 
   const handleReady = useCallback(() => {
@@ -39,7 +61,11 @@ export default function PreviewSurface({ previewId }: PreviewSurfaceProps) {
   }, []);
 
   return (
-    <PreviewSurfaceContainer status={status}>
+    <PreviewSurfaceContainer
+      status={status}
+      className={className}
+      containerSize={containerSize}
+    >
       <PreviewRendererClient
         previewId={previewId}
         onReady={handleReady}

--- a/tests/preview/PreviewPage.test.tsx
+++ b/tests/preview/PreviewPage.test.tsx
@@ -7,7 +7,9 @@ import { PreviewContent, PreviewUnavailable } from "@/app/preview/[slug]/page";
 (globalThis as { React?: typeof React }).React = React;
 
 vi.mock("@/components/gallery/PreviewSurfaceClient", () => ({
+  __esModule: true,
   default: () => <div data-testid="preview-surface" />,
+  PREVIEW_SURFACE_CONTAINER_CLASSNAME: "preview-surface",
 }));
 
 vi.mock("@/components/gallery/PreviewThemeClient", () => ({


### PR DESCRIPTION
## Summary
- add a client PreviewContent wrapper with theme/background pickers and a container-width slider for gallery previews
- persist per-preview control state, announce theme changes, and honour reduced-motion preferences
- expose preview container size utilities and pass container metadata through PreviewSurface

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68daddfcd4c8832c92727e74e41a6644