### PR TITLE
fix: highlight missing theme matrix backgrounds

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -34,7 +34,7 @@ For governance and enforcement workflows, read [Design System Governance](./desi
 - Run `npm run build-gallery-usage` after touching gallery files. It refreshes `src/components/gallery/generated-manifest.ts` with preview slugs and keeps Playwright coverage in sync.
 - Visit `/preview/[slug]` to render a single component or state in isolation. Slugs combine the gallery entry, optional state, and the theme variant (currently Glitch and Aurora). Axis metadata surfaces as `axis-…` query parameters so automation can label captured variants.
 - Trigger the **Visual Regression** workflow to record screenshots. It installs the production build, walks every generated preview route through the `@visual` Playwright suite, and uploads diffs when comparisons fail.
-- Visit `/preview/theme-matrix` to audit every gallery entry and state across Glitch, Aurora, Kitten, Oceanic, Citrus, Noir, and Hardstuck. The matrix reuses the in-gallery previews, ensuring Playwright screenshots and axe coverage span every theme without triggering layout shift.
+- Visit `/preview/theme-matrix` to audit every gallery entry and state across Glitch, Aurora, Kitten, Oceanic, Citrus, Noir, and Hardstuck. The matrix reuses the in-gallery previews, ensuring Playwright screenshots and axe coverage span every theme without triggering layout shift. Missing background previews now render explicit placeholder rows so reviewers can spot and resolve gaps before shipping.
 
 ## Tokens
 


### PR DESCRIPTION
## Summary
- iterate each theme matrix column across canonical backgrounds and render empty placeholders for missing previews
- document the new placeholder treatment in the design system review guidance

## Testing
- npm run verify-prompts
- npm run lint
- npm run lint:design
- npm run typecheck
- npx vitest --run --maxWorkers=2 *(aborted due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3779a0bc832c813bb5886eb8129b