### PR TITLE
feat: add depth and glitch surface tokens

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -55,6 +55,10 @@ For governance and enforcement workflows, read [Design System Governance](./desi
 - `--shadow-dropdown` – menu and popover elevation token shared by Tailwind's `shadow-dropdown` utility ([tokens.css](../tokens/tokens.css)).
 - `--shadow-neon` – layered neon text glow built from spacing tokens ([themes.css](../src/app/themes.css#L13-L16)).
 - `--aurora-g-light` / `--aurora-p-light` – static fallbacks for the aurora gradients when `color-mix` is unavailable. Use them with the `aurora` classes instead of blending alphas manually so the palette remains consistent across browsers.
+- `--shadow-inner-sm` / `--shadow-inner-md` / `--shadow-outer-lg` – inset and deep outer shadows that align with the neumorphic depth model. Use the small inner layer for pressed controls, the medium inner layer for sunken panels, and the large outer layer for wide surfaces. Hardstuck and Noir clamp the alpha mix to retain readable foreground contrast across the darker palettes ([themes.css](../src/app/themes.css#L784-L789), [Noir override](../src/app/themes.css#L620-L625)).
+- `--glow-primary` – chroma glow tied to `--primary`; upgrades via `color-mix` for richer bloom while honoring each theme's accessibility baseline ([themes.css](../src/app/themes.css#L244-L245), [Hardstuck mix](../src/app/themes.css#L449-L455)).
+- `--blob-surface-1` / `--blob-surface-2` / `--blob-surface-3` / `--blob-surface-shadow` – organic surface stops for hero blobs and vignette backgrounds. Default values borrow from the neutral surfaces and receive theme-specific blends in the color-mix block so Hardstuck and Noir lighten their fills without sacrificing depth ([themes.css](../src/app/themes.css#L246-L248), [color-mix overrides](../src/app/themes.css#L433-L470)).
+- `--glitch-noise-primary` / `--glitch-noise-secondary` / `--glitch-noise-contrast` – scoped noise overlays for glitch treatments. The base palette keys off accent, ring, and foreground tokens while Hardstuck/Noir swap in greener and ruby-tinted alphas for accessible luminance ([themes.css](../src/app/themes.css#L249-L253), [Hardstuck noise tuning](../src/app/themes.css#L793-L796)).
 
 ## Layout and spacing
 

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -235,6 +235,17 @@
 | ring-stroke-m | var(--ring-size-2) |
 | ring-stroke-l | var(--ring-size-2) |
 | ring-inset | calc(var(--space-3) / 2) |
+| shadow-inner-sm | inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.18) |
+| shadow-inner-md | inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.28) |
+| shadow-outer-lg | 0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36) |
+| glow-primary | hsl(var(--primary) / 0.55) |
+| blob-surface-1 | hsl(var(--surface)) |
+| blob-surface-2 | hsl(var(--surface-2)) |
+| blob-surface-3 | hsl(var(--card)) |
+| blob-surface-shadow | hsl(var(--shadow-color) / 0.4) |
+| glitch-noise-primary | hsl(var(--accent) / 0.25) |
+| glitch-noise-secondary | hsl(var(--ring) / 0.2) |
+| glitch-noise-contrast | hsl(var(--foreground) / 0.12) |
 | spacing-0-125 | calc(var(--spacing-1) / 8) |
 | spacing-0-25 | calc(var(--spacing-1) / 4) |
 | spacing-0-5 | calc(var(--spacing-1) / 2) |

--- a/scripts/generate-themes.ts
+++ b/scripts/generate-themes.ts
@@ -39,11 +39,32 @@ const SUPPORTS_SECTION = String.raw`/* Upgrade tokens when color-mix(oklab) is s
       hsl(var(--background)) 30%
     );
     --glow-active: color-mix(in oklab, hsl(var(--glow)) 50%, transparent);
+    --glow-primary: color-mix(in oklab, hsl(var(--primary)) 58%, transparent);
     --neon-soft: color-mix(in oklab, hsl(var(--neon)) 50%, transparent);
     --card-hairline: color-mix(
       in oklab,
       hsl(var(--border)) 82%,
       hsl(var(--accent)) 18%
+    );
+    --blob-surface-1: color-mix(
+      in oklab,
+      hsl(var(--surface)) 72%,
+      hsl(var(--accent)) 28%
+    );
+    --blob-surface-2: color-mix(
+      in oklab,
+      hsl(var(--surface-2)) 68%,
+      hsl(var(--accent-2)) 32%
+    );
+    --blob-surface-3: color-mix(
+      in oklab,
+      hsl(var(--card)) 70%,
+      hsl(var(--ring)) 30%
+    );
+    --blob-surface-shadow: color-mix(
+      in oklab,
+      hsl(var(--shadow-color)) 68%,
+      hsl(var(--background)) 32%
     );
     --aurora-g-light: color-mix(in oklab, hsl(var(--accent-2)) 37.5%, white);
     --aurora-g-light-color: var(--aurora-g-light);
@@ -55,6 +76,52 @@ const SUPPORTS_SECTION = String.raw`/* Upgrade tokens when color-mix(oklab) is s
     --aurora-g-light-color: var(--aurora-g-light);
     --aurora-p-light: color-mix(in oklab, hsl(var(--accent)) 37.5%, white);
     --aurora-p-light-color: var(--aurora-p-light);
+  }
+  html.theme-hardstuck {
+    --blob-surface-1: color-mix(
+      in oklab,
+      hsl(var(--surface)) 62%,
+      hsl(var(--hardstuck-foreground)) 38%
+    );
+    --blob-surface-2: color-mix(
+      in oklab,
+      hsl(var(--surface-2)) 58%,
+      hsl(var(--hardstuck-foreground)) 42%
+    );
+    --blob-surface-3: color-mix(
+      in oklab,
+      hsl(var(--card)) 60%,
+      hsl(var(--ring)) 40%
+    );
+    --blob-surface-shadow: color-mix(
+      in oklab,
+      hsl(var(--shadow-color)) 64%,
+      hsl(var(--background)) 36%
+    );
+    --glow-primary: color-mix(in oklab, hsl(var(--ring)) 52%, transparent);
+  }
+  html.theme-noir {
+    --blob-surface-1: color-mix(
+      in oklab,
+      hsl(var(--surface)) 66%,
+      hsl(var(--foreground)) 34%
+    );
+    --blob-surface-2: color-mix(
+      in oklab,
+      hsl(var(--surface-2)) 60%,
+      hsl(var(--foreground)) 40%
+    );
+    --blob-surface-3: color-mix(
+      in oklab,
+      hsl(var(--card)) 64%,
+      hsl(var(--accent)) 36%
+    );
+    --blob-surface-shadow: color-mix(
+      in oklab,
+      hsl(var(--shadow-color)) 66%,
+      hsl(var(--background)) 34%
+    );
+    --glow-primary: color-mix(in oklab, hsl(var(--ring)) 56%, transparent);
   }
 }
 

--- a/scripts/generate-tokens.ts
+++ b/scripts/generate-tokens.ts
@@ -142,6 +142,26 @@ async function buildTokens(): Promise<void> {
     colors[name] = { value: match[2].trim() };
   }
   colors.focus = { value: "var(--theme-ring)" };
+  const derivedColorTokens: Record<string, string> = {
+    "shadow-inner-sm":
+      "inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.18)",
+    "shadow-inner-md":
+      "inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.28)",
+    "shadow-outer-lg":
+      "0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36)",
+    "glow-primary": "hsl(var(--primary) / 0.55)",
+    "blob-surface-1": "hsl(var(--surface))",
+    "blob-surface-2": "hsl(var(--surface-2))",
+    "blob-surface-3": "hsl(var(--card))",
+    "blob-surface-shadow": "hsl(var(--shadow-color) / 0.4)",
+    "glitch-noise-primary": "hsl(var(--accent) / 0.25)",
+    "glitch-noise-secondary": "hsl(var(--ring) / 0.2)",
+    "glitch-noise-contrast": "hsl(var(--foreground) / 0.12)",
+  };
+
+  for (const [name, value] of Object.entries(derivedColorTokens)) {
+    colors[name] = { value };
+  }
   const globalsPath = path.resolve(__dirname, "../src/app/globals.css");
   const globalsCss = await fs.readFile(globalsPath, "utf8");
   const glowTokens = ["--glow-strong", "--glow-soft"];

--- a/scripts/themes.ts
+++ b/scripts/themes.ts
@@ -57,6 +57,20 @@ export const rootVariables: VariableDefinition[] = [
   { name: "depth-shadow-soft", value: "var(--shadow-neo-soft)" },
   { name: "depth-shadow-inner", value: "var(--shadow-neo-inset)" },
   {
+    name: "shadow-inner-sm",
+    value:
+      "inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.18)",
+  },
+  {
+    name: "shadow-inner-md",
+    value:
+      "inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.28)",
+  },
+  {
+    name: "shadow-outer-lg",
+    value: "0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36)",
+  },
+  {
     comment: "Depth glow ramps",
     name: "depth-glow-highlight-soft",
     value: "hsl(var(--highlight) / 0.08)",
@@ -100,6 +114,10 @@ export const rootVariables: VariableDefinition[] = [
   { name: "backdrop-drip-2", value: "var(--backdrop-blob-2)" },
   { name: "backdrop-drip-3", value: "var(--backdrop-blob-3)" },
   { name: "backdrop-drip-shadow", value: "var(--backdrop-blob-shadow)" },
+  { name: "blob-surface-1", value: "hsl(var(--surface))" },
+  { name: "blob-surface-2", value: "hsl(var(--surface-2))" },
+  { name: "blob-surface-3", value: "hsl(var(--card))" },
+  { name: "blob-surface-shadow", value: "hsl(var(--shadow-color) / 0.4)" },
   {
     comment: [
       "Glow parity (retro-futurism)",
@@ -108,6 +126,7 @@ export const rootVariables: VariableDefinition[] = [
     name: "neo-glow-strength",
     value: "0.45",
   },
+  { name: "glow-primary", value: "hsl(var(--primary) / 0.55)" },
   { name: "neon-outline-opacity", value: "0.35" },
   {
     comment: [
@@ -147,6 +166,9 @@ export const rootVariables: VariableDefinition[] = [
     name: "glitch-accent-shadow",
     value: "0 0 var(--glitch-accent-blur) var(--glitch-accent-color)",
   },
+  { name: "glitch-noise-primary", value: "hsl(var(--accent) / 0.25)" },
+  { name: "glitch-noise-secondary", value: "hsl(var(--ring) / 0.2)" },
+  { name: "glitch-noise-contrast", value: "hsl(var(--foreground) / 0.12)" },
   { comment: "Retro grid parity", name: "retro-grid-step", value: "24px" },
   { name: "retro-grid-opacity", value: "0.15" },
   {
@@ -353,10 +375,27 @@ export const themes: ThemeDefinition[] = [
       { name: "surface-streak", value: "352 30% 14%" },
       { name: "shadow-color", value: "356 70% 50%" },
       { name: "shadow", value: "0 18px 44px hsl(var(--shadow-color) / 0.38)" },
+      {
+        name: "shadow-inner-sm",
+        value:
+          "inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.2)",
+      },
+      {
+        name: "shadow-inner-md",
+        value:
+          "inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.3)",
+      },
+      {
+        name: "shadow-outer-lg",
+        value: "0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.42)",
+      },
       { name: "neo-glow-strength", value: "0.6" },
       { name: "glitch-intensity", value: "0.34" },
       { name: "glitch-fringe", value: "6deg" },
       { name: "glitch-static-opacity", value: "0.08" },
+      { name: "glitch-noise-primary", value: "hsl(var(--ring) / 0.28)" },
+      { name: "glitch-noise-secondary", value: "hsl(var(--accent) / 0.22)" },
+      { name: "glitch-noise-contrast", value: "hsl(var(--foreground) / 0.14)" },
       { name: "lav-deep", value: "356 80% 62%" },
       { name: "success", value: "136 56% 52%" },
       { name: "success-glow", value: "136 56% 42% / 0.6" },
@@ -364,6 +403,11 @@ export const themes: ThemeDefinition[] = [
       { name: "noir-rose", value: "352 68% 54%" },
       { name: "noir-ink", value: "352 80% 6%" },
       { name: "noir-ruby", value: "12 76% 46%" },
+      { name: "glow-primary", value: "hsl(var(--ring) / 0.58)" },
+      { name: "blob-surface-1", value: "hsl(352 46% 12%)" },
+      { name: "blob-surface-2", value: "hsl(352 38% 18%)" },
+      { name: "blob-surface-3", value: "hsl(184 68% 20%)" },
+      { name: "blob-surface-shadow", value: "hsl(356 72% 10% / 0.42)" },
       { name: "backdrop-blob-1", value: "var(--noir-red)" },
       { name: "backdrop-blob-2", value: "var(--noir-rose)" },
       { name: "backdrop-blob-3", value: "var(--noir-ruby)" },
@@ -515,16 +559,41 @@ export const themes: ThemeDefinition[] = [
       { name: "surface-streak", value: "120 18% 11%" },
       { name: "shadow-color", value: "120 84% 44%" },
       { name: "shadow", value: "0 18px 46px hsl(var(--shadow-color) / 0.4)" },
+      {
+        name: "shadow-inner-sm",
+        value:
+          "inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.16)",
+      },
+      {
+        name: "shadow-inner-md",
+        value:
+          "inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.24)",
+      },
+      {
+        name: "shadow-outer-lg",
+        value: "0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.34)",
+      },
       { name: "neo-glow-strength", value: "0.58" },
       { name: "glitch-intensity", value: "0.32" },
       { name: "glitch-fringe", value: "5deg" },
       { name: "glitch-static-opacity", value: "0.075" },
+      { name: "glitch-noise-primary", value: "hsl(var(--ring) / 0.24)" },
+      { name: "glitch-noise-secondary", value: "hsl(var(--accent) / 0.18)" },
+      {
+        name: "glitch-noise-contrast",
+        value: "hsl(var(--hardstuck-foreground) / 0.18)",
+      },
       { name: "lav-deep", value: "120 90% 52%" },
       { name: "icon-fg", value: "120 92% 64%" },
       { name: "success", value: "120 94% 52%" },
       { name: "success-glow", value: "120 90% 42% / 0.6" },
       { name: "hardstuck-forest", value: "120 70% 42%" },
       { name: "hardstuck-deep", value: "120 82% 8%" },
+      { name: "glow-primary", value: "hsl(var(--ring) / 0.5)" },
+      { name: "blob-surface-1", value: "hsl(120 38% 14%)" },
+      { name: "blob-surface-2", value: "hsl(120 44% 18%)" },
+      { name: "blob-surface-3", value: "hsl(120 48% 24%)" },
+      { name: "blob-surface-shadow", value: "hsl(120 72% 12% / 0.45)" },
       { name: "backdrop-blob-1", value: "var(--ring)" },
       { name: "backdrop-blob-2", value: "var(--hardstuck-forest)" },
       { name: "backdrop-blob-3", value: "var(--ring)" },

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -294,6 +294,9 @@
   --depth-shadow-outer-strong: var(--shadow-neo-strong);
   --depth-shadow-soft: var(--shadow-neo-soft);
   --depth-shadow-inner: var(--shadow-neo-inset);
+  --shadow-inner-sm: inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.18);
+  --shadow-inner-md: inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.28);
+  --shadow-outer-lg: 0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36);
   /* Depth glow ramps */
   --depth-glow-highlight-soft: hsl(var(--highlight) / 0.08);
   --depth-glow-highlight-medium: hsl(var(--highlight) / 0.35);
@@ -319,9 +322,14 @@
   --backdrop-drip-2: var(--backdrop-blob-2);
   --backdrop-drip-3: var(--backdrop-blob-3);
   --backdrop-drip-shadow: var(--backdrop-blob-shadow);
+  --blob-surface-1: hsl(var(--surface));
+  --blob-surface-2: hsl(var(--surface-2));
+  --blob-surface-3: hsl(var(--card));
+  --blob-surface-shadow: hsl(var(--shadow-color) / 0.4);
   /* Glow parity (retro-futurism) */
   /* neo-glow-strength multiplies --shadow-neon */
   --neo-glow-strength: 0.45;
+  --glow-primary: hsl(var(--primary) / 0.55);
   --neon-outline-opacity: 0.35;
   /* Glitch normalization (identical amplitude & cadence) */
   /* 0–1 scaling for transforms/opacity */
@@ -344,6 +352,9 @@
   --glitch-accent-color: hsl(var(--accent) / 0.35);
   --glitch-accent-blur: var(--spacing-0-5);
   --glitch-accent-shadow: 0 0 var(--glitch-accent-blur) var(--glitch-accent-color);
+  --glitch-noise-primary: hsl(var(--accent) / 0.25);
+  --glitch-noise-secondary: hsl(var(--ring) / 0.2);
+  --glitch-noise-contrast: hsl(var(--foreground) / 0.12);
   /* Retro grid parity */
   --retro-grid-step: 24px;
   --retro-grid-opacity: 0.15;
@@ -387,11 +398,32 @@
       hsl(var(--background)) 30%
     );
     --glow-active: color-mix(in oklab, hsl(var(--glow)) 50%, transparent);
+    --glow-primary: color-mix(in oklab, hsl(var(--primary)) 58%, transparent);
     --neon-soft: color-mix(in oklab, hsl(var(--neon)) 50%, transparent);
     --card-hairline: color-mix(
       in oklab,
       hsl(var(--border)) 82%,
       hsl(var(--accent)) 18%
+    );
+    --blob-surface-1: color-mix(
+      in oklab,
+      hsl(var(--surface)) 72%,
+      hsl(var(--accent)) 28%
+    );
+    --blob-surface-2: color-mix(
+      in oklab,
+      hsl(var(--surface-2)) 68%,
+      hsl(var(--accent-2)) 32%
+    );
+    --blob-surface-3: color-mix(
+      in oklab,
+      hsl(var(--card)) 70%,
+      hsl(var(--ring)) 30%
+    );
+    --blob-surface-shadow: color-mix(
+      in oklab,
+      hsl(var(--shadow-color)) 68%,
+      hsl(var(--background)) 32%
     );
     --aurora-g-light: color-mix(in oklab, hsl(var(--accent-2)) 37.5%, white);
     --aurora-g-light-color: var(--aurora-g-light);
@@ -403,6 +435,52 @@
     --aurora-g-light-color: var(--aurora-g-light);
     --aurora-p-light: color-mix(in oklab, hsl(var(--accent)) 37.5%, white);
     --aurora-p-light-color: var(--aurora-p-light);
+  }
+  html.theme-hardstuck {
+    --blob-surface-1: color-mix(
+      in oklab,
+      hsl(var(--surface)) 62%,
+      hsl(var(--hardstuck-foreground)) 38%
+    );
+    --blob-surface-2: color-mix(
+      in oklab,
+      hsl(var(--surface-2)) 58%,
+      hsl(var(--hardstuck-foreground)) 42%
+    );
+    --blob-surface-3: color-mix(
+      in oklab,
+      hsl(var(--card)) 60%,
+      hsl(var(--ring)) 40%
+    );
+    --blob-surface-shadow: color-mix(
+      in oklab,
+      hsl(var(--shadow-color)) 64%,
+      hsl(var(--background)) 36%
+    );
+    --glow-primary: color-mix(in oklab, hsl(var(--ring)) 52%, transparent);
+  }
+  html.theme-noir {
+    --blob-surface-1: color-mix(
+      in oklab,
+      hsl(var(--surface)) 66%,
+      hsl(var(--foreground)) 34%
+    );
+    --blob-surface-2: color-mix(
+      in oklab,
+      hsl(var(--surface-2)) 60%,
+      hsl(var(--foreground)) 40%
+    );
+    --blob-surface-3: color-mix(
+      in oklab,
+      hsl(var(--card)) 64%,
+      hsl(var(--accent)) 36%
+    );
+    --blob-surface-shadow: color-mix(
+      in oklab,
+      hsl(var(--shadow-color)) 66%,
+      hsl(var(--background)) 34%
+    );
+    --glow-primary: color-mix(in oklab, hsl(var(--ring)) 56%, transparent);
   }
 }
 /* Upgrade contrast token when color-contrast is supported */
@@ -560,10 +638,16 @@ html.theme-noir {
   --surface-streak: 352 30% 14%;
   --shadow-color: 356 70% 50%;
   --shadow: 0 18px 44px hsl(var(--shadow-color) / 0.38);
+  --shadow-inner-sm: inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.2);
+  --shadow-inner-md: inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.3);
+  --shadow-outer-lg: 0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.42);
   --neo-glow-strength: 0.6;
   --glitch-intensity: 0.34;
   --glitch-fringe: 6deg;
   --glitch-static-opacity: 0.08;
+  --glitch-noise-primary: hsl(var(--ring) / 0.28);
+  --glitch-noise-secondary: hsl(var(--accent) / 0.22);
+  --glitch-noise-contrast: hsl(var(--foreground) / 0.14);
   --lav-deep: 356 80% 62%;
   --success: 136 56% 52%;
   --success-glow: 136 56% 42% / 0.6;
@@ -571,6 +655,11 @@ html.theme-noir {
   --noir-rose: 352 68% 54%;
   --noir-ink: 352 80% 6%;
   --noir-ruby: 12 76% 46%;
+  --glow-primary: hsl(var(--ring) / 0.58);
+  --blob-surface-1: hsl(352 46% 12%);
+  --blob-surface-2: hsl(352 38% 18%);
+  --blob-surface-3: hsl(184 68% 20%);
+  --blob-surface-shadow: hsl(356 72% 10% / 0.42);
   --backdrop-blob-1: var(--noir-red);
   --backdrop-blob-2: var(--noir-rose);
   --backdrop-blob-3: var(--noir-ruby);
@@ -713,16 +802,27 @@ html.theme-hardstuck {
   --surface-streak: 120 18% 11%;
   --shadow-color: 120 84% 44%;
   --shadow: 0 18px 46px hsl(var(--shadow-color) / 0.4);
+  --shadow-inner-sm: inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.16);
+  --shadow-inner-md: inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.24);
+  --shadow-outer-lg: 0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.34);
   --neo-glow-strength: 0.58;
   --glitch-intensity: 0.32;
   --glitch-fringe: 5deg;
   --glitch-static-opacity: 0.075;
