### PR TITLE
fix: align planner gallery sizing tokens

### DIFF
--- a/src/components/prompts/component-gallery/PlannerPanel.tsx
+++ b/src/components/prompts/component-gallery/PlannerPanel.tsx
@@ -28,6 +28,7 @@ import WeekPickerDemo from "./WeekPickerDemo";
 import type { PlannerPanelData } from "./useComponentGalleryState";
 
 const GRID_CLASS = cn(layoutGridClassName, "sm:grid-cols-2 md:grid-cols-12");
+const PANEL_ITEM_WIDTH = "calc(var(--space-8) * 3 + var(--space-2))" as const;
 
 type WeekPickerShellDemoDay = {
   readonly iso: string;
@@ -214,7 +215,13 @@ export default function PlannerPanel({ data }: PlannerPanelProps) {
       [
         {
           label: "GoalsProgress",
-          element: <GoalsProgress total={5} pct={60} maxWidth={200} />,
+          element: (
+            <GoalsProgress
+              total={5}
+              pct={60}
+              maxWidth={PANEL_ITEM_WIDTH}
+            />
+          ),
         },
         {
           label: "Goals Tabs",
@@ -247,7 +254,7 @@ export default function PlannerPanel({ data }: PlannerPanelProps) {
         {
           label: "TaskRow",
           element: (
-            <ul className="w-64">
+            <ul style={{ width: PANEL_ITEM_WIDTH }}>
               <TaskRow
                 task={{
                   id: "t1",


### PR DESCRIPTION
## Summary
- reuse the planner gallery width constant derived from spacing tokens for goals progress and task previews
- update the task row wrapper to share the same token-based width so the gallery footprint stays aligned across themes

## Testing
- npm run verify-prompts
- npm run check *(fails: repository contains an invalid gallery manifest in src/components/gallery/generated-manifest.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68dc8165edd4832ca394eac32d5cc8b0