### PR TITLE
fix: unwrap bundle analyzer config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -85,7 +85,7 @@ const withBundleAnalyzer = bundleAnalyzer({
   logLevel: "warn",
 });
 
-const nextConfig = {
+const baseNextConfig = {
   reactStrictMode: true,
   output: "export",
   trailingSlash: true,
@@ -125,4 +125,6 @@ const nextConfig = {
   },
 };
 
-export default withBundleAnalyzer(nextConfig);
+const nextConfig = withBundleAnalyzer(baseNextConfig);
+
+export default nextConfig;


### PR DESCRIPTION
## Summary
- wrap the base Next.js configuration in a variable before applying the bundle analyzer plugin
- export the plugin-enhanced configuration so GitHub Pages tooling can inject the output setting without AST errors

## Testing
- npm run verify-prompts
- npm run check *(fails: type errors in generated gallery manifest present on main)*

------
https://chatgpt.com/codex/tasks/task_e_68dce0658204832cbdf6551404862760