### PR TITLE
fix: align skeleton avatar width token

### DIFF
--- a/src/components/prompts/SkeletonShowcase.tsx
+++ b/src/components/prompts/SkeletonShowcase.tsx
@@ -1,4 +1,8 @@
 import { Skeleton } from "@/components/ui";
+import { cn } from "@/lib/utils";
+
+const AVATAR_WIDTH = "var(--space-12)";
+const AVATAR_WIDTH_CLASS = `w-[${AVATAR_WIDTH}]`;
 
 export default function SkeletonShowcase() {
   return (
@@ -15,7 +19,10 @@ export default function SkeletonShowcase() {
         <Skeleton className="w-5/6" />
       </div>
       <div className="flex items-center gap-[var(--space-3)]">
-        <Skeleton className="h-[var(--space-8)] w-12 flex-none" radius="full" />
+        <Skeleton
+          className={cn("h-[var(--space-8)] flex-none", AVATAR_WIDTH_CLASS)}
+          radius="full"
+        />
         <div className="flex-1 space-y-[var(--space-2)]">
           <Skeleton className="w-3/4" />
           <Skeleton className="w-2/3" />


### PR DESCRIPTION
## Summary
- define an avatar width token for the skeleton showcase and reuse it when composing classes
- switch the skeleton avatar width to use the shared cn helper for future extension

## Testing
- npm run verify-prompts
- npm run check *(fails: existing type errors in src/components/gallery/generated-manifest.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68dc97812e48832c877cb870ab246afc