### PR TITLE
chore: align outer shadow tokens with depth scale

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -316,8 +316,8 @@
 | grid-color | var(--accent) |
 | grid-alpha | 0.1 |
 | grid-size | calc(var(--space-6) - var(--space-1)) |
-| shadow-outer-sm | 0 var(--spacing-2) var(--spacing-4) hsl(var(--shadow-color) / 0.24) |
-| shadow-outer-md | 0 var(--spacing-3) var(--spacing-6) hsl(var(--shadow-color) / 0.3) |
+| shadow-outer-sm | 0 calc(var(--neo-depth-sm) * 2) var(--neo-depth-lg) hsl(var(--shadow-color) / 0.24) |
+| shadow-outer-md | 0 var(--neo-depth-md) calc(var(--neo-depth-lg) * 2) hsl(var(--shadow-color) / 0.3) |
 | card-elev-1 | var(--shadow-outline-faint), var(--shadow-outer-sm) |
 | card-elev-2 | var(--shadow-outline-subtle), var(--shadow-outer-md) |
 | card-elev-3 | var(--shadow-outline-subtle), var(--shadow-outer-lg) |

--- a/scripts/generate-tokens.ts
+++ b/scripts/generate-tokens.ts
@@ -298,9 +298,9 @@ async function buildTokens(): Promise<void> {
     "shadow-inner-lg":
       "inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36)",
     "shadow-outer-sm":
-      "0 var(--spacing-2) var(--spacing-4) hsl(var(--shadow-color) / 0.24)",
+      "0 calc(var(--neo-depth-sm) * 2) var(--neo-depth-lg) hsl(var(--shadow-color) / 0.24)",
     "shadow-outer-md":
-      "0 var(--spacing-3) var(--spacing-6) hsl(var(--shadow-color) / 0.3)",
+      "0 var(--neo-depth-md) calc(var(--neo-depth-lg) * 2) hsl(var(--shadow-color) / 0.3)",
     "shadow-outer-lg":
       "0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36)",
     "shadow-outer-xl":

--- a/scripts/themes.ts
+++ b/scripts/themes.ts
@@ -72,6 +72,16 @@ export const rootVariables: VariableDefinition[] = [
       "inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36)",
   },
   {
+    name: "shadow-outer-sm",
+    value:
+      "0 calc(var(--neo-depth-sm) * 2) var(--neo-depth-lg) hsl(var(--shadow-color) / 0.24)",
+  },
+  {
+    name: "shadow-outer-md",
+    value:
+      "0 var(--neo-depth-md) calc(var(--neo-depth-lg) * 2) hsl(var(--shadow-color) / 0.3)",
+  },
+  {
     name: "shadow-outer-lg",
     value: "0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36)",
   },
@@ -481,6 +491,16 @@ export const themes: ThemeDefinition[] = [
           "inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.38)",
       },
       {
+        name: "shadow-outer-sm",
+        value:
+          "0 calc(var(--neo-depth-sm) * 2) var(--neo-depth-lg) hsl(var(--shadow-color) / 0.3)",
+      },
+      {
+        name: "shadow-outer-md",
+        value:
+          "0 var(--neo-depth-md) calc(var(--neo-depth-lg) * 2) hsl(var(--shadow-color) / 0.36)",
+      },
+      {
         name: "shadow-outer-lg",
         value: "0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.42)",
       },
@@ -726,6 +746,16 @@ export const themes: ThemeDefinition[] = [
         name: "shadow-inner-lg",
         value:
           "inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.3)",
+      },
+      {
+        name: "shadow-outer-sm",
+        value:
+          "0 calc(var(--neo-depth-sm) * 2) var(--neo-depth-lg) hsl(var(--shadow-color) / 0.22)",
+      },
+      {
+        name: "shadow-outer-md",
+        value:
+          "0 var(--neo-depth-md) calc(var(--neo-depth-lg) * 2) hsl(var(--shadow-color) / 0.28)",
       },
       {
         name: "shadow-outer-lg",

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -320,6 +320,23 @@
   --glow-ring: 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22);
   --blob-radius-soft: calc(var(--radius-2xl) + var(--spacing-2));
   --glitch-noise-hover: calc(var(--glitch-noise-level) * 1.3);
+  --grid-color: var(--accent);
+  --grid-alpha: 0.1;
+  --grid-size: calc(var(--space-6) - var(--space-1));
+  --shadow-outer-sm: 0 calc(var(--neo-depth-sm) * 2) var(--neo-depth-lg) hsl(var(--shadow-color) / 0.24);
+  --shadow-outer-md: 0 var(--neo-depth-md) calc(var(--neo-depth-lg) * 2) hsl(var(--shadow-color) / 0.3);
+  --card-elev-1: var(--shadow-outline-faint), var(--shadow-outer-sm);
+  --card-elev-2: var(--shadow-outline-subtle), var(--shadow-outer-md);
+  --card-elev-3: var(--shadow-outline-subtle), var(--shadow-outer-lg);
+  --glow-ring-sm: 0 0 0 calc(var(--spacing-0-25)) hsl(var(--ring) / 0.45);
+  --glow-ring-md: 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-2) hsl(var(--ring) / 0.2);
+  --glow-pulse: glow-pulse var(--dur-slow) var(--ease-out) infinite alternate;
+  --blob-surface: color-mix(in oklab, hsl(var(--surface)) 70%, hsl(var(--surface-2)) 30%);
+  --drip-surface: color-mix(in oklab, hsl(var(--accent)) 18%, hsl(var(--background)) 82%);
+  --gradient-blob-primary: radial-gradient(120% 120% at 50% 10%, hsl(var(--surface) / 0.85), hsl(var(--surface-2) / 0.35), transparent 85%);
+  --gradient-glitch-primary: linear-gradient(135deg, hsl(var(--accent) / 0.35), hsl(var(--accent-2) / 0.3));
+  --glitch-rgb-shift: drop-shadow(calc(var(--glitch-chromatic-offset-light) * -1) 0 0 hsl(var(--accent) / 0.45)) drop-shadow(var(--glitch-chromatic-offset-light) 0 0 hsl(var(--ring) / 0.45));
+  --glitch-scanline: glitch-scanline calc(var(--glitch-duration) * 1.2) steps(2, end) infinite;
   --spacing-0-125: calc(var(--spacing-1) / 8);
   --spacing-0-25: calc(var(--spacing-1) / 4);
   --spacing-0-5: calc(var(--spacing-1) / 2);
