### PR TITLE
fix: expose SectionCard header for server previews

### DIFF
--- a/src/app/preview/a11y/page.tsx
+++ b/src/app/preview/a11y/page.tsx
@@ -1,6 +1,11 @@
 import type { Metadata } from "next";
 
-import { PageShell, SectionCard } from "@/components/ui";
+import {
+  PageShell,
+  SectionCard,
+  SectionCardHeader,
+  SectionCardBody,
+} from "@/components/ui";
 
 import A11yPreviewClient from "./A11yPreviewClient";
 
@@ -20,19 +25,19 @@ export default function A11yPreviewPage() {
       className="py-[var(--space-6)] md:py-[var(--space-8)]"
     >
       <SectionCard className="col-span-full md:col-span-10 md:col-start-2 lg:col-span-8 lg:col-start-3">
-        <SectionCard.Header>
+        <SectionCardHeader>
           <div className="space-y-[var(--space-2)]" id="a11y-preview-heading">
             <p className="text-caption font-medium uppercase tracking-[0.2em] text-muted-foreground">Keyboard and focus</p>
             <h1 className="text-title font-semibold tracking-[-0.01em]">Accessibility guard rails</h1>
           </div>
-        </SectionCard.Header>
-        <SectionCard.Body className="space-y-[var(--space-6)] text-ui text-muted-foreground">
+        </SectionCardHeader>
+        <SectionCardBody className="space-y-[var(--space-6)] text-ui text-muted-foreground">
           <p>
             These demos exercise Planner&apos;s focus management primitives. The modal trap keeps keyboard users inside the
             dialog until they exit, and the roving listbox demonstrates arrow key loops without hijacking Tab order.
           </p>
           <A11yPreviewClient />
-        </SectionCard.Body>
+        </SectionCardBody>
       </SectionCard>
     </PageShell>
   );

--- a/src/app/preview/hero-images/page.tsx
+++ b/src/app/preview/hero-images/page.tsx
@@ -6,7 +6,12 @@ import {
   HERO_ILLUSTRATION_STATES,
   type HeroIllustrationState,
 } from "@/data/heroImages";
-import { PageShell, SectionCard } from "@/components/ui";
+import {
+  PageShell,
+  SectionCard,
+  SectionCardHeader,
+  SectionCardBody,
+} from "@/components/ui";
 import { VARIANTS, type Variant } from "@/lib/theme";
 
 import HeroImagesPreviewClient from "./HeroImagesPreviewClient";
