### PR TITLE
feat: tokenise gradient backgrounds

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -134,6 +134,7 @@ export function Submit() {
 
 - `ThemeToggle` (in `src/components/ui/theme`) lets users switch among preset themes and backgrounds while persisting preferences in local storage.
 - Apply the provided classes (`bg-intense`, variant names, etc.) to opt into specific theme behavior.
+- Gradient utilities like `bg-shell-card`, `bg-shell-bloom`, and `bg-drip-overlay` now point at the tokenized backgrounds so overlays stay consistent across themes.
 
 ```tsx
 import ThemeToggle from "@/components/ui/theme/ThemeToggle";

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -328,6 +328,15 @@
 | drip-surface | color-mix(in oklab, hsl(var(--accent)) 18%, hsl(var(--background)) 82%) |
 | gradient-blob-primary | radial-gradient(120% 120% at 50% 10%, hsl(var(--surface) / 0.85), hsl(var(--surface-2) / 0.35), transparent 85%) |
 | gradient-glitch-primary | linear-gradient(135deg, hsl(var(--accent) / 0.35), hsl(var(--accent-2) / 0.3)) |
+| gradient-shell-card | linear-gradient(140deg, hsl(var(--card) / 0.95), hsl(var(--surface-2) / 0.78)) |
+| gradient-shell-card-strong | linear-gradient(140deg, hsl(var(--card) / 0.98), hsl(var(--surface-2) / 0.82)) |
+| gradient-shell-card-soft | linear-gradient(140deg, hsl(var(--card) / 0.94), hsl(var(--surface-2) / 0.72)) |
+| gradient-shell-bloom | radial-gradient(125% 85% at 18% -25%, hsl(var(--accent) / 0.3), transparent 65%), radial-gradient(125% 85% at 82% -20%, hsl(var(--ring) / 0.28), transparent 60%) |
+| gradient-shell-veil | linear-gradient(120deg, hsl(var(--accent) / 0.12) 0%, transparent 58%, hsl(var(--ring) / 0.16) 100%), repeating-linear-gradient(0deg, hsl(var(--ring) / 0.12) 0, hsl(var(--ring) / 0.12) var(--hairline-w), transparent var(--hairline-w), transparent calc(var(--space-3))) |
+| gradient-shell-spotlight | radial-gradient(120% 95% at 50% 0%, hsl(var(--accent) / 0.24), transparent 65%) |
+| gradient-shell-divider | linear-gradient(90deg, hsl(var(--accent) / 0.28), transparent 55%, hsl(var(--accent-2) / 0.32)) |
+| gradient-hero-frame | linear-gradient(145deg, hsl(var(--card)), hsl(var(--panel))) |
+| gradient-drip-overlay | radial-gradient(60% 40% at 10% 0%, hsl(var(--backdrop-drip-1) / 0.2), transparent 60%), radial-gradient(50% 35% at 100% 5%, hsl(var(--backdrop-drip-2) / 0.18), transparent 60%), radial-gradient(55% 35% at 50% 120%, hsl(var(--backdrop-drip-3) / 0.14), transparent 65%), radial-gradient(120% 100% at 50% 100%, hsl(var(--backdrop-drip-shadow) / 0.35), transparent 70%) |
 | glitch-rgb-shift | drop-shadow(calc(var(--glitch-chromatic-offset-light) * -1) 0 0 hsl(var(--accent) / 0.45)) drop-shadow(var(--glitch-chromatic-offset-light) 0 0 hsl(var(--ring) / 0.45)) |
 | glitch-scanline | glitch-scanline calc(var(--glitch-duration) * 1.2) steps(2, end) infinite |
 | danger-surface-foreground | var(--danger-foreground) |

--- a/scripts/generate-tokens.ts
+++ b/scripts/generate-tokens.ts
@@ -359,6 +359,24 @@ async function buildTokens(): Promise<void> {
     "glitch-noise-hover": "calc(var(--glitch-noise-level) * 1.3)",
     "gradient-glitch-primary":
       "linear-gradient(135deg, hsl(var(--accent) / 0.35), hsl(var(--accent-2) / 0.3))",
+    "gradient-shell-card":
+      "linear-gradient(140deg, hsl(var(--card) / 0.95), hsl(var(--surface-2) / 0.78))",
+    "gradient-shell-card-strong":
+      "linear-gradient(140deg, hsl(var(--card) / 0.98), hsl(var(--surface-2) / 0.82))",
+    "gradient-shell-card-soft":
+      "linear-gradient(140deg, hsl(var(--card) / 0.94), hsl(var(--surface-2) / 0.72))",
+    "gradient-shell-bloom":
+      "radial-gradient(125% 85% at 18% -25%, hsl(var(--accent) / 0.3), transparent 65%), radial-gradient(125% 85% at 82% -20%, hsl(var(--ring) / 0.28), transparent 60%)",
+    "gradient-shell-veil":
+      "linear-gradient(120deg, hsl(var(--accent) / 0.12) 0%, transparent 58%, hsl(var(--ring) / 0.16) 100%), repeating-linear-gradient(0deg, hsl(var(--ring) / 0.12) 0, hsl(var(--ring) / 0.12) var(--hairline-w), transparent var(--hairline-w), transparent calc(var(--space-3)))",
+    "gradient-shell-spotlight":
+      "radial-gradient(120% 95% at 50% 0%, hsl(var(--accent) / 0.24), transparent 65%)",
+    "gradient-shell-divider":
+      "linear-gradient(90deg, hsl(var(--accent) / 0.28), transparent 55%, hsl(var(--accent-2) / 0.32))",
+    "gradient-hero-frame":
+      "linear-gradient(145deg, hsl(var(--card)), hsl(var(--panel)))",
+    "gradient-drip-overlay":
+      "radial-gradient(60% 40% at 10% 0%, hsl(var(--backdrop-drip-1) / 0.2), transparent 60%), radial-gradient(50% 35% at 100% 5%, hsl(var(--backdrop-drip-2) / 0.18), transparent 60%), radial-gradient(55% 35% at 50% 120%, hsl(var(--backdrop-drip-3) / 0.14), transparent 65%), radial-gradient(120% 100% at 50% 100%, hsl(var(--backdrop-drip-shadow) / 0.35), transparent 70%)",
     "glitch-rgb-shift":
       "drop-shadow(calc(var(--glitch-chromatic-offset-light) * -1) 0 0 hsl(var(--accent) / 0.45)) drop-shadow(var(--glitch-chromatic-offset-light) 0 0 hsl(var(--ring) / 0.45))",
     "glitch-scanline":

--- a/src/app/themes.css
+++ b/src/app/themes.css
@@ -176,9 +176,6 @@
   --space-6: var(--spacing-6);
   --space-7: var(--spacing-7);
   --space-8: var(--spacing-8);
-  --space-9: calc(var(--space-8) + var(--space-1));
-  --space-10: calc(var(--space-8) + var(--space-2));
-  --space-11: calc(var(--space-8) + var(--space-3));
   --font-size-md: var(--font-body);
   --font-weight-bold: 800;
   --shadow-neon: 0 0 var(--space-1) hsl(var(--neon) / 0.55),
@@ -340,6 +337,21 @@
   --gradient-glitch-primary: linear-gradient(135deg, hsl(var(--accent) / 0.35), hsl(var(--accent-2) / 0.3));
   --glitch-rgb-shift: drop-shadow(calc(var(--glitch-chromatic-offset-light) * -1) 0 0 hsl(var(--accent) / 0.45)) drop-shadow(var(--glitch-chromatic-offset-light) 0 0 hsl(var(--ring) / 0.45));
   --glitch-scanline: glitch-scanline calc(var(--glitch-duration) * 1.2) steps(2, end) infinite;
+  --danger-surface-foreground: var(--danger-foreground);
+  --surface-overlay-soft: 0.12;
+  --surface-overlay-strong: 0.2;
+  --glitch-card-surface-top: hsl(var(--card) / 0.78);
+  --glitch-card-surface-bottom: hsl(var(--panel) / 0.66);
+  --surface-card-soft: linear-gradient(180deg, hsl(var(--card) / 0.65), hsl(var(--card) / 0.45));
+  --surface-card-strong: linear-gradient(180deg, hsl(var(--card) / 0.85), hsl(var(--card) / 0.65));
+  --surface-card-strong-hover: linear-gradient(180deg, hsl(var(--card) / 0.95), hsl(var(--card) / 0.75));
+  --surface-card-strong-active: linear-gradient(180deg, hsl(var(--card) / 0.8), hsl(var(--card) / 0.6));
+  --surface-card-strong-today: linear-gradient(180deg, hsl(var(--card) / 0.9), hsl(var(--card) / 0.7));
+  --surface-card-strong-empty: linear-gradient(180deg, hsl(var(--card) / 0.6), hsl(var(--card) / 0.5));
+  --surface-rail-accent: linear-gradient(180deg, hsl(var(--accent)), hsl(var(--primary)));
+  --space-9: calc(var(--space-8) + var(--space-1));
+  --space-10: calc(var(--space-8) + var(--space-2));
+  --space-11: calc(var(--space-8) + var(--space-3));
   --spacing-0-125: calc(var(--spacing-1) / 8);
   --spacing-0-25: calc(var(--spacing-1) / 4);
   --spacing-0-5: calc(var(--spacing-1) / 2);
@@ -681,6 +693,10 @@ html.theme-aurora {
   --backdrop-drip-2: var(--accent);
   --backdrop-drip-3: var(--accent-2);
   --backdrop-drip-shadow: var(--card);
+  --gradient-drip-overlay:
+    radial-gradient(60% 40% at 12% -5%, hsl(var(--backdrop-drip-1) / 0.18), transparent 60%),
+    radial-gradient(50% 35% at 105% 10%, hsl(var(--backdrop-drip-2) / 0.16), transparent 60%),
+    radial-gradient(55% 35% at 50% 110%, hsl(var(--backdrop-drip-3) / 0.12), transparent 65%);
   --glow-ring: 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22);
   --blob-radius-soft: calc(var(--radius-2xl) + var(--spacing-2));
   --glitch-noise-hover: calc(var(--glitch-noise-level) * 1.3);
@@ -825,6 +841,10 @@ html.theme-noir {
   --backdrop-drip-2: var(--noir-red);
   --backdrop-drip-3: var(--noir-ruby);
   --backdrop-drip-shadow: var(--noir-ink);
+  --gradient-drip-overlay:
+    radial-gradient(80% 60% at 50% 120%, hsl(var(--backdrop-drip-1) / 0.45), transparent 70%),
+    radial-gradient(40% 25% at 6% 4%, hsl(var(--backdrop-drip-2) / 0.15), transparent 60%),
+    radial-gradient(40% 25% at 94% 10%, hsl(var(--backdrop-drip-3) / 0.12), transparent 60%);
   --glitch-noise-hover: calc(var(--glitch-noise-level) * 1.35);
 }
 /* ---------- Oceanic ---------- */
@@ -880,6 +900,10 @@ html.theme-ocean {
   --backdrop-drip-2: var(--ocean-indigo);
   --backdrop-drip-3: var(--success);
   --backdrop-drip-shadow: var(--card);
+  --gradient-drip-overlay:
+    radial-gradient(60% 40% at 14% -6%, hsl(var(--backdrop-drip-1) / 0.18), transparent 60%),
+    radial-gradient(55% 35% at 50% 114%, hsl(var(--backdrop-drip-2) / 0.12), transparent 65%),
+    radial-gradient(50% 35% at 102% 8%, hsl(var(--backdrop-drip-3) / 0.1), transparent 60%);
   --glow-ring: 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22);
   --blob-radius-soft: calc(var(--radius-2xl) + var(--spacing-2));
   --glitch-noise-hover: calc(var(--glitch-noise-level) * 1.3);
@@ -938,6 +962,10 @@ html.theme-kitten {
   --backdrop-drip-2: var(--kitten-pink);
   --backdrop-drip-3: var(--kitten-blush);
   --backdrop-drip-shadow: var(--card);
+  --gradient-drip-overlay:
+    radial-gradient(60% 40% at 12% -6%, hsl(var(--backdrop-drip-1) / 0.18), transparent 60%),
+    radial-gradient(55% 35% at 50% 116%, hsl(var(--backdrop-drip-2) / 0.12), transparent 65%),
+    radial-gradient(50% 35% at 100% 8%, hsl(var(--backdrop-drip-3) / 0.1), transparent 60%);
   --glow-ring: 0 0 0 calc(var(--spacing-0-5)) hsl(var(--ring) / 0.5), 0 0 var(--spacing-3) hsl(var(--ring) / 0.22);
   --blob-radius-soft: calc(var(--radius-2xl) + var(--spacing-2));
   --glitch-noise-hover: calc(var(--glitch-noise-level) * 1.3);
@@ -1014,6 +1042,10 @@ html.theme-hardstuck {
   --backdrop-drip-2: var(--ring);
   --backdrop-drip-3: var(--hardstuck-forest);
   --backdrop-drip-shadow: var(--hardstuck-deep);
+  --gradient-drip-overlay:
+    radial-gradient(80% 60% at 50% 120%, hsl(var(--backdrop-drip-1) / 0.45), transparent 70%),
+    radial-gradient(40% 25% at 6% 4%, hsl(var(--backdrop-drip-2) / 0.15), transparent 60%),
+    radial-gradient(40% 25% at 94% 10%, hsl(var(--backdrop-drip-3) / 0.12), transparent 60%);
   --glitch-noise-hover: calc(var(--glitch-noise-level) * 1.35);
 }
 /* ---------- Retro ---------- */
@@ -1184,27 +1216,7 @@ html:not(.theme-citrus):not(.theme-noir):not(.theme-ocean):not(
   inset: -10%;
   pointer-events: none;
   z-index: 0;
-  background:
-    radial-gradient(
-      60% 40% at 10% 0%,
-      hsl(var(--backdrop-drip-1) / 0.2),
-      transparent 60%
-    ),
-    radial-gradient(
-      50% 35% at 100% 5%,
-      hsl(var(--backdrop-drip-2) / 0.18),
-      transparent 60%
-    ),
-    radial-gradient(
-      55% 35% at 50% 120%,
-      hsl(var(--backdrop-drip-3) / 0.14),
-      transparent 65%
-    ),
-    radial-gradient(
-      120% 100% at 50% 100%,
-      hsl(var(--backdrop-drip-shadow) / 0.35),
-      transparent 70%
-    );
+  background: var(--gradient-drip-overlay);
   filter: blur(2px) saturate(110%);
   animation: lg-aurora-pan 24s ease-in-out infinite alternate;
 }
@@ -1263,22 +1275,7 @@ html.theme-citrus body::after {
   inset: -8%;
   pointer-events: none;
   z-index: 0;
-  background:
-    radial-gradient(
-      60% 40% at 12% -5%,
-      hsl(var(--backdrop-drip-1) / 0.18),
-      transparent 60%
-    ),
-    radial-gradient(
-      50% 35% at 105% 10%,
-      hsl(var(--backdrop-drip-2) / 0.16),
-      transparent 60%
-    ),
-    radial-gradient(
-      55% 35% at 50% 110%,
-      hsl(var(--backdrop-drip-3) / 0.12),
-      transparent 65%
-    );
+  background: var(--gradient-drip-overlay);
   filter: blur(2px) saturate(110%);
   animation: citrus-pan 28s ease-in-out infinite alternate;
 }
@@ -1318,22 +1315,7 @@ html.theme-noir body::after {
   inset: -12%;
   pointer-events: none;
   z-index: 0;
-  background:
-    radial-gradient(
-      80% 60% at 50% 120%,
-      hsl(var(--backdrop-drip-1) / 0.45),
-      transparent 70%
-    ),
-    radial-gradient(
-      40% 25% at 6% 4%,
-      hsl(var(--backdrop-drip-2) / 0.15),
-      transparent 60%
-    ),
-    radial-gradient(
-      40% 25% at 94% 10%,
-      hsl(var(--backdrop-drip-3) / 0.12),
-      transparent 60%
-    );
+  background: var(--gradient-drip-overlay);
   filter: blur(1.5px) saturate(110%);
   opacity: 0.9;
   animation: noir-drift 26s ease-in-out infinite alternate;
@@ -1368,22 +1350,7 @@ html.theme-ocean body::after {
   inset: -10%;
   z-index: 0;
   pointer-events: none;
-  background:
-    radial-gradient(
-      60% 40% at 14% -6%,
-      hsl(var(--backdrop-drip-1) / 0.18),
-      transparent 60%
-    ),
-    radial-gradient(
-      55% 35% at 50% 114%,
-      hsl(var(--backdrop-drip-2) / 0.12),
-      transparent 65%
-    ),
-    radial-gradient(
-      50% 35% at 102% 8%,
-      hsl(var(--backdrop-drip-3) / 0.1),
-      transparent 60%
-    );
+  background: var(--gradient-drip-overlay);
   filter: blur(2px) saturate(112%);
   animation: ocean-pan 26s ease-in-out infinite alternate;
 }
@@ -1423,22 +1390,7 @@ html.theme-kitten body::after {
   inset: -10%;
   z-index: 0;
   pointer-events: none;
-  background:
-    radial-gradient(
-      60% 40% at 12% -6%,
-      hsl(var(--backdrop-drip-1) / 0.18),
-      transparent 60%
-    ),
-    radial-gradient(
-      55% 35% at 50% 116%,
-      hsl(var(--backdrop-drip-2) / 0.12),
-      transparent 65%
-    ),
-    radial-gradient(
-      50% 35% at 100% 8%,
-      hsl(var(--backdrop-drip-3) / 0.1),
-      transparent 60%
-    );
+  background: var(--gradient-drip-overlay);
   filter: blur(2px) saturate(112%);
   animation: kitten-pan 27s ease-in-out infinite alternate;
 }
@@ -1472,22 +1424,7 @@ html.theme-hardstuck body::after {
   inset: -12%;
   pointer-events: none;
   z-index: 0;
-  background:
-    radial-gradient(
-      80% 60% at 50% 120%,
-      hsl(var(--backdrop-drip-1) / 0.45),
-      transparent 70%
-    ),
-    radial-gradient(
-      40% 25% at 6% 4%,
-      hsl(var(--backdrop-drip-2) / 0.15),
-      transparent 60%
-    ),
-    radial-gradient(
-      40% 25% at 94% 10%,
-      hsl(var(--backdrop-drip-3) / 0.12),
-      transparent 60%
-    );
+  background: var(--gradient-drip-overlay);
   filter: blur(1.5px) saturate(110%);
   opacity: 0.9;
   animation: hardstuck-drift 26s ease-in-out infinite alternate;

--- a/src/components/prompts/ComponentsView.tsx
+++ b/src/components/prompts/ComponentsView.tsx
@@ -41,15 +41,15 @@ const containerClassName = cn(
   "group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden",
   "rounded-card r-card-lg",
   "rounded-[var(--radius-card)] border border-card-hairline-75",
-  "bg-[linear-gradient(140deg,hsl(var(--card)/0.95),hsl(var(--surface-2)/0.78))]",
+  "bg-shell-card",
   "px-[var(--space-6)] py-[var(--space-5)]",
   "shadow-neo",
   "focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--card))]",
   "before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit]",
-  "before:bg-[radial-gradient(125%_85%_at_18%_-25%,hsl(var(--accent)/0.3),transparent_65%),radial-gradient(125%_85%_at_82%_-20%,hsl(var(--ring)/0.28),transparent_60%)]",
+  "before:bg-shell-bloom",
   "before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55",
   "after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit]",
-  "after:bg-[linear-gradient(120deg,hsl(var(--accent)/0.12)_0%,transparent_58%,hsl(var(--ring)/0.16)_100%),repeating-linear-gradient(0deg,hsl(var(--ring)/0.12)_0,hsl(var(--ring)/0.12)_var(--hairline-w),transparent_var(--hairline-w),transparent_calc(var(--space-3)))]",
+  "after:bg-shell-veil",
   "after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45",
 );
 
@@ -57,7 +57,7 @@ const frameClassName = cn(
   "relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)]",
   "shadow-[var(--shadow-inset-hairline)]",
   "before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude]",
-  "after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-[linear-gradient(90deg,hsl(var(--accent)/0.28),transparent_55%,hsl(var(--accent-2)/0.32))] after:opacity-70 after:mix-blend-screen",
+  "after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-shell-divider after:opacity-70 after:mix-blend-screen",
   "group-focus-within/component-view:before:opacity-55",
 );
 
@@ -293,7 +293,7 @@ function ShowCodeButton({
       className={cn(
         "group/button relative inline-flex h-[var(--control-h-md)] items-center justify-center gap-[var(--space-1)]",
         "rounded-full px-[var(--space-5)] text-ui font-medium tracking-[-0.01em]",
-        "bg-[linear-gradient(140deg,hsl(var(--card)/0.98),hsl(var(--surface-2)/0.82))] text-foreground",
+        "bg-shell-card-strong text-foreground",
         "border border-[hsl(var(--ring)/0.45)]",
         "shadow-neo",
         "hover:shadow-neo-soft focus-visible:shadow-neo-soft",
@@ -307,7 +307,7 @@ function ShowCodeButton({
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--card))]",
         "before:pointer-events-none before:absolute before:-inset-px before:rounded-full before:border before:border-[hsl(var(--ring)/0.35)] before:opacity-0 before:transition-opacity before:duration-quick before:ease-out",
         "focus-visible:before:opacity-100",
-        "after:pointer-events-none after:absolute after:inset-0 after:rounded-full after:bg-[radial-gradient(120%_95%_at_50%_0%,hsl(var(--accent)/0.24),transparent_65%)] after:opacity-0 after:transition-opacity after:duration-quick after:ease-out",
+        "after:pointer-events-none after:absolute after:inset-0 after:rounded-full after:bg-shell-spotlight after:opacity-0 after:transition-opacity after:duration-quick after:ease-out",
         "hover:after:opacity-100 focus-visible:after:opacity-100",
         "disabled:cursor-not-allowed disabled:opacity-disabled disabled:translate-y-0",
         "disabled:shadow-outline-subtle",
@@ -786,7 +786,7 @@ function StatePreviewCard({
 
   return (
     <article
-      className="flex flex-col gap-[var(--space-3)] rounded-card r-card-lg border border-card-hairline-60 bg-[linear-gradient(140deg,hsl(var(--card)/0.94),hsl(var(--surface-2)/0.72))] p-[var(--space-4)] shadow-neo"
+      className="flex flex-col gap-[var(--space-3)] rounded-card r-card-lg border border-card-hairline-60 bg-shell-card-soft p-[var(--space-4)] shadow-neo"
       aria-labelledby={headingId}
       aria-describedby={descriptionId}
     >

--- a/src/components/ui/layout/NeomorphicFrameStyles.css
+++ b/src/components/ui/layout/NeomorphicFrameStyles.css
@@ -1,5 +1,5 @@
 :global(.hero2-neomorph) {
-  background: linear-gradient(145deg, hsl(var(--card)), hsl(var(--panel)));
+  background: var(--gradient-hero-frame);
   --hero2-shadow-key: var(--depth-shadow-outer);
   --hero2-shadow-ambient: var(--depth-shadow-inner);
   box-shadow: var(--hero2-shadow-ambient), var(--hero2-shadow-key);

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -151,6 +151,15 @@ export const gradientTokenNames = [
   "review-result-loss-gradient",
   "gradient-blob-primary",
   "gradient-glitch-primary",
+  "gradient-shell-card",
+  "gradient-shell-card-strong",
+  "gradient-shell-card-soft",
+  "gradient-shell-bloom",
+  "gradient-shell-veil",
+  "gradient-shell-spotlight",
+  "gradient-shell-divider",
+  "gradient-hero-frame",
+  "gradient-drip-overlay",
 ] as const;
 
 export type GradientTokenName = (typeof gradientTokenNames)[number];

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -276,8 +276,17 @@ const config: Config = {
         loading: "var(--loading)",
       },
       backgroundImage: {
-        "blob-primary":
-          "radial-gradient(1200px 700px at 18% -10%, hsl(var(--backdrop-blob-1) / 0.16), transparent 60%), radial-gradient(1100px 600px at 110% 18%, hsl(var(--backdrop-blob-2) / 0.14), transparent 60%), radial-gradient(900px 480px at 50% 120%, hsl(var(--backdrop-blob-3) / 0.1), transparent 65%)",
+        "blob-primary": "var(--gradient-blob-primary)",
+        "glitch-primary": "var(--gradient-glitch-primary)",
+        "shell-card": "var(--gradient-shell-card)",
+        "shell-card-strong": "var(--gradient-shell-card-strong)",
+        "shell-card-soft": "var(--gradient-shell-card-soft)",
+        "shell-bloom": "var(--gradient-shell-bloom)",
+        "shell-veil": "var(--gradient-shell-veil)",
+        "shell-spotlight": "var(--gradient-shell-spotlight)",
+        "shell-divider": "var(--gradient-shell-divider)",
+        "hero-frame": "var(--gradient-hero-frame)",
+        "drip-overlay": "var(--gradient-drip-overlay)",
         "glitch-noise":
           "var(--glitch-noise-image, var(--asset-noise-url, url(\"/noise.svg\")))",
       },

--- a/tests/prompts/__snapshots__/ComponentsViewThemeMatrix.test.tsx.snap
+++ b/tests/prompts/__snapshots__/ComponentsViewThemeMatrix.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ComponentsView theme matrix > applies each theme variant and matches snapshots > aurora 1`] = `
 <article
-  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-card-hairline-75 bg-[linear-gradient(140deg,hsl(var(--card)/0.95),hsl(var(--surface-2)/0.78))] px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--card))] before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-[radial-gradient(125%_85%_at_18%_-25%,hsl(var(--accent)/0.3),transparent_65%),radial-gradient(125%_85%_at_82%_-20%,hsl(var(--ring)/0.28),transparent_60%)] before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-[linear-gradient(120deg,hsl(var(--accent)/0.12)_0%,transparent_58%,hsl(var(--ring)/0.16)_100%),repeating-linear-gradient(0deg,hsl(var(--ring)/0.12)_0,hsl(var(--ring)/0.12)_var(--hairline-w),transparent_var(--hairline-w),transparent_calc(var(--space-3)))] after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
+  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-card-hairline-75 bg-shell-card px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--card))] before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-shell-bloom before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-shell-veil after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
 >
   <header
     class="flex flex-wrap items-start justify-between gap-[var(--space-4)]"
@@ -43,7 +43,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
       >
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -52,7 +53,9 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="true"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          data-depth="raised"
+          data-selected="true"
           role="radio"
           tabindex="0"
           type="button"
@@ -61,7 +64,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -70,7 +74,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -79,7 +84,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -88,7 +94,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -97,7 +104,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -107,7 +115,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
       </div>
     </div>
     <div
-      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-[linear-gradient(90deg,hsl(var(--accent)/0.28),transparent_55%,hsl(var(--accent-2)/0.32))] after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
+      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-shell-divider after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
     >
       <div
         data-testid="gallery-preview"
@@ -147,7 +155,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         class="flex flex-wrap gap-[var(--space-2)]"
       >
         <span
-          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
+          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:hover:transition-none motion-reduce:active:transition-none motion-reduce:focus-visible:transition-none px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
         >
           Global
         </span>
@@ -162,7 +170,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
 
 exports[`ComponentsView theme matrix > applies each theme variant and matches snapshots > citrus 1`] = `
 <article
