### PR TITLE
feat: add cinematic portrait frame

### DIFF
--- a/src/components/gallery/generated-manifest.ts
+++ b/src/components/gallery/generated-manifest.ts
@@ -2810,6 +2810,21 @@ export const galleryPayload = {
           }
         },
         {
+          "id": "portrait-frame",
+          "name": "PortraitFrame",
+          "description": "Dual-character neumorphic portrait that stages the angel and demon busts with pose variants and theme-aware cinematic lighting.",
+          "tags": [
+            "hero",
+            "portrait",
+            "duo"
+          ],
+          "kind": "complex",
+          "code": "<div className=\"flex flex-wrap items-center justify-center gap-[var(--space-3)]\">\n  <PortraitFrame />\n  <PortraitFrame pose=\"angel-leading\" />\n  <PortraitFrame pose=\"back-to-back\" transparentBackground />\n</div>",
+          "preview": {
+            "id": "prompts:homepage:portrait-frame"
+          }
+        },
+        {
           "id": "welcome-hero-figure",
           "name": "WelcomeHeroFigure",
           "description": "Hero automation figure framed in a haloed neumorphic ring with eager loading tuned for the landing experience.",
@@ -6318,25 +6333,40 @@ export const galleryPayload = {
           "id": "prompts:homepage:hero-planner-cards"
         }
       },
