### PR TITLE
chore: register new depth and surface tokens

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -113,6 +113,41 @@
     hsl(var(--danger) / 0.24),
     hsl(var(--primary) / 0.2)
   ) |
+| surface-card-soft | linear-gradient(
+    180deg,
+    hsl(var(--card) / 0.65),
+    hsl(var(--card) / 0.45)
+  ) |
+| surface-card-strong | linear-gradient(
+    180deg,
+    hsl(var(--card) / 0.85),
+    hsl(var(--card) / 0.65)
+  ) |
+| surface-card-strong-hover | linear-gradient(
+    180deg,
+    hsl(var(--card) / 0.95),
+    hsl(var(--card) / 0.75)
+  ) |
+| surface-card-strong-active | linear-gradient(
+    180deg,
+    hsl(var(--card) / 0.8),
+    hsl(var(--card) / 0.6)
+  ) |
+| surface-card-strong-today | linear-gradient(
+    180deg,
+    hsl(var(--card) / 0.9),
+    hsl(var(--card) / 0.7)
+  ) |
+| surface-card-strong-empty | linear-gradient(
+    180deg,
+    hsl(var(--card) / 0.6),
+    hsl(var(--card) / 0.5)
+  ) |
+| surface-rail-accent | linear-gradient(
+    180deg,
+    hsl(var(--accent)),
+    hsl(var(--primary))
+  ) |
 | seg-active-base | hsl(var(--card)) |
 | shadow | 0 10px 30px hsl(250 38% 2% / 0.32) |
 | shadow-dropdown | 0 12px 40px hsl(var(--shadow-color) / 0.55) |
@@ -313,6 +348,9 @@
 | glow-ring | 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22) |
 | blob-radius-soft | calc(var(--radius-2xl) + var(--spacing-2)) |
 | glitch-noise-hover | calc(var(--glitch-noise-level) * 1.3) |
+| grid-color | var(--accent) |
+| grid-alpha | 0.1 |
+| grid-size | calc(var(--space-6) - var(--space-1)) |
 | spacing-0-125 | calc(var(--spacing-1) / 8) |
 | spacing-0-25 | calc(var(--spacing-1) / 4) |
 | spacing-0-5 | calc(var(--spacing-1) / 2) |

--- a/src/lib/design-token-registry.ts
+++ b/src/lib/design-token-registry.ts
@@ -49,12 +49,16 @@ const EXACT_CATEGORY_OVERRIDES = new Map<string, DesignTokenCategory>([
   ["shadow-color", "color"],
   ["glow-strong", "color"],
   ["glow-soft", "color"],
+  ["blob-radius-soft", "radius"],
 ]);
 
 const SPACING_SPECIFIC_NAMES = new Set<string>([
   "control-px",
   "header-stack",
   "hairline-w",
+  "neo-depth-sm",
+  "neo-depth-md",
+  "neo-depth-lg",
 ]);
 
 const MOTION_PREFIXES = ["ease-", "dur-", "motion-"];

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -91,6 +91,68 @@ export const colorTokens = [
   "bg-ring-contrast",
 ];
 
+export const depthTokenNames = [
+  "--neo-depth-sm",
+  "--neo-depth-md",
+  "--neo-depth-lg",
+  "--neo-surface",
+  "--neo-surface-alt",
+  "--neo-highlight",
+  "--depth-shadow-outer",
+  "--depth-shadow-outer-strong",
+  "--depth-shadow-soft",
+  "--depth-shadow-inner",
+  "--shadow-inner-lg",
+  "--depth-glow-highlight-soft",
+  "--depth-glow-highlight-medium",
+  "--depth-glow-highlight-strong",
+  "--depth-glow-shadow-soft",
+  "--depth-glow-shadow-medium",
+  "--depth-glow-shadow-strong",
+  "--depth-focus-ring-rest",
+  "--depth-focus-ring-active",
+  "--shadow-outer-xl",
+  "--glow-ring",
+] as const;
+
+export type DepthTokenName = (typeof depthTokenNames)[number];
+
+export const surfaceTokenNames = [
+  "--blob-surface-1",
+  "--blob-surface-2",
+  "--blob-surface-3",
+  "--blob-surface-shadow",
+  "--blob-radius-soft",
+  "--surface-card-soft",
+  "--surface-card-strong",
+  "--surface-card-strong-hover",
+  "--surface-card-strong-active",
+  "--surface-card-strong-today",
+  "--surface-card-strong-empty",
+  "--surface-rail-accent",
+] as const;
+
+export type SurfaceTokenName = (typeof surfaceTokenNames)[number];
+
+export const motionTokenNames = [
+  "--ease-out",
+  "--ease-snap",
+  "--dur-quick",
+  "--dur-chill",
+  "--dur-slow",
+] as const;
+
+export type MotionTokenName = (typeof motionTokenNames)[number];
+
+export const gradientTokenNames = [
+  "--edge-iris",
+  "--seg-active-grad",
+  "--review-result-win-gradient",
+  "--review-result-loss-gradient",
+] as const;
+
+export type GradientTokenName = (typeof gradientTokenNames)[number];
+
 export const spacingTokens = [4, 8, 12, 16, 24, 32, 48, 64];
 
 export const shellWidthToken = "--shell-width";

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -116,6 +116,41 @@
     hsl(var(--danger) / 0.24),
     hsl(var(--primary) / 0.2)
   );
