### PR TITLE
test: guard tailwind postcss config

### DIFF
--- a/tests/config/tailwind-postcss.test.ts
+++ b/tests/config/tailwind-postcss.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe("tailwind PostCSS configuration", () => {
+  it("uses the core tailwindcss plugin and avoids @tailwindcss/postcss", () => {
+    const config = require("../../postcss.config.cjs");
+
+    expect(Object.hasOwn(config, "plugins")).toBe(true);
+    expect(Object.hasOwn(config.plugins, "tailwindcss")).toBe(true);
+    expect(JSON.stringify(config)).not.toContain("@tailwindcss/postcss");
+  });
+
+  it("keeps tailwindcss 3.x without the @tailwindcss/postcss package", () => {
+    const packageJsonPath = resolve(__dirname, "../../package.json");
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    const devDependencies = packageJson.devDependencies ?? {};
+
+    expect(devDependencies["@tailwindcss/postcss"]).toBeUndefined();
+    expect(devDependencies.tailwindcss).toBeTypeOf("string");
+    expect(devDependencies.tailwindcss.startsWith("3.")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a config regression test to ensure the PostCSS setup keeps using the built-in tailwindcss plugin and never pulls in @tailwindcss/postcss
- assert package.json continues to depend on tailwindcss 3.x without adding @tailwindcss/postcss to devDependencies

## Testing
- npx vitest run tests/config/tailwind-postcss.test.ts --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68dc18709450832c964922026266e36d