### PR TITLE
fix: flatten next config export

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -85,16 +85,7 @@ const withBundleAnalyzer = bundleAnalyzer({
   logLevel: "warn",
 });
 
-const securityHeaders = async () => {
-  return [
-    {
-      source: "/:path*",
-      headers: baseSecurityHeaders.map((header) => ({ ...header })),
-    },
-  ];
-};
-
-const nextConfig = {
+export default withBundleAnalyzer({
   reactStrictMode: true,
   output: "export",
   trailingSlash: true,
@@ -116,19 +107,20 @@ const nextConfig = {
   env: {
     NEXT_PUBLIC_BASE_PATH: normalizedBasePathValue,
   },
+  headers: async () => {
+    if (isProduction || isExportStatic) {
+      return [];
+    }
+
+    return [
+      {
+        source: "/:path*",
+        headers: baseSecurityHeaders.map((header) => ({ ...header })),
+      },
+    ];
+  },
   webpack: (config) => {
     config.resolve.alias["@"] = path.resolve(__dirname, "src");
     return config;
   },
-};
-
-const configWithAnalyzer = shouldCollectBundleStats ? withBundleAnalyzer(nextConfig) : nextConfig;
-
-const finalConfig = !(isProduction || isExportStatic)
-  ? {
-      ...configWithAnalyzer,
-      headers: securityHeaders,
-    }
-  : configWithAnalyzer;
-
-export default finalConfig;
+});


### PR DESCRIPTION
## Summary
- flatten the Next.js configuration so the bundle analyzer wraps the object literal that now includes `output: "export"`
- fold the environment-dependent headers into the exported config so production and export builds return an empty headers array while still applying security headers elsewhere

## Testing
- npm run check *(fails in container: vitest workers exhaust memory / hang on long-running suites)*

------
https://chatgpt.com/codex/tasks/task_e_68dcbb6713b0832c8f5aa0d936c5e515