-  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-card-hairline-75 bg-[linear-gradient(140deg,hsl(var(--card)/0.95),hsl(var(--surface-2)/0.78))] px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--card))] before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-[radial-gradient(125%_85%_at_18%_-25%,hsl(var(--accent)/0.3),transparent_65%),radial-gradient(125%_85%_at_82%_-20%,hsl(var(--ring)/0.28),transparent_60%)] before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-[linear-gradient(120deg,hsl(var(--accent)/0.12)_0%,transparent_58%,hsl(var(--ring)/0.16)_100%),repeating-linear-gradient(0deg,hsl(var(--ring)/0.12)_0,hsl(var(--ring)/0.12)_var(--hairline-w),transparent_var(--hairline-w),transparent_calc(var(--space-3)))] after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
+  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-card-hairline-75 bg-shell-card px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--card))] before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-shell-bloom before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-shell-veil after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
 >
   <header
     class="flex flex-wrap items-start justify-between gap-[var(--space-4)]"
@@ -203,7 +211,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
       >
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -212,7 +221,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -221,7 +231,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -230,7 +241,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -239,7 +251,9 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="true"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          data-depth="raised"
+          data-selected="true"
           role="radio"
           tabindex="0"
           type="button"
@@ -248,7 +262,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -257,7 +272,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -267,7 +283,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
       </div>
     </div>
     <div