+  --surface-card-soft: linear-gradient(
+    180deg,
+    hsl(var(--card) / 0.65),
+    hsl(var(--card) / 0.45)
+  );
+  --surface-card-strong: linear-gradient(
+    180deg,
+    hsl(var(--card) / 0.85),
+    hsl(var(--card) / 0.65)
+  );
+  --surface-card-strong-hover: linear-gradient(
+    180deg,
+    hsl(var(--card) / 0.95),
+    hsl(var(--card) / 0.75)
+  );
+  --surface-card-strong-active: linear-gradient(
+    180deg,
+    hsl(var(--card) / 0.8),
+    hsl(var(--card) / 0.6)
+  );
+  --surface-card-strong-today: linear-gradient(
+    180deg,
+    hsl(var(--card) / 0.9),
+    hsl(var(--card) / 0.7)
+  );
+  --surface-card-strong-empty: linear-gradient(
+    180deg,
+    hsl(var(--card) / 0.6),
+    hsl(var(--card) / 0.5)
+  );
+  --surface-rail-accent: linear-gradient(
+    180deg,
+    hsl(var(--accent)),
+    hsl(var(--primary))
+  );
   --seg-active-base: hsl(var(--card));
   --shadow: 0 10px 30px hsl(250 38% 2% / 0.32);
   --shadow-dropdown: 0 12px 40px hsl(var(--shadow-color) / 0.55);
@@ -316,6 +351,9 @@
   --glow-ring: 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22);
   --blob-radius-soft: calc(var(--radius-2xl) + var(--spacing-2));
   --glitch-noise-hover: calc(var(--glitch-noise-level) * 1.3);
+  --grid-color: var(--accent);
+  --grid-alpha: 0.1;
+  --grid-size: calc(var(--space-6) - var(--space-1));
   --spacing-0-125: calc(var(--spacing-1) / 8);
   --spacing-0-25: calc(var(--spacing-1) / 4);
   --spacing-0-5: calc(var(--spacing-1) / 2);

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -100,6 +100,20 @@ export default {
     "linear-gradient(\n    90deg,\n    hsl(var(--success) / 0.22),\n    hsl(var(--accent) / 0.18)\n  )",
   reviewResultLossGradient:
     "linear-gradient(\n    90deg,\n    hsl(var(--danger) / 0.24),\n    hsl(var(--primary) / 0.2)\n  )",
+  surfaceCardSoft:
+    "linear-gradient(\n    180deg,\n    hsl(var(--card) / 0.65),\n    hsl(var(--card) / 0.45)\n  )",
+  surfaceCardStrong:
+    "linear-gradient(\n    180deg,\n    hsl(var(--card) / 0.85),\n    hsl(var(--card) / 0.65)\n  )",
+  surfaceCardStrongHover:
+    "linear-gradient(\n    180deg,\n    hsl(var(--card) / 0.95),\n    hsl(var(--card) / 0.75)\n  )",
+  surfaceCardStrongActive:
+    "linear-gradient(\n    180deg,\n    hsl(var(--card) / 0.8),\n    hsl(var(--card) / 0.6)\n  )",
+  surfaceCardStrongToday:
+    "linear-gradient(\n    180deg,\n    hsl(var(--card) / 0.9),\n    hsl(var(--card) / 0.7)\n  )",
+  surfaceCardStrongEmpty:
+    "linear-gradient(\n    180deg,\n    hsl(var(--card) / 0.6),\n    hsl(var(--card) / 0.5)\n  )",
+  surfaceRailAccent:
+    "linear-gradient(\n    180deg,\n    hsl(var(--accent)),\n    hsl(var(--primary))\n  )",
   segActiveBase: "hsl(var(--card))",
   shadow: "0 10px 30px hsl(250 38% 2% / 0.32)",
   shadowDropdown: "0 12px 40px hsl(var(--shadow-color) / 0.55)",
@@ -297,6 +311,9 @@ export default {
     "0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22)",
   blobRadiusSoft: "calc(var(--radius-2xl) + var(--spacing-2))",
   glitchNoiseHover: "calc(var(--glitch-noise-level) * 1.3)",
+  gridColor: "var(--accent)",
+  gridAlpha: "0.1",
+  gridSize: "calc(var(--space-6) - var(--space-1))",
   spacing0125: "calc(var(--spacing-1) / 8)",
   spacing025: "calc(var(--spacing-1) / 4)",
   spacing05: "calc(var(--spacing-1) / 2)",


### PR DESCRIPTION
## Summary
- document the new depth, surface, motion, and gradient token variables in `src/lib/tokens.ts`
- classify neo depth spacing and blob radius tokens correctly in the design token registry
- add the new surface gradient tokens to the generated token assets and docs

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68dc30d40648832c8eec826a13be647a