### PR TITLE
fix: expose display controls via region toolbar

### DIFF
--- a/src/components/chrome/MobileNavDrawer.tsx
+++ b/src/components/chrome/MobileNavDrawer.tsx
@@ -7,7 +7,7 @@ import { X } from "lucide-react";
 import Sheet from "@/components/ui/Sheet";
 import IconButton from "@/components/ui/primitives/IconButton";
 import { cn, withoutBasePath } from "@/lib/utils";
-import { NAV_ITEMS, type NavItem, isNavActive } from "./nav-items";
+import { NAV_ITEMS, type NavItem, isNavActive } from "@/config/nav";
 
 function useMediaQuery(query: string) {
   const getMatches = React.useCallback(() => {

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -83,10 +83,20 @@ export default function SiteChrome({ children }: SiteChromeProps) {
                 <Menu aria-hidden="true" className="size-[calc(var(--control-h-md)/2)]" />
               </IconButton>
             </div>
-            <div className="inline-flex items-center gap-[var(--space-1)] rounded-full bg-surface/70 px-[var(--space-2)] py-[var(--space-1)] shadow-[var(--shadow-glow-sm)] backdrop-blur">
-              <ThemeToggle className="shrink-0" />
-              <div className="shrink-0">
-                <AnimationToggle />
+            <div
+              role="region"
+              aria-label="Display controls"
+              className="rounded-full bg-surface/70 px-[var(--space-2)] py-[var(--space-1)] shadow-[var(--shadow-glow-sm)] backdrop-blur"
+            >
+              <div
+                role="toolbar"
+                aria-label="Display controls"
+                className="inline-flex items-center gap-[var(--space-1)]"
+              >
+                <ThemeToggle className="shrink-0" />
+                <div className="shrink-0">
+                  <AnimationToggle />
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- wrap the SiteChrome display toggles in a labeled region and toolbar for improved accessibility
- update the mobile navigation drawer to import nav items from the shared config so builds resolve the module consistently

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dbf73b1704832c807a24af611e0b27