### PR TITLE
fix: align calendar header collapse with spacing tokens

### DIFF
--- a/src/components/prompts/component-gallery/CalendarLayoutPreview.tsx
+++ b/src/components/prompts/component-gallery/CalendarLayoutPreview.tsx
@@ -23,6 +23,8 @@ const HOURS: readonly string[] = [
   "13:00",
 ];
 
+const HEADER_CONTROLS_COLLAPSE_BELOW = "calc(var(--space-8) * 8)" as const;
+
 type CalendarEventTone = "accent" | "primary" | "info";
 
 type CalendarEvent = {
@@ -384,7 +386,7 @@ function HeaderControls({ status }: { status: CalendarPreviewStatus }) {
       justify="flex-end"
       wrap={false}
       collapse="stack"
-      collapseBelow="32rem"
+      collapseBelow={HEADER_CONTROLS_COLLAPSE_BELOW}
     >
       <span className="rounded-[var(--radius-lg)] border border-[hsl(var(--card-hairline)/0.55)] bg-[hsl(var(--surface-2)/0.6)] px-[var(--space-3)] py-[var(--space-1)] text-label text-muted-foreground">
         Auto-sync is on


### PR DESCRIPTION
## Summary
- replace the calendar layout preview header collapse threshold with a spacing-token-based constant
- reuse the named constant when configuring the Cluster collapse breakpoint for consistency

## Testing
- npm run verify-prompts
- npm run lint
- npm run lint:design
- npm run typecheck
- npm test -- --run tests/lib/Db.test.ts tests/components/PageHeader.test.tsx tests/planner/WeekPicker.test.tsx tests/primitives/IconButton.test.tsx tests/planner/UsePlannerStore.test.tsx tests/lib/clipboard.test.ts tests/components/ComponentsGalleryState.test.tsx tests/home/useHomePlannerOverview.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc8edc5cb0832c8af276f9931e7696