### PR TITLE
fix: cap vitest workers on ci

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,8 @@
 import path from "path";
 import { defineConfig } from "vitest/config";
 
+const isCI = Boolean(process.env.CI);
+
 export default defineConfig({
   test: {
     environment: "jsdom",
@@ -8,6 +10,16 @@ export default defineConfig({
     include: ["tests/**/*.test.{ts,tsx}"],
     exclude: ["**/node_modules/**", "**/dist/**"],
     testTimeout: 15000,
+    ...(isCI
+      ? {
+          poolOptions: {
+            threads: {
+              minThreads: 1,
+              maxThreads: 1,
+            },
+          },
+        }
+      : {}),
     coverage: {
       exclude: ["src/components/gallery/generated-manifest.ts"],
     },


### PR DESCRIPTION
## Summary
- limit Vitest's thread pool to a single worker when running in CI to constrain memory usage during coverage runs

## Testing
- npx vitest run tests/lib/Db.test.ts tests/components/PageHeader.test.tsx tests/planner/WeekPicker.test.tsx tests/home/useHomePlannerOverview.test.tsx tests/primitives/IconButton.test.tsx tests/planner/UsePlannerStore.test.tsx tests/lib/clipboard.test.ts tests/components/ComponentsGalleryState.test.tsx
- npm run verify-prompts
- npm run lint
- npm run lint:design
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dc29262c78832c98ead52dfafa76c5