### PR TITLE
feat: expose shadow aliases and migrate utilities

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -235,9 +235,9 @@
 | ring-stroke-m | var(--ring-size-2) |
 | ring-stroke-l | var(--ring-size-2) |
 | ring-inset | calc(var(--space-3) / 2) |
-| shadow-inner-sm | inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.18) |
-| shadow-inner-md | inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.28) |
-| shadow-outer-lg | 0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36) |
+| shadow-inner-sm | var(--depth-shadow-inner) |
+| shadow-inner-md | var(--depth-shadow-inner) |
+| shadow-outer-lg | var(--depth-shadow-outer-strong) |
 | glow-primary | hsl(var(--primary) / 0.55) |
 | blob-surface-1 | hsl(var(--surface)) |
 | blob-surface-2 | hsl(var(--surface-2)) |
@@ -246,6 +246,9 @@
 | glitch-noise-primary | hsl(var(--accent) / 0.25) |
 | glitch-noise-secondary | hsl(var(--ring) / 0.2) |
 | glitch-noise-contrast | hsl(var(--foreground) / 0.12) |
+| shadow-outer-sm | var(--depth-shadow-soft) |
+| shadow-outer-md | var(--depth-shadow-outer) |
+| shadow-inner-lg | var(--depth-shadow-inner) |
 | spacing-0-125 | calc(var(--spacing-1) / 8) |
 | spacing-0-25 | calc(var(--spacing-1) / 4) |
 | spacing-0-5 | calc(var(--spacing-1) / 2) |

--- a/scripts/generate-tokens.ts
+++ b/scripts/generate-tokens.ts
@@ -143,12 +143,12 @@ async function buildTokens(): Promise<void> {
   }
   colors.focus = { value: "var(--theme-ring)" };
   const derivedColorTokens: Record<string, string> = {
-    "shadow-inner-sm":
-      "inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.18)",
-    "shadow-inner-md":
-      "inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.28)",
-    "shadow-outer-lg":
-      "0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36)",
+    "shadow-outer-sm": "var(--depth-shadow-soft)",
+    "shadow-outer-md": "var(--depth-shadow-outer)",
+    "shadow-outer-lg": "var(--depth-shadow-outer-strong)",
+    "shadow-inner-sm": "var(--depth-shadow-inner)",
+    "shadow-inner-md": "var(--depth-shadow-inner)",
+    "shadow-inner-lg": "var(--depth-shadow-inner)",
     "glow-primary": "hsl(var(--primary) / 0.55)",
     "blob-surface-1": "hsl(var(--surface))",
     "blob-surface-2": "hsl(var(--surface-2))",

--- a/scripts/themes.ts
+++ b/scripts/themes.ts
@@ -57,19 +57,15 @@ export const rootVariables: VariableDefinition[] = [
   { name: "depth-shadow-soft", value: "var(--shadow-neo-soft)" },
   { name: "depth-shadow-inner", value: "var(--shadow-neo-inset)" },
   {
-    name: "shadow-inner-sm",
-    value:
-      "inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.18)",
+    comment: "Shadow aliases for Tailwind utilities",
+    name: "shadow-outer-sm",
+    value: "var(--depth-shadow-soft)",
   },
-  {
-    name: "shadow-inner-md",
-    value:
-      "inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.28)",
-  },
-  {
-    name: "shadow-outer-lg",
-    value: "0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36)",
-  },
+  { name: "shadow-outer-md", value: "var(--depth-shadow-outer)" },
+  { name: "shadow-outer-lg", value: "var(--depth-shadow-outer-strong)" },
+  { name: "shadow-inner-sm", value: "var(--depth-shadow-inner)" },
+  { name: "shadow-inner-md", value: "var(--depth-shadow-inner)" },
+  { name: "shadow-inner-lg", value: "var(--depth-shadow-inner)" },
   {
     comment: "Depth glow ramps",
     name: "depth-glow-highlight-soft",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,8 +36,8 @@
     --glitch-card-surface-top: hsl(var(--card) / 0.78);
     --glitch-card-surface-bottom: hsl(var(--panel) / 0.66);
     --glitch-card-border-color: hsl(var(--card-hairline));
-    --shadow-glitch-card: var(--shadow-neo);
-    --shadow-glitch-card-hover: var(--shadow-neo-strong);
+    --shadow-glitch-card: var(--shadow-outer-md);
+    --shadow-glitch-card-hover: var(--shadow-outer-lg);
     --glitch-card-spectrum-a: hsl(var(--primary) / 0.55);
     --glitch-card-spectrum-b: hsl(var(--accent) / 0.45);
     --glitch-card-spectrum-c: hsl(var(--ring) / 0.55);

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -242,6 +242,17 @@
   --ring-stroke-m: var(--ring-size-2);
   --ring-stroke-l: var(--ring-size-2);
   --ring-inset: calc(var(--space-3) / 2);
+  --shadow-inner-sm: inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.18);
+  --shadow-inner-md: inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.28);
+  --shadow-outer-lg: 0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36);
+  --glow-primary: hsl(var(--primary) / 0.55);
+  --blob-surface-1: hsl(var(--surface));
+  --blob-surface-2: hsl(var(--surface-2));
+  --blob-surface-3: hsl(var(--card));
+  --blob-surface-shadow: hsl(var(--shadow-color) / 0.4);
+  --glitch-noise-primary: hsl(var(--accent) / 0.25);
+  --glitch-noise-secondary: hsl(var(--ring) / 0.2);
+  --glitch-noise-contrast: hsl(var(--foreground) / 0.12);
   --spacing-0-125: calc(var(--spacing-1) / 8);
   --spacing-0-25: calc(var(--spacing-1) / 4);
   --spacing-0-5: calc(var(--spacing-1) / 2);
