### PR TITLE
Align Storybook preview theming with app providers

### DIFF
--- a/storybook/preview.tsx
+++ b/storybook/preview.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+import "../app/globals.css";
+import "../app/themes.css";
+
+import DepthThemeProvider from "@/lib/depth-theme-context";
+import ThemeProvider from "@/lib/theme-context";
+import { depthThemeEnabled } from "@/lib/features";
+
+const depthThemeState = depthThemeEnabled;
+const depthThemeAttribute = depthThemeState ? "enabled" : "legacy";
+
+type StoryDecorator = (
+  Story: () => React.ReactElement | null,
+  context?: { args: Record<string, unknown> },
+) => React.ReactElement | null;
+
+export const decorators: StoryDecorator[] = [
+  (Story) => (
+    <ThemeProvider>
+      <DepthThemeProvider enabled={depthThemeState}>
+        <div
+          className="glitch-root theme-lg min-h-screen bg-background text-foreground"
+          data-depth-theme={depthThemeAttribute}
+        >
+          <Story />
+        </div>
+      </DepthThemeProvider>
+    </ThemeProvider>
+  ),
+];
+
+export const parameters: Record<string, unknown> = {
+  backgrounds: { disable: true },
+  layout: "fullscreen",
+};


### PR DESCRIPTION
## Summary
- register the app-level Tailwind layers in Storybook so tokens load before stories render
- wrap every story with the app ThemeProvider and DepthThemeProvider to enable depth theming
- disable Storybook's default backgrounds and use fullscreen layout to keep design-surface parity

## Testing
- npm run check
- npm run verify-prompts

------
https://chatgpt.com/codex/tasks/task_e_68dbd1b94438832cad834a912b75850b