### PR TITLE
fix: align inline input icon sizing

### DIFF
--- a/src/components/prompts/component-gallery/InputsPanel.tsx
+++ b/src/components/prompts/component-gallery/InputsPanel.tsx
@@ -17,6 +17,7 @@ import GalleryItem from "../GalleryItem";
 import { selectItems } from "./ComponentGallery.demoData";
 import type { InputsPanelData } from "./useComponentGalleryState";
 
+const INLINE_ICON_SIZE = "size-[var(--icon-size-sm)]";
 const GRID_CLASS = cn(layoutGridClassName, "sm:grid-cols-2 md:grid-cols-12");
 const sampleWidth = "calc(var(--space-8) * 3.5)";
 const sampleWidthStyle: React.CSSProperties = { width: sampleWidth };
@@ -219,7 +220,9 @@ export default function InputsPanel({ data }: InputsPanelProps) {
                 hasEndSlot
                 className="w-full"
               >
-                <Plus className="absolute right-[var(--space-3)] top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+                <Plus
+                  className={`absolute right-[var(--space-3)] top-1/2 -translate-y-1/2 ${INLINE_ICON_SIZE} text-muted-foreground`}
+                />
               </Input>
             </div>
           ),


### PR DESCRIPTION
## Summary
- add a reusable INLINE_ICON_SIZE token constant for input gallery samples
- swap the hard-coded plus icon size for the tokenised helper to keep alignment in dense inputs

## Testing
- `npm run verify-prompts`
- `npm run check` *(fails: TypeScript errors in src/components/gallery/generated-manifest.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9b6b6a00832c80b97aade162d4ea