### PR TITLE
fix: improve Hardstuck accent contrast

### DIFF
--- a/scripts/themes.ts
+++ b/scripts/themes.ts
@@ -321,6 +321,7 @@ export const themes: ThemeDefinition[] = [
       { name: "primary-soft", value: "120 100% 26%" },
       { name: "accent", value: "120 92% 58%" },
       { name: "accent-2", value: "120 76% 22%" },
+      { name: "accent-2-foreground", value: "120 32% 94%" },
       { name: "accent-foreground", value: "0 0% 8%" },
       { name: "text-on-accent", value: "hsl(var(--hardstuck-foreground))" },
       { name: "accent-soft", value: "120 90% 16%" },

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -556,6 +556,7 @@ html.theme-hardstuck {
   --primary-soft: 120 100% 26%;
   --accent: 120 92% 58%;
   --accent-2: 120 76% 22%;
+  --accent-2-foreground: 120 32% 94%;
   --accent-foreground: 0 0% 8%;
   --text-on-accent: hsl(var(--hardstuck-foreground));
   --accent-soft: 120 90% 16%;

--- a/src/components/reviews/ReviewListItem.tsx
+++ b/src/components/reviews/ReviewListItem.tsx
@@ -30,10 +30,10 @@ const itemLoading = cn(
 const loadingLine = "h-[var(--space-3)] rounded-card bg-muted";
 const scoreBadge = cn(
   "px-[var(--space-2)] py-[var(--space-1)] rounded-full text-ui leading-none font-medium",
-  "text-accent-foreground ring-1 ring-[theme('colors.interaction.accent.surfaceActive')] bg-gradient-to-br from-accent to-accent-2",
-  "hover:ring-[theme('colors.interaction.accent.surfaceHover')]",
-  "focus-visible:ring-[theme('colors.interaction.accent.surfaceHover')]",
-  "active:ring-[theme('colors.interaction.accent.surfaceActive')]",
+  "text-accent-2-foreground ring-1 ring-[theme('colors.interaction.info.surfaceActive')] bg-accent-2",
+  "hover:ring-[theme('colors.interaction.info.surfaceHover')]",
+  "focus-visible:ring-[theme('colors.interaction.info.surfaceHover')]",
+  "active:ring-[theme('colors.interaction.info.surfaceActive')]",
 );
 
 export type ReviewListItemProps = {

--- a/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewListItem.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`ReviewListItem > renders default state 1`] = `
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-[var(--space-2)] py-[var(--space-1)] rounded-full text-ui leading-none font-medium text-accent-foreground ring-1 ring-[theme('colors.interaction.accent.surfaceActive')] bg-gradient-to-br from-accent to-accent-2 hover:ring-[theme('colors.interaction.accent.surfaceHover')] focus-visible:ring-[theme('colors.interaction.accent.surfaceHover')] active:ring-[theme('colors.interaction.accent.surfaceActive')]"
+          class="px-[var(--space-2)] py-[var(--space-1)] rounded-full text-ui leading-none font-medium text-accent-2-foreground ring-1 ring-[theme('colors.interaction.info.surfaceActive')] bg-accent-2 hover:ring-[theme('colors.interaction.info.surfaceHover')] focus-visible:ring-[theme('colors.interaction.info.surfaceHover')] active:ring-[theme('colors.interaction.info.surfaceActive')]"
         >
           9
           /10
@@ -98,7 +98,7 @@ exports[`ReviewListItem > renders disabled state 1`] = `
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-[var(--space-2)] py-[var(--space-1)] rounded-full text-ui leading-none font-medium text-accent-foreground ring-1 ring-[theme('colors.interaction.accent.surfaceActive')] bg-gradient-to-br from-accent to-accent-2 hover:ring-[theme('colors.interaction.accent.surfaceHover')] focus-visible:ring-[theme('colors.interaction.accent.surfaceHover')] active:ring-[theme('colors.interaction.accent.surfaceActive')]"
+          class="px-[var(--space-2)] py-[var(--space-1)] rounded-full text-ui leading-none font-medium text-accent-2-foreground ring-1 ring-[theme('colors.interaction.info.surfaceActive')] bg-accent-2 hover:ring-[theme('colors.interaction.info.surfaceHover')] focus-visible:ring-[theme('colors.interaction.info.surfaceHover')] active:ring-[theme('colors.interaction.info.surfaceActive')]"
         >
           9
           /10
@@ -170,7 +170,7 @@ exports[`ReviewListItem > renders selected state 1`] = `
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-[var(--space-2)] py-[var(--space-1)] rounded-full text-ui leading-none font-medium text-accent-foreground ring-1 ring-[theme('colors.interaction.accent.surfaceActive')] bg-gradient-to-br from-accent to-accent-2 hover:ring-[theme('colors.interaction.accent.surfaceHover')] focus-visible:ring-[theme('colors.interaction.accent.surfaceHover')] active:ring-[theme('colors.interaction.accent.surfaceActive')]"
+          class="px-[var(--space-2)] py-[var(--space-1)] rounded-full text-ui leading-none font-medium text-accent-2-foreground ring-1 ring-[theme('colors.interaction.info.surfaceActive')] bg-accent-2 hover:ring-[theme('colors.interaction.info.surfaceHover')] focus-visible:ring-[theme('colors.interaction.info.surfaceHover')] active:ring-[theme('colors.interaction.info.surfaceActive')]"
         >
           9
           /10
@@ -225,7 +225,7 @@ exports[`ReviewListItem > renders untitled state 1`] = `
         </div>
         <span
           aria-label="Rating 9 out of 10"
-          class="px-[var(--space-2)] py-[var(--space-1)] rounded-full text-ui leading-none font-medium text-accent-foreground ring-1 ring-[theme('colors.interaction.accent.surfaceActive')] bg-gradient-to-br from-accent to-accent-2 hover:ring-[theme('colors.interaction.accent.surfaceHover')] focus-visible:ring-[theme('colors.interaction.accent.surfaceHover')] active:ring-[theme('colors.interaction.accent.surfaceActive')]"
+          class="px-[var(--space-2)] py-[var(--space-1)] rounded-full text-ui leading-none font-medium text-accent-2-foreground ring-1 ring-[theme('colors.interaction.info.surfaceActive')] bg-accent-2 hover:ring-[theme('colors.interaction.info.surfaceHover')] focus-visible:ring-[theme('colors.interaction.info.surfaceHover')] active:ring-[theme('colors.interaction.info.surfaceActive')]"
         >
           9
           /10


### PR DESCRIPTION
## Summary
- add a dedicated Hardstuck `accent-2-foreground` token and regenerate the theme stylesheet
- restyle the review score badge to use the accent-2 tone and info interaction tokens for AA contrast
- update review list item snapshots for the revised styling

## Testing
- npm run contrast-report
- npm run check
- npm run verify-prompts

------
https://chatgpt.com/codex/tasks/task_e_68daeb2b7f18832cbf9e16952f386d60