### PR TITLE
fix: align WeekPicker chips with state utilities

### DIFF
--- a/src/components/planner/WeekPicker.tsx
+++ b/src/components/planner/WeekPicker.tsx
@@ -68,6 +68,11 @@ type DayChipProps = {
   tabIndex: number;
 };
 
+const CHIP_SURFACE_CARD = "[--chip-surface-rest:hsl(var(--card))]";
+const CHIP_SURFACE_SUCCESS = "[--chip-surface-rest:hsl(var(--success) / 0.2)]";
+const CHIP_SURFACE_ACCENT_MED = "[--chip-surface-rest:hsl(var(--accent-3) / 0.2)]";
+const CHIP_SURFACE_ACCENT_LIGHT = "[--chip-surface-rest:hsl(var(--accent-3) / 0.3)]";
+
 const DayChip = React.forwardRef<HTMLButtonElement, DayChipProps>(function DayChip(
   {
     iso,
@@ -104,17 +109,17 @@ const DayChip = React.forwardRef<HTMLButtonElement, DayChipProps>(function DayCh
     }
     return ratio;
   }, [done, total]);
-  const { tint: completionTint, text: completionTextClass } = React.useMemo(() => {
+  const { surface: completionSurfaceClass, text: completionTextClass } = React.useMemo(() => {
     if (total === 0) {
-      return { tint: "bg-card", text: "text-muted-foreground" };
+      return { surface: CHIP_SURFACE_CARD, text: "text-muted-foreground" };
     }
     if (completionRatio >= 2 / 3) {
-      return { tint: "bg-success-soft", text: "text-foreground" };
+      return { surface: CHIP_SURFACE_SUCCESS, text: "text-foreground" };
     }
     if (completionRatio >= 1 / 3) {
-      return { tint: "bg-accent-3/20", text: "text-foreground" };
+      return { surface: CHIP_SURFACE_ACCENT_MED, text: "text-foreground" };
     }
-    return { tint: "bg-accent-3/30", text: "text-foreground" };
+    return { surface: CHIP_SURFACE_ACCENT_LIGHT, text: "text-foreground" };
   }, [completionRatio, total]);
   const instructionsId = React.useId();
   const countsId = React.useId();
@@ -174,17 +179,12 @@ const DayChip = React.forwardRef<HTMLButtonElement, DayChipProps>(function DayCh
           : "Click or press Enter to focus"
       }
       className={cn(
-        "chip chip-token relative flex-none w-[--chip-width] rounded-card r-card-lg border text-left transition snap-start",
-        "focus-visible:outline-none focus-visible:ring focus-visible:ring-offset-0 focus-visible:[--tw-ring-width:var(--ring-size-2)] focus-visible:[--tw-ring-color:var(--focus-outline,var(--theme-ring))]",
-        "data-[focus-visible]:outline-none data-[focus-visible]:ring data-[focus-visible]:ring-offset-0 data-[focus-visible]:[--tw-ring-width:var(--ring-size-2)] data-[focus-visible]:[--tw-ring-color:var(--focus-outline,var(--theme-ring))]",
-        // default border is NOT white; use card hairline tint
-        "border-card-hairline",
-        completionTint,
-        "active:border-primary/60 active:bg-card/85",
+        "chip chip-token relative flex-none w-[--chip-width] rounded-card r-card-lg border text-left transition snap-start chip-surface chip-border chip-ring",
+        "focus-visible:outline-none focus-visible:ring focus-visible:ring-offset-0 focus-visible:[--tw-ring-width:var(--ring-size-2)] focus-visible:[--tw-ring-color:var(--ring-accent)]",
+        "data-[focus-visible]:outline-none data-[focus-visible]:ring data-[focus-visible]:ring-offset-0 data-[focus-visible]:[--tw-ring-width:var(--ring-size-2)] data-[focus-visible]:[--tw-ring-color:var(--ring-accent)]",
+        completionSurfaceClass,
         today && "chip--today",
-        selected
-          ? "border-dashed border-primary/75"
-          : "hover:border-primary/40",
+        selected ? "chip--active border-dashed" : undefined,
       )}
       data-today={today || undefined}
       data-active={selected || undefined}
@@ -193,7 +193,9 @@ const DayChip = React.forwardRef<HTMLButtonElement, DayChipProps>(function DayCh
         className={cn(
           "chip__date",
           completionTextClass,
-          today && completionTint === "bg-card" ? "text-accent-3" : undefined,
+          today && completionSurfaceClass === CHIP_SURFACE_CARD
+            ? "text-accent-3"
+            : undefined,
         )}
         data-text={displayLabel}
       >
@@ -406,7 +408,7 @@ export default function WeekPicker() {
           <div
             role="group"
             aria-label="Week navigation"
-            className="flex flex-wrap items-center gap-[var(--space-2)]"
+            className="flex flex-wrap items-center chip-gap-x-tight chip-gap-y-tight"
           >
             <Button
               variant="ghost"
@@ -440,7 +442,7 @@ export default function WeekPicker() {
           <span className="sr-only" aria-live="polite">
             Week range {accessibleRange}
           </span>
-          <span className="inline-flex items-baseline gap-[var(--space-1)] text-ui text-muted-foreground">
+          <span className="inline-flex items-baseline chip-gap-x-tight text-ui text-muted-foreground">
             <span>Total tasks:</span>
             <span className="font-medium tabular-nums text-foreground">
               {weekDone} / {weekTotal}
@@ -451,7 +453,7 @@ export default function WeekPicker() {
           <div
             role="listbox"
             aria-label={`Select a focus day between ${rangeLabel}`}
-            className="flex flex-nowrap gap-[var(--space-3)] overflow-x-auto snap-x snap-mandatory lg:flex-wrap lg:gap-y-[var(--space-3)] lg:overflow-visible lg:[scroll-snap-type:none]"
+            className="flex flex-nowrap chip-gap-x overflow-x-auto snap-x snap-mandatory lg:flex-wrap lg:chip-gap-y lg:overflow-visible lg:[scroll-snap-type:none]"
           >
             {days.map((d, i) => (
               <DayChip

--- a/src/components/planner/style.css
+++ b/src/components/planner/style.css
@@ -454,10 +454,39 @@
   --tw-ring-shadow: 0 0 #0000;
   --tw-shadow: var(--chip-shadow);
   --tw-shadow-colored: var(--chip-shadow);
+  background: var(--chip-surface-rest, hsl(var(--card) / 0.7));
+  border-color: var(--chip-border-rest, hsl(var(--card-hairline)));
   box-shadow:
     var(--tw-ring-offset-shadow),
     var(--tw-ring-shadow),
     var(--tw-shadow);
+}
+
+.chip-surface {
+  --chip-surface-rest: hsl(var(--card) / 0.7);
+  --chip-surface-hover: var(
+    --surface-chip-hover,
+    color-mix(
+      in oklab,
+      hsl(var(--card)) 88%,
+      hsl(var(--accent-3)) 12% / 0.08
+    )
+  );
+  --chip-surface-active: hsl(var(--card) / 0.85);
+}
+
+.chip-border {
+  --chip-border-rest: hsl(var(--card-hairline));
+  --chip-border-hover: hsl(var(--accent-3) / 0.55);
+  --chip-border-active: var(--focus-outline, hsl(var(--ring)));
+  --chip-border-selected: var(
+    --chip-border-active,
+    var(--focus-outline, hsl(var(--ring)))
+  );
+}
+
+.chip-ring {
+  --ring-accent: var(--focus-outline, var(--theme-ring));
 }
 
 .chip-token {
@@ -472,22 +501,41 @@
 
 .chip:hover {
   background: var(
-    --surface-chip-hover,
-    color-mix(
-      in oklab,
-      hsl(var(--card)) 88%,
-      hsl(var(--accent-3)) 12% / 0.08
+    --chip-surface-hover,
+    var(
+      --surface-chip-hover,
+      color-mix(
+        in oklab,
+        hsl(var(--card)) 88%,
+        hsl(var(--accent-3)) 12% / 0.08
+      )
     )
   );
   border-color: var(
-    --border-chip-hover,
-    hsl(var(--accent-3) / 0.55)
+    --chip-border-hover,
+    var(--border-chip-hover, hsl(var(--accent-3) / 0.55))
   );
   --chip-shadow: var(--elev-chip-hover, var(--chip-elev-hover-fallback));
 }
 
+.chip:active {
+  background: var(
+    --chip-surface-active,
+    hsl(var(--card) / 0.85)
+  );
+  border-color: var(
+    --chip-border-active,
+    var(--focus-outline, hsl(var(--ring)))
+  );
+  --chip-shadow: var(--elev-chip-active, var(--chip-elev-active-fallback));
+}
+
 .chip[data-active] {
   --chip-shadow: var(--elev-chip-selected, var(--chip-elev-selected-fallback));
+  border-color: var(
+    --chip-border-selected,
+    var(--chip-border-active, var(--focus-outline, hsl(var(--ring))))
+  );
 }
 
 /* “Today” hint — faint ring and glow rail inside */
@@ -516,8 +564,8 @@
 /* Active selection: holo border + RGB split title */
 .chip--active {
   border-color: var(
-    --border-chip-active,
-    var(--focus-outline, hsl(var(--ring)))
+    --chip-border-selected,
+    var(--chip-border-active, var(--focus-outline, hsl(var(--ring))))
   );
   --chip-shadow: var(--elev-chip-active, var(--chip-elev-active-fallback));
 }

--- a/tests/planner/WeekPicker.test.tsx
+++ b/tests/planner/WeekPicker.test.tsx
@@ -169,6 +169,9 @@ describe("WeekPicker", () => {
     const srOnlyLabel = firstOption.querySelector('[data-chip-label="full"]');
     expect(srOnlyLabel?.textContent).toBe(accessibleText);
 
+    expect(firstOption).toHaveClass("chip-surface");
+    expect(firstOption).toHaveClass("chip-border");
+    expect(firstOption).toHaveClass("chip-ring");
     expect(firstOption).toHaveClass("focus-visible:outline-none");
     expect(firstOption).toHaveClass("focus-visible:ring");
     expect(firstOption).toHaveClass("focus-visible:ring-offset-0");
@@ -176,7 +179,7 @@ describe("WeekPicker", () => {
       "focus-visible:[--tw-ring-width:var(--ring-size-2)]",
     );
     expect(firstOption.className).toContain(
-      "focus-visible:[--tw-ring-color:var(--focus-outline,var(--theme-ring))]",
+      "focus-visible:[--tw-ring-color:var(--ring-accent)]",
     );
     expect(firstOption.className).toContain("data-[focus-visible]:outline-none");
     expect(firstOption.className).toContain("data-[focus-visible]:ring");
@@ -187,7 +190,7 @@ describe("WeekPicker", () => {
       "data-[focus-visible]:[--tw-ring-width:var(--ring-size-2)]",
     );
     expect(firstOption.className).toContain(
-      "data-[focus-visible]:[--tw-ring-color:var(--focus-outline,var(--theme-ring))]",
+      "data-[focus-visible]:[--tw-ring-color:var(--ring-accent)]",
     );
   });
 


### PR DESCRIPTION
## Summary
- map WeekPicker day chips to the chip-surface, chip-border, and chip-ring utilities while driving completion tints through custom properties
- swap planner navigation, totals, and chip rows to the shared chip spacing helpers
- extend the planner chip styles and expectations to the new state variables

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dbd7616e2c832ca8a3b325649626b5