### PR TITLE
chore: centralize nav configuration

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,6 +1,6 @@
 # Navigation Configuration
 
-The primary navigation bar reads from [`NAV_ITEMS`](../src/components/chrome/nav-items.ts), a shared list of `{ href, label }`
+The primary navigation bar reads from [`NAV_ITEMS`](../src/config/nav.ts), a shared list of `{ href, label }`
 objects (with an optional `mobileIcon` glyph for compact menus). Update that array when you need to rename, reorder, add, or remove top-level sections. Because the component consumes
 the exported list by default, no edits inside [`NavBar`](../src/components/chrome/NavBar.tsx) are required.
 
@@ -8,7 +8,7 @@ For feature- or context-specific navigation, pass an `items` prop to `<NavBar />
 
 ```tsx
 import NavBar from "@/components/chrome/NavBar";
-import { NAV_ITEMS } from "@/components/chrome/nav-items";
+import { NAV_ITEMS } from "@/config/nav";
 
 const projectNav = [
   ...NAV_ITEMS,

--- a/src/components/chrome/BottomNav.tsx
+++ b/src/components/chrome/BottomNav.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn, withoutBasePath } from "@/lib/utils";
-import { NAV_ITEMS, type NavItem, isNavActive } from "./nav-items";
+import { NAV_ITEMS, type NavItem, isNavActive } from "@/config/nav";
 import Spinner from "@/components/ui/feedback/Spinner";
 
 type BottomNavState =

--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -11,7 +11,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { motion, useReducedMotion } from "framer-motion";
 import { cn, withoutBasePath } from "@/lib/utils";
-import { NAV_ITEMS, NavItem, isNavActive } from "./nav-items";
+import { NAV_ITEMS, NavItem, isNavActive } from "@/config/nav";
 
 type NavBarProps = {
   items?: readonly NavItem[];

--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -78,7 +78,7 @@ import {
   PortraitFrame,
   WelcomeHeroFigure,
 } from "@/components/home";
-import { NAV_ITEMS, type NavItem } from "@/components/chrome/nav-items";
+import { NAV_ITEMS, type NavItem } from "@/config/nav";
 import ChampListEditor from "@/components/team/ChampListEditor";
 import {
   RoleSelector,

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -1,5 +1,5 @@
-// src/components/chrome/nav-items.ts
-// Navigation items shared across chrome components.
+// src/config/nav.ts
+// Shared navigation configuration for chrome components and documentation.
 
 import type { LucideIcon } from "lucide-react";
 import {

--- a/tests/chrome/SiteChrome.tab-order.e2e.ts
+++ b/tests/chrome/SiteChrome.tab-order.e2e.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { NAV_ITEMS } from "@/components/chrome/nav-items";
+import { NAV_ITEMS } from "@/config/nav";
 
 test.describe("SiteChrome tab order", () => {
   test("focus follows the primary navigation order", async ({ page }) => {

--- a/tests/chrome/SiteChrome.test.tsx
+++ b/tests/chrome/SiteChrome.test.tsx
@@ -17,7 +17,7 @@ vi.mock("@/components/ui/AnimationToggle", () => ({
 
 import SiteChrome from "@/components/chrome/SiteChrome";
 import BottomNav from "@/components/chrome/BottomNav";
-import { NAV_ITEMS } from "@/components/chrome/nav-items";
+import { NAV_ITEMS } from "@/config/nav";
 
 describe("SiteChrome", () => {
   it("links the brand to home", async () => {


### PR DESCRIPTION
## Summary
- move the shared nav configuration into src/config/nav.ts for reuse beyond chrome components
- update chrome components, gallery docs, and tests to import from the centralized config path

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dbea9978f8832cb1a6b959a59b1e8c