-      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-[linear-gradient(90deg,hsl(var(--accent)/0.28),transparent_55%,hsl(var(--accent-2)/0.32))] after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
+      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-shell-divider after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
     >
       <div
         data-testid="gallery-preview"
@@ -307,7 +323,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         class="flex flex-wrap gap-[var(--space-2)]"
       >
         <span
-          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
+          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:hover:transition-none motion-reduce:active:transition-none motion-reduce:focus-visible:transition-none px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
         >
           Global
         </span>
@@ -322,7 +338,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
 
 exports[`ComponentsView theme matrix > applies each theme variant and matches snapshots > hardstuck 1`] = `
 <article
-  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-card-hairline-75 bg-[linear-gradient(140deg,hsl(var(--card)/0.95),hsl(var(--surface-2)/0.78))] px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--card))] before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-[radial-gradient(125%_85%_at_18%_-25%,hsl(var(--accent)/0.3),transparent_65%),radial-gradient(125%_85%_at_82%_-20%,hsl(var(--ring)/0.28),transparent_60%)] before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-[linear-gradient(120deg,hsl(var(--accent)/0.12)_0%,transparent_58%,hsl(var(--ring)/0.16)_100%),repeating-linear-gradient(0deg,hsl(var(--ring)/0.12)_0,hsl(var(--ring)/0.12)_var(--hairline-w),transparent_var(--hairline-w),transparent_calc(var(--space-3)))] after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
+  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-card-hairline-75 bg-shell-card px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--card))] before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-shell-bloom before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-shell-veil after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
 >
   <header
     class="flex flex-wrap items-start justify-between gap-[var(--space-4)]"
@@ -363,7 +379,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
       >
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -372,7 +389,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -381,7 +399,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -390,7 +409,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -399,7 +419,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -408,7 +429,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -417,7 +439,9 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="true"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          data-depth="raised"
+          data-selected="true"
           role="radio"
           tabindex="0"
           type="button"
@@ -427,7 +451,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
       </div>
     </div>
     <div
-      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-[linear-gradient(90deg,hsl(var(--accent)/0.28),transparent_55%,hsl(var(--accent-2)/0.32))] after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
+      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-shell-divider after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
     >
       <div
         data-testid="gallery-preview"
@@ -467,7 +491,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         class="flex flex-wrap gap-[var(--space-2)]"
       >
         <span
-          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
+          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:hover:transition-none motion-reduce:active:transition-none motion-reduce:focus-visible:transition-none px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
         >
           Global
         </span>
@@ -482,7 +506,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
 
 exports[`ComponentsView theme matrix > applies each theme variant and matches snapshots > kitten 1`] = `
 <article
