### PR TITLE
fix: align SettingsSelect with chip trigger utility

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1215,6 +1215,54 @@ html.bg-intense body::after {
     border-color: hsl(var(--success));
     box-shadow: none;
   }
+
+  .chip-trigger-container {
+    --control-radius: var(--radius-full);
+    --chip-trigger-ring-color: var(--edge-iris);
+    --chip-trigger-ring-offset: var(--ring-size-1);
+    --tw-ring-color: var(--chip-trigger-ring-color);
+    --tw-ring-offset-color: hsl(var(--surface));
+    --tw-ring-offset-width: var(--chip-trigger-ring-offset);
+    --elevation-1: var(--shadow-neo-inset);
+    --elevation-2: var(--shadow-neo-soft);
+  }
+
+  .chip-trigger-container:focus-within {
+    --tw-ring-color: var(--chip-trigger-ring-color);
+    --tw-ring-offset-width: var(--chip-trigger-ring-offset);
+    --elevation-1: var(--shadow-neo-soft);
+  }
+
+  .chip-trigger {
+    --control-radius: var(--radius-full);
+    --chip-trigger-ring-color: var(--edge-iris);
+    --chip-trigger-ring-offset: var(--ring-size-1);
+    --tw-ring-color: var(--chip-trigger-ring-color);
+    --tw-ring-offset-color: hsl(var(--surface));
+    --tw-ring-offset-width: var(--chip-trigger-ring-offset);
+    --tw-shadow: var(--shadow-neo-inset);
+    --tw-shadow-colored: var(--shadow-neo-inset);
+    min-inline-size: var(
+      --settings-select-width,
+      var(--settings-column-width)
+    );
+    box-shadow:
+      var(--tw-ring-offset-shadow, 0 0 #0000),
+      var(--tw-ring-shadow, 0 0 #0000),
+      var(--tw-shadow);
+    @apply text-ui;
+  }
+
+  .chip-trigger:hover {
+    @apply ring;
+    --tw-ring-width: var(--ring-size-2);
+  }
+
+  .chip-trigger:focus-visible {
+    --tw-ring-width: var(--ring-size-2);
+    --tw-ring-offset-width: var(--chip-trigger-ring-offset);
+    --tw-ring-color: var(--chip-trigger-ring-color);
+  }
 }
 
 /* ---------- Planner visuals ---------- */

--- a/src/components/gallery/generated-manifest.ts
+++ b/src/components/gallery/generated-manifest.ts
@@ -3346,7 +3346,7 @@ export const galleryPayload = {
               "id": "focus",
               "name": "Focus-visible",
               "description": "Keyboard focus relies on the global `focus-visible` token, outlining the trigger without introducing extra wrappers.",
-              "code": "<ThemePicker\n  variant=\"lg\"\n  onVariantChange={() => {}}\n  className=\"ring-2 ring-[var(--focus)]\"\n  buttonClassName=\"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)]\"\n/>",
+              "code": "<ThemePicker\n  variant=\"lg\"\n  onVariantChange={() => {}}\n  className=\"[--chip-trigger-ring-color:var(--focus)]\"\n  buttonClassName=\"[--chip-trigger-ring-color:var(--focus)]\"\n/>",
               "preview": {
                 "id": "prompts:components:theme-picker:state:focus"
               }
@@ -3406,7 +3406,7 @@ export const galleryPayload = {
               "id": "focus",
               "name": "Focus-visible",
               "description": "The `focus-visible` utility outlines the trigger directly, keeping the indicator consistent with other settings controls.",
-              "code": "<BackgroundPicker\n  bg={0}\n  onBgChange={() => {}}\n  className=\"ring-2 ring-[var(--focus)]\"\n  buttonClassName=\"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)]\"\n/>",
+              "code": "<BackgroundPicker\n  bg={0}\n  onBgChange={() => {}}\n  className=\"[--chip-trigger-ring-color:var(--focus)]\"\n  buttonClassName=\"[--chip-trigger-ring-color:var(--focus)]\"\n/>",
               "preview": {
                 "id": "prompts:components:background-picker:state:focus"
               }
@@ -3466,7 +3466,7 @@ export const galleryPayload = {
               "id": "focus",
               "name": "Focus-visible",
               "description": "`focus-visible` keeps the focus ring within the control, matching buttons and toggles in the settings column.",
-              "code": "<SettingsSelect\n  ariaLabel=\"Theme\"\n  prefixLabel=\"Theme\"\n  items={[{ value: \"lg\", label: \"Glitch\" }, { value: \"aurora\", label: \"Aurora\" }]}\n  value=\"lg\"\n  onChange={() => {}}\n  className=\"ring-2 ring-[var(--focus)]\"\n  buttonClassName=\"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)]\"\n/>",
+              "code": "<SettingsSelect\n  ariaLabel=\"Theme\"\n  prefixLabel=\"Theme\"\n  items={[{ value: \"lg\", label: \"Glitch\" }, { value: \"aurora\", label: \"Aurora\" }]}\n  value=\"lg\"\n  onChange={() => {}}\n  className=\"[--chip-trigger-ring-color:var(--focus)]\"\n  buttonClassName=\"[--chip-trigger-ring-color:var(--focus)]\"\n/>",
               "preview": {
                 "id": "prompts:components:settings-select:state:focus"
               }
@@ -6865,7 +6865,7 @@ export const galleryPayload = {
             "id": "focus",
             "name": "Focus-visible",
             "description": "Keyboard focus relies on the global `focus-visible` token, outlining the trigger without introducing extra wrappers.",
-            "code": "<ThemePicker\n  variant=\"lg\"\n  onVariantChange={() => {}}\n  className=\"ring-2 ring-[var(--focus)]\"\n  buttonClassName=\"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)]\"\n/>",
+            "code": "<ThemePicker\n  variant=\"lg\"\n  onVariantChange={() => {}}\n  className=\"[--chip-trigger-ring-color:var(--focus)]\"\n  buttonClassName=\"[--chip-trigger-ring-color:var(--focus)]\"\n/>",
             "preview": {
               "id": "prompts:components:theme-picker:state:focus"
             }
@@ -6925,7 +6925,7 @@ export const galleryPayload = {
             "id": "focus",
             "name": "Focus-visible",
             "description": "The `focus-visible` utility outlines the trigger directly, keeping the indicator consistent with other settings controls.",
-            "code": "<BackgroundPicker\n  bg={0}\n  onBgChange={() => {}}\n  className=\"ring-2 ring-[var(--focus)]\"\n  buttonClassName=\"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)]\"\n/>",
+            "code": "<BackgroundPicker\n  bg={0}\n  onBgChange={() => {}}\n  className=\"[--chip-trigger-ring-color:var(--focus)]\"\n  buttonClassName=\"[--chip-trigger-ring-color:var(--focus)]\"\n/>",
             "preview": {
               "id": "prompts:components:background-picker:state:focus"
             }
@@ -6985,7 +6985,7 @@ export const galleryPayload = {
             "id": "focus",
             "name": "Focus-visible",
             "description": "`focus-visible` keeps the focus ring within the control, matching buttons and toggles in the settings column.",
-            "code": "<SettingsSelect\n  ariaLabel=\"Theme\"\n  prefixLabel=\"Theme\"\n  items={[{ value: \"lg\", label: \"Glitch\" }, { value: \"aurora\", label: \"Aurora\" }]}\n  value=\"lg\"\n  onChange={() => {}}\n  className=\"ring-2 ring-[var(--focus)]\"\n  buttonClassName=\"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)]\"\n/>",
+            "code": "<SettingsSelect\n  ariaLabel=\"Theme\"\n  prefixLabel=\"Theme\"\n  items={[{ value: \"lg\", label: \"Glitch\" }, { value: \"aurora\", label: \"Aurora\" }]}\n  value=\"lg\"\n  onChange={() => {}}\n  className=\"[--chip-trigger-ring-color:var(--focus)]\"\n  buttonClassName=\"[--chip-trigger-ring-color:var(--focus)]\"\n/>",
             "preview": {
               "id": "prompts:components:settings-select:state:focus"
             }

--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -690,8 +690,8 @@ function useSelectOpen(
 const HOVER_BG_TOKENS = "bg-[--hover] hover:bg-[--hover]";
 const ACTIVE_BG_TOKENS = "bg-[--active] data-[open=true]:bg-[--active]";
 const BUTTON_FOCUS_VISIBLE_TOKENS =
-  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)]";
-const WRAPPER_FOCUS_RING_TOKENS = "ring-2 ring-[var(--focus)]";
+  "[--chip-trigger-ring-color:var(--focus)]";
+const WRAPPER_FOCUS_RING_TOKENS = "[--chip-trigger-ring-color:var(--focus)]";
 const THEME_TOGGLE_TRIGGER_SELECTOR = "[&_button[aria-haspopup='listbox']]";
 const THEME_TOGGLE_HOVER_CLASS = `${THEME_TOGGLE_TRIGGER_SELECTOR}:bg-[--hover] ${THEME_TOGGLE_TRIGGER_SELECTOR}:hover:bg-[--hover]`;
 const THEME_TOGGLE_FOCUS_CLASS = [
@@ -4542,8 +4542,8 @@ React.useEffect(() => {
           code: `<ThemePicker
   variant="lg"
   onVariantChange={() => {}}
-  className="ring-2 ring-[var(--focus)]"
-  buttonClassName="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)]"
+  className="[--chip-trigger-ring-color:var(--focus)]"
+  buttonClassName="[--chip-trigger-ring-color:var(--focus)]"
 />`,
         },
         {
@@ -4609,8 +4609,8 @@ React.useEffect(() => {
           code: `<BackgroundPicker
   bg={0}
   onBgChange={() => {}}
-  className="ring-2 ring-[var(--focus)]"
-  buttonClassName="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)]"
+  className="[--chip-trigger-ring-color:var(--focus)]"
+  buttonClassName="[--chip-trigger-ring-color:var(--focus)]"
 />`,
         },
         {
@@ -4696,8 +4696,8 @@ React.useEffect(() => {
   items={[{ value: "lg", label: "Glitch" }, { value: "aurora", label: "Aurora" }]}
   value="lg"
   onChange={() => {}}
-  className="ring-2 ring-[var(--focus)]"
-  buttonClassName="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)]"
+  className="[--chip-trigger-ring-color:var(--focus)]"
+  buttonClassName="[--chip-trigger-ring-color:var(--focus)]"
 />`,
         },
         {

--- a/src/components/ui/theme/SettingsSelect.tsx
+++ b/src/components/ui/theme/SettingsSelect.tsx
@@ -5,8 +5,8 @@ import Select from "../Select";
 import type { AnimatedSelectProps } from "../select/shared";
 import { cn } from "@/lib/utils";
 
-const SETTINGS_SELECT_BUTTON_CLASS =
-  "!rounded-full !text-ui !shadow-neo-inset [--settings-select-width:var(--settings-column-width)] min-w-[var(--settings-select-width)] hover:ring-2 hover:ring-[var(--edge-iris)] focus-visible:ring-2 focus-visible:ring-[var(--edge-iris)]";
+const SETTINGS_SELECT_BUTTON_CLASS = "chip-trigger";
+const SETTINGS_SELECT_CONTAINER_CLASS = "chip-trigger-container";
 
 export type SettingsSelectProps = Omit<
   AnimatedSelectProps,
@@ -26,7 +26,7 @@ export default function SettingsSelect({
       size="sm"
       matchTriggerWidth={false}
       buttonClassName={cn(SETTINGS_SELECT_BUTTON_CLASS, buttonClassName)}
-      containerClassName={cn("rounded-full", containerClassName)}
+      containerClassName={cn(SETTINGS_SELECT_CONTAINER_CLASS, containerClassName)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- update SettingsSelect to rely on the shared chip-trigger classes for its trigger and container styling
- add global chip-trigger utilities so focus, hover, and shadow tokens come from the shared chip design system values
- refresh the prompts gallery focus examples to reference the new chip ring variable in both the docs source and generated manifest

## Testing
- npm test -- --run prompts

------
https://chatgpt.com/codex/tasks/task_e_68dbb4d3ded8832c91571032a0a2a3f1