### PR TITLE
feat: inline glitch overlays for controls

### DIFF
--- a/src/components/ui/primitives/Button.module.css
+++ b/src/components/ui/primitives/Button.module.css
@@ -12,16 +12,3 @@
       calc(var(--control-radius) * 1.05) !important;
 }
 
-.glitch {
-  position: relative;
-  isolation: isolate;
-  overflow: hidden;
-  --glitch-overlay-opacity: var(--glitch-overlay-button-opacity);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .glitch {
-    --glitch-overlay-opacity: var(--glitch-overlay-button-opacity-reduced);
-  }
-}
-

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -289,12 +289,20 @@ export const Button = React.forwardRef<
   const toneColorVar = colorVar[tone];
   const s = buttonSizes[size];
   const spinnerSize = buttonSpinnerSizes[size];
+  const blobAnimationClass = cn(
+    "motion-reduce:animate-none",
+    !reduceMotion && "motion-safe:animate-blob-drift",
+  );
+  const noiseAnimationClass = cn(
+    "motion-reduce:animate-none",
+    !reduceMotion && "motion-safe:animate-glitch-noise",
+  );
+
   const base = cn(
     neumorphicStyles.neu,
     styles.root,
     styles.organicControl,
-    glitch && "glitch-wrapper",
-    glitch && styles.glitch,
+    glitch && "group/glitch isolate overflow-hidden",
     "relative inline-flex items-center justify-center rounded-[var(--control-radius)] border font-medium tracking-[0.02em] transition-all duration-quick ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:ring-2 focus-visible:ring-[var(--ring-contrast)] focus-visible:shadow-[var(--shadow-glow-md)] focus-visible:[outline:var(--spacing-0-5)_solid_var(--ring-contrast)] focus-visible:[outline-offset:var(--spacing-0-5)] disabled:opacity-disabled disabled:pointer-events-none data-[loading=true]:opacity-loading",
     "data-[disabled=true]:opacity-disabled data-[disabled=true]:pointer-events-none",
     "[--neu-radius:var(--control-radius)]",
@@ -321,7 +329,7 @@ export const Button = React.forwardRef<
       : variantHover;
 
   const contentClasses = cn(
-    contentClass ?? cn("inline-flex items-center", s.gap),
+    contentClass ?? cn("relative z-10 inline-flex items-center", s.gap),
     loading && "opacity-0",
   );
 
@@ -342,10 +350,31 @@ export const Button = React.forwardRef<
 
   const renderInnerContent = (contentChildren: React.ReactNode) => (
     <>
+      {glitch ? (
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-0 -z-10 overflow-hidden rounded-[inherit]"
+        >
+          <span
+            className={cn(
+              "absolute inset-0 rounded-[inherit] bg-blob-primary opacity-0 blur-[var(--space-4)] transition-opacity duration-quick ease-out",
+              blobAnimationClass,
+              "group-hover/glitch:opacity-[var(--glitch-overlay-button-opacity)] group-focus-visible/glitch:opacity-[var(--glitch-overlay-button-opacity)] group-focus-within/glitch:opacity-[var(--glitch-overlay-button-opacity)] group-active/glitch:opacity-[var(--glitch-overlay-button-opacity)]",
+            )}
+          />
+          <span
+            className={cn(
+              "absolute inset-0 rounded-[inherit] bg-glitch-noise bg-cover opacity-0 mix-blend-screen transition-opacity duration-quick ease-out",
+              noiseAnimationClass,
+              "group-hover/glitch:opacity-[var(--glitch-noise-level,0.18)] group-focus-visible/glitch:opacity-[var(--glitch-noise-level,0.18)] group-focus-within/glitch:opacity-[var(--glitch-noise-level,0.18)] group-active/glitch:opacity-[calc(var(--glitch-noise-level,0.18)*1.4)]",
+            )}
+          />
+        </span>
+      ) : null}
       {variant === "primary" ? (
         <span
           className={cn(
-            "absolute inset-0 pointer-events-none rounded-[inherit]",
+            "absolute inset-0 z-0 pointer-events-none rounded-[inherit]",
             `bg-[linear-gradient(90deg,hsl(var(${toneColorVar})/.18),hsl(var(${toneColorVar})/.18))]`,
           )}
         />

--- a/src/components/ui/primitives/Card.module.css
+++ b/src/components/ui/primitives/Card.module.css
@@ -64,10 +64,6 @@
   opacity: 0.32;
 }
 
-.glitch {
-  --glitch-overlay-opacity: var(--glitch-overlay-opacity-card);
-}
-
 @media (prefers-reduced-motion: reduce) {
   .root {
     transition: none;

--- a/tests/primitives/Button.test.tsx
+++ b/tests/primitives/Button.test.tsx
@@ -125,13 +125,15 @@ describe("Button", () => {
   });
 
   it("references glitch overlay tokens", () => {
-    const css = fs.readFileSync(
-      "src/components/ui/primitives/Button.module.css",
+    const source = fs.readFileSync(
+      "src/components/ui/primitives/Button.tsx",
       "utf8",
     );
 
-    expect(css).toContain("var(--glitch-overlay-button-opacity)");
-    expect(css).toContain("var(--glitch-overlay-button-opacity-reduced)");
+    expect(source).toContain(
+      "opacity-[var(--glitch-overlay-button-opacity)]",
+    );
+    expect(source).toContain("opacity-[var(--glitch-noise-level,0.18)]");
   });
 
   it("defines button glitch overlay tokens in theme bundle", () => {

--- a/tests/primitives/__snapshots__/Button.test.tsx.snap
+++ b/tests/primitives/__snapshots__/Button.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Button > matches snapshot for secondary danger tone 1`] = `
   type="button"
 >
   <span
-    class="inline-flex items-center gap-[var(--space-2)]"
+    class="relative z-10 inline-flex items-center gap-[var(--space-2)]"
   >
     Delete
   </span>

--- a/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
+++ b/tests/reviews/__snapshots__/ReviewsPage.test.tsx.snap
@@ -281,7 +281,7 @@ exports[`ReviewsPage > renders default state 1`] = `
                         type="button"
                       >
                         <span
-                          class="absolute inset-0 pointer-events-none rounded-[inherit] bg-[linear-gradient(90deg,hsl(var(--primary)/.18),hsl(var(--primary)/.18))]"
+                          class="absolute inset-0 z-0 pointer-events-none rounded-[inherit] bg-[linear-gradient(90deg,hsl(var(--primary)/.18),hsl(var(--primary)/.18))]"
                         />
                         <span
                           class="relative z-10 inline-flex items-center gap-[var(--space-2)]"

--- a/tests/ui/Card.test.tsx
+++ b/tests/ui/Card.test.tsx
@@ -28,13 +28,13 @@ describe("Card", () => {
         .trim(),
     ).toMatchInlineSnapshot(`"0.72"`);
 
-    const css = fs.readFileSync(
-      "src/components/ui/primitives/Card.module.css",
+    const source = fs.readFileSync(
+      "src/components/ui/primitives/Card.tsx",
       "utf8",
     );
 
-    expect(css).toContain(
-      "--glitch-overlay-opacity: var(--glitch-overlay-opacity-card);",
+    expect(source).toContain(
+      "opacity-[var(--glitch-overlay-opacity-card,0.38)]",
     );
 
     document.documentElement.style.removeProperty(


### PR DESCRIPTION
## Summary
- add token-driven glitch overlays directly in Button, Card, and Field primitives
- wire Input to opt into the shared overlay layer and compute glitch text fallbacks
- update related tests and snapshots to validate new markup and token usage

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dbbbd130ec832c89e46f1227c201d3