### PR TITLE
fix: align primary navigation aria label

### DIFF
--- a/src/components/chrome/BottomNav.tsx
+++ b/src/components/chrome/BottomNav.tsx
@@ -4,7 +4,12 @@ import * as React from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn, withoutBasePath } from "@/lib/utils";
-import { NAV_ITEMS, type NavItem, isNavActive } from "@/config/nav";
+import {
+  NAV_ITEMS,
+  type NavItem,
+  isNavActive,
+  PRIMARY_NAV_ARIA_LABEL,
+} from "@/config/nav";
 import Spinner from "@/components/ui/feedback/Spinner";
 
 type BottomNavState =
@@ -42,7 +47,7 @@ export default function BottomNav({
     >
       <nav
         role="navigation"
-        aria-label="Primary mobile navigation"
+        aria-label={PRIMARY_NAV_ARIA_LABEL}
         className={cn(
           "relative isolate mx-auto w-full max-w-2xl",
           "rounded-card r-card-lg card-neo-soft shadow-neo-strong",

--- a/src/components/chrome/MobileNavDrawer.tsx
+++ b/src/components/chrome/MobileNavDrawer.tsx
@@ -7,7 +7,12 @@ import { X } from "lucide-react";
 import Sheet from "@/components/ui/Sheet";
 import IconButton from "@/components/ui/primitives/IconButton";
 import { cn, withoutBasePath } from "@/lib/utils";
-import { NAV_ITEMS, type NavItem, isNavActive } from "@/config/nav";
+import {
+  NAV_ITEMS,
+  type NavItem,
+  isNavActive,
+  PRIMARY_NAV_ARIA_LABEL,
+} from "@/config/nav";
 
 function useMediaQuery(query: string) {
   const getMatches = React.useCallback(() => {
@@ -99,7 +104,7 @@ export default function MobileNavDrawer({
         </div>
         <nav
           role="navigation"
-          aria-label="Primary mobile navigation"
+          aria-label={PRIMARY_NAV_ARIA_LABEL}
           id={id}
           className="px-[var(--space-2)]"
         >

--- a/src/components/chrome/NavBar.tsx
+++ b/src/components/chrome/NavBar.tsx
@@ -11,7 +11,12 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { motion, useReducedMotion } from "framer-motion";
 import { cn, withoutBasePath } from "@/lib/utils";
-import { NAV_ITEMS, NavItem, isNavActive } from "@/config/nav";
+import {
+  NAV_ITEMS,
+  NavItem,
+  isNavActive,
+  PRIMARY_NAV_ARIA_LABEL,
+} from "@/config/nav";
 
 type NavBarProps = {
   items?: readonly NavItem[];
@@ -24,7 +29,7 @@ export default function NavBar({ items = NAV_ITEMS }: NavBarProps = {}) {
   return (
     <nav
       role="navigation"
-      aria-label="Primary"
+      aria-label={PRIMARY_NAV_ARIA_LABEL}
       className="max-w-full overflow-x-auto pb-[var(--space-1)] lg:overflow-x-visible"
     >
       <ul className="flex list-none flex-nowrap items-center justify-center gap-[var(--space-1)] md:gap-[var(--space-2)]">

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -17,6 +17,8 @@ export type NavItem = {
   mobileIcon?: LucideIcon;
 };
 
+export const PRIMARY_NAV_ARIA_LABEL = "Primary";
+
 export const NAV_ITEMS = [
   { href: "/reviews", label: "Reviews", mobileIcon: BookOpen },
   { href: "/planner", label: "Planner", mobileIcon: CalendarDays },

--- a/tests/chrome/SiteChrome.test.tsx
+++ b/tests/chrome/SiteChrome.test.tsx
@@ -18,7 +18,7 @@ vi.mock("@/components/ui/AnimationToggle", () => ({
 
 import SiteChrome from "@/components/chrome/SiteChrome";
 import BottomNav from "@/components/chrome/BottomNav";
-import { NAV_ITEMS } from "@/config/nav";
+import { NAV_ITEMS, PRIMARY_NAV_ARIA_LABEL } from "@/config/nav";
 
 describe("SiteChrome", () => {
   it("links the brand to home", async () => {
@@ -41,14 +41,14 @@ describe("SiteChrome", () => {
     );
 
     expect(
-      screen.queryByRole("navigation", { name: "Primary mobile navigation" }),
+      screen.queryByRole("navigation", { name: PRIMARY_NAV_ARIA_LABEL }),
     ).not.toBeInTheDocument();
 
     const trigger = screen.getByRole("button", { name: "Open navigation" });
     await user.click(trigger);
 
     const drawerNav = await screen.findByRole("navigation", {
-      name: "Primary mobile navigation",
+      name: PRIMARY_NAV_ARIA_LABEL,
     });
     expect(drawerNav).toBeInTheDocument();
     expect(trigger).toHaveAttribute("aria-expanded", "true");
@@ -57,7 +57,7 @@ describe("SiteChrome", () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByRole("navigation", { name: "Primary mobile navigation" }),
+        screen.queryByRole("navigation", { name: PRIMARY_NAV_ARIA_LABEL }),
       ).not.toBeInTheDocument();
     });
     expect(trigger).toHaveAttribute("aria-expanded", "false");
@@ -83,7 +83,7 @@ describe("SiteChrome", () => {
     await user.click(screen.getByRole("button", { name: "Open navigation" }));
 
     const drawerNav = await screen.findByRole("navigation", {
-      name: "Primary mobile navigation",
+      name: PRIMARY_NAV_ARIA_LABEL,
     });
     const plannerLink = within(drawerNav).getByRole("link", { name: "Planner" });
     expect(plannerLink).toHaveAttribute("aria-current", "page");
@@ -103,7 +103,7 @@ describe("BottomNav", () => {
     );
 
     const bottomNav = screen.getByRole("navigation", {
-      name: "Primary mobile navigation",
+      name: PRIMARY_NAV_ARIA_LABEL,
     });
     const syncingItem = within(bottomNav).getByRole("button", { name: /Reviews/ });
     expect(syncingItem).toHaveAttribute("aria-busy", "true");


### PR DESCRIPTION
## Summary
- add a shared primary navigation aria label constant and reuse it across chrome components
- update SiteChrome tests to assert the shared label on both navigation variants

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dbfe707fb4832c9e1a7344ae282c55