### PR TITLE
feat: add mobile nav drawer to site chrome

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -4,6 +4,8 @@ The primary navigation bar reads from [`NAV_ITEMS`](../src/components/chrome/nav
 objects (with an optional `mobileIcon` glyph for compact menus). Update that array when you need to rename, reorder, add, or remove top-level sections. Because the component consumes
 the exported list by default, no edits inside [`NavBar`](../src/components/chrome/NavBar.tsx) are required.
 
+On smaller breakpoints the same data powers [`MobileNavDrawer`](../src/components/chrome/MobileNavDrawer.tsx), a sheet-based menu that opens from the hamburger trigger in `SiteChrome`. The drawer automatically closes when a destination is chosen, and it will dismiss itself if the viewport crosses up to the `md` breakpoint. No extra wiring is required—`SiteChrome` handles the open state and accessibility attributes.
+
 For feature- or context-specific navigation, pass an `items` prop to `<NavBar />`:
 
 ```tsx

--- a/src/components/chrome/MobileNavDrawer.tsx
+++ b/src/components/chrome/MobileNavDrawer.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { X } from "lucide-react";
+import Sheet from "@/components/ui/Sheet";
+import IconButton from "@/components/ui/primitives/IconButton";
+import { cn, withoutBasePath } from "@/lib/utils";
+import { NAV_ITEMS, type NavItem, isNavActive } from "./nav-items";
+
+function useMediaQuery(query: string) {
+  const getMatches = React.useCallback(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return false;
+    }
+
+    try {
+      return window.matchMedia(query).matches;
+    } catch {
+      return false;
+    }
+  }, [query]);
+
+  const [matches, setMatches] = React.useState(getMatches);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const mediaQueryList = window.matchMedia(query);
+    const handleChange = (event: MediaQueryListEvent) => {
+      setMatches(event.matches);
+    };
+
+    setMatches(mediaQueryList.matches);
+
+    if (typeof mediaQueryList.addEventListener === "function") {
+      mediaQueryList.addEventListener("change", handleChange);
+      return () => {
+        mediaQueryList.removeEventListener("change", handleChange);
+      };
+    }
+
+    mediaQueryList.addListener(handleChange);
+    return () => {
+      mediaQueryList.removeListener(handleChange);
+    };
+  }, [getMatches, query]);
+
+  return matches;
+}
+
+export type MobileNavDrawerProps = {
+  open: boolean;
+  onClose: () => void;
+  items?: readonly NavItem[];
+  id?: string;
+};
+
+export default function MobileNavDrawer({
+  open,
+  onClose,
+  items = NAV_ITEMS,
+  id,
+}: MobileNavDrawerProps) {
+  const rawPathname = usePathname() ?? "/";
+  const pathname = withoutBasePath(rawPathname);
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+
+  React.useEffect(() => {
+    if (open && isDesktop) {
+      onClose();
+    }
+  }, [open, isDesktop, onClose]);
+
+  return (
+    <Sheet
+      open={open && !isDesktop}
+      onClose={onClose}
+      side="left"
+      className="md:hidden border border-border/40 bg-surface/95 shadow-[var(--shadow-neo-soft)]"
+    >
+      <div className="flex h-full flex-col pb-[calc(env(safe-area-inset-bottom)+var(--space-4))]">
+        <div className="flex items-center justify-between px-[var(--space-4)] pt-[calc(env(safe-area-inset-top)+var(--space-2))] pb-[var(--space-3)]">
+          <p className="text-label font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+            Menu
+          </p>
+          <IconButton
+            aria-label="Close navigation"
+            variant="secondary"
+            size="md"
+            onClick={onClose}
+            className="shadow-[var(--shadow-glow-sm)]"
+          >
+            <X aria-hidden="true" className="size-[calc(var(--control-h-md)/2)]" />
+          </IconButton>
+        </div>
+        <nav
+          role="navigation"
+          aria-label="Primary mobile navigation"
+          id={id}
+          className="px-[var(--space-2)]"
+        >
+          <ul className="flex flex-col gap-[var(--space-1)]">
+            {items.map(({ href, label, mobileIcon: Icon }) => {
+              const active = isNavActive(pathname, href);
+
+              return (
+                <li key={href}>
+                  <Link
+                    href={href}
+                    aria-current={active ? "page" : undefined}
+                    onClick={onClose}
+                    className={cn(
+                      "group flex items-center gap-[var(--space-2)] rounded-full px-[var(--space-3)] py-[var(--space-2)] text-ui font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus)] focus-visible:ring-offset-0",
+                      "bg-surface/80 text-muted-foreground shadow-[var(--shadow-glow-sm)] backdrop-blur",
+                      "hover:text-foreground focus-visible:text-foreground",
+                      active &&
+                        "text-foreground shadow-[var(--shadow-glow-md)] ring-1 ring-[hsl(var(--accent)/0.4)]",
+                    )}
+                  >
+                    {Icon ? (
+                      <span
+                        aria-hidden="true"
+                        className="flex size-[var(--space-4)] items-center justify-center text-muted-foreground transition-colors group-hover:text-foreground group-focus-visible:text-foreground"
+                      >
+                        <Icon className="size-full" strokeWidth={1.75} />
+                      </span>
+                    ) : null}
+                    <span className="flex-1 text-left">{label}</span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+      </div>
+    </Sheet>
+  );
+}

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -3,12 +3,14 @@
 import "@/app/globals.css";
 import * as React from "react";
 import NavBar from "@/components/chrome/NavBar";
-import BottomNav from "@/components/chrome/BottomNav";
+import MobileNavDrawer from "@/components/chrome/MobileNavDrawer";
 import BrandWordmark from "@/components/chrome/BrandWordmark";
 import ThemeToggle from "@/components/ui/theme/ThemeToggle";
 import AnimationToggle from "@/components/ui/AnimationToggle";
 import { PageShell } from "@/components/ui";
 import Link from "next/link";
+import IconButton from "@/components/ui/primitives/IconButton";
+import { Menu } from "lucide-react";
 
 export type SiteChromeProps = {
   children?: React.ReactNode;
@@ -21,6 +23,15 @@ export type SiteChromeProps = {
  * - Z-index > heroes, so it stays above scrolling headers
  */
 export default function SiteChrome({ children }: SiteChromeProps) {
+  const [mobileNavOpen, setMobileNavOpen] = React.useState(false);
+  const navId = React.useId();
+  const openMobileNav = React.useCallback(() => {
+    setMobileNavOpen(true);
+  }, []);
+  const closeMobileNav = React.useCallback(() => {
+    setMobileNavOpen(false);
+  }, []);
+
   return (
     <React.Fragment>
       <header
@@ -57,7 +68,21 @@ export default function SiteChrome({ children }: SiteChromeProps) {
             <NavBar />
           </div>
 
-          <div className="col-span-full flex items-center justify-end md:col-span-3 md:justify-self-end">
+          <div className="col-span-full flex items-center justify-end gap-[var(--space-1)] md:col-span-3 md:justify-self-end">
+            <div className="md:hidden">
+              <IconButton
+                aria-label="Open navigation"
+                aria-haspopup="dialog"
+                aria-expanded={mobileNavOpen}
+                aria-controls={navId}
+                variant="secondary"
+                size="md"
+                onClick={openMobileNav}
+                className="shadow-[var(--shadow-glow-sm)]"
+              >
+                <Menu aria-hidden="true" className="size-[calc(var(--control-h-md)/2)]" />
+              </IconButton>
+            </div>
             <div className="inline-flex items-center gap-[var(--space-1)] rounded-full bg-surface/70 px-[var(--space-2)] py-[var(--space-1)] shadow-[var(--shadow-glow-sm)] backdrop-blur">
               <ThemeToggle className="shrink-0" />
               <div className="shrink-0">
@@ -65,10 +90,11 @@ export default function SiteChrome({ children }: SiteChromeProps) {
               </div>
             </div>
           </div>
-
-          <div className="col-span-full md:hidden">
-            <BottomNav />
-          </div>
+          <MobileNavDrawer
+            id={navId}
+            open={mobileNavOpen}
+            onClose={closeMobileNav}
+          />
         </PageShell>
       </header>
       {children}

--- a/tests/chrome/SiteChrome.tab-order.e2e.ts
+++ b/tests/chrome/SiteChrome.tab-order.e2e.ts
@@ -25,20 +25,25 @@ test.describe("SiteChrome tab order", () => {
     }
   });
 
-  test("mobile bottom nav supports keyboard activation", async ({ page }) => {
+  test("mobile drawer supports keyboard activation", async ({ page }) => {
     await page.setViewportSize({ width: 480, height: 720 });
 
     await page.goto("/planner");
+    const trigger = page.getByRole("button", { name: "Open navigation" });
+    await trigger.focus();
+    await page.keyboard.press("Enter");
+
     await expect(
       page.getByRole("navigation", { name: "Primary mobile navigation" }),
     ).toBeVisible();
 
-    const promptsItem = page.getByRole("button", { name: /Prompts/ });
+    const promptsItem = page.getByRole("link", { name: /Prompts/ });
     await promptsItem.focus();
     await expect(promptsItem).toBeFocused();
 
     await page.keyboard.press("Enter");
-    await expect(promptsItem).toHaveAttribute("aria-pressed", "true");
-    await expect(promptsItem).toHaveAttribute("aria-current", "page");
+    await page.waitForFunction(
+      () => window.location.pathname.endsWith("/prompts"),
+    );
   });
 });

--- a/tests/chrome/SiteChrome.test.tsx
+++ b/tests/chrome/SiteChrome.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, within, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 
 vi.mock("next/navigation", () => ({
@@ -31,15 +32,35 @@ describe("SiteChrome", () => {
     expect(link).toHaveAttribute("href", "/");
   });
 
-  it("renders the mobile navigation", () => {
+  it("renders the mobile navigation drawer when opened", async () => {
+    const user = userEvent.setup();
     render(
       <SiteChrome>
         <div />
       </SiteChrome>,
     );
+
     expect(
-      screen.getByRole("navigation", { name: "Primary mobile navigation" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("navigation", { name: "Primary mobile navigation" }),
+    ).not.toBeInTheDocument();
+
+    const trigger = screen.getByRole("button", { name: "Open navigation" });
+    await user.click(trigger);
+
+    const drawerNav = await screen.findByRole("navigation", {
+      name: "Primary mobile navigation",
+    });
+    expect(drawerNav).toBeInTheDocument();
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(within(drawerNav).getByRole("link", { name: "Planner" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("navigation", { name: "Primary mobile navigation" }),
+      ).not.toBeInTheDocument();
+    });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
   });
 
   it("renders provided children", () => {
@@ -51,18 +72,21 @@ describe("SiteChrome", () => {
     expect(screen.getByTestId("inner")).toBeInTheDocument();
   });
 
-  it("exposes pressed and busy states for bottom navigation items", () => {
+  it("marks the active route inside the mobile drawer", async () => {
+    const user = userEvent.setup();
     render(
       <SiteChrome>
         <div />
       </SiteChrome>,
     );
-    const bottomNav = screen.getByRole("navigation", {
+
+    await user.click(screen.getByRole("button", { name: "Open navigation" }));
+
+    const drawerNav = await screen.findByRole("navigation", {
       name: "Primary mobile navigation",
     });
-    const plannerItem = within(bottomNav).getByRole("button", { name: "Planner" });
-    expect(plannerItem).toHaveAttribute("aria-pressed", "true");
-    expect(plannerItem).toHaveAttribute("aria-current", "page");
+    const plannerLink = within(drawerNav).getByRole("link", { name: "Planner" });
+    expect(plannerLink).toHaveAttribute("aria-current", "page");
   });
 });
 

--- a/tests/ui/SiteChrome.test.tsx
+++ b/tests/ui/SiteChrome.test.tsx
@@ -1,9 +1,6 @@
 import * as React from "react";
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
-vi.mock("@/components/chrome/BottomNav", () => ({
-  default: () => <nav />,
-}));
+import { describe, it, expect } from "vitest";
 import SiteChrome from "@/components/chrome/SiteChrome";
 import { ThemeProvider } from "@/lib/theme-context";
 


### PR DESCRIPTION
## Summary
- replace the BottomNav footer in SiteChrome with a hamburger trigger that controls a Sheet-based MobileNavDrawer
- implement the MobileNavDrawer component so it renders NAV_ITEMS on small screens and auto-closes on navigation or when resizing above md
- document the drawer in navigation guidance and update unit/e2e coverage for the drawer behaviour

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dbea9a3704832c8ec96d29fbf267ae