@@ -345,6 +362,20 @@
     --aurora-g-light-color: var(--aurora-g-light);
     --aurora-p-light: color-mix(in oklab, hsl(var(--accent)) 37.5%, white);
     --aurora-p-light-color: var(--aurora-p-light);
+  }
+}
+@media (prefers-reduced-motion: no-preference) {
+  :root {
+    --glitch-scanline: glitch-scanline calc(var(--glitch-duration) * 1.2) steps(2, end) infinite;
+    --glitch-rgb-shift: drop-shadow(calc(var(--glitch-chromatic-offset-light) * -1) 0 0 hsl(var(--accent) / 0.45)) drop-shadow(var(--glitch-chromatic-offset-light) 0 0 hsl(var(--ring) / 0.45));
+    --glow-pulse: glow-pulse var(--dur-slow) var(--ease-out) infinite alternate;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --glitch-scanline: none;
+    --glitch-rgb-shift: none;
+    --glow-pulse: none;
   }
 }
 :root {
@@ -375,6 +406,8 @@
   --shadow-inner-sm: inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.18);
   --shadow-inner-md: inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.28);
   --shadow-inner-lg: inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.36);
+  --shadow-outer-sm: 0 calc(var(--neo-depth-sm) * 2) var(--neo-depth-lg) hsl(var(--shadow-color) / 0.24);
+  --shadow-outer-md: 0 var(--neo-depth-md) calc(var(--neo-depth-lg) * 2) hsl(var(--shadow-color) / 0.3);
   --shadow-outer-lg: 0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.36);
   --shadow-outer-xl: 0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.45);
   /* Depth glow ramps */
@@ -749,6 +782,8 @@ html.theme-noir {
   --shadow-inner-sm: inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.2);
   --shadow-inner-md: inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.3);
   --shadow-inner-lg: inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.38);
