### PR TITLE
fix: align title glow typography and cta depth tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1924,8 +1924,8 @@ textarea:-webkit-autofill {
     filter: blur(1px);
   }
   .title-glow {
-    font-size: 1.5rem;
-    line-height: 2rem;
+    font-size: var(--font-title);
+    line-height: 1.35;
     font-weight: 600;
   }
 }
@@ -2407,10 +2407,7 @@ textarea:-webkit-autofill {
     hsl(var(--ring)) 55%,
     hsl(var(--card-hairline))
   );
-  box-shadow:
-    0 0 0 var(--spacing-0-25) hsl(var(--ring) / 0.28),
-    0 var(--space-3) calc(var(--space-5) + var(--space-1))
-      hsl(var(--shadow-color) / 0.28);
+  box-shadow: var(--card-elev-3);
 }
 .btn-cta.is-active,
 .btn-cta[aria-current="page"],
@@ -2419,10 +2416,7 @@ textarea:-webkit-autofill {
   background-image: var(--seg-active-grad);
   background-repeat: no-repeat;
   color: hsl(var(--primary-foreground));
-  box-shadow:
-    0 0 0 var(--spacing-0-5) hsl(var(--ring) / 0.38),
-    0 var(--space-4) calc(var(--space-6) + var(--space-1))
-      hsl(var(--shadow-color) / 0.35);
+  box-shadow: var(--shadow-nav-active), var(--shadow-outer-xl);
 }
 /* ---------- Icon styling ---------- */
 .lucide {


### PR DESCRIPTION
## Summary
- map the `title-glow` utility to the shared title typography token for consistent sizing
- replace custom CTA button drop shadows with depth tokens to preserve design system elevation

## Testing
- `npm run verify-prompts`
- `npm run check` *(fails: vitest OOM in this environment; sequential retry also timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9b6bdbe0832ca2d499c02367dd02