### PR TITLE
Fix nav and background preview server module

### DIFF
--- a/src/app/(previews)/nav-and-bg/ThemeCycleControl.tsx
+++ b/src/app/(previews)/nav-and-bg/ThemeCycleControl.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  BG_CLASSES,
+  VARIANTS,
+  VARIANT_LABELS,
+  applyTheme,
+  type Background,
+  type ThemeState,
+} from "@/lib/theme";
+import { useTheme } from "@/lib/theme-context";
+
+const BACKGROUND_VALUES: readonly Background[] = BG_CLASSES.map(
+  (_, index) => index as Background,
+);
+
+const THEME_SEQUENCE: readonly ThemeState[] = VARIANTS.flatMap(({ id }) =>
+  BACKGROUND_VALUES.map((bg) => ({
+    variant: id,
+    bg,
+  })),
+);
+
+const BACKGROUND_LABELS: Record<Background, string> = {
+  0: "Base",
+  1: "Alt 1",
+  2: "Alt 2",
+  3: "VHS",
+  4: "Streak",
+};
+
+const themeSequenceLength = THEME_SEQUENCE.length;
+
+const findThemeIndex = ({ variant, bg }: ThemeState): number => {
+  return THEME_SEQUENCE.findIndex(
+    (candidate) => candidate.variant === variant && candidate.bg === bg,
+  );
+};
+
+const getNextThemeState = (current: ThemeState): ThemeState => {
+  const currentIndex = findThemeIndex(current);
+  const nextIndex =
+    currentIndex >= 0
+      ? (currentIndex + 1) % themeSequenceLength
+      : 0;
+  return THEME_SEQUENCE[nextIndex];
+};
+
+export default function ThemeCycleControl(): React.JSX.Element {
+  const [theme, setTheme] = useTheme();
+  const variantLabel = VARIANT_LABELS[theme.variant] ?? theme.variant;
+  const backgroundLabel = BACKGROUND_LABELS[theme.bg] ?? `Alt ${theme.bg}`;
+
+  const handleCycle = React.useCallback(() => {
+    setTheme((previous) => {
+      const nextTheme = getNextThemeState(previous);
+
+      if (typeof document !== "undefined") {
+        const { documentElement } = document;
+        if (documentElement) {
+          documentElement.dataset.themePref = "persisted";
+        }
+      }
+
+      applyTheme(nextTheme);
+      return nextTheme;
+    });
+  }, [setTheme]);
+
+  const currentIndex = React.useMemo(() => {
+    const index = findThemeIndex(theme);
+    return index >= 0 ? index + 1 : 1;
+  }, [theme]);
+
+  return (
+    <div className="flex flex-wrap items-center gap-[var(--space-2)] text-body-sm text-muted-foreground">
+      <span>
+        Showing <span className="font-medium text-foreground">{variantLabel}</span>
+        {" · "}
+        <span className="font-medium text-foreground">{backgroundLabel}</span>
+      </span>
+      <span className="text-body-xs text-muted-foreground/80">
+        {currentIndex} of {themeSequenceLength}
+      </span>
+      <button
+        type="button"
+        onClick={handleCycle}
+        className="inline-flex items-center gap-[var(--space-1)] rounded-full border border-border bg-surface px-[var(--space-3)] py-[var(--space-1)] font-medium text-foreground transition-colors duration-quick ease-out hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0 active:text-[hsl(var(--accent-contrast))]"
+      >
+        Cycle theme
+      </button>
+    </div>
+  );
+}

--- a/src/app/(previews)/nav-and-bg/page.tsx
+++ b/src/app/(previews)/nav-and-bg/page.tsx
@@ -1,20 +1,11 @@
-"use client";
-
 import * as React from "react";
 import type { Metadata } from "next";
 
 import SiteChrome from "@/components/chrome/SiteChrome";
 import NavBar from "@/components/chrome/NavBar";
 import { DecorLayer, PageShell } from "@/components/ui";