+  --shadow-outer-sm: 0 calc(var(--neo-depth-sm) * 2) var(--neo-depth-lg) hsl(var(--shadow-color) / 0.3);
+  --shadow-outer-md: 0 var(--neo-depth-md) calc(var(--neo-depth-lg) * 2) hsl(var(--shadow-color) / 0.36);
   --shadow-outer-lg: 0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.42);
   --shadow-outer-xl: 0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.48);
   --neo-glow-strength: 0.6;
@@ -937,6 +972,8 @@ html.theme-hardstuck {
   --shadow-inner-sm: inset 0 var(--spacing-0-125) var(--spacing-0-5) hsl(var(--shadow-color) / 0.16);
   --shadow-inner-md: inset 0 var(--spacing-0-25) var(--spacing-1) hsl(var(--shadow-color) / 0.24);
   --shadow-inner-lg: inset 0 var(--spacing-0-5) var(--spacing-2) hsl(var(--shadow-color) / 0.3);
+  --shadow-outer-sm: 0 calc(var(--neo-depth-sm) * 2) var(--neo-depth-lg) hsl(var(--shadow-color) / 0.22);
+  --shadow-outer-md: 0 var(--neo-depth-md) calc(var(--neo-depth-lg) * 2) hsl(var(--shadow-color) / 0.28);
   --shadow-outer-lg: 0 var(--spacing-4) var(--spacing-7) hsl(var(--shadow-color) / 0.34);
   --shadow-outer-xl: 0 var(--spacing-5) var(--spacing-8) hsl(var(--shadow-color) / 0.42);
   --neo-glow-strength: 0.58;

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -319,8 +319,8 @@
   --grid-color: var(--accent);
   --grid-alpha: 0.1;
   --grid-size: calc(var(--space-6) - var(--space-1));
-  --shadow-outer-sm: 0 var(--spacing-2) var(--spacing-4) hsl(var(--shadow-color) / 0.24);
-  --shadow-outer-md: 0 var(--spacing-3) var(--spacing-6) hsl(var(--shadow-color) / 0.3);
+  --shadow-outer-sm: 0 calc(var(--neo-depth-sm) * 2) var(--neo-depth-lg) hsl(var(--shadow-color) / 0.24);
+  --shadow-outer-md: 0 var(--neo-depth-md) calc(var(--neo-depth-lg) * 2) hsl(var(--shadow-color) / 0.3);
   --card-elev-1: var(--shadow-outline-faint), var(--shadow-outer-sm);
   --card-elev-2: var(--shadow-outline-subtle), var(--shadow-outer-md);
   --card-elev-3: var(--shadow-outline-subtle), var(--shadow-outer-lg);

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -301,9 +301,9 @@ export default {
   gridAlpha: "0.1",
   gridSize: "calc(var(--space-6) - var(--space-1))",
   shadowOuterSm:
-    "0 var(--spacing-2) var(--spacing-4) hsl(var(--shadow-color) / 0.24)",
+    "0 calc(var(--neo-depth-sm) * 2) var(--neo-depth-lg) hsl(var(--shadow-color) / 0.24)",
   shadowOuterMd:
-    "0 var(--spacing-3) var(--spacing-6) hsl(var(--shadow-color) / 0.3)",
+    "0 var(--neo-depth-md) calc(var(--neo-depth-lg) * 2) hsl(var(--shadow-color) / 0.3)",
   cardElev1: "var(--shadow-outline-faint), var(--shadow-outer-sm)",
   cardElev2: "var(--shadow-outline-subtle), var(--shadow-outer-md)",
   cardElev3: "var(--shadow-outline-subtle), var(--shadow-outer-lg)",


### PR DESCRIPTION
## Summary
- add generated shadow-outer-sm/md definitions to the token generators and theme sources using the neumorphic depth variables
- update the base token documentation and JS bundle to emit the new depth-aligned shadows
- refresh theme overrides so Noir and Hardstuck reuse the calibrated outer shadow strengths

## Testing
- npx tailwindcss -c tailwind.config.ts -i src/app/globals.css -o /tmp/tailwind-shadows.css --content /tmp/shadow-test.html
- npm run lint
- npm run lint:design
- npm run typecheck
- NODE_OPTIONS="--max-old-space-size=8192" npx vitest --run tests/primitives/IconButton.test.tsx --maxWorkers=2

------
https://chatgpt.com/codex/tasks/task_e_68dc38640140832cae8b8416bc83f4d3