### PR TITLE
chore: expand depth and glitch token coverage

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -306,6 +306,11 @@
 | retro-grid-opacity | 0.15 |
 | aa-min-contrast | 4.5 |
 | glitch-overlay-opacity-card | 0.55 |
+| shadow-inner-lg | inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36) |
+| shadow-outer-xl | 0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.45) |
+| glow-ring | 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22) |
+| blob-radius-soft | calc(var(--radius-2xl) + var(--spacing-2)) |
+| glitch-noise-hover | calc(var(--glitch-noise-level) * 1.3) |
 | spacing-0-125 | calc(var(--spacing-1) / 8) |
 | spacing-0-25 | calc(var(--spacing-1) / 4) |
 | spacing-0-5 | calc(var(--spacing-1) / 2) |

--- a/scripts/generate-tokens.ts
+++ b/scripts/generate-tokens.ts
@@ -36,6 +36,7 @@ const REQUIRED_THEME_TOKEN_GROUPS = {
     "depth-shadow-outer-strong",
     "depth-shadow-soft",
     "depth-shadow-inner",
+    "shadow-inner-lg",
     "depth-glow-highlight-soft",
     "depth-glow-highlight-medium",
     "depth-glow-highlight-strong",
@@ -44,6 +45,8 @@ const REQUIRED_THEME_TOKEN_GROUPS = {
     "depth-glow-shadow-strong",
     "depth-focus-ring-rest",
     "depth-focus-ring-active",
+    "shadow-outer-xl",
+    "glow-ring",
   ],
   organicBackdrop: [
     "backdrop-blob-1",
@@ -61,6 +64,7 @@ const REQUIRED_THEME_TOKEN_GROUPS = {
     "blob-surface-2",
     "blob-surface-3",
     "blob-surface-shadow",
+    "blob-radius-soft",
   ],
   glitch: [
     "neo-glow-strength",
@@ -86,6 +90,7 @@ const REQUIRED_THEME_TOKEN_GROUPS = {
     "glitch-noise-primary",
     "glitch-noise-secondary",
     "glitch-noise-contrast",
+    "glitch-noise-hover",
   ],
 } as const;
 
@@ -271,16 +276,24 @@ async function buildTokens(): Promise<void> {
       "inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.18)",
     "shadow-inner-md":
       "inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.28)",
+    "shadow-inner-lg":
+      "inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36)",
     "shadow-outer-lg":
       "0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36)",
+    "shadow-outer-xl":
+      "0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.45)",
+    "glow-ring":
+      "0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22)",
     "glow-primary": "hsl(var(--primary) / 0.55)",
     "blob-surface-1": "hsl(var(--surface))",
     "blob-surface-2": "hsl(var(--surface-2))",
     "blob-surface-3": "hsl(var(--card))",
     "blob-surface-shadow": "hsl(var(--shadow-color) / 0.4)",
+    "blob-radius-soft": "calc(var(--radius-2xl) + var(--spacing-2))",
     "glitch-noise-primary": "hsl(var(--accent) / 0.25)",
     "glitch-noise-secondary": "hsl(var(--ring) / 0.2)",
     "glitch-noise-contrast": "hsl(var(--foreground) / 0.12)",
+    "glitch-noise-hover": "calc(var(--glitch-noise-level) * 1.3)",
   };
 
   for (const [name, value] of Object.entries(derivedColorTokens)) {

--- a/scripts/themes.ts
+++ b/scripts/themes.ts
@@ -67,8 +67,17 @@ export const rootVariables: VariableDefinition[] = [
       "inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.28)",
   },
   {
+    name: "shadow-inner-lg",
+    value:
+      "inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36)",
+  },
+  {
     name: "shadow-outer-lg",
     value: "0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36)",
+  },
+  {
+    name: "shadow-outer-xl",
+    value: "0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.45)",
   },
   {
     comment: "Depth glow ramps",
@@ -119,6 +128,10 @@ export const rootVariables: VariableDefinition[] = [
   { name: "blob-surface-3", value: "hsl(var(--card))" },
   { name: "blob-surface-shadow", value: "hsl(var(--shadow-color) / 0.4)" },
   {
+    name: "blob-radius-soft",
+    value: "calc(var(--radius-2xl) + var(--spacing-2))",
+  },
+  {
     comment: [
       "Glow parity (retro-futurism)",
       "neo-glow-strength multiplies --shadow-neon",
@@ -127,6 +140,11 @@ export const rootVariables: VariableDefinition[] = [
     value: "0.45",
   },
   { name: "glow-primary", value: "hsl(var(--primary) / 0.55)" },
+  {
+    name: "glow-ring",
+    value:
+      "0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22)",
+  },
   { name: "neon-outline-opacity", value: "0.35" },
   {
     comment: [
@@ -183,6 +201,10 @@ export const rootVariables: VariableDefinition[] = [
   { name: "glitch-noise-primary", value: "hsl(var(--accent) / 0.25)" },
   { name: "glitch-noise-secondary", value: "hsl(var(--ring) / 0.2)" },
   { name: "glitch-noise-contrast", value: "hsl(var(--foreground) / 0.12)" },
+  {
+    name: "glitch-noise-hover",
+    value: "calc(var(--glitch-noise-level) * 1.3)",
+  },
   { comment: "Retro grid parity", name: "retro-grid-step", value: "24px" },
   { name: "retro-grid-opacity", value: "0.15" },
   {
@@ -260,6 +282,15 @@ export const themes: ThemeDefinition[] = [
       { name: "surface-streak", value: "280 42% 14%" },
       { name: "shadow-color", value: "152 80% 50%" },
       { name: "shadow", value: "0 12px 32px hsl(var(--shadow-color) / 0.3)" },
+      {
+        name: "shadow-inner-lg",
+        value:
+          "inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36)",
+      },
+      {
+        name: "shadow-outer-xl",
+        value: "0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.45)",
+      },
       { name: "neo-glow-strength", value: "0.4" },
       { name: "glitch-intensity", value: "0.4" },
       { name: "glitch-fringe", value: "8deg" },
@@ -282,6 +313,13 @@ export const themes: ThemeDefinition[] = [
       { name: "backdrop-drip-2", value: "var(--accent)" },
       { name: "backdrop-drip-3", value: "var(--accent-2)" },
       { name: "backdrop-drip-shadow", value: "var(--card)" },
+      {
+        name: "glow-ring",
+        value:
+          "0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22)",
+      },
+      { name: "blob-radius-soft", value: "calc(var(--radius-2xl) + var(--spacing-2))" },
+      { name: "glitch-noise-hover", value: "calc(var(--glitch-noise-level) * 1.3)" },
       {
         name: "edge-iris",
         value: [
@@ -339,6 +377,15 @@ export const themes: ThemeDefinition[] = [
       { name: "surface-streak", value: "212 18% 16%" },
       { name: "shadow-color", value: "28 90% 42%" },
       { name: "shadow", value: "0 14px 36px hsl(var(--shadow-color) / 0.32)" },
+      {
+        name: "shadow-inner-lg",
+        value:
+          "inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36)",
+      },
+      {
+        name: "shadow-outer-xl",
+        value: "0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.45)",
+      },
       { name: "neo-glow-strength", value: "0.45" },
       { name: "glitch-intensity", value: "0.38" },
       { name: "glitch-fringe", value: "7deg" },
@@ -358,6 +405,13 @@ export const themes: ThemeDefinition[] = [
       { name: "backdrop-drip-2", value: "var(--citrus-teal)" },
       { name: "backdrop-drip-3", value: "var(--ring)" },
       { name: "backdrop-drip-shadow", value: "var(--card)" },
+      {
+        name: "glow-ring",
+        value:
+          "0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22)",
+      },
+      { name: "blob-radius-soft", value: "calc(var(--radius-2xl) + var(--spacing-2))" },
+      { name: "glitch-noise-hover", value: "calc(var(--glitch-noise-level) * 1.3)" },
     ],
   },
   {
@@ -400,8 +454,17 @@ export const themes: ThemeDefinition[] = [
           "inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.3)",
       },
       {
+        name: "shadow-inner-lg",
+        value:
+          "inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.38)",
+      },
+      {
         name: "shadow-outer-lg",
         value: "0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.42)",
+      },
+      {
+        name: "shadow-outer-xl",
+        value: "0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.48)",
       },
       { name: "neo-glow-strength", value: "0.6" },
       { name: "glitch-intensity", value: "0.34" },
@@ -418,10 +481,16 @@ export const themes: ThemeDefinition[] = [
       { name: "noir-ink", value: "352 80% 6%" },
       { name: "noir-ruby", value: "12 76% 46%" },
       { name: "glow-primary", value: "hsl(var(--ring) / 0.58)" },
+      {
+        name: "glow-ring",
+        value:
+          "0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.52), 0 0 var(--spacing-3) hsl(var(--ring) / 0.24)",
+      },
       { name: "blob-surface-1", value: "hsl(352 46% 12%)" },
       { name: "blob-surface-2", value: "hsl(352 38% 18%)" },
       { name: "blob-surface-3", value: "hsl(184 68% 20%)" },
       { name: "blob-surface-shadow", value: "hsl(356 72% 10% / 0.42)" },
+      { name: "blob-radius-soft", value: "calc(var(--radius-2xl) + var(--spacing-2))" },
       { name: "backdrop-blob-1", value: "var(--noir-red)" },
       { name: "backdrop-blob-2", value: "var(--noir-rose)" },
       { name: "backdrop-blob-3", value: "var(--noir-ruby)" },
@@ -433,6 +502,10 @@ export const themes: ThemeDefinition[] = [
       { name: "backdrop-drip-2", value: "var(--noir-red)" },
       { name: "backdrop-drip-3", value: "var(--noir-ruby)" },
       { name: "backdrop-drip-shadow", value: "var(--noir-ink)" },
+      {
+        name: "glitch-noise-hover",
+        value: "calc(var(--glitch-noise-level) * 1.35)",
+      },
     ],
   },
   {
@@ -464,6 +537,15 @@ export const themes: ThemeDefinition[] = [
       { name: "surface-streak", value: "218 22% 15%" },
       { name: "shadow-color", value: "198 84% 52%" },
       { name: "shadow", value: "0 16px 40px hsl(var(--shadow-color) / 0.34)" },
+      {
+        name: "shadow-inner-lg",
+        value:
+          "inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36)",
+      },
+      {
+        name: "shadow-outer-xl",
+        value: "0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.45)",
+      },
       { name: "neo-glow-strength", value: "0.52" },
       { name: "glitch-intensity", value: "0.4" },
       { name: "glitch-fringe", value: "7deg" },
@@ -484,6 +566,13 @@ export const themes: ThemeDefinition[] = [
       { name: "backdrop-drip-2", value: "var(--ocean-indigo)" },
       { name: "backdrop-drip-3", value: "var(--success)" },
       { name: "backdrop-drip-shadow", value: "var(--card)" },
+      {
+        name: "glow-ring",
+        value:
+          "0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22)",
+      },
+      { name: "blob-radius-soft", value: "calc(var(--radius-2xl) + var(--spacing-2))" },
+      { name: "glitch-noise-hover", value: "calc(var(--glitch-noise-level) * 1.3)" },
     ],
   },
   {
@@ -515,6 +604,15 @@ export const themes: ThemeDefinition[] = [
       { name: "surface-streak", value: "334 50% 12%" },
       { name: "shadow-color", value: "336 72% 48%" },
       { name: "shadow", value: "0 12px 30px hsl(var(--shadow-color) / 0.3)" },
+      {
+        name: "shadow-inner-lg",
+        value:
+          "inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36)",
+      },
+      {
+        name: "shadow-outer-xl",
+        value: "0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.45)",
+      },
       { name: "neo-glow-strength", value: "0.42" },
       { name: "glitch-intensity", value: "0.36" },
       { name: "glitch-fringe", value: "6deg" },
@@ -536,6 +634,13 @@ export const themes: ThemeDefinition[] = [
       { name: "backdrop-drip-2", value: "var(--kitten-pink)" },
       { name: "backdrop-drip-3", value: "var(--kitten-blush)" },
       { name: "backdrop-drip-shadow", value: "var(--card)" },
+      {
+        name: "glow-ring",
+        value:
+          "0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22)",
+      },
+      { name: "blob-radius-soft", value: "calc(var(--radius-2xl) + var(--spacing-2))" },
+      { name: "glitch-noise-hover", value: "calc(var(--glitch-noise-level) * 1.3)" },
     ],
   },
   {
@@ -584,8 +689,17 @@ export const themes: ThemeDefinition[] = [
           "inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.24)",
       },
       {
+        name: "shadow-inner-lg",
+        value:
+          "inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.3)",
+      },
+      {
         name: "shadow-outer-lg",
         value: "0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.34)",
+      },
+      {
+        name: "shadow-outer-xl",
+        value: "0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.42)",
       },
       { name: "neo-glow-strength", value: "0.58" },
       { name: "glitch-intensity", value: "0.32" },
@@ -604,10 +718,16 @@ export const themes: ThemeDefinition[] = [
       { name: "hardstuck-forest", value: "120 70% 42%" },
       { name: "hardstuck-deep", value: "120 82% 8%" },
       { name: "glow-primary", value: "hsl(var(--ring) / 0.5)" },
+      {
+        name: "glow-ring",
+        value:
+          "0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.48), 0 0 var(--spacing-3) hsl(var(--ring) / 0.2)",
+      },
       { name: "blob-surface-1", value: "hsl(120 38% 14%)" },
       { name: "blob-surface-2", value: "hsl(120 44% 18%)" },
       { name: "blob-surface-3", value: "hsl(120 48% 24%)" },
       { name: "blob-surface-shadow", value: "hsl(120 72% 12% / 0.45)" },
+      { name: "blob-radius-soft", value: "calc(var(--radius-2xl) + var(--spacing-2))" },
       { name: "backdrop-blob-1", value: "var(--ring)" },
       { name: "backdrop-blob-2", value: "var(--hardstuck-forest)" },
       { name: "backdrop-blob-3", value: "var(--ring)" },
@@ -619,6 +739,10 @@ export const themes: ThemeDefinition[] = [
       { name: "backdrop-drip-2", value: "var(--ring)" },
       { name: "backdrop-drip-3", value: "var(--hardstuck-forest)" },
       { name: "backdrop-drip-shadow", value: "var(--hardstuck-deep)" },
+      {
+        name: "glitch-noise-hover",
+        value: "calc(var(--glitch-noise-level) * 1.35)",
+      },
     ],
   },
   {
@@ -651,11 +775,25 @@ export const themes: ThemeDefinition[] = [
       { name: "surface-vhs", value: "258 76% 5%" },
       { name: "surface-streak", value: "260 44% 13%" },
       { name: "shadow-color", value: "304 92% 56%" },
+      {
+        name: "shadow-inner-lg",
+        value:
+          "inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36)",
+      },
+      {
+        name: "shadow-outer-xl",
+        value: "0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.45)",
+      },
       { name: "lav-deep", value: "257.5 85.7% 72.5%" },
       { name: "success", value: "158 72% 48%" },
       { name: "success-glow", value: "158 72% 38% / 0.6" },
       { name: "glow", value: "304 100% 68%" },
       { name: "glow-active", value: "hsl(var(--accent-2))" },
+      {
+        name: "glow-ring",
+        value:
+          "0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22)",
+      },
       {
         name: "shadow-glow-sm",
         value: [
@@ -702,6 +840,7 @@ export const themes: ThemeDefinition[] = [
       { name: "backdrop-drip-2", value: "var(--accent-2)" },
       { name: "backdrop-drip-3", value: "var(--accent)" },
       { name: "backdrop-drip-shadow", value: "var(--accent)" },
+      { name: "blob-radius-soft", value: "calc(var(--radius-2xl) + var(--spacing-2))" },
       {
         name: "grid-lines",
         value: [
@@ -726,6 +865,7 @@ export const themes: ThemeDefinition[] = [
           ")",
         ],
       },
+      { name: "glitch-noise-hover", value: "calc(var(--glitch-noise-level) * 1.35)" },
     ],
   },
 ];

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -313,6 +313,11 @@
   --retro-grid-opacity: 0.15;
   --aa-min-contrast: 4.5;
   --glitch-overlay-opacity-card: 0.55;
+  --shadow-inner-lg: inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36);
+  --shadow-outer-xl: 0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.45);
+  --glow-ring: 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22);
+  --blob-radius-soft: calc(var(--radius-2xl) + var(--spacing-2));
+  --glitch-noise-hover: calc(var(--glitch-noise-level) * 1.3);
   --spacing-0-125: calc(var(--spacing-1) / 8);
   --spacing-0-25: calc(var(--spacing-1) / 4);
   --spacing-0-5: calc(var(--spacing-1) / 2);
@@ -367,7 +372,9 @@
   --depth-shadow-inner: var(--shadow-neo-inset);
   --shadow-inner-sm: inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.18);
   --shadow-inner-md: inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.28);
+  --shadow-inner-lg: inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36);
   --shadow-outer-lg: 0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36);
+  --shadow-outer-xl: 0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.45);
   /* Depth glow ramps */
   --depth-glow-highlight-soft: hsl(var(--highlight) / 0.08);
   --depth-glow-highlight-medium: hsl(var(--highlight) / 0.35);
@@ -397,10 +404,12 @@
   --blob-surface-2: hsl(var(--surface-2));
   --blob-surface-3: hsl(var(--card));
   --blob-surface-shadow: hsl(var(--shadow-color) / 0.4);
+  --blob-radius-soft: calc(var(--radius-2xl) + var(--spacing-2));
   /* Glow parity (retro-futurism) */
   /* neo-glow-strength multiplies --shadow-neon */
   --neo-glow-strength: 0.45;
   --glow-primary: hsl(var(--primary) / 0.55);
+  --glow-ring: 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22);
   --neon-outline-opacity: 0.35;
   /* Glitch normalization (identical amplitude & cadence) */
   /* 0–1 scaling for transforms/opacity */
@@ -431,6 +440,7 @@
   --glitch-noise-primary: hsl(var(--accent) / 0.25);
   --glitch-noise-secondary: hsl(var(--ring) / 0.2);
   --glitch-noise-contrast: hsl(var(--foreground) / 0.12);
+  --glitch-noise-hover: calc(var(--glitch-noise-level) * 1.3);
   /* Retro grid parity */
   --retro-grid-step: 24px;
   --retro-grid-opacity: 0.15;
@@ -601,6 +611,8 @@ html.theme-aurora {
   --surface-streak: 280 42% 14%;
   --shadow-color: 152 80% 50%;
   --shadow: 0 12px 32px hsl(var(--shadow-color) / 0.3);
+  --shadow-inner-lg: inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36);
+  --shadow-outer-xl: 0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.45);
   --neo-glow-strength: 0.4;
   --glitch-intensity: 0.4;
   --glitch-fringe: 8deg;
@@ -623,6 +635,9 @@ html.theme-aurora {
   --backdrop-drip-2: var(--accent);
   --backdrop-drip-3: var(--accent-2);
   --backdrop-drip-shadow: var(--card);
+  --glow-ring: 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22);
+  --blob-radius-soft: calc(var(--radius-2xl) + var(--spacing-2));
+  --glitch-noise-hover: calc(var(--glitch-noise-level) * 1.3);
   --edge-iris: conic-gradient(
     from 180deg,
     hsl(var(--accent-2) / 0),
@@ -667,6 +682,8 @@ html.theme-citrus {
   --surface-streak: 212 18% 16%;
   --shadow-color: 28 90% 42%;
   --shadow: 0 14px 36px hsl(var(--shadow-color) / 0.32);
+  --shadow-inner-lg: inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36);
+  --shadow-outer-xl: 0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.45);
   --neo-glow-strength: 0.45;
   --glitch-intensity: 0.38;
   --glitch-fringe: 7deg;
@@ -686,6 +703,9 @@ html.theme-citrus {
   --backdrop-drip-2: var(--citrus-teal);
   --backdrop-drip-3: var(--ring);
   --backdrop-drip-shadow: var(--card);
+  --glow-ring: 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22);
+  --blob-radius-soft: calc(var(--radius-2xl) + var(--spacing-2));
+  --glitch-noise-hover: calc(var(--glitch-noise-level) * 1.3);
 }
 /* ---------- Noir ---------- */
 html.theme-noir {
@@ -716,7 +736,9 @@ html.theme-noir {
   --shadow: 0 18px 44px hsl(var(--shadow-color) / 0.38);
   --shadow-inner-sm: inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.2);
   --shadow-inner-md: inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.3);
+  --shadow-inner-lg: inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.38);
   --shadow-outer-lg: 0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.42);
+  --shadow-outer-xl: 0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.48);
   --neo-glow-strength: 0.6;
   --glitch-intensity: 0.34;
   --glitch-fringe: 6deg;
@@ -732,10 +754,12 @@ html.theme-noir {
   --noir-ink: 352 80% 6%;
   --noir-ruby: 12 76% 46%;
   --glow-primary: hsl(var(--ring) / 0.58);
+  --glow-ring: 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.52), 0 0 var(--spacing-3) hsl(var(--ring) / 0.24);
   --blob-surface-1: hsl(352 46% 12%);
   --blob-surface-2: hsl(352 38% 18%);
   --blob-surface-3: hsl(184 68% 20%);
   --blob-surface-shadow: hsl(356 72% 10% / 0.42);
+  --blob-radius-soft: calc(var(--radius-2xl) + var(--spacing-2));
   --backdrop-blob-1: var(--noir-red);
   --backdrop-blob-2: var(--noir-rose);
   --backdrop-blob-3: var(--noir-ruby);
@@ -747,6 +771,7 @@ html.theme-noir {
   --backdrop-drip-2: var(--noir-red);
   --backdrop-drip-3: var(--noir-ruby);
   --backdrop-drip-shadow: var(--noir-ink);
+  --glitch-noise-hover: calc(var(--glitch-noise-level) * 1.35);
 }
 /* ---------- Oceanic ---------- */
 html.theme-ocean {
@@ -775,6 +800,8 @@ html.theme-ocean {
   --surface-streak: 218 22% 15%;
   --shadow-color: 198 84% 52%;
   --shadow: 0 16px 40px hsl(var(--shadow-color) / 0.34);
+  --shadow-inner-lg: inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36);
+  --shadow-outer-xl: 0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.45);
   --neo-glow-strength: 0.52;
   --glitch-intensity: 0.4;
   --glitch-fringe: 7deg;
@@ -795,6 +822,9 @@ html.theme-ocean {
   --backdrop-drip-2: var(--ocean-indigo);
   --backdrop-drip-3: var(--success);
   --backdrop-drip-shadow: var(--card);
+  --glow-ring: 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22);
+  --blob-radius-soft: calc(var(--radius-2xl) + var(--spacing-2));
+  --glitch-noise-hover: calc(var(--glitch-noise-level) * 1.3);
 }
 /* ---------- Kitten ---------- */
 html.theme-kitten {
@@ -823,6 +853,8 @@ html.theme-kitten {
   --surface-streak: 334 50% 12%;
   --shadow-color: 336 72% 48%;
   --shadow: 0 12px 30px hsl(var(--shadow-color) / 0.3);
+  --shadow-inner-lg: inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36);
+  --shadow-outer-xl: 0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.45);
   --neo-glow-strength: 0.42;
   --glitch-intensity: 0.36;
   --glitch-fringe: 6deg;
@@ -844,6 +876,9 @@ html.theme-kitten {
   --backdrop-drip-2: var(--kitten-pink);
   --backdrop-drip-3: var(--kitten-blush);
   --backdrop-drip-shadow: var(--card);
+  --glow-ring: 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22);
+  --blob-radius-soft: calc(var(--radius-2xl) + var(--spacing-2));
+  --glitch-noise-hover: calc(var(--glitch-noise-level) * 1.3);
 }
 /* ---------- Hardstuck ---------- */
 html.theme-hardstuck {
@@ -880,7 +915,9 @@ html.theme-hardstuck {
   --shadow: 0 18px 46px hsl(var(--shadow-color) / 0.4);
   --shadow-inner-sm: inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.16);
   --shadow-inner-md: inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.24);
+  --shadow-inner-lg: inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.3);
   --shadow-outer-lg: 0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.34);
+  --shadow-outer-xl: 0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.42);
   --neo-glow-strength: 0.58;
   --glitch-intensity: 0.32;
   --glitch-fringe: 5deg;
@@ -895,10 +932,12 @@ html.theme-hardstuck {
   --hardstuck-forest: 120 70% 42%;
   --hardstuck-deep: 120 82% 8%;
   --glow-primary: hsl(var(--ring) / 0.5);
+  --glow-ring: 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.48), 0 0 var(--spacing-3) hsl(var(--ring) / 0.2);
   --blob-surface-1: hsl(120 38% 14%);
   --blob-surface-2: hsl(120 44% 18%);
   --blob-surface-3: hsl(120 48% 24%);
   --blob-surface-shadow: hsl(120 72% 12% / 0.45);
+  --blob-radius-soft: calc(var(--radius-2xl) + var(--spacing-2));
   --backdrop-blob-1: var(--ring);
   --backdrop-blob-2: var(--hardstuck-forest);
   --backdrop-blob-3: var(--ring);
@@ -910,6 +949,7 @@ html.theme-hardstuck {
   --backdrop-drip-2: var(--ring);
   --backdrop-drip-3: var(--hardstuck-forest);
   --backdrop-drip-shadow: var(--hardstuck-deep);
+  --glitch-noise-hover: calc(var(--glitch-noise-level) * 1.35);
 }
 /* ---------- Retro ---------- */
 html.theme-retro {
@@ -939,11 +979,14 @@ html.theme-retro {
   --surface-vhs: 258 76% 5%;
   --surface-streak: 260 44% 13%;
   --shadow-color: 304 92% 56%;
+  --shadow-inner-lg: inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36);
+  --shadow-outer-xl: 0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.45);
   --lav-deep: 257.5 85.7% 72.5%;
   --success: 158 72% 48%;
   --success-glow: 158 72% 38% / 0.6;
   --glow: 304 100% 68%;
   --glow-active: hsl(var(--accent-2));
+  --glow-ring: 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22);
   --shadow-glow-sm:
     0 0 var(--spacing-2) hsl(var(--glow) / 0.7),
     0 0 var(--spacing-4) hsl(var(--accent-2) / 0.45);
@@ -970,6 +1013,7 @@ html.theme-retro {
   --backdrop-drip-2: var(--accent-2);
   --backdrop-drip-3: var(--accent);
   --backdrop-drip-shadow: var(--accent);
+  --blob-radius-soft: calc(var(--radius-2xl) + var(--spacing-2));
   --grid-lines:
     repeating-linear-gradient(
       90deg,
@@ -984,6 +1028,7 @@ html.theme-retro {
       hsl(var(--accent-3) / 0.12) 14px 15px,
       transparent 15px 28px
   );
+  --glitch-noise-hover: calc(var(--glitch-noise-level) * 1.35);
 }
 /* =========================================================
    Per-theme glitch backdrops

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -309,6 +309,11 @@
   --retro-grid-opacity: 0.15;
   --aa-min-contrast: 4.5;
   --glitch-overlay-opacity-card: 0.55;
+  --shadow-inner-lg: inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36);
+  --shadow-outer-xl: 0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.45);
+  --glow-ring: 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22);
+  --blob-radius-soft: calc(var(--radius-2xl) + var(--spacing-2));
+  --glitch-noise-hover: calc(var(--glitch-noise-level) * 1.3);
   --spacing-0-125: calc(var(--spacing-1) / 8);
   --spacing-0-25: calc(var(--spacing-1) / 4);
   --spacing-0-5: calc(var(--spacing-1) / 2);

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -287,6 +287,14 @@ export default {
   retroGridOpacity: "0.15",
   aaMinContrast: "4.5",
   glitchOverlayOpacityCard: "0.55",
+  shadowInnerLg:
+    "inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36)",
+  shadowOuterXl:
+    "0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.45)",
+  glowRing:
+    "0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22)",
+  blobRadiusSoft: "calc(var(--radius-2xl) + var(--spacing-2))",
+  glitchNoiseHover: "calc(var(--glitch-noise-level) * 1.3)",
   spacing0125: "calc(var(--spacing-1) / 8)",
   spacing025: "calc(var(--spacing-1) / 4)",
   spacing05: "calc(var(--spacing-1) / 2)",


### PR DESCRIPTION
## Summary
- add depth, glow, blob radius, and glitch hover tokens to the generator requirements
- provide defaults plus per-theme overrides for the new tokens to keep palettes in parity
- regenerate token docs, JS, CSS, and theme outputs to sync the pipeline

## Testing
- npm run generate-tokens
- npm run generate-themes
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dbe01fb810832cbf7767c28c27103b