### PR TITLE
feat: render hero illustration

### DIFF
--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -25,6 +25,7 @@ export * from "./layout/Hero";
 export { default as Hero } from "./layout/hero/Hero";
 export * from "./layout/hero/Hero";
 export * from "./layout/hero/HeroGlitchStyles";
+export * from "./layout/hero/HeroImage";
 export * from "./layout/hero/HeroSearchBar";
 export * from "./layout/hero/HeroTabs";
 export * from "./layout/hero/useHeroStyles";

--- a/src/components/ui/layout/hero/Hero.tsx
+++ b/src/components/ui/layout/hero/Hero.tsx
@@ -8,9 +8,16 @@ import TabBar, {
   type TabItem,
 } from "../TabBar";
 import type { HeaderTabsProps } from "@/components/ui/layout/Header";
+import {
+  DEFAULT_HERO_STATE,
+  DEFAULT_HERO_VARIANT,
+  getHeroIllustration,
+  type HeroIllustrationState,
+} from "@/data/heroImages";
 import { cn } from "@/lib/utils";
 import { NeomorphicFrameStyles } from "../NeomorphicFrameStyles";
 import { HeroGlitchStyles } from "./HeroGlitchStyles";
+import { HeroImage } from "./HeroImage";
 import { HeroSearchBar, type HeroSearchBarProps } from "./HeroSearchBar";
 import { useHeroStyles } from "./useHeroStyles";
 
@@ -27,6 +34,10 @@ export interface HeroProps<Key extends string = string>
   icon?: React.ReactNode;
   children?: React.ReactNode;
   actions?: React.ReactNode;
+  /** Illustration state from the hero library. */
+  illustrationState?: HeroIllustrationState;
+  /** Explicit alternate text for the illustration (defaults to heading or library description). */
+  illustrationAlt?: string;
   sticky?: boolean;
   topClassName?: string;
   barClassName?: string;
@@ -80,6 +91,11 @@ export interface HeroProps<Key extends string = string>
   search?: (HeroSearchBarProps & { round?: boolean }) | null;
 }
 
+const defaultIllustrationAlt = getHeroIllustration(
+  DEFAULT_HERO_VARIANT,
+  DEFAULT_HERO_STATE,
+).alt;
+
 function Hero<Key extends string = string>({
   eyebrow,
   heading,
@@ -87,6 +103,8 @@ function Hero<Key extends string = string>({
   icon,
   children,
   actions,
+  illustrationState,
+  illustrationAlt,
   tone = "heroic",
   frame = true,
   glitch = "subtle",
@@ -107,6 +125,8 @@ function Hero<Key extends string = string>({
 }: HeroProps<Key>) {
   void _deprecatedRail;
   const headingStr = typeof heading === "string" ? heading : undefined;
+  const illustrationAltText =
+    illustrationAlt ?? headingStr ?? defaultIllustrationAlt;
   const Component: HeroElement = as ?? "section";
 
   const {
@@ -214,8 +234,15 @@ function Hero<Key extends string = string>({
         }
       : search;
 
+  const rootClassName = cn("relative", className);
+
   return (
-    <Component className={className} {...(rest as React.HTMLAttributes<HTMLElement>)}>
+    <Component className={rootClassName} {...(rest as React.HTMLAttributes<HTMLElement>)}>
+      <HeroImage
+        variant={heroVariant}
+        state={illustrationState ?? DEFAULT_HERO_STATE}
+        alt={illustrationAltText}
+      />
       {shouldRenderGlitchStyles ? <HeroGlitchStyles /> : null}
       {frame || isRaisedBar ? <NeomorphicFrameStyles /> : null}
 

--- a/src/components/ui/layout/hero/HeroImage.tsx
+++ b/src/components/ui/layout/hero/HeroImage.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import * as React from "react";
+import Image from "next/image";
+
+import {
+  DEFAULT_HERO_VARIANT,
+  getHeroIllustration,
+  type HeroIllustrationState,
+} from "@/data/heroImages";
+import { useOptionalTheme } from "@/lib/theme-context";
+import { cn } from "@/lib/utils";
+
+import type { HeroStyleResult } from "./useHeroStyles";
+
+const heroImageSizes =
+  "(max-width: 767px) 68vw, (max-width: 1279px) 46vw, (max-width: 1919px) 420px, 480px";
+
+export interface HeroImageProps {
+  variant: HeroStyleResult["heroVariant"];
+  state: HeroIllustrationState;
+  alt: string;
+}
+
+export function HeroImage({ variant, state, alt }: HeroImageProps) {
+  const themeEntry = useOptionalTheme();
+  const themeVariant = themeEntry?.[0].variant ?? DEFAULT_HERO_VARIANT;
+
+  const { src, alt: computedAlt } = React.useMemo(
+    () => getHeroIllustration(themeVariant, state),
+    [themeVariant, state],
+  );
+
+  if (variant !== "neo") {
+    return null;
+  }
+
+  const resolvedAlt = alt?.trim().length ? alt : computedAlt;
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-[1] overflow-hidden rounded-card">
+      <div
+        className={cn(
+          "relative ml-auto flex h-full w-full items-end justify-end",
+          "px-[var(--space-2)] pb-[var(--space-2)]",
+          "sm:px-[var(--space-3)] sm:pb-[var(--space-3)]",
+          "lg:px-[var(--space-4)] lg:pb-[var(--space-4)]",
+        )}
+      >
+        <div className="relative aspect-[4/5] w-full max-w-[min(28rem,64%)]">
+          <Image
+            src={src}
+            alt={resolvedAlt}
+            fill
+            sizes={heroImageSizes}
+            className="object-contain object-bottom"
+            priority={false}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/layout/hero/index.ts
+++ b/src/components/ui/layout/hero/index.ts
@@ -3,6 +3,9 @@
 export { default } from "./Hero";
 export type { HeroProps } from "./Hero";
 export * from "./Hero";
+export { HeroImage } from "./HeroImage";
+export type { HeroImageProps } from "./HeroImage";
+export type { HeroIllustrationState } from "@/data/heroImages";
 export { HeroTabs } from "./HeroTabs";
 export type { HeroTabsProps, HeroTab } from "./HeroTabs";
 export { HeroSearchBar } from "./HeroSearchBar";


### PR DESCRIPTION
## Summary
- render the shared hero illustration before the neomorphic frame and allow callers to provide state/alt overrides
- introduce a dedicated `HeroImage` component that resolves theme-specific assets and stays inert when the frame is disabled
- re-export the illustration props and component so downstream consumers can adopt the new options

## Testing
- npm run verify-prompts
- npm run lint
- npm run lint:design
- npm run typecheck
- npm test -- --run *(partially executed; aborted after hero-related suites due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9351a7f8832c91a55cf737a229f2