### PR TITLE
fix: normalize interactive states and motion

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -403,6 +403,16 @@ html.no-animations *::after {
   box-shadow: 0 0 calc(var(--space-2) - var(--spacing-0-5)) hsl(var(--glow) / 0.6);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  *:focus-visible {
+    box-shadow: none;
+  }
+}
+
+html.no-animations *:focus-visible {
+  box-shadow: none;
+}
+
 @media (forced-colors: active) {
   *:focus-visible {
     outline: var(--spacing-0-5) solid CanvasText;

--- a/src/components/ui/neumorphic.module.css
+++ b/src/components/ui/neumorphic.module.css
@@ -31,3 +31,15 @@
     )
   );
 }
+
+:global(html.no-animations) .neu-hover:hover,
+:global(html.no-animations) .neu-hover:focus-visible,
+:global(html.no-animations) .neu-hover:focus-within {
+  box-shadow: var(
+    --neo-shadow,
+    var(
+      --depth-shadow-outer,
+      var(--shadow-outer-lg, var(--shadow-neo))
+    )
+  );
+}

--- a/src/components/ui/primitives/BlobContainer.tsx
+++ b/src/components/ui/primitives/BlobContainer.tsx
@@ -14,7 +14,10 @@ export type GlitchNoiseToken = "glitch-noise-level" | "glitch-static-opacity";
 
 type StyleWithCustomVars = React.CSSProperties & {
   "--blob-overlay-target"?: string;
+  "--blob-overlay-hover"?: string;
+  "--blob-overlay-active"?: string;
   "--blob-noise-target"?: string;
+  "--blob-noise-hover"?: string;
   "--blob-noise-active-target"?: string;
 };
 
