### PR TITLE
chore: share goal textarea min height token

### DIFF
--- a/src/components/goals/GoalForm.tsx
+++ b/src/components/goals/GoalForm.tsx
@@ -6,6 +6,8 @@ import Textarea from "@/components/ui/primitives/Textarea";
 import Button from "@/components/ui/primitives/Button";
 import SectionCard from "@/components/ui/layout/SectionCard";
 import Label from "@/components/ui/Label";
+import { cn } from "@/lib/utils";
+import { GOAL_TEXTAREA_MIN_HEIGHT_CLASS } from "./constants";
 
 interface GoalFormProps {
   title: string;
@@ -104,7 +106,10 @@ export default React.forwardRef<GoalFormHandle, GoalFormProps>(function GoalForm
             Notes (optional)
             <Textarea
               id="goal-notes"
-              textareaClassName="min-h-[calc(var(--space-8)*3)] text-ui font-medium"
+              textareaClassName={cn(
+                GOAL_TEXTAREA_MIN_HEIGHT_CLASS,
+                "text-ui font-medium",
+              )}
               value={notes}
               onChange={(e) => onNotesChange(e.target.value)}
               aria-describedby={describedBy || undefined}

--- a/src/components/goals/Reminders.tsx
+++ b/src/components/goals/Reminders.tsx
@@ -24,7 +24,8 @@ import SegmentedButton from "@/components/ui/primitives/SegmentedButton";
 import { uid, usePersistentState } from "@/lib/db";
 import useAutoFocus from "@/lib/useAutoFocus";
 import useDebouncedCallback from "@/lib/useDebouncedCallback";
-import { GOALS_STICKY_TOP_CLASS } from "./constants";
+import { cn } from "@/lib/utils";
+import { GOAL_TEXTAREA_MIN_HEIGHT_CLASS, GOALS_STICKY_TOP_CLASS } from "./constants";
 import {
   Search,
   Plus,
@@ -456,7 +457,7 @@ function ReminderCard({
               placeholder="Short, skimmable sentence. Keep it actionable."
               value={body}
               onChange={(e) => setBody(e.currentTarget.value)}
-              textareaClassName="min-h-[calc(var(--space-8)*3)]"
+              textareaClassName={cn(GOAL_TEXTAREA_MIN_HEIGHT_CLASS)}
             />
             <Input
               aria-label="Tags (comma separated)"

--- a/src/components/goals/constants.ts
+++ b/src/components/goals/constants.ts
@@ -1,1 +1,2 @@
 export const GOALS_STICKY_TOP_CLASS = "top-[var(--header-stack)]";
+export const GOAL_TEXTAREA_MIN_HEIGHT_CLASS = "min-h-[calc(var(--space-8)*3)]";


### PR DESCRIPTION
## Summary
- add a shared goal textarea min-height token for reuse across the feature
- update GoalForm and Reminders to consume the shared helper while preserving existing typography styling

## Testing
- npm run check *(fails: existing type errors in gallery generated-manifest.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9aed2500832ca8907af602a8d5f5