### PR TITLE
feat: refresh tab bar styling

### DIFF
--- a/src/components/ui/layout/TabBar.module.css
+++ b/src/components/ui/layout/TabBar.module.css
@@ -1,4 +1,105 @@
 @layer components {
+  .defaultTablist[data-variant="default"] {
+    position: relative;
+    isolation: isolate;
+    --tablist-surface: color-mix(
+      in oklab,
+      hsl(var(--card)) 88%,
+      hsl(var(--background)) 12%
+    );
+    --tablist-depth: color-mix(
+      in oklab,
+      hsl(var(--panel)) 72%,
+      hsl(var(--background)) 28%
+    );
+    --tablist-border: color-mix(
+      in oklab,
+      hsl(var(--border)) 70%,
+      hsl(var(--foreground)) 30%
+    );
+    --tablist-highlight: color-mix(
+      in oklab,
+      hsl(var(--highlight)) 65%,
+      transparent 35%
+    );
+    --hover: color-mix(
+      in oklab,
+      hsl(var(--card)) 92%,
+      hsl(var(--seg-active-base)) 8%
+    );
+    --active: color-mix(
+      in oklab,
+      hsl(var(--card)) 88%,
+      hsl(var(--seg-active-base)) 12%
+    );
+    background: linear-gradient(140deg, var(--tablist-surface), var(--tablist-depth));
+    border-color: var(--tablist-border);
+    box-shadow:
+      inset 0 1px 0 var(--tablist-highlight),
+      var(--shadow-outline-subtle),
+      0 var(--space-3) var(--space-6) hsl(var(--shadow-color) / 0.24);
+  }
+
+  .defaultTab[data-variant="default"] {
+    background-color: color-mix(
+      in oklab,
+      hsl(var(--card)) 96%,
+      hsl(var(--background)) 4%
+    );
+    box-shadow:
+      inset 0 1px 0 color-mix(in oklab, hsl(var(--highlight)) 72%, transparent 28%),
+      inset 0 -1px 0 hsl(var(--shadow-color) / 0.12),
+      var(--shadow-outline-faint);
+    color: color-mix(
+      in oklab,
+      hsl(var(--foreground)) 92%,
+      hsl(var(--card)) 8%
+    );
+    transition: background-color var(--duration-quick, 220ms) var(--ease-out, ease-out),
+      box-shadow var(--duration-quick, 220ms) var(--ease-out, ease-out),
+      color var(--duration-quick, 220ms) var(--ease-out, ease-out);
+  }
+
+  .defaultTab[data-variant="default"][data-active="true"] {
+    background-color: var(--seg-active-base);
+    background-image: var(--seg-active-grad);
+    color: hsl(var(--foreground));
+    box-shadow:
+      inset 0 0 0 var(--hairline-w) color-mix(in oklab, hsl(var(--ring)) 65%, transparent 35%),
+      var(--shadow-outline-subtle),
+      0 var(--space-2) var(--space-4) hsl(var(--shadow-color) / 0.28);
+  }
+
+  .defaultTab[data-variant="default"]:hover:not([data-disabled="true"]):not([data-loading="true"]):not(:disabled) {
+    background-color: var(--hover);
+    box-shadow:
+      inset 0 1px 0 color-mix(in oklab, hsl(var(--highlight)) 72%, transparent 28%),
+      0 var(--space-2) var(--space-4) hsl(var(--shadow-color) / 0.22),
+      var(--shadow-outline-subtle);
+    color: hsl(var(--foreground));
+  }
+
+  .defaultTab[data-variant="default"]:active:not([data-disabled="true"]):not([data-loading="true"]):not(:disabled),
+  .defaultTab[data-variant="default"][data-active="true"]:active {
+    background-color: var(--active);
+    box-shadow:
+      inset 0 1px 0 color-mix(in oklab, hsl(var(--highlight)) 62%, transparent 38%),
+      inset 0 0 0 var(--hairline-w) hsl(var(--ring) / 0.4),
+      0 var(--space-2) var(--space-4) hsl(var(--shadow-color) / 0.24);
+  }
+
+  .defaultTab[data-variant="default"][data-loading="true"],
+  .defaultTab[data-variant="default"]:disabled,
+  .defaultTab[data-variant="default"][data-disabled="true"] {
+    background-color: color-mix(
+      in oklab,
+      hsl(var(--card)) 90%,
+      hsl(var(--background)) 10%
+    );
+    color: hsl(var(--muted-foreground));
+    box-shadow: var(--shadow-outline-faint);
+  }
+
   .neoTablist[data-variant="neo"] {
     --neo-tablist-bg: linear-gradient(
       140deg,

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -46,6 +46,8 @@ export type TabElementProps = React.HTMLAttributes<HTMLElement> & {
   "aria-busy"?: boolean;
   "data-active"?: boolean;
   "data-loading"?: boolean;
+  "data-disabled"?: boolean;
+  "data-variant"?: Variant;
 };
 
 export type TabRenderContext<
@@ -185,20 +187,11 @@ export default function TabBar<
   const isGlitch = variant === "glitch";
 
   const neoVariantClassName = isNeo ? styles.neoTablist : undefined;
+  const defaultVariantClassName = !isNeo && !isGlitch ? styles.defaultTablist : undefined;
 
   const containerVariant = isNeo
     ? "hero2-frame border-border/45 bg-[var(--neo-tablist-bg)] shadow-[var(--neo-tablist-shadow)] [--hover:var(--neo-tab-bg)] [--active:var(--neo-tab-bg)] [--focus:var(--theme-ring)]"
-    : isGlitch
-      ? "[--focus:var(--theme-ring)]"
-      : cn(
-          "border-border/30 bg-card/60 shadow-[var(--shadow-neo-inset)]",
-          "[--hover:hsl(var(--primary)/0.18)]",
-          "[--active:hsl(var(--primary)/0.28)]",
-          "[--focus:var(--theme-ring)]",
-          "[--tab-shadow:inset_0_1px_0_hsl(var(--border)/0.18)]",
-          "[--tab-shadow-hover:inset_0_1px_0_hsl(var(--border)/0.24)]",
-          "[--tab-shadow-active:inset_0_1px_0_hsl(var(--border)/0.3)]",
-        );
+    : "[--focus:var(--theme-ring)]";
 
   const containerClasses = cn(
     "inline-flex max-w-full items-center overflow-x-auto",
@@ -213,7 +206,7 @@ export default function TabBar<
     ? "bg-[var(--neo-tab-bg)] shadow-[var(--shadow-raised)] hover:shadow-[var(--shadow-raised-hover,var(--shadow-raised))] active:shadow-[var(--shadow-inset)] data-[active=true]:shadow-[var(--shadow-inset)] data-[active=true]:hover:shadow-[var(--shadow-inset)] data-[active=true]:active:shadow-[var(--shadow-inset)] data-[active=true]:ring-1 data-[active=true]:ring-ring/60"
     : isGlitch
       ? ""
-      : "shadow-[var(--tab-shadow)] hover:shadow-[var(--tab-shadow-hover,var(--tab-shadow))] active:shadow-[var(--tab-shadow-active,var(--tab-shadow-hover,var(--tab-shadow)))] data-[active=true]:shadow-ring data-[active=true]:hover:shadow-ring data-[active=true]:active:shadow-ring";
+      : styles.defaultTab;
 
   return (
     <div className={cn("relative w-full", className)}>
@@ -232,7 +225,7 @@ export default function TabBar<
           aria-orientation="horizontal"
           onKeyDown={onKeyDown}
           data-variant={variant}
-          className={cn(containerClasses, neoVariantClassName)}
+          className={cn(containerClasses, neoVariantClassName, defaultVariantClassName)}
         >
           {items.map((item) => {
             const active = item.key === activeKey;
@@ -305,6 +298,8 @@ export default function TabBar<
               tabIndex: isDisabled ? -1 : active ? 0 : -1,
               "data-active": active || undefined,
               "data-loading": isLoading || undefined,
+              "data-disabled": isDisabled || undefined,
+              "data-variant": variant,
               className: baseClass,
               onClick: (event) => {
                 if (isDisabled) {


### PR DESCRIPTION
## Summary
- restyle the default TabBar variant with theme-driven neumorphic gradients and depth
- add data flags so custom renders inherit variant-aware styling hooks

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dbae5cbd0c832cb3cbdf637bef4611