-  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-card-hairline-75 bg-[linear-gradient(140deg,hsl(var(--card)/0.95),hsl(var(--surface-2)/0.78))] px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--card))] before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-[radial-gradient(125%_85%_at_18%_-25%,hsl(var(--accent)/0.3),transparent_65%),radial-gradient(125%_85%_at_82%_-20%,hsl(var(--ring)/0.28),transparent_60%)] before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-[linear-gradient(120deg,hsl(var(--accent)/0.12)_0%,transparent_58%,hsl(var(--ring)/0.16)_100%),repeating-linear-gradient(0deg,hsl(var(--ring)/0.12)_0,hsl(var(--ring)/0.12)_var(--hairline-w),transparent_var(--hairline-w),transparent_calc(var(--space-3)))] after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
+  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-card-hairline-75 bg-shell-card px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--card))] before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-shell-bloom before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-shell-veil after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
 >
   <header
     class="flex flex-wrap items-start justify-between gap-[var(--space-4)]"
@@ -523,7 +547,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
       >
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -532,7 +557,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -541,7 +567,9 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="true"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          data-depth="raised"
+          data-selected="true"
           role="radio"
           tabindex="0"
           type="button"
@@ -550,7 +578,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -559,7 +588,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -568,7 +598,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -577,7 +608,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -587,7 +619,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
       </div>
     </div>
     <div
