### PR TITLE
Fix Next.js config shape for configure-pages tooling

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -85,7 +85,8 @@ const withBundleAnalyzer = bundleAnalyzer({
   logLevel: "warn",
 });
 
-const baseNextConfig = {
+/** @type {import("next").NextConfig} */
+let nextConfig = {
   reactStrictMode: true,
   output: "export",
   trailingSlash: true,
@@ -125,6 +126,6 @@ const baseNextConfig = {
   },
 };
 
-const nextConfig = withBundleAnalyzer(baseNextConfig);
+nextConfig = withBundleAnalyzer(nextConfig);
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- ensure `next.config.mjs` exports a plain configuration object before applying the bundle analyzer so GitHub Pages can inject settings without errors

## Testing
- npm run verify-prompts
- npm run lint
- npm run lint:design
- npm run typecheck
- npm run check *(fails locally: Node.js OOM while running vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68dd039a501c832cbcf25aec57175cba