@@ -53,17 +56,24 @@ const BlobContainer = React.forwardRef<HTMLSpanElement, BlobContainerProps>(
       ? resolveTokenVar(noiseActiveToken)
       : undefined;
 
+    const overlayHoverVar = `calc(${overlayVar} * var(--glitch-intensity-subtle, 1))`;
+    const overlayTargetVar = `calc(${overlayVar} * var(--glitch-intensity-default, 1))`;
+    const overlayActiveVar = `calc(${overlayVar} * var(--glitch-intensity, var(--glitch-intensity-default, 1)))`;
+
+    const noiseHoverVar = `calc(${noiseVar} * var(--glitch-intensity-subtle, 1))`;
+    const noiseTargetVar = `calc(${noiseVar} * var(--glitch-intensity-default, 1))`;
+    const noiseActiveBaseVar = activeNoiseVar ?? noiseVar;
+    const noiseActiveScaledVar = `calc(${noiseActiveBaseVar} * var(--glitch-intensity, var(--glitch-intensity-default, 1)))`;
+
     const mergedStyle: StyleWithCustomVars = {
       ...(style as StyleWithCustomVars | undefined),
-      "--blob-overlay-target": overlayVar,
-      "--blob-noise-target": noiseVar,
+      "--blob-overlay-hover": overlayHoverVar,
+      "--blob-overlay-target": overlayTargetVar,
+      "--blob-overlay-active": overlayActiveVar,
+      "--blob-noise-hover": noiseHoverVar,
+      "--blob-noise-target": noiseTargetVar,
+      "--blob-noise-active-target": noiseActiveScaledVar,
     };
-
-    if (activeNoiseVar) {
-      mergedStyle["--blob-noise-active-target"] = activeNoiseVar;
-    } else if (!mergedStyle["--blob-noise-active-target"]) {
-      mergedStyle["--blob-noise-active-target"] = noiseVar;
-    }
 
     const blobAnimationClass = cn(
       "motion-reduce:animate-none",
@@ -90,7 +100,7 @@ const BlobContainer = React.forwardRef<HTMLSpanElement, BlobContainerProps>(
           className={cn(
             "absolute inset-0 rounded-[inherit] bg-gradient-blob-primary opacity-0 blur-[var(--space-4)] transition-opacity duration-quick ease-out",
             blobAnimationClass,
-            "group-hover/glitch:opacity-[var(--blob-overlay-target)] group-focus-visible/glitch:opacity-[var(--blob-overlay-target)] group-focus-within/glitch:opacity-[var(--blob-overlay-target)] group-active/glitch:opacity-[var(--blob-overlay-target)]",
+              "group-hover/glitch:opacity-[var(--blob-overlay-hover,var(--blob-overlay-target))] group-focus-visible/glitch:opacity-[var(--blob-overlay-target)] group-focus-within/glitch:opacity-[var(--blob-overlay-target)] group-active/glitch:opacity-[var(--blob-overlay-active,var(--blob-overlay-target))]",
           )}
         />
         {withNoise ? (
@@ -98,7 +108,7 @@ const BlobContainer = React.forwardRef<HTMLSpanElement, BlobContainerProps>(
             className={cn(
               "absolute inset-0 rounded-[inherit] bg-glitch-noise bg-cover opacity-0 mix-blend-screen transition-opacity duration-quick ease-out",
               noiseAnimationClass,
-              "group-hover/glitch:opacity-[var(--blob-noise-target)] group-focus-visible/glitch:opacity-[var(--blob-noise-target)] group-focus-within/glitch:opacity-[var(--blob-noise-target)] group-active/glitch:opacity-[var(--blob-noise-active-target,var(--blob-noise-target))]",
+              "group-hover/glitch:opacity-[var(--blob-noise-hover,var(--blob-noise-target))] group-focus-visible/glitch:opacity-[var(--blob-noise-target)] group-focus-within/glitch:opacity-[var(--blob-noise-target)] group-active/glitch:opacity-[var(--blob-noise-active-target,var(--blob-noise-target))]",
             )}
           />
         ) : null}

--- a/src/components/ui/primitives/Button.tsx
+++ b/src/components/ui/primitives/Button.tsx
@@ -6,6 +6,7 @@ import { Slot } from "@radix-ui/react-slot";
 import { motion, useReducedMotion } from "framer-motion";
 import type { HTMLMotionProps } from "framer-motion";
 import { cn, withBasePath } from "@/lib/utils";
+import { useAnimationsDisabled } from "@/lib/useAnimationsDisabled";
 import { useOrganicDepthEnabled } from "@/lib/depth-theme-context";
 import Spinner, { type SpinnerTone, type SpinnerSize } from "../feedback/Spinner";
 import neumorphicStyles from "../neumorphic.module.css";
@@ -291,7 +292,9 @@ export const Button = React.forwardRef<
     glitchIntensity = "glitch-overlay-button-opacity",
   } = props;
   const asChild = props.asChild ?? false;
-  const reduceMotion = useReducedMotion();
+  const animationsDisabled = useAnimationsDisabled();
+  const reduceMotionPreference = useReducedMotion();
+  const reduceMotion = reduceMotionPreference || animationsDisabled;
   const disabledProp =
     "disabled" in props && typeof props.disabled !== "undefined"
       ? props.disabled
@@ -313,6 +316,7 @@ export const Button = React.forwardRef<
     organicDepth && styles.organicControl,
     glitch && "group/glitch isolate overflow-hidden",
     "relative inline-flex items-center justify-center rounded-card r-card-md border font-medium tracking-[0.02em] transition-all duration-quick ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:ring-2 focus-visible:ring-[var(--ring-contrast)] focus-visible:shadow-[var(--shadow-glow-md)] focus-visible:[outline:var(--spacing-0-5)_solid_var(--ring-contrast)] focus-visible:[outline-offset:var(--spacing-0-5)] disabled:opacity-disabled disabled:pointer-events-none data-[loading=true]:opacity-loading",
+    "data-[reduce-motion=true]:focus-visible:shadow-none data-[reduce-motion=true]:focus-visible:[box-shadow:none]",
     "data-[disabled=true]:opacity-disabled data-[disabled=true]:pointer-events-none",
     "[--neu-radius:var(--radius-card)]",
     s.height,
@@ -412,6 +416,7 @@ export const Button = React.forwardRef<
       tabIndex: tabIndex ?? (isDisabled ? -1 : undefined),
       "data-variant": resolvedVariant,
       "data-tone": tone,
+      "data-reduce-motion": reduceMotion ? "true" : undefined,
       ...slotProps,
     };
     const childCount = React.Children.count(children);
@@ -488,6 +493,7 @@ export const Button = React.forwardRef<
       tabIndex: tabIndex ?? (isDisabled ? -1 : undefined),
       "data-variant": resolvedVariant,
       "data-tone": tone,
+      "data-reduce-motion": reduceMotion ? "true" : undefined,
       ...anchorProps,
     };
     let resolvedHref = href;
@@ -562,6 +568,7 @@ export const Button = React.forwardRef<
     tabIndex,
     "data-variant": resolvedVariant,
     "data-tone": tone,
+    "data-reduce-motion": reduceMotion ? "true" : undefined,
     ...buttonProps,
   };
 

--- a/src/components/ui/primitives/IconButton.tsx
+++ b/src/components/ui/primitives/IconButton.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { hasTextContent } from "@/lib/react";
 import { cn } from "@/lib/utils";
+import { useAnimationsDisabled } from "@/lib/useAnimationsDisabled";
 import neumorphicStyles from "../neumorphic.module.css";
 import BlobContainer, { type GlitchOverlayToken } from "./BlobContainer";
 import DripEdge from "./DripEdge";
