### PR TITLE
Fix theme matrix column sizing to use spacing tokens

### DIFF
--- a/src/app/preview/theme-matrix/ThemeMatrixEntryCard.tsx
+++ b/src/app/preview/theme-matrix/ThemeMatrixEntryCard.tsx
@@ -18,7 +18,9 @@ const BACKGROUND_LABELS: Record<number, string> = {
   4: "Streak background",
 };
 
-const GRID_TEMPLATE = `repeat(${VARIANTS.length}, minmax(320px, 1fr))`;
+const COLUMN_WIDTH = "calc(var(--space-8) * 5)";
+
+const GRID_TEMPLATE = `repeat(${VARIANTS.length}, minmax(${COLUMN_WIDTH}, 1fr))`;
 
 const variantColumnsStyle = {
   gridTemplateColumns: GRID_TEMPLATE,
@@ -145,9 +147,8 @@ function ThemeMatrixVariantGridCell({
   );
 }
 
-const COLUMN_MIN_WIDTH = 320;
 const matrixContainerStyle = {
-  minWidth: `${VARIANTS.length * COLUMN_MIN_WIDTH}px`,
+  minWidth: `calc(${VARIANTS.length} * ${COLUMN_WIDTH})`,
 } satisfies React.CSSProperties;
 
 interface ThemeMatrixEntryCardProps {


### PR DESCRIPTION
## Summary
- align the theme matrix column widths with the spacing token scale for consistent preview sizing
- reuse the token-derived width for both the grid template and overall minimum width so the matrix stays aligned within the preview shell

## Testing
- npm run lint
- npm run lint:design
- npm run typecheck
- npm test -- --run *(hangs around `tests/planner/UsePlannerStore.integration.test.tsx`; aborted after ~1 minute)*

------
https://chatgpt.com/codex/tasks/task_e_68dc8edd0428832c8c1edc7907e656f4