### PR TITLE
fix: align retro glow tokens with palette variables

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -159,6 +159,14 @@
 | lg-black | var(--background) |
 | glow-strong | var(--ring) / 0.55 |
 | glow-soft | var(--accent) / 0.25 |
+| space-1 | var(--spacing-1) |
+| space-2 | var(--spacing-2) |
+| space-3 | var(--spacing-3) |
+| space-4 | var(--spacing-4) |
+| space-5 | var(--spacing-5) |
+| space-6 | var(--spacing-6) |
+| space-7 | var(--spacing-7) |
+| space-8 | var(--spacing-8) |
 | font-size-md | var(--font-body) |
 | font-weight-bold | 800 |
 | shadow-neon | 0 0 var(--space-1) hsl(var(--neon) / 0.55),
@@ -231,14 +239,14 @@
 | spacing-0-25 | calc(var(--spacing-1) / 4) |
 | spacing-0-5 | calc(var(--spacing-1) / 2) |
 | spacing-0-75 | calc(var(--spacing-1) * 0.75) |
-| spacing-1 / space-1 | 4px |
-| spacing-2 / space-2 | 8px |
-| spacing-3 / space-3 | 12px |
-| spacing-4 / space-4 | 16px |
-| spacing-5 / space-5 | 24px |
-| spacing-6 / space-6 | 32px |
-| spacing-7 / space-7 | 48px |
-| spacing-8 / space-8 | 64px |
+| spacing-1 | 4px |
+| spacing-2 | 8px |
+| spacing-3 | 12px |
+| spacing-4 | 16px |
+| spacing-5 | 24px |
+| spacing-6 | 32px |
+| spacing-7 | 48px |
+| spacing-8 | 64px |
 | radius-sm | 6px |
 | radius-md | 8px |
 | radius-lg | 12px |