@@ -81,7 +86,7 @@ export default async function HeroImagesPreviewPage({
       contentClassName="gap-y-[var(--space-6)] md:gap-y-[var(--space-7)]"
     >
       <SectionCard className="col-span-full md:col-span-10 md:col-start-2 lg:col-span-8 lg:col-start-3">
-        <SectionCard.Header className="space-y-[var(--space-2)]">
+        <SectionCardHeader className="space-y-[var(--space-2)]">
           <div className="space-y-[var(--space-1)]">
             <p className="text-caption font-medium uppercase tracking-[0.2em] text-muted-foreground">
               Gallery preview
@@ -98,14 +103,14 @@ export default async function HeroImagesPreviewPage({
             controls below to pin a theme/state combination or disable the automatic cycle for motion-sensitive
             reviews.
           </p>
-        </SectionCard.Header>
-        <SectionCard.Body>
+        </SectionCardHeader>
+        <SectionCardBody>
           <HeroImagesPreviewClient
             initialVariant={variant}
             initialState={state}
             autoplay={autoplay}
           />
-        </SectionCard.Body>
+        </SectionCardBody>
       </SectionCard>
     </PageShell>
   );

--- a/src/app/preview/perf/page.tsx
+++ b/src/app/preview/perf/page.tsx
@@ -1,6 +1,11 @@
 import type { Metadata } from "next";
 
-import { PageShell, SectionCard } from "@/components/ui";
+import {
+  PageShell,
+  SectionCard,
+  SectionCardHeader,
+  SectionCardBody,
+} from "@/components/ui";
 
 import PerfPreviewClient from "./PerfPreviewClient";
 
@@ -21,21 +26,21 @@ export default function PerfPreviewPage() {
       className="py-[var(--space-6)] md:py-[var(--space-8)]"
     >
       <SectionCard className="col-span-full md:col-span-10 md:col-start-2 lg:col-span-8 lg:col-start-3">
-        <SectionCard.Header>
+        <SectionCardHeader>
           <div className="space-y-[var(--space-2)]" id="perf-preview-heading">
             <p className="text-caption font-medium uppercase tracking-[0.2em] text-muted-foreground">
               Virtualization demo
             </p>
             <h1 className="text-title font-semibold tracking-[-0.01em]">Performance guard rails</h1>
           </div>
-        </SectionCard.Header>
-        <SectionCard.Body className="space-y-[var(--space-6)] text-ui text-muted-foreground">
+        </SectionCardHeader>
+        <SectionCardBody className="space-y-[var(--space-6)] text-ui text-muted-foreground">
           <p>
             Preview how Planner keeps large datasets responsive. Lists flip to windowed rendering when row counts
             spike, while charts downsample heavy series so Playwright and axe sweeps stay deterministic across themes.
           </p>
           <PerfPreviewClient />
-        </SectionCard.Body>
+        </SectionCardBody>
       </SectionCard>
     </PageShell>
   );

--- a/src/app/preview/tabs/page.tsx
+++ b/src/app/preview/tabs/page.tsx
@@ -4,7 +4,12 @@ import {
   DESIGN_TOKEN_GROUPS,
   buildGalleryNavigation,
 } from "@/components/gallery-page/ComponentsPage";
-import { PageShell, SectionCard } from "@/components/ui";
+import {
+  PageShell,
+  SectionCard,
+  SectionCardHeader,
+  SectionCardBody,
+} from "@/components/ui";
 
 import TabsPreviewMatrixClient from "./TabsPreviewMatrixClient";
 
@@ -29,7 +34,7 @@ export default function TabsPreviewPage() {
       contentClassName="gap-y-[var(--space-6)] md:gap-y-[var(--space-7)]"
     >
       <SectionCard className="col-span-full" aria-labelledby="tabs-preview-heading">
-        <SectionCard.Header className="space-y-[var(--space-2)]">
+        <SectionCardHeader className="space-y-[var(--space-2)]">
           <div className="space-y-[var(--space-1)]">
             <p className="text-caption font-medium uppercase tracking-[0.2em] text-muted-foreground">
               Gallery preview
@@ -45,10 +50,10 @@ export default function TabsPreviewPage() {
             Confirm the components gallery navigation stays legible across all Planner themes.
             This preview renders the four gallery categories using the production tabs layout.
           </p>
-        </SectionCard.Header>
-        <SectionCard.Body className="space-y-[var(--space-5)]">
+        </SectionCardHeader>
+        <SectionCardBody className="space-y-[var(--space-5)]">
           <TabsPreviewMatrixClient navigation={navigation} tokenGroups={tokenGroups} />
-        </SectionCard.Body>
+        </SectionCardBody>
       </SectionCard>
     </PageShell>
   );

--- a/src/components/ui/layout/SectionCard.tsx
+++ b/src/components/ui/layout/SectionCard.tsx
@@ -30,7 +30,7 @@ const SectionCardContext = React.createContext<SectionCardContextValue | null>(
   null,
 );
 
-const Root = React.forwardRef<HTMLElement, RootProps>(
+const SectionCardRoot = React.forwardRef<HTMLElement, RootProps>(
   ({ variant = "neo", className, children, ...props }, ref) => {
     const [headingId, setHeadingId] = React.useState<string | undefined>();
     const contextValue = React.useMemo(
@@ -60,9 +60,9 @@ const Root = React.forwardRef<HTMLElement, RootProps>(
     );
   },
 );
-Root.displayName = "SectionCard";
+SectionCardRoot.displayName = "SectionCard";
 
-function Header({
+function SectionCardHeader({
   sticky,
   topClassName = "top-[var(--space-8)]",
   className,
@@ -138,7 +138,7 @@ function Header({
   );
 }
 
-function Body({ className, ...props }: BodyProps) {
+function SectionCardBody({ className, ...props }: BodyProps) {
   const context = React.useContext(SectionCardContext);
   const labelledBy =
     (props as React.HTMLAttributes<HTMLDivElement>)["aria-labelledby"] ??
@@ -153,5 +153,10 @@ function Body({ className, ...props }: BodyProps) {
   );
 }
 
-const SectionCard = Object.assign(Root, { Header, Body });
+const SectionCard = Object.assign(SectionCardRoot, {
+  Header: SectionCardHeader,
+  Body: SectionCardBody,
+});
+
+export { SectionCardHeader, SectionCardBody };
 export default SectionCard;


### PR DESCRIPTION
## Summary
- export SectionCardHeader and SectionCardBody so server modules can import the subcomponents directly
- update preview pages to consume the named exports instead of `SectionCard.Header` to avoid undefined client boundary proxies

## Testing
- npm run verify-prompts
- npm run lint
- npm run lint:design
- npm run typecheck
- npm test -- --run *(aborted after ~2m due to long-running integration suite)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0c48b1e0832c833535f6b7c3131f