### PR TITLE
feat: add outer shadow tokens

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -313,6 +313,11 @@
 | glow-ring | 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22) |
 | blob-radius-soft | calc(var(--radius-2xl) + var(--spacing-2)) |
 | glitch-noise-hover | calc(var(--glitch-noise-level) * 1.3) |
+| grid-color | var(--accent) |
+| grid-alpha | 0.1 |
+| grid-size | calc(var(--space-6) - var(--space-1)) |
+| shadow-outer-sm | 0 var(--spacing-2) var(--spacing-4) hsl(var(--shadow-color) / 0.24) |
+| shadow-outer-md | 0 var(--spacing-3) var(--spacing-6) hsl(var(--shadow-color) / 0.3) |
 | spacing-0-125 | calc(var(--spacing-1) / 8) |
 | spacing-0-25 | calc(var(--spacing-1) / 4) |
 | spacing-0-5 | calc(var(--spacing-1) / 2) |

--- a/scripts/generate-tokens.ts
+++ b/scripts/generate-tokens.ts
@@ -45,6 +45,8 @@ const REQUIRED_THEME_TOKEN_GROUPS = {
     "depth-glow-shadow-strong",
     "depth-focus-ring-rest",
     "depth-focus-ring-active",
+    "shadow-outer-sm",
+    "shadow-outer-md",
     "shadow-outer-xl",
     "glow-ring",
   ],
@@ -278,6 +280,10 @@ async function buildTokens(): Promise<void> {
       "inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.28)",
     "shadow-inner-lg":
       "inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36)",
+    "shadow-outer-sm":
+      "0 var(--spacing-2) var(--spacing-4) hsl(var(--shadow-color) / 0.24)",
+    "shadow-outer-md":
+      "0 var(--spacing-3) var(--spacing-6) hsl(var(--shadow-color) / 0.3)",
     "shadow-outer-lg":
       "0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36)",
     "shadow-outer-xl":

--- a/scripts/themes.ts
+++ b/scripts/themes.ts
@@ -72,6 +72,14 @@ export const rootVariables: VariableDefinition[] = [
       "inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36)",
   },
   {
+    name: "shadow-outer-sm",
+    value: "0 var(--spacing-2) var(--spacing-4) hsl(var(--shadow-color) / 0.24)",
+  },
+  {
+    name: "shadow-outer-md",
+    value: "0 var(--spacing-3) var(--spacing-6) hsl(var(--shadow-color) / 0.3)",
+  },
+  {
     name: "shadow-outer-lg",
     value: "0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36)",
   },
@@ -481,6 +489,14 @@ export const themes: ThemeDefinition[] = [
           "inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.38)",
       },
       {
+        name: "shadow-outer-sm",
+        value: "0 var(--spacing-2) var(--spacing-4) hsl(var(--shadow-color) / 0.3)",
+      },
+      {
+        name: "shadow-outer-md",
+        value: "0 var(--spacing-3) var(--spacing-6) hsl(var(--shadow-color) / 0.36)",
+      },
+      {
         name: "shadow-outer-lg",
         value: "0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.42)",
       },
@@ -726,6 +742,14 @@ export const themes: ThemeDefinition[] = [
         name: "shadow-inner-lg",
         value:
           "inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.3)",
+      },
+      {
+        name: "shadow-outer-sm",
+        value: "0 var(--spacing-2) var(--spacing-4) hsl(var(--shadow-color) / 0.22)",
+      },
+      {
+        name: "shadow-outer-md",
+        value: "0 var(--spacing-3) var(--spacing-6) hsl(var(--shadow-color) / 0.28)",
       },
       {
         name: "shadow-outer-lg",

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -320,6 +320,11 @@
   --glow-ring: 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22);
   --blob-radius-soft: calc(var(--radius-2xl) + var(--spacing-2));
   --glitch-noise-hover: calc(var(--glitch-noise-level) * 1.3);
+  --grid-color: var(--accent);
+  --grid-alpha: 0.1;
+  --grid-size: calc(var(--space-6) - var(--space-1));
+  --shadow-outer-sm: 0 var(--spacing-2) var(--spacing-4) hsl(var(--shadow-color) / 0.24);
+  --shadow-outer-md: 0 var(--spacing-3) var(--spacing-6) hsl(var(--shadow-color) / 0.3);
   --spacing-0-125: calc(var(--spacing-1) / 8);
   --spacing-0-25: calc(var(--spacing-1) / 4);
   --spacing-0-5: calc(var(--spacing-1) / 2);
@@ -375,6 +380,8 @@
   --shadow-inner-sm: inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.18);
   --shadow-inner-md: inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.28);
   --shadow-inner-lg: inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36);