-      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-[linear-gradient(90deg,hsl(var(--accent)/0.28),transparent_55%,hsl(var(--accent-2)/0.32))] after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
+      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-shell-divider after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
     >
       <div
         data-testid="gallery-preview"
@@ -627,7 +659,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         class="flex flex-wrap gap-[var(--space-2)]"
       >
         <span
-          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
+          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:hover:transition-none motion-reduce:active:transition-none motion-reduce:focus-visible:transition-none px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
         >
           Global
         </span>
@@ -642,7 +674,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
 
 exports[`ComponentsView theme matrix > applies each theme variant and matches snapshots > lg 1`] = `
 <article
-  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-card-hairline-75 bg-[linear-gradient(140deg,hsl(var(--card)/0.95),hsl(var(--surface-2)/0.78))] px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--card))] before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-[radial-gradient(125%_85%_at_18%_-25%,hsl(var(--accent)/0.3),transparent_65%),radial-gradient(125%_85%_at_82%_-20%,hsl(var(--ring)/0.28),transparent_60%)] before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-[linear-gradient(120deg,hsl(var(--accent)/0.12)_0%,transparent_58%,hsl(var(--ring)/0.16)_100%),repeating-linear-gradient(0deg,hsl(var(--ring)/0.12)_0,hsl(var(--ring)/0.12)_var(--hairline-w),transparent_var(--hairline-w),transparent_calc(var(--space-3)))] after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
+  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-card-hairline-75 bg-shell-card px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--card))] before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-shell-bloom before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-shell-veil after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
 >
   <header
     class="flex flex-wrap items-start justify-between gap-[var(--space-4)]"
@@ -683,7 +715,9 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
       >
         <button
           aria-checked="true"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          data-depth="raised"
+          data-selected="true"
           role="radio"
           tabindex="0"
           type="button"
@@ -692,7 +726,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -701,7 +736,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -710,7 +746,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -719,7 +756,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -728,7 +766,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -737,7 +776,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -747,7 +787,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
       </div>
     </div>
     <div
-      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-[linear-gradient(90deg,hsl(var(--accent)/0.28),transparent_55%,hsl(var(--accent-2)/0.32))] after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
+      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-shell-divider after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
     >
       <div
         data-testid="gallery-preview"
@@ -787,7 +827,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         class="flex flex-wrap gap-[var(--space-2)]"
       >
         <span
-          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
+          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:hover:transition-none motion-reduce:active:transition-none motion-reduce:focus-visible:transition-none px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
         >
           Global
         </span>
@@ -802,7 +842,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
 
 exports[`ComponentsView theme matrix > applies each theme variant and matches snapshots > noir 1`] = `
 <article
