### PR TITLE
fix: reset usePersistentState when storage key changes

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -344,11 +344,6 @@ export function usePersistentState<T>(
     stateRef.current = state;
     stateRevisionRef.current += 1;
   }, [state]);
-  React.useEffect(() => {
-    if (!Object.is(initialRef.current, initial)) {
-      initialRef.current = initial;
-    }
-  }, [initial]);
 
   const decodeRef = React.useRef<PersistentStateDecode<T> | null>(
     options?.decode ?? null,
@@ -405,6 +400,19 @@ export function usePersistentState<T>(
       hasHydratedRef.current = false;
     }
   }, [key]);
+
+  React.useEffect(() => {
+    if (!Object.is(initialRef.current, initial)) {
+      initialRef.current = initial;
+    }
+
+    if (!hasHydratedRef.current) {
+      const nextInitial = initialRef.current;
+      if (!Object.is(stateRef.current, nextInitial)) {
+        setState(nextInitial);
+      }
+    }
+  }, [initial, key]);
 
   React.useEffect(() => {
     if (!isBrowser) return;

--- a/tests/lib/Db.test.ts
+++ b/tests/lib/Db.test.ts
@@ -559,6 +559,37 @@ describe("Db", () => {
       expect(result.current[0]).toBe(0);
     });
 
+    it("resets to the new initial state when the key changes", async () => {
+      const { usePersistentState } = await import("@/lib/db");
+
+      const { result, rerender } = renderHook(
+        ({ storageKey, initial }) => usePersistentState(storageKey, initial),
+        {
+          initialProps: {
+            storageKey: "preview:first",
+            initial: { variant: "aurora" },
+          },
+        },
+      );
+
+      expect(result.current[0]).toEqual({ variant: "aurora" });
+
+      act(() => {
+        result.current[1]({ variant: "glitch" });
+      });
+
+      expect(result.current[0]).toEqual({ variant: "glitch" });
+
+      rerender({
+        storageKey: "preview:second",
+        initial: { variant: "oceanic" },
+      });
+
+      await waitFor(() => {
+        expect(result.current[0]).toEqual({ variant: "oceanic" });
+      });
+    });
+
     it("persists prompts saved before hydration completes", async () => {
       const { usePromptLibrary } = await import(
         "@/components/prompts/usePromptLibrary"


### PR DESCRIPTION
## Summary
- reset the usePersistentState hook to the latest initial value whenever the storage key changes before hydration completes
- cover the regression with a hook test that verifies fresh defaults are used when swapping keys

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dbc35ce288832cacf921242ec3654f