### PR TITLE
Fix goal list controls for reduced motion

### DIFF
--- a/src/components/goals/GoalList.tsx
+++ b/src/components/goals/GoalList.tsx
@@ -105,7 +105,7 @@ export default function GoalList({
                             size="sm"
                             variant="ghost"
                             tone="accent"
-                            className="transition-transform hover:-translate-y-0.5"
+                            className="transition-transform hover:-translate-y-0.5 motion-reduce:transition-none motion-reduce:transform-none"
                           >
                             <X />
                           </IconButton>
@@ -115,7 +115,7 @@ export default function GoalList({
                             size="sm"
                             variant="secondary"
                             tone="accent"
-                            className="transition-transform hover:-translate-y-0.5"
+                            className="transition-transform hover:-translate-y-0.5 motion-reduce:transition-none motion-reduce:transform-none"
                           >
                             <Check />
                           </IconButton>
@@ -127,7 +127,7 @@ export default function GoalList({
                             checked={g.done}
                             onChange={() => onToggleDone(g.id)}
                             size="sm"
-                            className="transition-transform hover:-translate-y-0.5"
+                            className="transition-transform hover:-translate-y-0.5 motion-reduce:transition-none motion-reduce:transform-none"
                           />
                           <IconButton
                             title="Edit"
@@ -136,7 +136,7 @@ export default function GoalList({
                             size="sm"
                             variant="ghost"
                             tone="accent"
-                            className="transition-transform hover:-translate-y-0.5"
+                            className="transition-transform hover:-translate-y-0.5 motion-reduce:transition-none motion-reduce:transform-none"
                           >
                             <Pencil />
                           </IconButton>
@@ -147,7 +147,7 @@ export default function GoalList({
                             size="sm"
                             variant="secondary"
                             tone="accent"
-                            className="transition-transform hover:-translate-y-0.5"
+                            className="transition-transform hover:-translate-y-0.5 motion-reduce:transition-none motion-reduce:transform-none"
                           >
                             <Trash2 />
                           </IconButton>


### PR DESCRIPTION
## Summary
- ensure goal list action controls include motion-reduce fallbacks so they stay stationary when reduced motion is preferred

## Testing
- npm run check *(fails: Db > usePersistentState > uses the latest initial value provided after a key swap)*
- npx vitest run tests/lib/Db.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc30910388832c9c9c2cc0c7f8046f