@@ -225,7 +226,9 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
     },
     ref,
   ) => {
-    const reduceMotion = useReducedMotion();
+    const animationsDisabled = useAnimationsDisabled();
+    const reduceMotionPreference = useReducedMotion();
+    const reduceMotion = reduceMotionPreference || animationsDisabled;
     const sizeClass = getSizeClass(size);
     const appliedIconSize = iconSize ?? defaultIcon[size];
     const trimmedAriaLabel =
@@ -289,6 +292,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
           glitch && styles.glitch,
           glitch && "group/glitch isolate overflow-hidden",
           "inline-flex items-center justify-center select-none rounded-full transition-colors duration-quick ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:ring-2 focus-visible:ring-[var(--ring-contrast)] focus-visible:shadow-[var(--shadow-glow-md)] focus-visible:[outline:var(--spacing-0-5)_solid_var(--ring-contrast)] focus-visible:[outline-offset:var(--spacing-0-5)] disabled:opacity-disabled disabled:pointer-events-none data-[loading=true]:opacity-loading",
+          "data-[reduce-motion=true]:focus-visible:shadow-none data-[reduce-motion=true]:focus-visible:[box-shadow:none]",
           "[--neu-radius:var(--radius-full)]",
           variantClass,
           toneClasses[resolvedVariant][tone],
@@ -307,6 +311,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
         aria-label={resolvedAriaLabel}
         aria-labelledby={normalizedAriaLabelledBy}
         title={normalizedTitle}
+        data-reduce-motion={reduceMotion ? "true" : undefined}
         {...(domProps as typeof rest)}
       >
         {glitch ? <BlobContainer overlayToken={glitchIntensity} /> : null}

--- a/src/lib/useAnimationsDisabled.ts
+++ b/src/lib/useAnimationsDisabled.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import * as React from "react";
+
+const NO_ANIMATIONS_CLASS = "no-animations";
+
+function isAnimationsDisabled(): boolean {
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  return document.documentElement.classList.contains(NO_ANIMATIONS_CLASS);
+}
+
+/**
+ * Returns `true` when the global `no-animations` class is applied to the
+ * `<html>` element. This mirrors the reduced motion toggle that we expose in
+ * Storybook and the runtime animation toggle, ensuring components can opt out
+ * of motion treatments.
+ */
+export function useAnimationsDisabled(): boolean {
+  const [disabled, setDisabled] = React.useState(isAnimationsDisabled);
+
+  React.useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    const root = document.documentElement;
+
+    const sync = () => {
+      setDisabled(root.classList.contains(NO_ANIMATIONS_CLASS));
+    };
+
+    sync();
+
+    if (typeof MutationObserver === "undefined") {
+      return;
+    }
+
+    const observer = new MutationObserver(sync);
+    observer.observe(root, { attributes: true, attributeFilter: ["class"] });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return disabled;
+}
+

--- a/tests/primitives/BlobContainer.test.tsx
+++ b/tests/primitives/BlobContainer.test.tsx
@@ -17,14 +17,16 @@ describe("BlobContainer", () => {
     }
 
     expect(root.style.getPropertyValue("--blob-overlay-target").trim()).toBe(
-      "var(--glitch-overlay-button-opacity)",
+      "calc(var(--glitch-overlay-button-opacity) * var(--glitch-intensity-default, 1))",
     );
     expect(root.style.getPropertyValue("--blob-noise-target").trim()).toBe(
-      "var(--glitch-noise-level)",
+      "calc(var(--glitch-noise-level) * var(--glitch-intensity-default, 1))",
     );
     expect(
       root.style.getPropertyValue("--blob-noise-active-target").trim(),
-    ).toBe("var(--glitch-noise-level)");
+    ).toBe(
+      "calc(var(--glitch-noise-level) * var(--glitch-intensity, var(--glitch-intensity-default, 1)))",
+    );
   });
 
   it("respects explicit overlay and noise token overrides", () => {
@@ -43,14 +45,16 @@ describe("BlobContainer", () => {
     }
 
     expect(root.style.getPropertyValue("--blob-overlay-target").trim()).toBe(
-      "var(--glitch-overlay-opacity-card)",
+      "calc(var(--glitch-overlay-opacity-card) * var(--glitch-intensity-default, 1))",
     );
     expect(root.style.getPropertyValue("--blob-noise-target").trim()).toBe(
-      "var(--glitch-static-opacity)",
+      "calc(var(--glitch-static-opacity) * var(--glitch-intensity-default, 1))",
     );
     expect(
       root.style.getPropertyValue("--blob-noise-active-target").trim(),
-    ).toBe("var(--glitch-noise-level)");
+    ).toBe(
+      "calc(var(--glitch-noise-level) * var(--glitch-intensity, var(--glitch-intensity-default, 1)))",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- add a reusable `useAnimationsDisabled` hook and wire buttons/icon buttons to disable hover motion and focus glows when reduced motion is requested
- drive BlobContainer overlays/noise with the new glitch intensity tokens for consistent hover/focus/active feedback and cover with tests
- mute global focus/neumorphic glows when `prefers-reduced-motion` or the `no-animations` class is present to keep focus rings accessible without animation

## Testing
- npm run verify-prompts
- npm run check *(fails: Node heap out of memory while running the Vitest suite)*
- npx vitest run tests/primitives/BlobContainer.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68dc9d0cab1c832c889603508f0b6777