+  --shadow-outer-sm: 0 var(--spacing-2) var(--spacing-4) hsl(var(--shadow-color) / 0.24);
+  --shadow-outer-md: 0 var(--spacing-3) var(--spacing-6) hsl(var(--shadow-color) / 0.3);
   --shadow-outer-lg: 0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36);
   --shadow-outer-xl: 0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.45);
   /* Depth glow ramps */
@@ -749,6 +756,8 @@ html.theme-noir {
   --shadow-inner-sm: inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.2);
   --shadow-inner-md: inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.3);
   --shadow-inner-lg: inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.38);
+  --shadow-outer-sm: 0 var(--spacing-2) var(--spacing-4) hsl(var(--shadow-color) / 0.3);
+  --shadow-outer-md: 0 var(--spacing-3) var(--spacing-6) hsl(var(--shadow-color) / 0.36);
   --shadow-outer-lg: 0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.42);
   --shadow-outer-xl: 0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.48);
   --neo-glow-strength: 0.6;
@@ -937,6 +946,8 @@ html.theme-hardstuck {
   --shadow-inner-sm: inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.16);
   --shadow-inner-md: inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.24);
   --shadow-inner-lg: inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.3);
+  --shadow-outer-sm: 0 var(--spacing-2) var(--spacing-4) hsl(var(--shadow-color) / 0.22);
+  --shadow-outer-md: 0 var(--spacing-3) var(--spacing-6) hsl(var(--shadow-color) / 0.28);
   --shadow-outer-lg: 0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.34);
   --shadow-outer-xl: 0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.42);
   --neo-glow-strength: 0.58;

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -316,6 +316,11 @@
   --glow-ring: 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22);
   --blob-radius-soft: calc(var(--radius-2xl) + var(--spacing-2));
   --glitch-noise-hover: calc(var(--glitch-noise-level) * 1.3);
+  --grid-color: var(--accent);
+  --grid-alpha: 0.1;
+  --grid-size: calc(var(--space-6) - var(--space-1));
+  --shadow-outer-sm: 0 var(--spacing-2) var(--spacing-4) hsl(var(--shadow-color) / 0.24);
+  --shadow-outer-md: 0 var(--spacing-3) var(--spacing-6) hsl(var(--shadow-color) / 0.3);
   --spacing-0-125: calc(var(--spacing-1) / 8);
   --spacing-0-25: calc(var(--spacing-1) / 4);
   --spacing-0-5: calc(var(--spacing-1) / 2);

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -297,6 +297,13 @@ export default {
     "0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22)",
   blobRadiusSoft: "calc(var(--radius-2xl) + var(--spacing-2))",
   glitchNoiseHover: "calc(var(--glitch-noise-level) * 1.3)",
+  gridColor: "var(--accent)",
+  gridAlpha: "0.1",
+  gridSize: "calc(var(--space-6) - var(--space-1))",
+  shadowOuterSm:
+    "0 var(--spacing-2) var(--spacing-4) hsl(var(--shadow-color) / 0.24)",
+  shadowOuterMd:
+    "0 var(--spacing-3) var(--spacing-6) hsl(var(--shadow-color) / 0.3)",
   spacing0125: "calc(var(--spacing-1) / 8)",
   spacing025: "calc(var(--spacing-1) / 4)",
   spacing05: "calc(var(--spacing-1) / 2)",


### PR DESCRIPTION
## Summary
- add `shadow-outer-sm` and `shadow-outer-md` to the token pipeline and generated CSS/JS bundles so Tailwind can surface the neumorphic depth scale
- extend theme sources to provide per-theme overrides for the new outer shadows in Noir and Hardstuck while keeping root defaults aligned with existing spacing and opacity ramps

## Testing
- `npx tailwindcss -c tailwind.config.ts -i ./src/app/globals.css -o /tmp/tailwind.css --content './app/**/*.{ts,tsx}' --content './src/**/*.{ts,tsx}' --content tmp-tailwind-check.html`
- `NODE_OPTIONS=--max-old-space-size=8192 npm run check` *(fails: vitest workers exit with ERR_IPC_CHANNEL_CLOSED in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3099f140832ca145007f347137cd