### PR TITLE
fix: ensure reminder delete button stays focus-visible

### DIFF
--- a/src/components/goals/reminders/ReminderList.tsx
+++ b/src/components/goals/reminders/ReminderList.tsx
@@ -169,7 +169,7 @@ function RemTileBase({ reminder, onChange, onDelete }: RemTileProps) {
             size="sm"
             iconSize="sm"
             variant="ghost"
-            className="opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity"
+            className="opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto transition-opacity"
           >
             <Trash2 />
           </IconButton>


### PR DESCRIPTION
## Summary
- keep the reminder delete icon button interactive when it or its tile receives keyboard focus by extending the focus-visible and focus-within styles

## Testing
- npm run lint
- npm run lint:design
- npm run typecheck
- npx vitest --run tests/primitives/IconButton.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc30838f24832c9e041da472104ff2