### PR TITLE
Fix persistent state reset when storage key changes

### DIFF
--- a/tests/lib/Db.test.ts
+++ b/tests/lib/Db.test.ts
@@ -590,6 +590,42 @@ describe("Db", () => {
       });
     });
 
+    it("uses the latest initial value provided after a key swap", async () => {
+      const { usePersistentState } = await import("@/lib/db");
+
+      const { result, rerender } = renderHook(
+        ({ storageKey, initial }) => usePersistentState(storageKey, initial),
+        {
+          initialProps: {
+            storageKey: "preview:first",
+            initial: { variant: "aurora" },
+          },
+        },
+      );
+
+      act(() => {
+        result.current[1]({ variant: "glitch" });
+      });
+
+      rerender({
+        storageKey: "preview:second",
+        initial: { variant: "aurora" },
+      });
+
+      await waitFor(() => {
+        expect(result.current[0]).toEqual({ variant: "aurora" });
+      });
+
+      rerender({
+        storageKey: "preview:second",
+        initial: { variant: "oceanic" },
+      });
+
+      await waitFor(() => {
+        expect(result.current[0]).toEqual({ variant: "oceanic" });
+      });
+    });
+
     it("persists prompts saved before hydration completes", async () => {
       const { usePromptLibrary } = await import(
         "@/components/prompts/usePromptLibrary"


### PR DESCRIPTION
## Summary
- ensure `usePersistentState` tracks pending resets per storage key so fresh views adopt the latest initial value
- update storage and external sync handlers to clear or restore the pending reset flag appropriately and wrap the setter
- add a regression test that covers swapping storage keys before new defaults finish hydrating

## Testing
- npx vitest run tests/lib/Db.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dbfee62108832caa67f5efcdb91d59