--- a/scripts/themes.ts
+++ b/scripts/themes.ts
@@ -364,40 +364,40 @@ export const themes: ThemeDefinition[] = [
       { name: "success", value: "158 72% 48%" },
       { name: "success-glow", value: "158 72% 38% / 0.6" },
       { name: "glow", value: "304 100% 68%" },
-      { name: "glow-active", value: "hsl(188.7 89.6% 69.8%)" },
+      { name: "glow-active", value: "hsl(var(--accent-2))" },
       {
         name: "shadow-glow-sm",
         value: [
           "",
-          "0 0 var(--spacing-2) hsl(304 100% 68% / 0.7),",
-          "0 0 var(--spacing-4) hsl(188.7 89.6% 69.8% / 0.45)",
+          "0 0 var(--spacing-2) hsl(var(--glow) / 0.7),",
+          "0 0 var(--spacing-4) hsl(var(--accent-2) / 0.45)",
         ],
       },
       {
         name: "shadow-glow-md",
         value: [
           "",
-          "0 0 var(--spacing-3) hsl(304 100% 68% / 0.55),",
-          "0 0 var(--spacing-5) hsl(188.7 89.6% 69.8% / 0.4),",
-          "0 0 var(--spacing-6) hsl(257.5 85.7% 72.5% / 0.3)",
+          "0 0 var(--spacing-3) hsl(var(--glow) / 0.55),",
+          "0 0 var(--spacing-5) hsl(var(--accent-2) / 0.4),",
+          "0 0 var(--spacing-6) hsl(var(--accent-3) / 0.3)",
         ],
       },
       {
         name: "shadow-glow-lg",
         value: [
           "",
-          "0 0 var(--spacing-4) hsl(304 100% 68% / 0.5),",
-          "0 0 var(--spacing-6) hsl(188.7 89.6% 69.8% / 0.38),",
-          "0 0 var(--spacing-7) hsl(257.5 85.7% 72.5% / 0.28)",
+          "0 0 var(--spacing-4) hsl(var(--glow) / 0.5),",
+          "0 0 var(--spacing-6) hsl(var(--accent-2) / 0.38),",
+          "0 0 var(--spacing-7) hsl(var(--accent-3) / 0.28)",
         ],
       },
       {
         name: "shadow-glow-xl",
         value: [
           "",
-          "0 var(--spacing-1) var(--spacing-5) hsl(304 100% 68% / 0.45),",
-          "0 var(--spacing-2) var(--spacing-7) hsl(188.7 89.6% 69.8% / 0.32),",
-          "0 var(--spacing-3) var(--spacing-8) hsl(257.5 85.7% 72.5% / 0.24)",
+          "0 var(--spacing-1) var(--spacing-5) hsl(var(--glow) / 0.45),",
+          "0 var(--spacing-2) var(--spacing-7) hsl(var(--accent-2) / 0.32),",
+          "0 var(--spacing-3) var(--spacing-8) hsl(var(--accent-3) / 0.24)",
         ],
       },
       {

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -599,22 +599,22 @@ html.theme-retro {
   --success: 158 72% 48%;
   --success-glow: 158 72% 38% / 0.6;
   --glow: 304 100% 68%;
-  --glow-active: hsl(188.7 89.6% 69.8%);
+  --glow-active: hsl(var(--accent-2));
   --shadow-glow-sm:
-    0 0 var(--spacing-2) hsl(304 100% 68% / 0.7),
-    0 0 var(--spacing-4) hsl(188.7 89.6% 69.8% / 0.45);
+    0 0 var(--spacing-2) hsl(var(--glow) / 0.7),
+    0 0 var(--spacing-4) hsl(var(--accent-2) / 0.45);
   --shadow-glow-md:
-    0 0 var(--spacing-3) hsl(304 100% 68% / 0.55),
-    0 0 var(--spacing-5) hsl(188.7 89.6% 69.8% / 0.4),
-    0 0 var(--spacing-6) hsl(257.5 85.7% 72.5% / 0.3);
+    0 0 var(--spacing-3) hsl(var(--glow) / 0.55),
+    0 0 var(--spacing-5) hsl(var(--accent-2) / 0.4),
+    0 0 var(--spacing-6) hsl(var(--accent-3) / 0.3);
   --shadow-glow-lg:
-    0 0 var(--spacing-4) hsl(304 100% 68% / 0.5),
-    0 0 var(--spacing-6) hsl(188.7 89.6% 69.8% / 0.38),
-    0 0 var(--spacing-7) hsl(257.5 85.7% 72.5% / 0.28);
+    0 0 var(--spacing-4) hsl(var(--glow) / 0.5),
+    0 0 var(--spacing-6) hsl(var(--accent-2) / 0.38),
+    0 0 var(--spacing-7) hsl(var(--accent-3) / 0.28);
   --shadow-glow-xl:
-    0 var(--spacing-1) var(--spacing-5) hsl(304 100% 68% / 0.45),
-    0 var(--spacing-2) var(--spacing-7) hsl(188.7 89.6% 69.8% / 0.32),
-    0 var(--spacing-3) var(--spacing-8) hsl(257.5 85.7% 72.5% / 0.24);
+    0 var(--spacing-1) var(--spacing-5) hsl(var(--glow) / 0.45),
+    0 var(--spacing-2) var(--spacing-7) hsl(var(--accent-2) / 0.32),
+    0 var(--spacing-3) var(--spacing-8) hsl(var(--accent-3) / 0.24);
   --grid-lines:
     repeating-linear-gradient(
       90deg,


### PR DESCRIPTION
## Summary
- reference retro theme glow-active and halo layers to existing accent/glow tokens
- regenerate themes and token docs to capture tokenized retro shadows

## Testing
- npm run generate-themes
- npm run generate-tokens
- npm run contrast-report
- npm run check *(fails: vitest snapshots hit 5s timeout in multiple suites even with 10s allowance)*
- npm test -- --run --testTimeout=10000 *(aborted due to output volume; validated flaking suites individually instead)*
- npx vitest run tests/team/JungleClears.test.tsx *(pass)*
- npx vitest run tests/planner/PlannerViewMode.test.tsx *(pass after increasing timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68dada61ae30832cace4746c34281d6f