-  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-card-hairline-75 bg-[linear-gradient(140deg,hsl(var(--card)/0.95),hsl(var(--surface-2)/0.78))] px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--card))] before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-[radial-gradient(125%_85%_at_18%_-25%,hsl(var(--accent)/0.3),transparent_65%),radial-gradient(125%_85%_at_82%_-20%,hsl(var(--ring)/0.28),transparent_60%)] before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-[linear-gradient(120deg,hsl(var(--accent)/0.12)_0%,transparent_58%,hsl(var(--ring)/0.16)_100%),repeating-linear-gradient(0deg,hsl(var(--ring)/0.12)_0,hsl(var(--ring)/0.12)_var(--hairline-w),transparent_var(--hairline-w),transparent_calc(var(--space-3)))] after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
+  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-card-hairline-75 bg-shell-card px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--card))] before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-shell-bloom before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-shell-veil after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
 >
   <header
     class="flex flex-wrap items-start justify-between gap-[var(--space-4)]"
@@ -843,7 +883,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
       >
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -852,7 +893,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -861,7 +903,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -870,7 +913,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -879,7 +923,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -888,7 +933,9 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="true"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          data-depth="raised"
+          data-selected="true"
           role="radio"
           tabindex="0"
           type="button"
@@ -897,7 +944,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -907,7 +955,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
       </div>
     </div>
     <div
