### PR TITLE
fix: tokenise HomeSplash glitch offsets

### DIFF
--- a/src/components/home/HomeSplash.module.css
+++ b/src/components/home/HomeSplash.module.css
@@ -64,8 +64,8 @@
 }
 
 .logoMotion {
-  --glitch-x: 1.5px;
-  --glitch-y: 1.2px;
+  --glitch-x: calc(var(--hairline-w) * 1.5);
+  --glitch-y: calc(var(--hairline-w) * 1.2);
   --glitch-speed: 2.6s;
   --glitch-flicker: 3.8s;
   position: absolute;


### PR DESCRIPTION
## Summary
- replace the HomeSplash glitch offset variables with hairline token multiples to avoid px literals

## Testing
- npm run verify-prompts
- npm run check *(fails: existing Vitest suite hang, aborted after several minutes)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb4f5464c832cb525077fa3bfb2d2