### PR TITLE
chore: centralize md media query

### DIFF
--- a/src/components/chrome/MobileNavDrawer.tsx
+++ b/src/components/chrome/MobileNavDrawer.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import { X } from "lucide-react";
 import Sheet from "@/components/ui/Sheet";
 import IconButton from "@/components/ui/primitives/IconButton";
+import { MEDIA_QUERY_MD } from "@/lib/breakpoints";
 import { cn, withoutBasePath } from "@/lib/utils";
 import { type NavItem, NAV_ITEMS, isNavActive } from "@/config/nav";
 
@@ -67,7 +68,7 @@ export default function MobileNavDrawer({
 }: MobileNavDrawerProps) {
   const rawPathname = usePathname() ?? "/";
   const pathname = withoutBasePath(rawPathname);
-  const isDesktop = useMediaQuery("(min-width: 768px)");
+  const isDesktop = useMediaQuery(MEDIA_QUERY_MD);
 
   React.useEffect(() => {
     if (open && isDesktop) {

--- a/src/lib/breakpoints.ts
+++ b/src/lib/breakpoints.ts
@@ -1,0 +1,1 @@
+export const MEDIA_QUERY_MD = "(min-width: 48rem)" as const;


### PR DESCRIPTION
## Summary
- add a shared MEDIA_QUERY_MD constant aligned with Tailwind's md breakpoint
- update MobileNavDrawer to consume the shared breakpoint constant instead of a literal string

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dc010716ac832c8a8fef8affb98baf