### PR TITLE
fix: align header demo icon sizing

### DIFF
--- a/src/components/prompts/PageHeaderDemo.tsx
+++ b/src/components/prompts/PageHeaderDemo.tsx
@@ -18,6 +18,8 @@ import { Bell, CircleUser } from "lucide-react";
 
 type CompactNav = "summary" | "timeline" | "reports";
 
+const ICON_BUTTON_SIZE = "size-[var(--icon-size-sm)]";
+
 const compactNavItems: Array<{ key: CompactNav; label: string }> = [
   { key: "summary", label: "Summary" },
   { key: "timeline", label: "Timeline" },
@@ -103,7 +105,7 @@ export default function PageHeaderDemo() {
         className="text-muted-foreground data-[state=active]:text-foreground"
         data-state="active"
       >
-        <Bell className="h-4 w-4" />
+        <Bell className={ICON_BUTTON_SIZE} />
       </IconButton>
       <button
         type="button"
@@ -120,7 +122,7 @@ export default function PageHeaderDemo() {
         data-state={profileOpen ? "open" : "inactive"}
         className="inline-flex items-center gap-[var(--space-2)] rounded-full border border-transparent bg-[hsl(var(--card)/0.55)] px-[var(--space-3)] py-[var(--spacing-0-75)] text-ui font-medium transition-colors hover:bg-[--hover] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=open]:bg-[hsl(var(--card)/0.85)]"
       >
-        <CircleUser className="h-4 w-4" />
+        <CircleUser className={ICON_BUTTON_SIZE} />
         <span className="hidden sm:inline">Profile</span>
       </button>
     </>


### PR DESCRIPTION
## Summary
- add a shared icon sizing helper for the header demo utilities
- align the Bell and CircleUser icons with the IconButton sizing token

## Testing
- `npm run verify-prompts`
- `npm run lint`
- `npm run lint:design`
- `npm run typecheck`
- `VITEST_MAX_THREADS=1 npm test -- --run` *(hangs around planner integration tests, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68dc95919ee4832c89c914842d8c36bd