-      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-[linear-gradient(90deg,hsl(var(--accent)/0.28),transparent_55%,hsl(var(--accent-2)/0.32))] after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
+      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-shell-divider after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
     >
       <div
         data-testid="gallery-preview"
@@ -947,7 +995,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         class="flex flex-wrap gap-[var(--space-2)]"
       >
         <span
-          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
+          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:hover:transition-none motion-reduce:active:transition-none motion-reduce:focus-visible:transition-none px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
         >
           Global
         </span>
@@ -962,7 +1010,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
 
 exports[`ComponentsView theme matrix > applies each theme variant and matches snapshots > ocean 1`] = `
 <article
-  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-card-hairline-75 bg-[linear-gradient(140deg,hsl(var(--card)/0.95),hsl(var(--surface-2)/0.78))] px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--card))] before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-[radial-gradient(125%_85%_at_18%_-25%,hsl(var(--accent)/0.3),transparent_65%),radial-gradient(125%_85%_at_82%_-20%,hsl(var(--ring)/0.28),transparent_60%)] before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-[linear-gradient(120deg,hsl(var(--accent)/0.12)_0%,transparent_58%,hsl(var(--ring)/0.16)_100%),repeating-linear-gradient(0deg,hsl(var(--ring)/0.12)_0,hsl(var(--ring)/0.12)_var(--hairline-w),transparent_var(--hairline-w),transparent_calc(var(--space-3)))] after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
+  class="group/component-view relative isolate flex flex-col gap-[var(--space-6)] overflow-hidden rounded-card r-card-lg rounded-[var(--radius-card)] border border-card-hairline-75 bg-shell-card px-[var(--space-6)] py-[var(--space-5)] shadow-neo focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-[hsl(var(--card))] before:pointer-events-none before:absolute before:-inset-px before:-z-10 before:rounded-[inherit] before:bg-shell-bloom before:opacity-75 before:mix-blend-screen motion-reduce:before:opacity-55 after:pointer-events-none after:absolute after:-inset-px after:-z-10 after:rounded-[inherit] after:bg-shell-veil after:opacity-65 after:mix-blend-soft-light motion-reduce:after:opacity-45"
 >
   <header
     class="flex flex-wrap items-start justify-between gap-[var(--space-4)]"
@@ -1003,7 +1051,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
       >
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -1012,7 +1061,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -1021,7 +1071,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -1030,7 +1081,9 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="true"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui is-active text-foreground"
+          data-depth="raised"
+          data-selected="true"
           role="radio"
           tabindex="0"
           type="button"
@@ -1039,7 +1092,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -1048,7 +1102,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -1057,7 +1112,8 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         </button>
         <button
           aria-checked="false"
-          class="btn-like-segmented min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          class="_root_6813af min-h-[var(--control-h-md)] px-[var(--space-4)] py-[var(--space-2)] text-ui text-muted-foreground"
+          data-depth="raised"
           role="radio"
           tabindex="-1"
           type="button"
@@ -1067,7 +1123,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
       </div>
     </div>
     <div
-      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-[linear-gradient(90deg,hsl(var(--accent)/0.28),transparent_55%,hsl(var(--accent-2)/0.32))] after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
+      class="relative rounded-card r-card-md bg-[hsl(var(--background)/0.94)] p-[var(--space-4)] shadow-[var(--shadow-inset-hairline)] before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:p-[var(--spacing-0-25)] before:bg-[var(--edge-iris)] before:opacity-35 before:[mask:linear-gradient(hsl(var(--foreground))_0_0)_content-box,linear-gradient(hsl(var(--foreground))_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-x-0 after:top-0 after:h-[var(--spacing-0-5)] after:rounded-[inherit] after:bg-shell-divider after:opacity-70 after:mix-blend-screen group-focus-within/component-view:before:opacity-55"
     >
       <div
         data-testid="gallery-preview"
@@ -1107,7 +1163,7 @@ exports[`ComponentsView theme matrix > applies each theme variant and matches sn
         class="flex flex-wrap gap-[var(--space-2)]"
       >
         <span
-          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
+          class="inline-flex max-w-full items-center gap-[var(--space-2)] whitespace-nowrap rounded-card r-card-lg font-medium tracking-[0.02em] border bg-muted/18 shadow-outline-subtle transition-[background,box-shadow,transform] duration-140 ease-out motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:hover:transition-none motion-reduce:active:transition-none motion-reduce:focus-visible:transition-none px-[var(--space-3)] py-[var(--space-2)] text-label leading-none [&_svg]:size-[var(--icon-size-sm)] border-tone-sup text-muted-foreground"
         >
           Global
         </span>

--- a/tokens/tokens.css
+++ b/tokens/tokens.css
@@ -331,6 +331,23 @@
   --drip-surface: color-mix(in oklab, hsl(var(--accent)) 18%, hsl(var(--background)) 82%);
   --gradient-blob-primary: radial-gradient(120% 120% at 50% 10%, hsl(var(--surface) / 0.85), hsl(var(--surface-2) / 0.35), transparent 85%);
   --gradient-glitch-primary: linear-gradient(135deg, hsl(var(--accent) / 0.35), hsl(var(--accent-2) / 0.3));
