### PR TITLE
fix: raise vitest memory limit for ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "typecheck": "tsx scripts/typecheck.ts",
     "typecheck:ci": "npm run typecheck -- --pretty false",
     "test": "vitest",
-    "test:ci": "vitest run --reporter=default --reporter=junit --outputFile artifacts/unit/junit.xml --coverage --coverage.reporter=lcov --coverage.reporter=json-summary",
+    "test:ci": "node --max-old-space-size=6144 ./node_modules/vitest/vitest.mjs run --reporter=default --reporter=junit --outputFile artifacts/unit/junit.xml --coverage --coverage.reporter=lcov --coverage.reporter=json-summary",
     "e2e:ci": "playwright test",
     "lint:design": "tsx scripts/design-lint.ts",
     "design-lint": "npm run lint:design",


### PR DESCRIPTION
## Summary
- increase the Node.js heap size used by the CI coverage test run to stop vitest from crashing with out-of-memory errors

## Testing
- npm run verify-prompts
- npm run lint
- npm run lint:design
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dc29bd5c9c832cb63e6b9a10998f15