### PR TITLE
Refactor Next config export wrapper

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -85,7 +85,7 @@ const withBundleAnalyzer = bundleAnalyzer({
   logLevel: "warn",
 });
 
-export default withBundleAnalyzer({
+const nextConfig = {
   reactStrictMode: true,
   output: "export",
   trailingSlash: true,
@@ -123,4 +123,6 @@ export default withBundleAnalyzer({
     config.resolve.alias["@"] = path.resolve(__dirname, "src");
     return config;
   },
-});
+};
+
+export default withBundleAnalyzer(nextConfig);


### PR DESCRIPTION
## Summary
- wrap the existing Next.js configuration object in a reusable `nextConfig` constant
- continue exporting the configuration through the bundle analyzer helper without changing any options

## Testing
- npm run lint
- npm run lint:design
- npm run typecheck
- CI=true npm test -- --run --reporter=basic *(hangs after several suites, manually interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68dccc29dc50832ca0eb13aee0297a0a