### PR TITLE
fix: format theme matrix preview min height calc

### DIFF
--- a/src/app/preview/theme-matrix/ThemeMatrixEntryCard.tsx
+++ b/src/app/preview/theme-matrix/ThemeMatrixEntryCard.tsx
@@ -29,7 +29,7 @@ const variantColumnsStyle = {
 } satisfies React.CSSProperties;
 
 const PREVIEW_HEIGHT_VARIABLE =
-  "[--theme-matrix-preview-min-h:calc(var(--space-8)*5+var(--space-4))]";
+  "[--theme-matrix-preview-min-h:calc(var(--space-8) * 5 + var(--space-4))]";
 const PREVIEW_MIN_HEIGHT_CLASS =
   "min-h-[var(--theme-matrix-preview-min-h)]";
 


### PR DESCRIPTION
## Summary
- format the theme matrix preview min-height calc with spacing so Tailwind emits the custom property
- verified the generated assets and live HTML include the spaced calc so the iframe wrapper respects the CSS variable

## Testing
- npm run verify-prompts
- NODE_OPTIONS=--max-old-space-size=8192 npm run check *(fails: vitest worker closed its channel after a long run, likely due to resource limits)*
- CI=1 npm run build
- NODE_OPTIONS=--max-old-space-size=8192 npx vitest run tests/lib/Db.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc314ad218832c9ad76c393f3c72fd