-import {
-  BG_CLASSES,
-  VARIANTS,
-  VARIANT_LABELS,
-  applyTheme,
-  type Background,
-  type ThemeState,
-} from "@/lib/theme";
-import { useTheme } from "@/lib/theme-context";
+
+import ThemeCycleControl from "./ThemeCycleControl";
 
 export const metadata: Metadata = {
   title: "Navigation & background preview",
@@ -27,89 +18,6 @@ export const dynamicParams = false;
 
 export function generateStaticParams(): never[] {
   return [];
-}
-
-const BACKGROUND_VALUES: readonly Background[] = BG_CLASSES.map(
-  (_, index) => index as Background,
-);
-
-const THEME_SEQUENCE: readonly ThemeState[] = VARIANTS.flatMap(({ id }) =>
-  BACKGROUND_VALUES.map((bg) => ({
-    variant: id,
-    bg,
-  })),
-);
-
-const BACKGROUND_LABELS: Record<Background, string> = {
-  0: "Base",
-  1: "Alt 1",
-  2: "Alt 2",
-  3: "VHS",
-  4: "Streak",
-};
-
-const themeSequenceLength = THEME_SEQUENCE.length;
-
-const findThemeIndex = ({ variant, bg }: ThemeState): number => {
-  return THEME_SEQUENCE.findIndex(
-    (candidate) => candidate.variant === variant && candidate.bg === bg,
-  );
-};
-
-const getNextThemeState = (current: ThemeState): ThemeState => {
-  const currentIndex = findThemeIndex(current);
-  const nextIndex =
-    currentIndex >= 0
-      ? (currentIndex + 1) % themeSequenceLength
-      : 0;
-  return THEME_SEQUENCE[nextIndex];
-};
-
-function ThemeCycleControl() {
-  const [theme, setTheme] = useTheme();
-  const variantLabel = VARIANT_LABELS[theme.variant] ?? theme.variant;
-  const backgroundLabel = BACKGROUND_LABELS[theme.bg] ?? `Alt ${theme.bg}`;
-
-  const handleCycle = React.useCallback(() => {
-    setTheme((previous) => {
-      const nextTheme = getNextThemeState(previous);
-
-      if (typeof document !== "undefined") {
-        const { documentElement } = document;
-        if (documentElement) {
-          documentElement.dataset.themePref = "persisted";
-        }
-      }
-
-      applyTheme(nextTheme);
-      return nextTheme;
-    });
-  }, [setTheme]);
-
-  const currentIndex = React.useMemo(() => {
-    const index = findThemeIndex(theme);
-    return index >= 0 ? index + 1 : 1;
-  }, [theme]);
-
-  return (
-    <div className="flex flex-wrap items-center gap-[var(--space-2)] text-body-sm text-muted-foreground">
-      <span>
-        Showing <span className="font-medium text-foreground">{variantLabel}</span>
-        {" · "}
-        <span className="font-medium text-foreground">{backgroundLabel}</span>
-      </span>
-      <span className="text-body-xs text-muted-foreground/80">
-        {currentIndex} of {themeSequenceLength}
-      </span>
-      <button
-        type="button"
-        onClick={handleCycle}
-        className="inline-flex items-center gap-[var(--space-1)] rounded-full border border-border bg-surface px-[var(--space-3)] py-[var(--space-1)] font-medium text-foreground transition-colors duration-quick ease-out hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0 active:text-[hsl(var(--accent-contrast))]"
-      >
-        Cycle theme
-      </button>
-    </div>
-  );
 }
 
 export default function NavAndBackgroundPreviewPage() {


### PR DESCRIPTION
## Summary
- keep the Navigation & Background preview page as a server component so metadata and static exports compile
- move the theme cycling controls into a dedicated client component to retain interactive behaviour

## Testing
- npm run verify-prompts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dc0bf2c890832c8110bd20ba3eab35