### PR TITLE
Add glitch states to primitive galleries

### DIFF
--- a/src/components/chrome/MobileNavDrawer.tsx
+++ b/src/components/chrome/MobileNavDrawer.tsx
@@ -7,7 +7,7 @@ import { X } from "lucide-react";
 import Sheet from "@/components/ui/Sheet";
 import IconButton from "@/components/ui/primitives/IconButton";
 import { cn, withoutBasePath } from "@/lib/utils";
-import { NAV_ITEMS, type NavItem, isNavActive } from "./nav-items";
+import { NAV_ITEMS, type NavItem, isNavActive } from "@/config/nav";
 
 function useMediaQuery(query: string) {
   const getMatches = React.useCallback(() => {

--- a/src/components/ui/primitives/Badge.gallery.tsx
+++ b/src/components/ui/primitives/Badge.gallery.tsx
@@ -52,6 +52,11 @@ function BadgeGalleryPreview() {
           </Badge>
         ))}
       </div>
+      <p className="text-caption text-muted-foreground">
+        Glitch rail tokens hue-shift per theme; Noir + Hardstuck clamp the
+        overlay alpha so these role badges keep ≥3:1 text contrast across the
+        noise.
+      </p>
     </div>
   );
 }
@@ -114,6 +119,11 @@ export default defineGallerySection({
             { value: "Interactive" },
             { value: "Selected" },
             { value: "Disabled" },
+            {
+              value: "Glitch overlay",
+              description:
+                "Glitch rail uses theme hue/alpha clamps so Noir + Hardstuck preserve ≥3:1 text contrast.",
+            },
           ],
         },
       ],

--- a/src/components/ui/primitives/Button.gallery.tsx
+++ b/src/components/ui/primitives/Button.gallery.tsx
@@ -55,6 +55,16 @@ const BUTTON_STATES: readonly ButtonStateSpec[] = [
     props: { children: "Loading", loading: true },
     code: "<Button loading>Loading</Button>",
   },
+  {
+    id: "glitch",
+    name: "Glitch overlay",
+    props: {
+      children: "Glitch overlay",
+      glitch: true,
+      glitchIntensity: "glitch-overlay-button-opacity",
+    },
+    code: `<Button glitch glitchIntensity="glitch-overlay-button-opacity">Glitch overlay</Button>`,
+  },
 ];
 
 const BUTTON_SIZE_ORDER: readonly ButtonSize[] = ["sm", "md", "lg", "xl"];
@@ -77,6 +87,9 @@ function ButtonStatePreview({ state }: { state: ButtonStateSpec }) {
 }
 
 function ButtonGalleryPreview() {
+  const glitchState = BUTTON_STATES.find((state) => state.id === "glitch");
+  const standardStates = BUTTON_STATES.filter((state) => state.id !== "glitch");
+
   return (
     <div className="flex flex-col gap-[var(--space-4)]">
       <div className="flex flex-wrap gap-[var(--space-2)]">
@@ -120,10 +133,22 @@ function ButtonGalleryPreview() {
         ))}
       </div>
       <div className="flex flex-wrap gap-[var(--space-2)]">