-      {
-        "id": "hero-portrait-frame",
-        "name": "HeroPortraitFrame",
-        "description": "Circular neumorphic portrait frame with lavender glow, glitch accent rim, and configurable `frame` toggle built from semantic tokens.",
-        "tags": [
-          "hero",
-          "portrait",
-          "glitch"
-        ],
-        "kind": "complex",
-        "code": "<div className=\"flex flex-wrap items-center justify-center gap-[var(--space-3)]\">\n  <HeroPortraitFrame\n    imageSrc=\"/hero_image.png\"\n    imageAlt=\"Illustration of the Planner hero floating above a holographic dashboard with full frame treatment\"\n  />\n  <HeroPortraitFrame\n    frame={false}\n    imageSrc=\"/hero_image.png\"\n    imageAlt=\"Illustration of the Planner hero floating above a holographic dashboard without frame treatment\"\n  />\n</div>",
-        "preview": {
-          "id": "prompts:homepage:hero-portrait-frame"
-        }
-      },
-      {
-        "id": "welcome-hero-figure",
-        "name": "WelcomeHeroFigure",
-        "description": "Hero automation figure framed in a haloed neumorphic ring with eager loading tuned for the landing experience.",
+        {
+          "id": "hero-portrait-frame",
+          "name": "HeroPortraitFrame",
+          "description": "Circular neumorphic portrait frame with lavender glow, glitch accent rim, and configurable `frame` toggle built from semantic tokens.",
+          "tags": [
+            "hero",
+            "portrait",
+            "glitch"
+          ],
+          "kind": "complex",
+          "code": "<div className=\"flex flex-wrap items-center justify-center gap-[var(--space-3)]\">\n  <HeroPortraitFrame\n    imageSrc=\"/hero_image.png\"\n    imageAlt=\"Illustration of the Planner hero floating above a holographic dashboard with full frame treatment\"\n  />\n  <HeroPortraitFrame\n    frame={false}\n    imageSrc=\"/hero_image.png\"\n    imageAlt=\"Illustration of the Planner hero floating above a holographic dashboard without frame treatment\"\n  />\n</div>",
+          "preview": {
+            "id": "prompts:homepage:hero-portrait-frame"
+          }
+        },
+        {
+          "id": "portrait-frame",
+          "name": "PortraitFrame",
+          "description": "Dual-character neumorphic portrait that stages the angel and demon busts with pose variants and theme-aware cinematic lighting.",
+          "tags": [
+            "hero",
+            "portrait",
+            "duo"
+          ],
+          "kind": "complex",
+          "code": "<div className=\"flex flex-wrap items-center justify-center gap-[var(--space-3)]\">\n  <PortraitFrame />\n  <PortraitFrame pose=\"angel-leading\" />\n  <PortraitFrame pose=\"back-to-back\" transparentBackground />\n</div>",
+          "preview": {
+            "id": "prompts:homepage:portrait-frame"
+          }
+        },
+        {
+          "id": "welcome-hero-figure",
+          "name": "WelcomeHeroFigure",
+          "description": "Hero automation figure framed in a haloed neumorphic ring with eager loading tuned for the landing experience.",
         "tags": [
           "hero",
           "figure",
@@ -11919,23 +11949,47 @@ export const galleryPreviewRoutes = [
     "themeBackground": 0,
     "axisParams": []
   },
-  {
-    "slug": "section-homepage--entry-hero-portrait-frame--preview-prompts-homepage-hero-portrait-frame--theme-lg",
-    "previewId": "prompts:homepage:hero-portrait-frame",
-    "entryId": "hero-portrait-frame",
-    "entryName": "HeroPortraitFrame",
-    "sectionId": "homepage",
-    "stateId": null,
-    "stateName": null,
-    "themeVariant": "lg",
-    "themeBackground": 0,
-    "axisParams": []
-  },
-  {
-    "slug": "section-homepage--entry-isometric-room--preview-prompts-homepage-isometric-room--theme-aurora",
-    "previewId": "prompts:homepage:isometric-room",
-    "entryId": "isometric-room",
-    "entryName": "IsometricRoom",
+    {
+      "slug": "section-homepage--entry-hero-portrait-frame--preview-prompts-homepage-hero-portrait-frame--theme-lg",
+      "previewId": "prompts:homepage:hero-portrait-frame",
+      "entryId": "hero-portrait-frame",
+      "entryName": "HeroPortraitFrame",
+      "sectionId": "homepage",
+      "stateId": null,
+      "stateName": null,
+      "themeVariant": "lg",
+      "themeBackground": 0,
+      "axisParams": []
+    },
+    {
+      "slug": "section-homepage--entry-portrait-frame--preview-prompts-homepage-portrait-frame--theme-aurora",
+      "previewId": "prompts:homepage:portrait-frame",
+      "entryId": "portrait-frame",
+      "entryName": "PortraitFrame",
+      "sectionId": "homepage",
+      "stateId": null,
+      "stateName": null,
+      "themeVariant": "aurora",
+      "themeBackground": 0,
+      "axisParams": []
+    },
+    {
+      "slug": "section-homepage--entry-portrait-frame--preview-prompts-homepage-portrait-frame--theme-lg",
+      "previewId": "prompts:homepage:portrait-frame",
+      "entryId": "portrait-frame",
+      "entryName": "PortraitFrame",
+      "sectionId": "homepage",
+      "stateId": null,
+      "stateName": null,
+      "themeVariant": "lg",
+      "themeBackground": 0,
+      "axisParams": []
+    },
+    {
+      "slug": "section-homepage--entry-isometric-room--preview-prompts-homepage-isometric-room--theme-aurora",
+      "previewId": "prompts:homepage:isometric-room",
+      "entryId": "isometric-room",
+      "entryName": "IsometricRoom",
     "sectionId": "homepage",
     "stateId": null,
     "stateName": null,
@@ -21458,10 +21512,11 @@ export const galleryPreviewModules = [
       "prompts:homepage:dashboard-card",
       "prompts:homepage:dashboard-list",
       "prompts:homepage:isometric-room",
-      "prompts:homepage:quick-action-grid",
-      "prompts:homepage:hero-planner-cards",
-      "prompts:homepage:hero-portrait-frame",
-      "prompts:homepage:welcome-hero-figure",
+        "prompts:homepage:quick-action-grid",
+        "prompts:homepage:hero-planner-cards",
+        "prompts:homepage:hero-portrait-frame",
+        "prompts:homepage:portrait-frame",
+        "prompts:homepage:welcome-hero-figure",
       "prompts:reviews:review-surface",
       "prompts:reviews:review-slider-track",
       "prompts:reviews:score-meter",

--- a/src/components/home/PortraitFrame.module.css
+++ b/src/components/home/PortraitFrame.module.css
@@ -1,0 +1,244 @@
+.stage {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: calc(var(--space-2) * 1.1);
+  overflow: visible;
+  isolation: isolate;
+  background: radial-gradient(
+    circle at 50% 92%,
+    hsl(var(--accent-2) / 0.24),
+    hsl(var(--surface) / 0.86) 70%,
+    transparent 92%
+  );
+  box-shadow:
+    inset 0 0 0 calc(var(--hairline-w) * 2) hsl(var(--card-hairline) / 0.4),
+    inset 0 calc(var(--spacing-1) * -1) calc(var(--spacing-3))
+      hsl(var(--shadow-color) / 0.3);
+}
+
+.innerTransparent {
+  background: transparent;
+  box-shadow: none;
+}
+
+.stageTransparent {
+  background: transparent;
+  box-shadow: none;
+}
+
+.rimLighting {
+  position: absolute;
+  inset: calc(var(--space-1) * -0.4);
+  border-radius: inherit;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  background: radial-gradient(
+    circle at 50% 18%,
+    hsl(var(--highlight) / 0.5),
+    transparent 70%
+  );
+  opacity: 0.6;
+}
+
+.character {
+  position: absolute;
+  bottom: calc(var(--space-1) * -0.3);
+  width: 58%;
+  aspect-ratio: 3 / 4;
+  transform-origin: center bottom;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  filter: drop-shadow(0 0 calc(var(--space-1)) hsl(var(--shadow-color) / 0.32));
+  transition: transform var(--dur-chill) var(--ease-out),
+    opacity var(--dur-chill) var(--ease-out),
+    filter var(--dur-chill) var(--ease-out);
+}
+
+.character::before,
+.character::after {
+  content: "";
+  position: absolute;
+  pointer-events: none;
+}
+
+.characterBody {
+  position: absolute;
+  inset: 28% 16% 4% 16%;
+  border-radius: 46% 46% 56% 56% / 60% 60% 40% 40%;
+  background: linear-gradient(152deg, var(--portrait-body-start), var(--portrait-body-end));
+  box-shadow:
+    0 0 0 calc(var(--hairline-w) * 2) hsl(var(--card-hairline) / 0.55),
+    0 calc(var(--spacing-1) / 2) calc(var(--spacing-3) / 1.2)
+      hsl(var(--shadow-color) / 0.45);
+  opacity: 0.95;
+  z-index: 1;
+}
+
+.characterHead {
+  position: absolute;
+  top: 6%;
+  left: 50%;
+  translate: -50% 0;
+  width: 46%;
+  aspect-ratio: 1;
+  border-radius: 44% 44% 50% 50%;
+  background:
+    radial-gradient(circle at 50% 28%, var(--portrait-head-highlight), transparent 72%),
+    radial-gradient(circle at 50% 60%, var(--portrait-head-core), transparent 85%);
+  box-shadow:
+    0 0 0 calc(var(--hairline-w) * 1.6) hsl(var(--card-hairline) / 0.45),
+    var(--shadow-glow-sm);
+  z-index: 3;
+}
+
+.characterCollar {
+  position: absolute;
+  inset: auto 24% 16% 24%;
+  height: 18%;
+  border-radius: 50% / 90% 90% 30% 30%;
+  background: linear-gradient(160deg, var(--portrait-collar-start), var(--portrait-collar-end));
+  box-shadow: 0 0 0 calc(var(--hairline-w) * 1.2) hsl(var(--card-hairline) / 0.35);
+  z-index: 2;
+}
+
+.layerFront {
+  z-index: 2;
+}
+
+.layerRear {
+  z-index: 1;
+}
+
+.layerDimmed {
+  opacity: 0.84;
+  filter: saturate(0.82) drop-shadow(0 0 calc(var(--space-1)) hsl(var(--shadow-color) / 0.26));
+}
+
+.angel {
+  --portrait-body-start: hsl(var(--accent-2) / 0.95);
+  --portrait-body-end: hsl(var(--accent) / 0.55);
+  --portrait-head-core: hsl(var(--highlight) / 0.78);
+  --portrait-head-highlight: hsl(var(--accent-2) / 0.32);
+  --portrait-collar-start: hsl(var(--accent) / 0.52);
+  --portrait-collar-end: hsl(var(--accent-2) / 0.46);
+}
+
+.angelWings {
+  position: absolute;
+  inset: 12% -6% 22% -6%;
+  border-radius: 48% 48% 58% 58% / 70% 70% 46% 46%;
+  background:
+    radial-gradient(120% 120% at 0% 40%, hsl(var(--highlight) / 0.28), transparent 64%),
+    radial-gradient(120% 120% at 100% 40%, hsl(var(--highlight) / 0.28), transparent 64%),
+    radial-gradient(140% 110% at 50% 50%, hsl(var(--accent-2) / 0.32), transparent 72%);
+  opacity: 0.88;
+  filter: drop-shadow(0 0 calc(var(--space-2)) hsl(var(--glow-active)))
+    drop-shadow(0 calc(var(--spacing-1) / 2) calc(var(--spacing-3) / 1.4) hsl(var(--accent-2) / 0.25));
+  mix-blend-mode: screen;
+  z-index: 0;
+}
+
+.demon {
+  --portrait-body-start: hsl(var(--lav-deep) / 0.92);
+  --portrait-body-end: hsl(var(--accent) / 0.68);
+  --portrait-head-core: hsl(var(--accent) / 0.62);
+  --portrait-head-highlight: hsl(var(--lav-deep) / 0.32);
+  --portrait-collar-start: hsl(var(--accent) / 0.64);
+  --portrait-collar-end: hsl(var(--accent-2) / 0.52);
+}
+
+.demonHorns {
+  position: absolute;
+  top: 4%;
+  left: 50%;
+  translate: -50% 0;
+  width: 68%;
+  height: 32%;
+}
+
+.demonHorns::before,
+.demonHorns::after {
+  content: "";
+  position: absolute;
+  top: 4%;
+  width: 42%;
+  height: 92%;
+  border-radius: 70% 70% 0 40%;
+  background: linear-gradient(165deg, hsl(var(--lav-deep) / 0.9), hsl(var(--accent) / 0.7));
+  box-shadow: 0 0 0 calc(var(--hairline-w) * 1.2) hsl(var(--card-hairline) / 0.4);
+  filter: drop-shadow(0 calc(var(--spacing-1) / 2) calc(var(--spacing-3) / 1.8) hsl(var(--accent) / 0.45));
+  z-index: 2;
+}
+
+.demonHorns::before {
+  left: 0;
+  transform: rotate(-12deg);
+}
+
+.demonHorns::after {
+  right: 0;
+  transform: rotate(12deg);
+}
+
+.poseDuoAngel {
+  transform: translate(-26%, 6%) scale(0.94);
+}
+
+.poseDuoDemon {
+  transform: translate(26%, 10%) scale(1.02);
+}
+
+.poseAngelLeadingAngel {
+  transform: translate(-12%, 4%) scale(1.04);
+}
+
+.poseAngelLeadingDemon {
+  transform: translate(34%, 12%) scale(0.9);
+}
+
+.poseDemonLeadingAngel {
+  transform: translate(-34%, 10%) scale(0.9);
+}
+
+.poseDemonLeadingDemon {
+  transform: translate(12%, 6%) scale(1.05);
+}
+
+.poseBackToBackAngel {
+  transform: translate(-18%, 8%) scale(0.96) rotate(-6deg);
+}
+
+.poseBackToBackDemon {
+  transform: translate(18%, 12%) scale(0.98) rotate(6deg);
+}
+
+.stageBackToBack {
+  background: radial-gradient(
+      circle at 36% 26%,
+      hsl(var(--accent-2) / 0.18),
+      transparent 72%
+    ),
+    radial-gradient(
+      circle at 64% 24%,
+      hsl(var(--lav-deep) / 0.2),
+      transparent 78%
+    ),
+    radial-gradient(
+      circle at 50% 92%,
+      hsl(var(--accent-2) / 0.2),
+      hsl(var(--surface) / 0.84) 72%,
+      transparent 92%
+    );
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .character {
+    transition: none;
+  }
+}

--- a/src/components/home/PortraitFrame.tsx
+++ b/src/components/home/PortraitFrame.tsx
@@ -1,0 +1,168 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import frameStyles from "./HeroPortraitFrame.module.css";
+import styles from "./PortraitFrame.module.css";
+
+export type PoseVariant =
+  | "duo"
+  | "angel-leading"
+  | "demon-leading"
+  | "back-to-back";
+
+export interface PortraitFrameProps {
+  pose?: PoseVariant;
+  /**
+   * When true, the inner surface keeps the rim treatment but exposes a transparent backdrop.
+   */
+  transparentBackground?: boolean;
+  className?: string;
+}
+
+type CharacterConfig = {
+  className: string;
+  description: string;
+};
+
+type PoseConfig = {
+  label: string;
+  stageClassName?: string;
+  angel: CharacterConfig;
+  demon: CharacterConfig;
+};
+
+const poseConfigs: Record<PoseVariant, PoseConfig> = {
+  duo: {
+    label: "Angel and demon busts sharing a circular portrait frame",
+    angel: {
+      className: cn(styles.poseDuoAngel, styles.layerFront),
+      description:
+        "Luminous angel bust facing forward with wings framing the left edge of the frame.",
+    },
+    demon: {
+      className: cn(styles.poseDuoDemon, styles.layerRear),
+      description:
+        "Violet demon bust leaning inward with curved horns catching the rim lighting on the right.",
+    },
+  },
+  "angel-leading": {
+    label: "Angel steps forward while the demon softens into the rim light",
+    angel: {
+      className: cn(styles.poseAngelLeadingAngel, styles.layerFront),
+      description:
+        "Angel bust leading the frame with wings swept wide and haloed highlights toward the viewer.",
+    },
+    demon: {
+      className: cn(styles.poseAngelLeadingDemon, styles.layerRear, styles.layerDimmed),
+      description:
+        "Demon bust recessed behind the angel, horns still outlined by the accent glow.",
+    },
+  },
+  "demon-leading": {
+    label: "Demon steps into focus while the angel supports from behind",
+    angel: {
+      className: cn(styles.poseDemonLeadingAngel, styles.layerRear, styles.layerDimmed),
+      description:
+        "Angel bust easing back with wings diffused while keeping the left rim illuminated.",
+    },
+    demon: {
+      className: cn(styles.poseDemonLeadingDemon, styles.layerFront),
+      description:
+        "Demon bust leading the pose with forward-set horns and a saturated rim highlight.",
+    },
+  },
+  "back-to-back": {
+    label: "Angel and demon posed back to back with crossed silhouettes",
+    stageClassName: styles.stageBackToBack,
+    angel: {
+      className: cn(styles.poseBackToBackAngel, styles.layerFront),
+      description:
+        "Angel bust glancing over the shoulder with wings fanning outward across the left rim.",
+    },
+    demon: {
+      className: cn(styles.poseBackToBackDemon, styles.layerFront),
+      description:
+        "Demon bust rotated outward with horns arcing above the right edge of the frame.",
+    },
+  },
+};
+
+export default function PortraitFrame({
+  pose = "duo",
+  transparentBackground = false,
+  className,
+}: PortraitFrameProps) {
+  const config = poseConfigs[pose];
+  const figureId = React.useId();
+  const angelId = React.useId();
+  const demonId = React.useId();
+
+  return (
+    <figure
+      role="img"
+      aria-labelledby={`${figureId} ${angelId} ${demonId}`}
+      className={cn(
+        "relative isolate flex shrink-0 items-center justify-center",
+        frameStyles.framed,
+        className,
+      )}
+    >
+      <span id={figureId} className="sr-only">
+        {config.label}
+      </span>
+      <span id={angelId} className="sr-only">
+        {config.angel.description}
+      </span>
+      <span id={demonId} className="sr-only">
+        {config.demon.description}
+      </span>
+      <span
+        aria-hidden
+        className={cn(
+          "pointer-events-none absolute -inset-[calc(var(--portrait-rim)*1.6)] rounded-full blur-[var(--portrait-glow)] opacity-80",
+          frameStyles.glow,
+        )}
+      />
+      <span
+        aria-hidden
+        className="glitch-rail pointer-events-none absolute -inset-[calc(var(--portrait-rim)*1.1)] rounded-full mix-blend-screen opacity-70"
+      />
+      <div
+        className={cn(
+          "relative flex items-center justify-center rounded-full shadow-neo",
+          frameStyles.rim,
+        )}
+      >
+        <div
+          className={cn(
+            "relative flex h-full w-full items-center justify-center overflow-hidden rounded-full",
+            frameStyles.inner,
+            transparentBackground && styles.innerTransparent,
+          )}
+        >
+          <span aria-hidden className={styles.rimLighting} />
+          <div
+            aria-hidden
+            className={cn(
+              styles.stage,
+              config.stageClassName,
+              transparentBackground && styles.stageTransparent,
+            )}
+          >
+            <div className={cn(styles.character, styles.angel, config.angel.className)}>
+              <span aria-hidden className={styles.angelWings} />
+              <span aria-hidden className={styles.characterBody} />
+              <span aria-hidden className={styles.characterCollar} />
+              <span aria-hidden className={styles.characterHead} />
+            </div>
+            <div className={cn(styles.character, styles.demon, config.demon.className)}>
+              <span aria-hidden className={styles.demonHorns} />
+              <span aria-hidden className={styles.characterBody} />
+              <span aria-hidden className={styles.characterCollar} />
+              <span aria-hidden className={styles.characterHead} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </figure>
+  );
+}

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -13,6 +13,8 @@ export { default as IsometricRoom } from "./IsometricRoom";
 export { default as HeroPlannerCards } from "./HeroPlannerCards";
 export { default as HeroPortraitFrame } from "./HeroPortraitFrame";
 export type { HeroPortraitFrameProps } from "./HeroPortraitFrame";
+export { default as PortraitFrame } from "./PortraitFrame";
+export type { PortraitFrameProps, PoseVariant } from "./PortraitFrame";
 export { default as WelcomeHeroFigure } from "./WelcomeHeroFigure";
 export { default as HomeSplash } from "./HomeSplash";
 export {

--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -75,6 +75,7 @@ import {
   IsometricRoom,
   QuickActionGrid,
   HeroPortraitFrame,
+  PortraitFrame,
   WelcomeHeroFigure,
 } from "@/components/home";
 import { NAV_ITEMS, type NavItem } from "@/components/chrome/nav-items";
@@ -4042,6 +4043,25 @@ React.useEffect(() => {
     imageSrc="/hero_image.png"
     imageAlt="Illustration of the Planner hero floating above a holographic dashboard without frame treatment"
   />
+</div>`,
+    },
+    {
+      id: "portrait-frame",
+      name: "PortraitFrame",
+      description:
+        "Dual-character neumorphic portrait that stages the angel and demon busts with pose variants and theme-aware cinematic lighting.",
+      element: (
+        <div className="flex flex-wrap items-center justify-center gap-[var(--space-3)]">
+          <PortraitFrame />
+          <PortraitFrame pose="angel-leading" />
+          <PortraitFrame pose="back-to-back" transparentBackground />
+        </div>
+      ),
+      tags: ["hero", "portrait", "duo"],
+      code: `<div className="flex flex-wrap items-center justify-center gap-[var(--space-3)]">
+  <PortraitFrame />
+  <PortraitFrame pose="angel-leading" />
+  <PortraitFrame pose="back-to-back" transparentBackground />
 </div>`,
     },
     {


### PR DESCRIPTION
## Summary
- introduce a reusable PortraitFrame that renders the angel and demon busts with accessible pose variants and optional transparent background
- reuse the HeroPortraitFrame neumorphic rim while layering theme-aware horns, wings, and rim lighting tokens for cinematic presentation
- export the component for home features and surface new gallery examples demonstrating each pose

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68db114f62b4832c80dd1ff3b54ba2cb