### PR TITLE
fix: neutralize cat companion idle color

### DIFF
--- a/src/components/ui/CatCompanion.tsx
+++ b/src/components/ui/CatCompanion.tsx
@@ -5,7 +5,7 @@ export default function CatCompanion() {
   return (
     <div className="fixed bottom-[var(--space-4)] left-[var(--space-4)] z-50 pointer-events-none select-none">
       <CatCompanionIcon
-        className="w-[var(--space-8)] h-[var(--space-8)] text-accent motion-safe:animate-[cat-float_3s_ease-in-out_infinite]"
+        className="w-[var(--space-8)] h-[var(--space-8)] text-foreground/80 motion-safe:animate-[cat-float_3s_ease-in-out_infinite]"
         aria-label="Cat companion"
         tabIndex={-1}
       />


### PR DESCRIPTION
## Summary
- replace the CatCompanion idle icon color with the neutral `text-foreground/80` token so it stays theme-agnostic outside of accent states.

## Testing
- `npm run lint`
- `npm run lint:design`
- `npm run typecheck`
- `NODE_OPTIONS=--max-old-space-size=8192 npm test -- --run` *(hangs on UsePlannerStore.integration suite, manual abort after >4 minutes)*
- `npm run verify-prompts`

------
https://chatgpt.com/codex/tasks/task_e_68dc65b9d960832ca147d144efe53ec3