### PR TITLE
fix: align dashboard list empty icon sizing

### DIFF
--- a/src/components/home/DashboardList.tsx
+++ b/src/components/home/DashboardList.tsx
@@ -6,6 +6,8 @@ import { CircleSlash } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
+const EMPTY_ICON_SIZE = "size-[var(--icon-size-xs)]";
+
 function isReactKey(value: unknown): value is React.Key {
   return typeof value === "string" || typeof value === "number";
 }
@@ -115,7 +117,7 @@ export default function DashboardList<T>({
               )}
             >
               <span className="flex items-center gap-[var(--space-2)]">
-                <CircleSlash aria-hidden className="size-3" />
+                <CircleSlash aria-hidden className={EMPTY_ICON_SIZE} />
                 {empty}
               </span>
               {cta ? (


### PR DESCRIPTION
## Summary
- add an EMPTY_ICON_SIZE helper to DashboardList to re-use the icon sizing token
- replace the hard-coded empty state icon size with the helper for visual alignment

## Testing
- npm run verify-prompts
- npm run check *(fails: vitest run does not complete in this environment; it stalls around 8/132 files even after increasing Node max-old-space-size)*

------
https://chatgpt.com/codex/tasks/task_e_68dccbd40044832c8119e03627502df3