### PR TITLE
feat: gate glitch landing experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The app reads configuration from your shell environment at build time. Use `.env
 | `GH_PAGES_BRANCH` | `gh-pages` | Target branch for the GitHub Pages deploy script. Override if your site publishes from a different branch. |
 | `GITHUB_PAGES_BRANCH` | `""` | Optional alias the deploy script reads when `GH_PAGES_BRANCH` is unset. Useful when reusing existing CI variables. |
 | `NEXT_PUBLIC_API_*` | _unset_ | Placeholder namespace for future API endpoints (for example, `NEXT_PUBLIC_API_BASE_URL`). Prefix additional public URLs with `NEXT_PUBLIC_` so Next.js exposes them to the client. |
+| `NEXT_PUBLIC_UI_GLITCH_LANDING` | `true` | Gates the glitch landing experience. Set to `false` to render the legacy landing layout without glitch overlays while retaining the standard planner preview. |
 
 > **Tip:** Keep `.env.local` out of version control. Only `.env.example` belongs in the repository so collaborators and CI pipelines can discover the supported configuration.
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,11 @@ import ThemeProvider from "@/lib/theme-context";
 import { THEME_BOOTSTRAP_SCRIPT_PATH } from "@/lib/theme";
 import StyledJsxRegistry from "@/lib/styled-jsx-registry";
 import DepthThemeProvider from "@/lib/depth-theme-context";
-import { depthThemeEnabled, organicDepthEnabled } from "@/lib/features";
+import {
+  depthThemeEnabled,
+  glitchLandingEnabled,
+  organicDepthEnabled,
+} from "@/lib/features";
 
 const createNonceInitializer = (nonce: string): string => {
   const nonceValue = JSON.stringify(nonce);
@@ -135,8 +139,10 @@ export default async function RootLayout({
 }) {
   const depthThemeState = depthThemeEnabled;
   const organicDepthState = organicDepthEnabled;
+  const glitchLandingState = glitchLandingEnabled;
   const depthThemeDataAttribute = depthThemeState ? "enabled" : "legacy";
   const organicDepthDataAttribute = organicDepthState ? "organic" : "legacy";
+  const glitchLandingDataAttribute = glitchLandingState ? "enabled" : "legacy";
   const year = new Date().getFullYear();
   const assetUrlCss = [
     ":root {",
@@ -153,6 +159,7 @@ export default async function RootLayout({
         className="theme-lg color-scheme-dark"
         data-depth-theme={depthThemeDataAttribute}
         data-organic-depth={organicDepthDataAttribute}
+        data-glitch-landing={glitchLandingDataAttribute}
         suppressHydrationWarning
       >
         <head>
@@ -179,9 +186,10 @@ export default async function RootLayout({
           />
         </head>
         <body
-          className={`${geistSansClassName} ${geistSansVariable} ${geistMonoVariable} min-h-screen bg-background text-foreground glitch-root`}
+          className={`${geistSansClassName} ${geistSansVariable} ${geistMonoVariable} min-h-screen bg-background text-foreground${glitchLandingState ? " glitch-root" : ""}`}
           data-depth-theme={depthThemeDataAttribute}
           data-organic-depth={organicDepthDataAttribute}
+          data-glitch-landing={glitchLandingDataAttribute}
         >
           <a
             className="fixed left-[var(--space-4)] top-[var(--space-4)] z-50 inline-flex items-center rounded-[var(--radius-lg)] bg-background px-[var(--space-4)] py-[var(--space-2)] text-ui font-medium text-foreground shadow-outline-subtle outline-none transition-all duration-quick ease-out opacity-0 -translate-y-full pointer-events-none focus-visible:translate-y-0 focus-visible:opacity-100 focus-visible:pointer-events-auto focus-visible:shadow-ring focus-visible:no-underline focus-visible:outline-none hover:shadow-ring focus-visible:active:translate-y-[var(--space-1)]"
@@ -198,7 +206,7 @@ export default async function RootLayout({
             </div>
           </noscript>
           <StyledJsxRegistry nonce={nonce}>
-            <ThemeProvider>
+            <ThemeProvider glitchLandingEnabled={glitchLandingState}>
               <DepthThemeProvider
                 enabled={depthThemeState}
                 organicDepthEnabled={organicDepthState}

--- a/src/app/page-client.tsx
+++ b/src/app/page-client.tsx
@@ -11,7 +11,7 @@ import {
 import type { HeroPlannerHighlight, PlannerOverviewProps } from "@/components/home";
 import { PageShell, Button, ThemeToggle, SectionCard } from "@/components/ui";
 import { PlannerProvider } from "@/components/planner";
-import { useTheme } from "@/lib/theme-context";
+import { useTheme, useUiFeatureFlags } from "@/lib/theme-context";
 import { useThemeQuerySync } from "@/lib/theme-hooks";
 import type { Variant } from "@/lib/theme";
 import styles from "./page-client.module.css";
@@ -39,27 +39,37 @@ const weeklyHighlights = [
 
 function HomePageContent() {
   const [theme] = useTheme();
+  const { glitchLandingEnabled } = useUiFeatureFlags();
   useThemeQuerySync();
 
   return (
     <PlannerProvider>
-      <HomePagePlannerContent themeVariant={theme.variant} />
+      <HomePagePlannerContent
+        themeVariant={theme.variant}
+        glitchLandingEnabled={glitchLandingEnabled}
+      />
     </PlannerProvider>
   );
 }
 
 type HomePagePlannerContentProps = {
   themeVariant: Variant;
+  glitchLandingEnabled: boolean;
 };
 
 function HomePagePlannerContent({
   themeVariant,
+  glitchLandingEnabled,
 }: HomePagePlannerContentProps) {
   const plannerOverviewProps = useHomePlannerOverview();
   const { hydrated } = plannerOverviewProps;
 
-  const [isSplashVisible, setSplashVisible] = React.useState(() => !hydrated);
-  const [isSplashMounted, setSplashMounted] = React.useState(() => !hydrated);
+  const [isSplashVisible, setSplashVisible] = React.useState(
+    () => glitchLandingEnabled && !hydrated,
+  );
+  const [isSplashMounted, setSplashMounted] = React.useState(
+    () => glitchLandingEnabled && !hydrated,
+  );
 
   const beginHideSplash = React.useCallback(() => {
     setSplashVisible((prev) => {
@@ -71,13 +81,18 @@ function HomePagePlannerContent({
   }, []);
 
   React.useEffect(() => {
+    if (!glitchLandingEnabled) {
+      setSplashVisible(false);
+      setSplashMounted(false);
+      return;
+    }
     if (!hydrated) {
       setSplashMounted(true);
       setSplashVisible(true);
       return;
     }
     beginHideSplash();
-  }, [beginHideSplash, hydrated]);
+  }, [beginHideSplash, glitchLandingEnabled, hydrated]);
 
   const handleClientReady = React.useCallback(() => {
     beginHideSplash();
@@ -89,7 +104,7 @@ function HomePagePlannerContent({
 
   return (
     <div className={styles.root}>
-      {isSplashMounted ? (
+      {glitchLandingEnabled && isSplashMounted ? (
         <HomeSplash active={isSplashVisible} onExited={handleSplashExit} />
       ) : null}
       <section
@@ -101,7 +116,8 @@ function HomePagePlannerContent({
         <HomePageBody
           themeVariant={themeVariant}
           plannerOverviewProps={plannerOverviewProps}
-          onClientReady={handleClientReady}
+          onClientReady={glitchLandingEnabled ? handleClientReady : undefined}
+          glitchLandingEnabled={glitchLandingEnabled}
         />
       </section>
     </div>
@@ -112,12 +128,14 @@ type HomePageBodyProps = {
   themeVariant: Variant;
   plannerOverviewProps: PlannerOverviewProps;
   onClientReady?: () => void;
+  glitchLandingEnabled: boolean;
 };
 
 function HomePageBody({
   themeVariant,
   plannerOverviewProps,
   onClientReady,
+  glitchLandingEnabled,
 }: HomePageBodyProps) {
   const { hydrated } = plannerOverviewProps;
   const heroHeadingId = "home-hero-heading";
@@ -153,6 +171,17 @@ function HomePageBody({
     onClientReady();
     hasAnnouncedReadyRef.current = true;
   }, [hydrated, onClientReady]);
+
+  if (!glitchLandingEnabled) {
+    return (
+      <LegacyHomePageBody
+        plannerOverviewProps={plannerOverviewProps}
+        heroActions={heroActions}
+        heroHeadingId={heroHeadingId}
+        overviewHeadingId={overviewHeadingId}
+      />
+    );
+  }
 
   return (
     <>
@@ -208,4 +237,199 @@ function HomePageBody({
 
 export default function Page() {
   return <HomePageContent />;
+}
+
+type LegacyHomePageBodyProps = {
+  plannerOverviewProps: PlannerOverviewProps;
+  heroActions: React.ReactNode;
+  heroHeadingId: string;
+  overviewHeadingId: string;
+};
+
+function LegacyHomePageBody({
+  plannerOverviewProps,
+  heroActions,
+  heroHeadingId,
+  overviewHeadingId,
+}: LegacyHomePageBodyProps) {
+  const {
+    hydrating,
+    summary,
+    focus,
+    goals,
+    calendar,
+  } = plannerOverviewProps;
+
+  const activeGoals = goals.active;
+
+  return (
+    <>
+      <PageShell
+        as="header"
+        grid
+        aria-labelledby={heroHeadingId}
+        className="pt-[var(--space-6)] md:pt-[var(--space-8)]"
+      >
+        <SectionCard
+          aria-labelledby={heroHeadingId}
+          className="col-span-full"
+        >
+          <SectionCard.Header
+            id={heroHeadingId}
+            title="Planner preview"
+            titleAs="h1"
+            titleClassName="text-balance text-title-lg font-semibold tracking-[-0.01em]"
+            sticky={false}
+          />
+          <SectionCard.Body className="flex flex-col gap-[var(--space-4)] md:flex-row md:items-center md:justify-between">
+            <div className="space-y-[var(--space-3)]">
+              <p className="text-body text-muted-foreground">
+                Planner highlights your next focus day, surfaces weekly goals, and gives the team a quick win tracker.
+              </p>
+              <p className="text-body text-muted-foreground">
+                Use the controls below to switch themes or open the full planner experience.
+              </p>
+            </div>
+            <div
+              role="group"
+              aria-label="Planner actions"
+              className="flex flex-wrap items-center gap-[var(--space-3)]"
+            >
+              {heroActions}
+            </div>
+          </SectionCard.Body>
+        </SectionCard>
+      </PageShell>
+      <PageShell
+        as="section"
+        grid
+        role="region"
+        aria-labelledby={overviewHeadingId}
+        className="mt-[var(--space-6)] pb-[var(--space-6)] md:mt-[var(--space-8)] md:pb-[var(--space-8)]"
+      >
+        <SectionCard
+          aria-labelledby={overviewHeadingId}
+          className="col-span-full"
+        >
+          <SectionCard.Header
+            id={overviewHeadingId}
+            sticky={false}
+            title="Planner overview"
+            titleAs="h2"
+            titleClassName="text-title font-semibold tracking-[-0.01em]"
+          />
+          <SectionCard.Body className="space-y-[var(--space-5)]" aria-busy={hydrating}
+            aria-live={hydrating ? "polite" : undefined}
+          >
+            <div className="grid gap-[var(--space-3)] md:grid-cols-3" role="list">
+              {summary.items.map((item) => (
+                <article
+                  key={item.key}
+                  className="flex flex-col gap-[var(--space-2)] rounded-[var(--radius-lg)] border border-border bg-surface p-[var(--space-3)]"
+                  role="listitem"
+                >
+                  <p className="text-label text-muted-foreground">{item.label}</p>
+                  <p className="text-ui font-semibold text-foreground text-balance">
+                    {item.value}
+                  </p>
+                  <Link
+                    href={item.href}
+                    className="text-label font-medium text-primary transition-colors hover:text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  >
+                    {item.cta}
+                  </Link>
+                </article>
+              ))}
+            </div>
+            <div className="grid gap-[var(--space-4)] md:grid-cols-2">
+              <section className="space-y-[var(--space-3)]" aria-labelledby="legacy-focus-heading">
+                <div className="flex items-center justify-between gap-[var(--space-2)]">
+                  <h3 id="legacy-focus-heading" className="text-body font-semibold text-foreground">
+                    {focus.label}
+                  </h3>
+                  <p className="text-label text-muted-foreground">
+                    {hydrating ? "—" : `${focus.doneCount}/${focus.totalCount} done`}
+                  </p>
+                </div>
+                <ul className="grid gap-[var(--space-2)]" role="list">
+                  {focus.tasks.map((task) => (
+                    <li
+                      key={task.id}
+                      className="flex flex-col gap-[var(--space-1)] rounded-[var(--radius-md)] border border-border/80 bg-card/70 px-[var(--space-3)] py-[var(--space-2)]"
+                    >
+                      <span className="text-ui font-medium text-foreground">{task.title}</span>
+                      {task.projectName ? (
+                        <span className="text-label text-muted-foreground">{task.projectName}</span>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+                {focus.remainingTasks > 0 ? (
+                  <p className="text-label text-muted-foreground">
+                    +{focus.remainingTasks} additional task{focus.remainingTasks === 1 ? "" : "s"} scheduled for the day
+                  </p>
+                ) : null}
+              </section>
+              <section className="space-y-[var(--space-3)]" aria-labelledby="legacy-goals-heading">
+                <div className="flex items-center justify-between gap-[var(--space-2)]">
+                  <h3 id="legacy-goals-heading" className="text-body font-semibold text-foreground">
+                    {goals.label ?? "Goals"}
+                  </h3>
+                  <p className="text-label text-muted-foreground">
+                    {hydrating ? "—" : `${goals.completed}/${goals.total} complete`}
+                  </p>
+                </div>
+                <div className="flex flex-col gap-[var(--space-2)] rounded-[var(--radius-md)] border border-border/80 bg-card/70 p-[var(--space-3)]">
+                  {activeGoals.length > 0 ? (
+                    <ul className="grid gap-[var(--space-2)]" role="list">
+                      {activeGoals.map((goal) => (
+                        <li key={goal.id} className="flex flex-col gap-[var(--space-1)]">
+                          <span className="text-ui font-medium text-foreground">{goal.title}</span>
+                          {goal.detail ? (
+                            <span className="text-label text-muted-foreground">{goal.detail}</span>
+                          ) : null}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-label text-muted-foreground">
+                      {hydrating ? "Loading goals…" : goals.emptyMessage}
+                    </p>
+                  )}
+                  <p className="text-label text-muted-foreground">
+                    {hydrating
+                      ? "Momentum updates after data loads."
+                      : goals.total === goals.completed && goals.total > 0
+                        ? goals.allCompleteMessage
+                        : "Track progress without the glitch visuals."}
+                  </p>
+                </div>
+              </section>
+            </div>
+            <section className="space-y-[var(--space-3)]" aria-labelledby="legacy-calendar-heading">
+              <div className="flex items-center justify-between gap-[var(--space-2)]">
+                <h3 id="legacy-calendar-heading" className="text-body font-semibold text-foreground">
+                  {calendar.label}
+                </h3>
+                <p className="text-label text-muted-foreground">{calendar.summary}</p>
+              </div>
+              <div className="flex flex-wrap gap-[var(--space-2)]">
+                {calendar.days.map((day) => (
+                  <span
+                    key={day.iso}
+                    className="inline-flex min-w-[var(--space-8)] items-center justify-center rounded-full border border-border bg-card/60 px-[var(--space-2)] py-[var(--space-1)] text-label text-muted-foreground"
+                    data-state={day.selected ? "selected" : undefined}
+                    aria-current={day.selected ? "date" : undefined}
+                  >
+                    <span className="font-semibold text-foreground">{day.weekday}</span>
+                    <span className="ml-[var(--space-1)] text-label text-muted-foreground">{day.dayNumber}</span>
+                  </span>
+                ))}
+              </div>
+            </section>
+          </SectionCard.Body>
+        </SectionCard>
+      </PageShell>
+    </>
+  );
 }

--- a/src/lib/depth-theme-context.tsx
+++ b/src/lib/depth-theme-context.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { reportFeatureFlagAnalytics } from "@/lib/feature-flags";
 
 type DepthThemeContextValue = {
   enabled: boolean;
@@ -13,51 +14,6 @@ const defaultContext: DepthThemeContextValue = Object.freeze({
 });
 
 const DepthThemeContext = React.createContext<DepthThemeContextValue>(defaultContext);
-
-function reportDepthThemeAnalytics(enabled: boolean) {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  const detail = {
-    flag: "depth-theme",
-    enabled,
-    state: enabled ? "enabled" : "legacy",
-  } as const;
-
-  window.dispatchEvent(
-    new CustomEvent("planner:feature-flag", {
-      detail,
-    }),
-  );
-
-  const plausible = (window as typeof window & {
-    plausible?: (event: string, options?: { props?: Record<string, unknown> }) => void;
-  }).plausible;
-
-  if (typeof plausible === "function") {
-    plausible("feature_flag", { props: detail });
-  }
-
-  const analytics = (window as typeof window & {
-    analytics?: { track?: (event: string, properties?: Record<string, unknown>) => void };
-  }).analytics;
-
-  analytics?.track?.("feature_flag", detail);
-
-  const dataLayer = (window as typeof window & {
-    dataLayer?: unknown[];
-  }).dataLayer;
-
-  if (Array.isArray(dataLayer)) {
-    dataLayer.push({
-      event: "feature_flag",
-      feature_flag: detail.flag,
-      feature_flag_enabled: detail.enabled,
-      feature_flag_state: detail.state,
-    });
-  }
-}
 
 type DepthThemeProviderProps = {
   enabled: boolean;
@@ -88,8 +44,20 @@ export function DepthThemeProvider({
   }, [enabled, organicDepthEnabled]);
 
   React.useEffect(() => {
-    reportDepthThemeAnalytics(enabled);
+    reportFeatureFlagAnalytics({
+      flag: "depth-theme",
+      enabled,
+      state: enabled ? "enabled" : "legacy",
+    });
   }, [enabled]);
+
+  React.useEffect(() => {
+    reportFeatureFlagAnalytics({
+      flag: "depth-theme-organic",
+      enabled: organicDepthEnabled,
+      state: organicDepthEnabled ? "organic" : "legacy",
+    });
+  }, [organicDepthEnabled]);
 
   const value = React.useMemo<DepthThemeContextValue>(
     () => ({ enabled, organicDepthEnabled }),

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,0 +1,56 @@
+// src/lib/feature-flags.ts
+export type FeatureFlagAnalyticsDetail = {
+  flag: string;
+  enabled: boolean;
+  state?: string;
+};
+
+export function reportFeatureFlagAnalytics(detail: FeatureFlagAnalyticsDetail) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const state = typeof detail.state === "string"
+    ? detail.state
+    : detail.enabled
+      ? "enabled"
+      : "disabled";
+
+  const eventDetail = {
+    ...detail,
+    state,
+  } as const;
+
+  window.dispatchEvent(
+    new CustomEvent("planner:feature-flag", {
+      detail: eventDetail,
+    }),
+  );
+
+  const plausible = (window as typeof window & {
+    plausible?: (event: string, options?: { props?: Record<string, unknown> }) => void;
+  }).plausible;
+
+  if (typeof plausible === "function") {
+    plausible("feature_flag", { props: eventDetail });
+  }
+
+  const analytics = (window as typeof window & {
+    analytics?: { track?: (event: string, properties?: Record<string, unknown>) => void };
+  }).analytics;
+
+  analytics?.track?.("feature_flag", eventDetail);
+
+  const dataLayer = (window as typeof window & {
+    dataLayer?: unknown[];
+  }).dataLayer;
+
+  if (Array.isArray(dataLayer)) {
+    dataLayer.push({
+      event: "feature_flag",
+      feature_flag: eventDetail.flag,
+      feature_flag_enabled: eventDetail.enabled,
+      feature_flag_state: eventDetail.state,
+    });
+  }
+}

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -1,6 +1,7 @@
 const rawSvgNumericFilters = process.env.NEXT_PUBLIC_FEATURE_SVG_NUMERIC_FILTERS;
 const rawDepthTheme = process.env.NEXT_PUBLIC_DEPTH_THEME;
 const rawOrganicDepth = process.env.NEXT_PUBLIC_ORGANIC_DEPTH;
+const rawGlitchLanding = process.env.NEXT_PUBLIC_UI_GLITCH_LANDING;
 
 const enabledValues = new Set(["1", "true", "on", "yes"]);
 const disabledValues = new Set(["0", "false", "off", "no"]);
@@ -26,5 +27,11 @@ function parseBooleanFlag(raw: string | undefined, fallback: boolean): boolean {
 const svgNumericFilters = parseBooleanFlag(rawSvgNumericFilters, true);
 const depthThemeEnabled = parseBooleanFlag(rawDepthTheme, false);
 const organicDepthEnabled = parseBooleanFlag(rawOrganicDepth, false);
+const glitchLandingEnabled = parseBooleanFlag(rawGlitchLanding, true);
 
-export { depthThemeEnabled, organicDepthEnabled, svgNumericFilters };
+export {
+  depthThemeEnabled,
+  glitchLandingEnabled,
+  organicDepthEnabled,
+  svgNumericFilters,
+};

--- a/tests/home/HomePage.test.tsx
+++ b/tests/home/HomePage.test.tsx
@@ -56,4 +56,23 @@ describe("Home page", () => {
     const landmarks = container.querySelectorAll("main, [role=\"main\"]");
     expect(landmarks).toHaveLength(1);
   });
+
+  it("falls back to the legacy landing experience when the flag is disabled", () => {
+    render(
+      <ThemeProvider glitchLandingEnabled={false}>
+        <main id="main-content">
+          <Suspense fallback="loading">
+            <Page />
+          </Suspense>
+        </main>
+      </ThemeProvider>,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Planner preview" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: "Planner overview" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/tests/lib/theme-context.test.tsx
+++ b/tests/lib/theme-context.test.tsx
@@ -28,6 +28,8 @@ describe("ThemeProvider", () => {
     resetLocalStorage();
     document.documentElement.className = "";
     document.documentElement.removeAttribute("data-theme-pref");
+    document.documentElement.removeAttribute("data-glitch-landing");
+    document.body?.removeAttribute("data-glitch-landing");
     Consumer.lastTheme = undefined;
     Consumer.setTheme = undefined;
   });


### PR DESCRIPTION
## Summary
- add a `NEXT_PUBLIC_UI_GLITCH_LANDING` feature flag and thread it through the theme/layout providers
- provide a legacy landing fallback when the glitch landing flag is disabled and surface the flag in analytics reporting
- document the new flag in the README and extend tests to cover the legacy landing path

## Testing
- `npm run verify-prompts`
- `npm run lint`
- `npm run lint:design`
- `npm run typecheck`
- `npm test -- --run` *(fails: Node.js OOM / long runtime in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc30db795c832c8bcdd986e313b249