### PR TITLE
fix: align goals textarea min height token

### DIFF
--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -6,6 +6,8 @@ import Textarea from "@/components/ui/primitives/Textarea";
 import Button from "@/components/ui/primitives/Button";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import Label from "@/components/ui/Label";
+import { cn } from "@/lib/utils";
+import { GOAL_TEXTAREA_MIN_HEIGHT_CLASS } from "./constants";
 
 interface GoalFormProps {
   title: string;
@@ -104,7 +106,10 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
             Notes (optional)
             <Textarea
               id="goal-notes"
-              textareaClassName="min-h-24 text-ui font-medium"
+              textareaClassName={cn(
+                GOAL_TEXTAREA_MIN_HEIGHT_CLASS,
+                "text-ui font-medium",
+              )}
               value={notes}
               onChange={(e) => onNotesChange(e.target.value)}
               aria-describedby={describedBy || undefined}

--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -24,7 +24,10 @@ import SegmentedButton from "@/components/ui/primitives/SegmentedButton";
 import { uid, usePersistentState } from "@/lib/db";
 import useAutoFocus from "@/lib/useAutoFocus";
 import useDebouncedCallback from "@/lib/useDebouncedCallback";
-import { GOALS_STICKY_TOP_CLASS } from "./constants";
+import {
+  GOAL_TEXTAREA_MIN_HEIGHT_CLASS,
+  GOALS_STICKY_TOP_CLASS,
+} from "./constants";
 import {
   Search,
   Plus,
@@ -456,7 +459,7 @@ function ReminderCard({
               placeholder="Short, skimmable sentence. Keep it actionable."
               value={body}
               onChange={(e) => setBody(e.currentTarget.value)}
-              textareaClassName="min-h-24"
+              textareaClassName={GOAL_TEXTAREA_MIN_HEIGHT_CLASS}
             />
             <Input
               aria-label="Tags (comma separated)"

--- a/src/components/goals/constants.ts
+++ b/src/components/goals/constants.ts
@@ -1,1 +1,3 @@
 export const GOALS_STICKY_TOP_CLASS = "top-[var(--header-stack)]";
+
+export const GOAL_TEXTAREA_MIN_HEIGHT_CLASS = "min-h-[calc(var(--space-8)*3)]";


### PR DESCRIPTION
## Summary
- add a shared tokenized min-height class for goal textareas
- update GoalForm and Reminders to consume the shared helper for consistent spacing

## Testing
- `npm run check` *(fails: vitest exceeds container resources and hangs after ~40s despite increased heap)*

------
https://chatgpt.com/codex/tasks/task_e_68dc952d5d14832c84c2d33ccc079786