### PR TITLE
fix: align neon icon radii tokens

### DIFF
--- a/src/components/ui/toggles/NeonIcon.module.css
+++ b/src/components/ui/toggles/NeonIcon.module.css
@@ -3,10 +3,11 @@
   display: inline-grid;
   place-items: center;
   overflow: visible;
-  border-radius: 9999px;
+  border-radius: var(--ni-radius);
   width: var(--ni-size);
   height: var(--ni-size);
   --ni-size: var(--icon-size-md);
+  --ni-radius: var(--radius-full);
   --ni-k: calc(0.56 * var(--ni-size));
   --ni-color: hsl(var(--accent));
   --ni-core-blur: calc(var(--hairline-w) * 2.5);
@@ -146,7 +147,7 @@
   pointer-events: none;
   position: absolute;
   inset: 0;
-  border-radius: 9999px;
+  border-radius: var(--ni-radius);
   mix-blend-mode: overlay;
   background: repeating-linear-gradient(
     0deg,
@@ -167,7 +168,7 @@
   pointer-events: none;
   position: absolute;
   inset: 0;
-  border-radius: 9999px;
+  border-radius: var(--ni-radius);
   mix-blend-mode: screen;
   opacity: 0;
 }


### PR DESCRIPTION
## Summary
- switch the neon icon container to use the design-system full radius token via a local --ni-radius variable
- reuse the shared radius token on scanline and glow layers to eliminate remaining literal 9999px radii

## Testing
- npm run verify-prompts
- npm run lint
- npm run lint:design
- npm run typecheck
- npm test -- --run *(hangs on integration suite locally; aborted after ~60s)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb4f1ab40832cacc949b70f522667