### PR TITLE
Add button glitch overlay tokens

### DIFF
--- a/scripts/themes.ts
+++ b/scripts/themes.ts
@@ -122,6 +122,15 @@ export const rootVariables: VariableDefinition[] = [
   { comment: "overlay alpha", name: "glitch-static-opacity", value: "0.18" },
   { name: "glitch-noise-level", value: "var(--glitch-static-opacity)" },
   {
+    comment: "Button glitch overlays",
+    name: "glitch-overlay-button-opacity",
+    value: "0.42",
+  },
+  {
+    name: "glitch-overlay-button-opacity-reduced",
+    value: "0.28",
+  },
+  {
     comment: "Chromatic separation offsets",
     name: "glitch-chromatic-offset-strong",
     value: "calc(var(--spacing-0-25) / 4)",

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -333,6 +333,9 @@
   /* overlay alpha */
   --glitch-static-opacity: 0.18;
   --glitch-noise-level: var(--glitch-static-opacity);
+  /* Button glitch overlays */
+  --glitch-overlay-button-opacity: 0.42;
+  --glitch-overlay-button-opacity-reduced: 0.28;
   /* Chromatic separation offsets */
   --glitch-chromatic-offset-strong: calc(var(--spacing-0-25) / 4);
   --glitch-chromatic-offset-medium: calc(var(--spacing-0-25) * 3 / 20);

--- a/src/components/ui/primitives/Button.module.css
+++ b/src/components/ui/primitives/Button.module.css
@@ -92,12 +92,12 @@
   position: relative;
   isolation: isolate;
   overflow: hidden;
-  --glitch-overlay-opacity: 0.42;
+  --glitch-overlay-opacity: var(--glitch-overlay-button-opacity);
 }
 
 @media (prefers-reduced-motion: reduce) {
   .glitch {
-    --glitch-overlay-opacity: 0.28;
+    --glitch-overlay-opacity: var(--glitch-overlay-button-opacity-reduced);
   }
 }
 

--- a/tests/primitives/Button.test.tsx
+++ b/tests/primitives/Button.test.tsx
@@ -114,6 +114,33 @@ describe("Button", () => {
     expect(content).not.toMatch(/\bpx-(5|6)\b/);
   });
 
+  it("passes data-glitch through", () => {
+    const { getByRole } = render(
+      <Button glitch>
+        Glitched
+      </Button>,
+    );
+
+    expect(getByRole("button")).toHaveAttribute("data-glitch", "true");
+  });
+
+  it("references glitch overlay tokens", () => {
+    const css = fs.readFileSync(
+      "src/components/ui/primitives/Button.module.css",
+      "utf8",
+    );
+
+    expect(css).toContain("var(--glitch-overlay-button-opacity)");
+    expect(css).toContain("var(--glitch-overlay-button-opacity-reduced)");
+  });
+
+  it("defines button glitch overlay tokens in theme bundle", () => {
+    const themeCss = fs.readFileSync("src/app/themes.css", "utf8");
+
+    expect(themeCss).toContain("--glitch-overlay-button-opacity:");
+    expect(themeCss).toContain("--glitch-overlay-button-opacity-reduced:");
+  });
+
   it("warns and renders nothing when asChild is missing a valid child", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     let renderResult: ReturnType<typeof render> | undefined;


### PR DESCRIPTION
## Summary
- add button-specific glitch overlay opacity tokens and regenerate the shared theme bundle
- update the button primitive to read the new tokens for default and reduced-motion glitch overlays
- extend button tests to cover the glitch data attribute and token presence

## Testing
- npm run verify-prompts
- npm run check
- npm run e2e:ci *(fails: Playwright browsers are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbab4dcd38832ca3cca96766b3a0f5