@@ -294,9 +305,13 @@
   --depth-shadow-outer-strong: var(--shadow-neo-strong);
   --depth-shadow-soft: var(--shadow-neo-soft);
   --depth-shadow-inner: var(--shadow-neo-inset);
-  --shadow-inner-sm: inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.18);
-  --shadow-inner-md: inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.28);
-  --shadow-outer-lg: 0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36);
+  /* Shadow aliases for Tailwind utilities */
+  --shadow-outer-sm: var(--depth-shadow-soft);
+  --shadow-outer-md: var(--depth-shadow-outer);
+  --shadow-outer-lg: var(--depth-shadow-outer-strong);
+  --shadow-inner-sm: var(--depth-shadow-inner);
+  --shadow-inner-md: var(--depth-shadow-inner);
+  --shadow-inner-lg: var(--depth-shadow-inner);
   /* Depth glow ramps */
   --depth-glow-highlight-soft: hsl(var(--highlight) / 0.08);
   --depth-glow-highlight-medium: hsl(var(--highlight) / 0.35);
@@ -308,7 +323,7 @@
     0 0 0 0 hsl(var(--ring) / 0),
     0 0 0 0 hsl(var(--ring) / 0);
   --depth-focus-ring-active:
-    0 0 0 calc(var(--hairline-w) * 1) hsl(var(--ring)),
+    0 0 0 calc(var(--hairline-w) * 1) hsl(var(--ring))
     var(--shadow-glow-lg);
   /* Organic backdrops */
   --backdrop-blob-1: var(--lg-violet);

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -647,7 +647,7 @@ function GoalsPageContent() {
           onClose={handleCloseNuke}
           aria-labelledby={nukeHeadingId}
           aria-describedby={nukeDescriptionId}
-          className="shadow-[var(--shadow-neo-soft)]"
+          className="shadow-outer-sm"
         >
           <CardHeader className="space-y-[var(--space-2)]">
             <CardTitle id={nukeHeadingId}>Delete all goals?</CardTitle>

--- a/src/components/goals/TimerTab.tsx
+++ b/src/components/goals/TimerTab.tsx
@@ -470,7 +470,7 @@ export default function TimerTab() {
             >
               <TimerRing pct={pct} className="size-full" />
               <div className="pointer-events-none absolute inset-0 grid place-items-center">
-                <div className="text-title font-semibold tabular-nums text-foreground drop-shadow-[0_0_var(--space-2)_hsl(var(--neon-soft))] transition-transform duration-quick group-hover:translate-y-0.5 sm:text-title-lg">
+                <div className="text-title font-semibold tabular-nums text-foreground drop-shadow-glow-primary-sm transition-transform duration-quick group-hover:translate-y-0.5 sm:text-title-lg">
                   {formatMmSs(remaining, {
                     unit: "milliseconds",
                     padMinutes: true,
@@ -491,10 +491,10 @@ export default function TimerTab() {
 
             {/* progress bar */}
             <div className="mt-[var(--space-6)] w-full">
-              <div className="relative h-[var(--space-2)] w-full rounded-full bg-background/20 shadow-neo-inset">
+              <div className="relative h-[var(--space-2)] w-full rounded-full bg-background/20 shadow-inner-md">
                 <div className="absolute inset-0 bg-[repeating-linear-gradient(to_right,transparent,transparent_9%,hsl(var(--foreground)/0.15)_9%,hsl(var(--foreground)/0.15)_10%)]" />
                 <div
-                  className={`${styles.progressFill} h-full rounded-full bg-[linear-gradient(90deg,hsl(var(--accent)),hsl(var(--accent-2)))] shadow-[var(--shadow-glow-md)] transition-transform duration-quick ease-linear motion-reduce:transition-none`}
+                  className={`${styles.progressFill} h-full rounded-full bg-[linear-gradient(90deg,hsl(var(--accent)),hsl(var(--accent-2)))] shadow-glow-md transition-transform duration-quick ease-linear motion-reduce:transition-none`}
                   data-progress={pct}
                   {...(timerProgressScopeProps ?? {})}
                   style={timerProgressStyle}

--- a/src/components/planner/PlannerFab.tsx
+++ b/src/components/planner/PlannerFab.tsx
@@ -312,7 +312,7 @@ export default function PlannerFab() {
         aria-label="Open planner creation sheet"
         className={cn(
           FLOATING_BUTTON_POSITION,
-          "h-[var(--space-12)] min-w-[var(--space-12)] rounded-full px-[var(--space-5)] shadow-[var(--shadow-neo-strong)]",
+          "h-[var(--space-12)] min-w-[var(--space-12)] rounded-full px-[var(--space-5)] shadow-outer-lg",
         )}
         onClick={openSheet}
         variant="primary"

--- a/src/components/reviews/ResultScoreSection.tsx
+++ b/src/components/reviews/ResultScoreSection.tsx
@@ -98,7 +98,7 @@ function ResultScoreSection(
             data-result={result}
             className={cn(
               styles.indicator,
-              "absolute top-[var(--space-1)] bottom-[var(--space-1)] left-[var(--space-1)] rounded-[inherit] transition-transform duration-chill motion-reduce:transition-none shadow-[var(--shadow-neo-soft)]",
+              "absolute top-[var(--space-1)] bottom-[var(--space-1)] left-[var(--space-1)] rounded-[inherit] transition-transform duration-chill motion-reduce:transition-none shadow-outer-sm",
             )}
           />
           <div className="relative z-10 grid w-full grid-cols-2 text-ui font-mono">

--- a/src/components/ui/layout/SectionCard.tsx
+++ b/src/components/ui/layout/SectionCard.tsx
@@ -43,7 +43,7 @@ const Root = React.forwardRef<HTMLElement, RootProps>(
         <section
           ref={ref}
           className={cn(
-            variant === "glitch" ? undefined : "shadow-neo-strong",
+            variant === "glitch" ? undefined : "shadow-outer-lg",
             "rounded-card r-card-lg text-card-foreground",
             variant === "neo"
               ? "card-neo-soft"

--- a/src/components/ui/layout/TabBar.tsx
+++ b/src/components/ui/layout/TabBar.tsx
@@ -191,7 +191,7 @@ export default function TabBar<
     : isGlitch
       ? "[--focus:var(--theme-ring)]"
       : cn(
-          "border-border/30 bg-card/60 shadow-[var(--shadow-neo-inset)]",
+          "border-border/30 bg-card/60 shadow-inner-md",
           "[--hover:hsl(var(--primary)/0.18)]",
           "[--active:hsl(var(--primary)/0.28)]",
           "[--focus:var(--theme-ring)]",

--- a/src/components/ui/league/pillars/PillarSelector.tsx
+++ b/src/components/ui/league/pillars/PillarSelector.tsx
@@ -52,7 +52,7 @@ export default function PillarSelector({
                 "pill transition",
                 styles.button,
                 active &&
-                  "pill--medium text-foreground shadow-[var(--shadow-neo-soft)]",
+                  "pill--medium text-foreground shadow-outer-sm",
               )}
               data-active={active ? "true" : undefined}
             >

--- a/src/icons/TimerRingIcon.tsx
+++ b/src/icons/TimerRingIcon.tsx
@@ -59,7 +59,7 @@ export default function TimerRingIcon({
         strokeDasharray={circumference}
         strokeDashoffset={offset}
         className={cn(
-          "drop-shadow-[0_0_calc(var(--space-3)/2)_hsl(var(--neon-soft))] transition-[stroke-dashoffset] duration-quick ease-linear motion-reduce:transition-none",
+          "drop-shadow-glow-primary-sm transition-[stroke-dashoffset] duration-quick ease-linear motion-reduce:transition-none",
           pulse && "motion-safe:animate-pulse motion-reduce:animate-none",
         )}
         filter={`url(#${noiseFilterId})`}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -249,6 +249,10 @@ const config: Config = {
         "elev-2": "var(--elevation-2)",
         "elev-3": "var(--elevation-3)",
       },
+      dropShadow: {
+        "glow-primary-sm": "0 0 var(--space-2) var(--glow-primary)",
+        "glow-primary": "0 0 var(--space-3) var(--glow-primary)",
+      },
       transitionTimingFunction: {
         out: "var(--ease-out)",
         snap: "var(--ease-snap)",

--- a/tests/e2e/team-glitch-acceptance.spec.ts
+++ b/tests/e2e/team-glitch-acceptance.spec.ts
@@ -22,12 +22,14 @@ test.describe("Team glitch components acceptance", () => {
       (elements) =>
         elements.map((element) => {
           const style = getComputedStyle(element);
+          const baseShadow = style.getPropertyValue("--shadow-glitch-card").trim();
+          const hoverShadow = style
+            .getPropertyValue("--shadow-glitch-card-hover")
+            .trim();
           return {
             className: element.className,
-            hasBaseShadow: style.getPropertyValue("--shadow-glitch-card").trim().length > 0,
-            hasHoverShadow: style
-              .getPropertyValue("--shadow-glitch-card-hover")
-              .trim().length > 0,
+            baseShadow,
+            hoverShadow,
             hasSpectrum: style
               .getPropertyValue("--glitch-card-spectrum-a")
               .trim().length > 0,
@@ -41,8 +43,10 @@ test.describe("Team glitch components acceptance", () => {
     expect(cardTokenAudits.length).toBeGreaterThan(0);
     for (const audit of cardTokenAudits) {
       expect(audit.className).toContain("glitch-card");
-      expect(audit.hasBaseShadow).toBe(true);
-      expect(audit.hasHoverShadow).toBe(true);
+      expect(audit.baseShadow.length).toBeGreaterThan(0);
+      expect(audit.baseShadow).toContain("var(--shadow-outer-md)");
+      expect(audit.hoverShadow.length).toBeGreaterThan(0);
+      expect(audit.hoverShadow).toContain("var(--shadow-outer-lg)");
       expect(audit.hasSpectrum).toBe(true);
       expect(audit.hasHaloOpacity).toBe(true);
       expect(/shadow-\[[^\]]*(?:px|rem)/.test(audit.className)).toBe(false);

--- a/tests/icons/__snapshots__/RingIcons.theme.test.tsx.snap
+++ b/tests/icons/__snapshots__/RingIcons.theme.test.tsx.snap
@@ -142,7 +142,7 @@ exports[`Ring icons across themes > renders ring icons for the aurora theme 1`] 
       stroke-width="4"
     />
     <circle
-      class="drop-shadow-[0_0_calc(var(--space-3)/2)_hsl(var(--neon-soft))] transition-[stroke-dashoffset] duration-quick ease-linear motion-reduce:transition-none"
+      class="drop-shadow-glow-primary-sm transition-[stroke-dashoffset] duration-quick ease-linear motion-reduce:transition-none"
       cx="112"
       cy="112"
       fill="none"
@@ -300,7 +300,7 @@ exports[`Ring icons across themes > renders ring icons for the citrus theme 1`] 
       stroke-width="4"
     />
     <circle
-      class="drop-shadow-[0_0_calc(var(--space-3)/2)_hsl(var(--neon-soft))] transition-[stroke-dashoffset] duration-quick ease-linear motion-reduce:transition-none"
+      class="drop-shadow-glow-primary-sm transition-[stroke-dashoffset] duration-quick ease-linear motion-reduce:transition-none"
       cx="112"
       cy="112"
       fill="none"
@@ -458,7 +458,7 @@ exports[`Ring icons across themes > renders ring icons for the hardstuck theme 1
       stroke-width="4"
     />
     <circle
-      class="drop-shadow-[0_0_calc(var(--space-3)/2)_hsl(var(--neon-soft))] transition-[stroke-dashoffset] duration-quick ease-linear motion-reduce:transition-none"
+      class="drop-shadow-glow-primary-sm transition-[stroke-dashoffset] duration-quick ease-linear motion-reduce:transition-none"
       cx="112"
       cy="112"
       fill="none"
@@ -616,7 +616,7 @@ exports[`Ring icons across themes > renders ring icons for the kitten theme 1`] 
       stroke-width="4"
     />
     <circle
-      class="drop-shadow-[0_0_calc(var(--space-3)/2)_hsl(var(--neon-soft))] transition-[stroke-dashoffset] duration-quick ease-linear motion-reduce:transition-none"
+      class="drop-shadow-glow-primary-sm transition-[stroke-dashoffset] duration-quick ease-linear motion-reduce:transition-none"
       cx="112"
       cy="112"
       fill="none"
@@ -774,7 +774,7 @@ exports[`Ring icons across themes > renders ring icons for the lg theme 1`] = `
       stroke-width="4"
     />
     <circle
-      class="drop-shadow-[0_0_calc(var(--space-3)/2)_hsl(var(--neon-soft))] transition-[stroke-dashoffset] duration-quick ease-linear motion-reduce:transition-none"
+      class="drop-shadow-glow-primary-sm transition-[stroke-dashoffset] duration-quick ease-linear motion-reduce:transition-none"
       cx="112"
       cy="112"
       fill="none"
@@ -932,7 +932,7 @@ exports[`Ring icons across themes > renders ring icons for the noir theme 1`] = 
       stroke-width="4"
     />
     <circle
-      class="drop-shadow-[0_0_calc(var(--space-3)/2)_hsl(var(--neon-soft))] transition-[stroke-dashoffset] duration-quick ease-linear motion-reduce:transition-none"
+      class="drop-shadow-glow-primary-sm transition-[stroke-dashoffset] duration-quick ease-linear motion-reduce:transition-none"
       cx="112"
       cy="112"
       fill="none"
@@ -1090,7 +1090,7 @@ exports[`Ring icons across themes > renders ring icons for the ocean theme 1`] =
       stroke-width="4"
     />
     <circle
-      class="drop-shadow-[0_0_calc(var(--space-3)/2)_hsl(var(--neon-soft))] transition-[stroke-dashoffset] duration-quick ease-linear motion-reduce:transition-none"
+      class="drop-shadow-glow-primary-sm transition-[stroke-dashoffset] duration-quick ease-linear motion-reduce:transition-none"
       cx="112"
       cy="112"
       fill="none"

--- a/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewEditor.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ReviewEditor > renders default state 1`] = `
 <div>
   <section
-    class="shadow-neo-strong rounded-card r-card-lg text-card-foreground card-soft transition-none shadow-none"
+    class="shadow-outer-lg rounded-card r-card-lg text-card-foreground card-soft transition-none shadow-none"
   >
     <div
       class="section-h sticky"
@@ -432,7 +432,7 @@ exports[`ReviewEditor > renders default state 1`] = `
         >
           <span
             aria-hidden="true"
-            class="_indicator_1d5032 absolute top-[var(--space-1)] bottom-[var(--space-1)] left-[var(--space-1)] rounded-[inherit] transition-transform duration-chill motion-reduce:transition-none shadow-[var(--shadow-neo-soft)]"
+            class="_indicator_1d5032 absolute top-[var(--space-1)] bottom-[var(--space-1)] left-[var(--space-1)] rounded-[inherit] transition-transform duration-chill motion-reduce:transition-none shadow-outer-sm"
             data-result="Win"
           />
           <div

--- a/tests/ui/SectionCard.test.tsx
+++ b/tests/ui/SectionCard.test.tsx
@@ -28,7 +28,7 @@ describe("SectionCard", () => {
   it("uses the neumorphic token stack for the default variant", () => {
     const root = renderSectionCard();
 
-    expect(root.className).toContain("shadow-neo-strong");
+    expect(root.className).toContain("shadow-outer-lg");
     expect(root.className).toContain("card-neo-soft");
     expect(root.className).toContain("rounded-card");
   });

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -238,9 +238,9 @@
   --ring-stroke-m: var(--ring-size-2);
   --ring-stroke-l: var(--ring-size-2);
   --ring-inset: calc(var(--space-3) / 2);
-  --shadow-inner-sm: inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.18);
-  --shadow-inner-md: inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.28);
-  --shadow-outer-lg: 0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36);
+  --shadow-inner-sm: var(--depth-shadow-inner);
+  --shadow-inner-md: var(--depth-shadow-inner);
+  --shadow-outer-lg: var(--depth-shadow-outer-strong);
   --glow-primary: hsl(var(--primary) / 0.55);
   --blob-surface-1: hsl(var(--surface));
   --blob-surface-2: hsl(var(--surface-2));
@@ -249,6 +249,9 @@
   --glitch-noise-primary: hsl(var(--accent) / 0.25);
   --glitch-noise-secondary: hsl(var(--ring) / 0.2);
   --glitch-noise-contrast: hsl(var(--foreground) / 0.12);
+  --shadow-outer-sm: var(--depth-shadow-soft);
+  --shadow-outer-md: var(--depth-shadow-outer);
+  --shadow-inner-lg: var(--depth-shadow-inner);
   --spacing-0-125: calc(var(--spacing-1) / 8);
   --spacing-0-25: calc(var(--spacing-1) / 4);
   --spacing-0-5: calc(var(--spacing-1) / 2);

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -210,12 +210,9 @@ export default {
   ringStrokeM: "var(--ring-size-2)",
   ringStrokeL: "var(--ring-size-2)",
   ringInset: "calc(var(--space-3) / 2)",
-  shadowInnerSm:
-    "inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.18)",
-  shadowInnerMd:
-    "inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.28)",
-  shadowOuterLg:
-    "0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36)",
+  shadowInnerSm: "var(--depth-shadow-inner)",
+  shadowInnerMd: "var(--depth-shadow-inner)",
+  shadowOuterLg: "var(--depth-shadow-outer-strong)",
   glowPrimary: "hsl(var(--primary) / 0.55)",
   blobSurface1: "hsl(var(--surface))",
   blobSurface2: "hsl(var(--surface-2))",
@@ -224,6 +221,9 @@ export default {
   glitchNoisePrimary: "hsl(var(--accent) / 0.25)",
   glitchNoiseSecondary: "hsl(var(--ring) / 0.2)",
   glitchNoiseContrast: "hsl(var(--foreground) / 0.12)",
+  shadowOuterSm: "var(--depth-shadow-soft)",
+  shadowOuterMd: "var(--depth-shadow-outer)",
+  shadowInnerLg: "var(--depth-shadow-inner)",
   spacing0125: "calc(var(--spacing-1) / 8)",
   spacing025: "calc(var(--spacing-1) / 4)",
   spacing05: "calc(var(--spacing-1) / 2)",


### PR DESCRIPTION
## Summary
- add depth-backed shadow aliases in scripts/themes.ts and regenerate tokens/docs for the runtime bundle
- expose the new shadow and glow utilities through tailwind and switch components to the shared classes
- tighten glitch token expectations so e2e/unit snapshots verify the standardized aliases

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dbb0e68ed0832c830dfa0d031b8993