-        {BUTTON_STATES.map((state) => (
+        {standardStates.map((state) => (
           <ButtonStatePreview key={state.id} state={state} />
         ))}
       </div>
+      {glitchState ? (
+        <div className="space-y-[var(--space-1)]">
+          <div className="flex flex-wrap gap-[var(--space-2)]">
+            <ButtonStatePreview state={glitchState} />
+          </div>
+          <p className="text-caption text-muted-foreground">
+            Glitch overlay uses theme noise tokens so Noir and Hardstuck clamp
+            the static mix for ≥3:1 contrast—keep copy on the default{" "}
+            <code className="ml-[var(--space-1)]">text-foreground</code> tone.
+          </p>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -181,7 +206,13 @@ export default defineGallerySection({
           id: "state",
           label: "State",
           type: "state",
-          values: BUTTON_STATES.map(({ name }) => ({ value: name })),
+          values: BUTTON_STATES.map(({ name, id }) => ({
+            value: name,
+            description:
+              id === "glitch"
+                ? "Glitch overlay relies on --glitch-overlay-button-opacity and theme noise tokens; Noir + Hardstuck clamp intensity for ≥3:1 contrast."
+                : undefined,
+          })),
         },
       ],
       preview: createGalleryPreview({

--- a/src/components/ui/primitives/Field.gallery.tsx
+++ b/src/components/ui/primitives/Field.gallery.tsx
@@ -99,6 +99,21 @@ const SearchFieldState: React.FC = () => {
   );
 };
 
+const GlitchFieldState: React.FC = () => (
+  <Field.Root
+    glitch
+    glitchText="Player lookup"
+    helper="Overlay pulls from accent + ring tokens"
+    helperId="field-glitch-helper"
+  >
+    <Field.Input
+      aria-describedby="field-glitch-helper"
+      placeholder="Glitch overlay"
+      indent
+    />
+  </Field.Root>
+);
+
 const FIELD_STATES: readonly FieldStateSpec[] = [
   {
     id: "default",
@@ -200,14 +215,33 @@ const FIELD_STATES: readonly FieldStateSpec[] = [
   />
 </Field.Root>`,
   },
+  {
+    id: "glitch",
+    name: "Glitch overlay",
+    Component: GlitchFieldState,
+    code: `<Field.Root glitch glitchText="Player lookup" helper="Overlay pulls from accent + ring tokens" helperId="field-glitch-helper">\n  <Field.Input aria-describedby="field-glitch-helper" placeholder="Glitch overlay" indent />\n</Field.Root>`,
+  },
 ];
 
 function FieldGalleryPreview() {
   return (
     <div className="flex flex-col gap-[var(--space-3)]">
-      {FIELD_STATES.map(({ id, Component }) => (
-        <Component key={id} />
-      ))}
+      {FIELD_STATES.filter((state) => state.id !== "glitch").map(
+        ({ id, Component }) => (
+          <Component key={id} />
+        ),
+      )}
+      <div className="space-y-[var(--space-1)]">
+        <GlitchFieldState />
+        <p className="text-caption text-muted-foreground">
+          Glitch fields default to{" "}
+          <code className="mx-[var(--space-1)]">
+            --glitch-overlay-button-opacity-reduced
+          </code>
+          so Noir and Hardstuck keep helper/counter copy legible while the
+          chroma noise animates.
+        </p>
+      </div>
     </div>
   );
 }
@@ -236,7 +270,13 @@ export default defineGallerySection({
           id: "state",
           label: "State",
           type: "state",
-          values: FIELD_STATES.map(({ name }) => ({ value: name })),
+          values: FIELD_STATES.map(({ name, id }) => ({
+            value: name,
+            description:
+              id === "glitch"
+                ? "Glitch overlay rides reduced opacity + hue tokens to keep helper/counter text readable in Noir + Hardstuck."
+                : undefined,
+          })),
         },
       ],
       preview: createGalleryPreview({

--- a/src/components/ui/primitives/IconButton.gallery.tsx
+++ b/src/components/ui/primitives/IconButton.gallery.tsx
@@ -67,6 +67,17 @@ const ICON_BUTTON_STATES: readonly IconButtonStateSpec[] = [
     },
     code: "<IconButton loading aria-label=\"Loading\">\n  <Plus />\n</IconButton>",
   },
+  {
+    id: "glitch",
+    name: "Glitch overlay",
+    props: {
+      "aria-label": "Glitch overlay",
+      children: <Plus aria-hidden />,
+      glitch: true,
+      glitchIntensity: "glitch-overlay-button-opacity",
+    },
+    code: "<IconButton glitch glitchIntensity=\"glitch-overlay-button-opacity\" aria-label=\"Glitch overlay\">\n  <Plus />\n</IconButton>",
+  },
 ];
 
 const PRIMARY_ICON_BUTTON_STATES: readonly IconButtonStateSpec[] = [
@@ -114,6 +125,11 @@ function IconButtonStatePreview({ state }: { state: IconButtonStateSpec }) {
 const ICON_BUTTON_SIZES = ["sm", "md", "lg", "xl"] as const;
 
 function IconButtonGalleryPreview() {
+  const glitchState = ICON_BUTTON_STATES.find((state) => state.id === "glitch");
+  const standardIconStates = ICON_BUTTON_STATES.filter(
+    (state) => state.id !== "glitch",
+  );
+
   return (
     <div className="flex flex-col gap-[var(--space-4)]">
       <div className="flex flex-wrap gap-[var(--space-2)]">
@@ -143,10 +159,22 @@ function IconButtonGalleryPreview() {
         </IconButton>
       </div>
       <div className="flex flex-wrap gap-[var(--space-2)]">
-        {ICON_BUTTON_STATES.map((state) => (
+        {standardIconStates.map((state) => (
           <IconButtonStatePreview key={state.id} state={state} />
         ))}
       </div>
+      {glitchState ? (
+        <div className="space-y-[var(--space-1)]">
+          <div className="flex flex-wrap gap-[var(--space-2)]">
+            <IconButtonStatePreview state={glitchState} />
+          </div>
+          <p className="text-caption text-muted-foreground">
+            Primary glitch tokens hue-shift per theme; Noir and Hardstuck thin
+            the ring/halo alpha to hold ≥3:1 contrast around the control
+            silhouette.
+          </p>
+        </div>
+      ) : null}
       <div className="flex flex-wrap gap-[var(--space-2)]">
         {PRIMARY_ICON_BUTTON_STATES.map((state) => (
           <IconButtonStatePreview key={state.id} state={state} />
@@ -198,7 +226,13 @@ export default defineGallerySection({
           label: "State",
           type: "state",
           values: [...ICON_BUTTON_STATES, ...PRIMARY_ICON_BUTTON_STATES].map(
-            ({ name }) => ({ value: name }),
+            ({ name, id }) => ({
+              value: name,
+              description:
+                id === "glitch"
+                  ? "Glitch overlay uses theme hue + alpha adjustments so Noir and Hardstuck keep the halo readable."
+                  : undefined,
+            }),
           ),
         },
       ],

--- a/src/components/ui/primitives/Input.gallery.tsx
+++ b/src/components/ui/primitives/Input.gallery.tsx
@@ -60,6 +60,16 @@ const INPUT_STATES: readonly InputStateSpec[] = [
     props: { placeholder: "Custom ring", ringTone: "danger" },
     code: "<Input placeholder=\"Custom ring\" ringTone=\"danger\" />",
   },
+  {
+    id: "glitch",
+    name: "Glitch overlay",
+    props: {
+      placeholder: "Glitch overlay",
+      glitch: true,
+      glitchText: "Summoner search",
+    },
+    code: `<Input glitch glitchText="Summoner search" placeholder="Glitch overlay" />`,
+  },
 ];
 
 function InputStatePreview({ state }: { state: InputStateSpec }) {
@@ -68,11 +78,27 @@ function InputStatePreview({ state }: { state: InputStateSpec }) {
 }
 
 function InputGalleryPreview() {
+  const glitchState = INPUT_STATES.find((state) => state.id === "glitch");
+  const standardStates = INPUT_STATES.filter((state) => state.id !== "glitch");
+
   return (
     <div className="flex flex-col gap-[var(--space-2)]">
-      {INPUT_STATES.map((state) => (
+      {standardStates.map((state) => (
         <InputStatePreview key={state.id} state={state} />
       ))}
+      {glitchState ? (
+        <div className="space-y-[var(--space-1)]">
+          <InputStatePreview state={glitchState} />
+          <p className="text-caption text-muted-foreground">
+            Field shells use{" "}
+            <code className="mx-[var(--space-1)]">
+              --glitch-overlay-button-opacity-reduced
+            </code>
+            so Noir and Hardstuck maintain ≥4.5:1 placeholder contrast while the
+            overlay animates.
+          </p>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -102,7 +128,13 @@ export default defineGallerySection({
           id: "state",
           label: "State",
           type: "state",
-          values: INPUT_STATES.map(({ name }) => ({ value: name })),
+          values: INPUT_STATES.map(({ name, id }) => ({
+            value: name,
+            description:
+              id === "glitch"
+                ? "Glitch overlay inherits Field's reduced opacity token so Noir + Hardstuck stay above 4.5:1."
+                : undefined,
+          })),
         },
       ],
       preview: createGalleryPreview({


### PR DESCRIPTION
## Summary
- add glitch overlay coverage, notes, and axis metadata to button, input, icon button, field, and badge galleries
- surface theme-specific contrast guidance for the new glitch variants so reviewers can audit overlays across themes
- fix the mobile nav drawer to read NAV_ITEMS from the shared config module, restoring the failing gallery checks

## Testing
- npm run check
- npx playwright test tests/e2e/gallery-preview.spec.ts --reporter=line *(skipped by environment guard)*
- npx playwright test tests/e2e/accessibility.spec.ts --reporter=line *(skipped by environment guard)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf7d283e8832ca367e7521b16066b