### PR TITLE
fix: align goal icons with token helpers

### DIFF
--- a/src/components/goals/GoalList.tsx
+++ b/src/components/goals/GoalList.tsx
@@ -8,11 +8,7 @@ import { shortDate } from "@/lib/date";
 import type { Goal } from "@/lib/types";
 
 const ICON_SM = "size-[var(--icon-size-sm)]";
-const ICON_XS = "size-[var(--icon-size-xs)]";
-const ICON_CLASS = {
-  sm: ICON_SM,
-  xs: ICON_XS,
-} as const;
+const ICON_MD = "size-[var(--icon-size-md)]";
 
 interface GoalListProps {
   goals: Goal[];
@@ -64,7 +60,7 @@ export default function GoalList({
       {goals.length === 0 ? (
         <li className="flex">
           <div className="card-pad flex h-full w-full flex-1 flex-col items-center justify-center gap-[var(--space-2)] text-center text-ui font-medium text-muted-foreground rounded-card border border-card-hairline-60 bg-surface">
-            <Flag aria-hidden className={cn(ICON_CLASS.sm, "text-accent")} />
+            <Flag aria-hidden className={cn(ICON_MD, "text-accent")} />
             <p className="max-w-[calc(var(--space-7)*5)]">
               No goals here. Add one simple, finishable thing.
             </p>
@@ -114,8 +110,9 @@ export default function GoalList({
                             variant="ghost"
                             tone="accent"
                             className="transition-transform hover:-translate-y-0.5 motion-reduce:transition-none motion-reduce:transform-none"
+                            iconSize="sm"
                           >
-                            <X />
+                            <X aria-hidden className={ICON_SM} />
                           </IconButton>
                           <IconButton
                             aria-label="Save"
@@ -124,8 +121,9 @@ export default function GoalList({
                             variant="soft"
                             tone="accent"
                             className="transition-transform hover:-translate-y-0.5 motion-reduce:transition-none motion-reduce:transform-none"
+                            iconSize="sm"
                           >
-                            <Check />
+                            <Check aria-hidden className={ICON_SM} />
                           </IconButton>
                         </>
                       ) : (
@@ -145,8 +143,9 @@ export default function GoalList({
                             variant="ghost"
                             tone="accent"
                             className="transition-transform hover:-translate-y-0.5 motion-reduce:transition-none motion-reduce:transform-none"
+                            iconSize="sm"
                           >
-                            <Pencil />
+                            <Pencil aria-hidden className={ICON_SM} />
                           </IconButton>
                           <IconButton
                             title="Delete"
@@ -156,8 +155,9 @@ export default function GoalList({
                             variant="soft"
                             tone="accent"
                             className="transition-transform hover:-translate-y-0.5 motion-reduce:transition-none motion-reduce:transform-none"
+                            iconSize="sm"
                           >
-                            <Trash2 />
+                            <Trash2 aria-hidden className={ICON_SM} />
                           </IconButton>
                         </>
                       )}

--- a/src/components/goals/GoalSlot.tsx
+++ b/src/components/goals/GoalSlot.tsx
@@ -9,6 +9,9 @@ import { PillarBadge } from "@/components/ui";
 import Input from "@/components/ui/primitives/Input";
 import IconButton from "@/components/ui/primitives/IconButton";
 
+const ICON_SM = "size-[var(--icon-size-sm)]";
+const ICON_MD = "size-[var(--icon-size-md)]";
+
 interface GoalSlotProps {
   goal?: Goal | null;
   onToggleDone?: (id: string) => void;
@@ -86,21 +89,21 @@ export default function GoalSlot({
               <div className="flex items-center gap-[var(--space-1)]">
                 <IconButton
                   size="sm"
-                  iconSize="xs"
+                  iconSize="sm"
                   tone="accent"
                   onClick={saveEdit}
                   aria-label="Save goal title"
                 >
-                  <Check />
+                  <Check aria-hidden className={ICON_SM} />
                 </IconButton>
                 <IconButton
                   size="sm"
-                  iconSize="xs"
+                  iconSize="sm"
                   tone="danger"
                   onClick={cancelEdit}
                   aria-label="Cancel editing"
                 >
-                  <X />
+                  <X aria-hidden className={ICON_SM} />
                 </IconButton>
               </div>
             </div>
@@ -118,42 +121,42 @@ export default function GoalSlot({
                   />
                 )}
               </div>
-              <IconButton
-                size="sm"
-                iconSize="xs"
-                tone={goal.done ? "accent" : "primary"}
-                variant="ghost"
-                className="absolute bottom-[var(--space-1)] right-[var(--space-1)]"
-                aria-label={goal.done ? "Mark goal undone" : "Mark goal done"}
-                aria-pressed={goal.done}
-                onClick={() => onToggleDone?.(goal.id)}
-              >
-                <Check />
-              </IconButton>
+                <IconButton
+                  size="sm"
+                  iconSize="md"
+                  tone={goal.done ? "accent" : "primary"}
+                  variant="ghost"
+                  className="absolute bottom-[var(--space-1)] right-[var(--space-1)]"
+                  aria-label={goal.done ? "Mark goal undone" : "Mark goal done"}
+                  aria-pressed={goal.done}
+                  onClick={() => onToggleDone?.(goal.id)}
+                >
+                  <Check aria-hidden className={ICON_MD} />
+                </IconButton>
               <div
                 className="pointer-events-none absolute bottom-[var(--space-1)] left-[var(--space-1)] flex items-center gap-[var(--space-1)] opacity-0 transition-opacity duration-quick ease-out group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100"
               >
                 <IconButton
                   ref={editButtonRef}
                   size="sm"
-                  iconSize="xs"
+                  iconSize="sm"
                   variant="ghost"
                   aria-label="Edit goal"
                   title="Edit goal"
                   onClick={startEdit}
                 >
-                  <Pencil />
+                  <Pencil aria-hidden className={ICON_SM} />
                 </IconButton>
                 <IconButton
                   size="sm"
-                  iconSize="xs"
+                  iconSize="sm"
                   tone="danger"
                   variant="ghost"
                   aria-label="Delete goal"
                   title="Delete goal"
                   onClick={() => onDelete?.(goal.id)}
                 >
-                  <Trash2 />
+                  <Trash2 aria-hidden className={ICON_SM} />
                 </IconButton>
               </div>
             </>


### PR DESCRIPTION
## Summary
- add shared icon size token helpers to GoalSlot and GoalList
- update Goal actions to rely on tokenized icon sizing and hide decorative glyphs from assistive tech
- refresh the empty-state icon to use the same token helper family for theme parity

## Testing
- npm run check *(fails: requires gallery manifest generation in this environment)*
- npm test -- --run *(aborted after ~60s; suite stalled on queued gallery tests)*

------
https://chatgpt.com/codex/tasks/task_e_68dcbbaddb40832c8a5ea55a483798f9