+  --glitch-noise-primary: hsl(var(--ring) / 0.24);
+  --glitch-noise-secondary: hsl(var(--accent) / 0.18);
+  --glitch-noise-contrast: hsl(var(--hardstuck-foreground) / 0.18);
   --lav-deep: 120 90% 52%;
   --icon-fg: 120 92% 64%;
   --success: 120 94% 52%;
   --success-glow: 120 90% 42% / 0.6;
   --hardstuck-forest: 120 70% 42%;
   --hardstuck-deep: 120 82% 8%;
+  --glow-primary: hsl(var(--ring) / 0.5);
+  --blob-surface-1: hsl(120 38% 14%);
+  --blob-surface-2: hsl(120 44% 18%);
+  --blob-surface-3: hsl(120 48% 24%);
+  --blob-surface-shadow: hsl(120 72% 12% / 0.45);
   --backdrop-blob-1: var(--ring);
   --backdrop-blob-2: var(--hardstuck-forest);
   --backdrop-blob-3: var(--ring);

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -238,6 +238,17 @@
   --ring-stroke-m: var(--ring-size-2);
   --ring-stroke-l: var(--ring-size-2);
   --ring-inset: calc(var(--space-3) / 2);
+  --shadow-inner-sm: inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.18);
+  --shadow-inner-md: inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.28);
+  --shadow-outer-lg: 0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36);
+  --glow-primary: hsl(var(--primary) / 0.55);
+  --blob-surface-1: hsl(var(--surface));
+  --blob-surface-2: hsl(var(--surface-2));
+  --blob-surface-3: hsl(var(--card));
+  --blob-surface-shadow: hsl(var(--shadow-color) / 0.4);
+  --glitch-noise-primary: hsl(var(--accent) / 0.25);
+  --glitch-noise-secondary: hsl(var(--ring) / 0.2);
+  --glitch-noise-contrast: hsl(var(--foreground) / 0.12);
   --spacing-0-125: calc(var(--spacing-1) / 8);
   --spacing-0-25: calc(var(--spacing-1) / 4);
   --spacing-0-5: calc(var(--spacing-1) / 2);

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -210,6 +210,20 @@ export default {
   ringStrokeM: "var(--ring-size-2)",
   ringStrokeL: "var(--ring-size-2)",
   ringInset: "calc(var(--space-3) / 2)",
+  shadowInnerSm:
+    "inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.18)",
+  shadowInnerMd:
+    "inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.28)",
+  shadowOuterLg:
+    "0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36)",
+  glowPrimary: "hsl(var(--primary) / 0.55)",
+  blobSurface1: "hsl(var(--surface))",
+  blobSurface2: "hsl(var(--surface-2))",
+  blobSurface3: "hsl(var(--card))",
+  blobSurfaceShadow: "hsl(var(--shadow-color) / 0.4)",
+  glitchNoisePrimary: "hsl(var(--accent) / 0.25)",
+  glitchNoiseSecondary: "hsl(var(--ring) / 0.2)",
+  glitchNoiseContrast: "hsl(var(--foreground) / 0.12)",
   spacing0125: "calc(var(--spacing-1) / 8)",
   spacing025: "calc(var(--spacing-1) / 4)",
   spacing05: "calc(var(--spacing-1) / 2)",


### PR DESCRIPTION
## Summary
- introduce inner/outer depth shadows, primary glow, blob surface, and glitch noise design tokens with generated CSS/JS artifacts
- update theme generation to provide luminance-safe Hardstuck/Noir overrides and color-mix blends for the new tokens
- document the tokens for designers and regenerate the reference docs

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dba99798b0832c8b5fd5729b4a3612