+  --gradient-shell-card: linear-gradient(140deg, hsl(var(--card) / 0.95), hsl(var(--surface-2) / 0.78));
+  --gradient-shell-card-strong: linear-gradient(140deg, hsl(var(--card) / 0.98), hsl(var(--surface-2) / 0.82));
+  --gradient-shell-card-soft: linear-gradient(140deg, hsl(var(--card) / 0.94), hsl(var(--surface-2) / 0.72));
+  --gradient-shell-bloom:
+    radial-gradient(125% 85% at 18% -25%, hsl(var(--accent) / 0.3), transparent 65%),
+    radial-gradient(125% 85% at 82% -20%, hsl(var(--ring) / 0.28), transparent 60%);
+  --gradient-shell-veil:
+    linear-gradient(120deg, hsl(var(--accent) / 0.12) 0%, transparent 58%, hsl(var(--ring) / 0.16) 100%),
+    repeating-linear-gradient(0deg, hsl(var(--ring) / 0.12) 0, hsl(var(--ring) / 0.12) var(--hairline-w), transparent var(--hairline-w), transparent calc(var(--space-3)));
+  --gradient-shell-spotlight: radial-gradient(120% 95% at 50% 0%, hsl(var(--accent) / 0.24), transparent 65%);
+  --gradient-shell-divider: linear-gradient(90deg, hsl(var(--accent) / 0.28), transparent 55%, hsl(var(--accent-2) / 0.32));
+  --gradient-hero-frame: linear-gradient(145deg, hsl(var(--card)), hsl(var(--panel)));
+  --gradient-drip-overlay:
+    radial-gradient(60% 40% at 10% 0%, hsl(var(--backdrop-drip-1) / 0.2), transparent 60%),
+    radial-gradient(50% 35% at 100% 5%, hsl(var(--backdrop-drip-2) / 0.18), transparent 60%),
+    radial-gradient(55% 35% at 50% 120%, hsl(var(--backdrop-drip-3) / 0.14), transparent 65%),
+    radial-gradient(120% 100% at 50% 100%, hsl(var(--backdrop-drip-shadow) / 0.35), transparent 70%);
   --glitch-rgb-shift: drop-shadow(calc(var(--glitch-chromatic-offset-light) * -1) 0 0 hsl(var(--accent) / 0.45)) drop-shadow(var(--glitch-chromatic-offset-light) 0 0 hsl(var(--ring) / 0.45));
   --glitch-scanline: glitch-scanline calc(var(--glitch-duration) * 1.2) steps(2, end) infinite;
   --danger-surface-foreground: var(--danger-foreground);

--- a/tokens/tokens.js
+++ b/tokens/tokens.js
@@ -319,6 +319,23 @@ export default {
     "radial-gradient(120% 120% at 50% 10%, hsl(var(--surface) / 0.85), hsl(var(--surface-2) / 0.35), transparent 85%)",
   gradientGlitchPrimary:
     "linear-gradient(135deg, hsl(var(--accent) / 0.35), hsl(var(--accent-2) / 0.3))",
+  gradientShellCard:
+    "linear-gradient(140deg, hsl(var(--card) / 0.95), hsl(var(--surface-2) / 0.78))",
+  gradientShellCardStrong:
+    "linear-gradient(140deg, hsl(var(--card) / 0.98), hsl(var(--surface-2) / 0.82))",
+  gradientShellCardSoft:
+    "linear-gradient(140deg, hsl(var(--card) / 0.94), hsl(var(--surface-2) / 0.72))",
+  gradientShellBloom:
+    "radial-gradient(125% 85% at 18% -25%, hsl(var(--accent) / 0.3), transparent 65%), radial-gradient(125% 85% at 82% -20%, hsl(var(--ring) / 0.28), transparent 60%)",
+  gradientShellVeil:
+    "linear-gradient(120deg, hsl(var(--accent) / 0.12) 0%, transparent 58%, hsl(var(--ring) / 0.16) 100%), repeating-linear-gradient(0deg, hsl(var(--ring) / 0.12) 0, hsl(var(--ring) / 0.12) var(--hairline-w), transparent var(--hairline-w), transparent calc(var(--space-3)))",
+  gradientShellSpotlight:
+    "radial-gradient(120% 95% at 50% 0%, hsl(var(--accent) / 0.24), transparent 65%)",
+  gradientShellDivider:
+    "linear-gradient(90deg, hsl(var(--accent) / 0.28), transparent 55%, hsl(var(--accent-2) / 0.32))",
+  gradientHeroFrame: "linear-gradient(145deg, hsl(var(--card)), hsl(var(--panel)))",
+  gradientDripOverlay:
+    "radial-gradient(60% 40% at 10% 0%, hsl(var(--backdrop-drip-1) / 0.2), transparent 60%), radial-gradient(50% 35% at 100% 5%, hsl(var(--backdrop-drip-2) / 0.18), transparent 60%), radial-gradient(55% 35% at 50% 120%, hsl(var(--backdrop-drip-3) / 0.14), transparent 65%), radial-gradient(120% 100% at 50% 100%, hsl(var(--backdrop-drip-shadow) / 0.35), transparent 70%)",
   glitchRgbShift:
     "drop-shadow(calc(var(--glitch-chromatic-offset-light) * -1) 0 0 hsl(var(--accent) / 0.45)) drop-shadow(var(--glitch-chromatic-offset-light) 0 0 hsl(var(--ring) / 0.45))",
   glitchScanline:


### PR DESCRIPTION
## Summary
- expose gradient background utilities in Tailwind and token outputs so components can bind to theme variables
- swap hard-coded gradients in ComponentsView, hero frame styles, and theme overlays to use the new utilities
- refresh documentation and snapshot fixtures to reflect the new background tokens

## Testing
- npm run verify-prompts
- npm run lint
- npm run lint:design
- npm run typecheck
- npx vitest run --poolOptions.threads=1 (hangs on planner/goals integration suites; manually terminated)

------
https://chatgpt.com/codex/tasks/task_e_68dc7388a798832ca57759cd0ca7a361