### PR TITLE
fix: align tab bar shadows with hairline token

### DIFF
--- a/src/components/ui/layout/TabBar.module.css
+++ b/src/components/ui/layout/TabBar.module.css
@@ -34,7 +34,7 @@
   background: linear-gradient(140deg, var(--tablist-surface), var(--tablist-depth));
   border-color: var(--tablist-border);
   box-shadow:
-    inset 0 1px 0 var(--tablist-highlight),
+    inset 0 calc(1 * var(--hairline-w)) 0 var(--tablist-highlight),
     var(--shadow-outline-subtle),
     0 var(--space-3) var(--space-6) hsl(var(--shadow-color) / 0.24);
 }
@@ -46,8 +46,8 @@
     hsl(var(--bg)) 4%
   );
   box-shadow:
-    inset 0 1px 0 color-mix(in oklab, hsl(var(--highlight)) 72%, transparent 28%),
-    inset 0 -1px 0 hsl(var(--shadow-color) / 0.12),
+    inset 0 calc(1 * var(--hairline-w)) 0 color-mix(in oklab, hsl(var(--highlight)) 72%, transparent 28%),
+    inset 0 calc(-1 * var(--hairline-w)) 0 hsl(var(--shadow-color) / 0.12),
     var(--shadow-outline-faint);
   color: color-mix(
     in oklab,
@@ -72,7 +72,7 @@
 .defaultTab[data-variant="default"]:hover:not([data-disabled="true"]):not([data-loading="true"]):not(:disabled) {
   background-color: var(--hover);
   box-shadow:
-    inset 0 1px 0 color-mix(in oklab, hsl(var(--highlight)) 72%, transparent 28%),
+    inset 0 calc(1 * var(--hairline-w)) 0 color-mix(in oklab, hsl(var(--highlight)) 72%, transparent 28%),
     0 var(--space-2) var(--space-4) hsl(var(--shadow-color) / 0.22),
     var(--shadow-outline-subtle);
   color: hsl(var(--foreground));
@@ -82,7 +82,7 @@
 .defaultTab[data-variant="default"][data-active="true"]:active {
   background-color: var(--active);
   box-shadow:
-    inset 0 1px 0 color-mix(in oklab, hsl(var(--highlight)) 62%, transparent 38%),
+    inset 0 calc(1 * var(--hairline-w)) 0 color-mix(in oklab, hsl(var(--highlight)) 62%, transparent 38%),
     inset 0 0 0 var(--hairline-w) hsl(var(--ring) / 0.4),
     0 var(--space-2) var(--space-4) hsl(var(--shadow-color) / 0.24);
 }
@@ -131,6 +131,6 @@
       hsl(var(--panel) / 0.85),
     inset calc(var(--space-1) * -1.75) calc(var(--space-1) * -1.75)
       var(--space-4) hsl(var(--foreground) / 0.08),
-    inset 0 0 0 1px hsl(var(--ring) / 0.35),
+    inset 0 0 0 var(--hairline-w) hsl(var(--ring) / 0.35),
     0 var(--space-3) var(--space-6) hsl(var(--shadow-color) / 0.35);
 }


### PR DESCRIPTION
## Summary
- swap hard-coded 1px box-shadow offsets in the tab bar styles for hairline token references
- ensure inset outline shadows also reference the shared hairline thickness token for theme parity

## Testing
- `npm run verify-prompts`
- `npm run lint`
- `npm run lint:design`
- `npm run typecheck`
- `NODE_OPTIONS=--max-old-space-size=8192 npm test -- --run` *(stalls on `tests/planner/UsePlannerStore.integration.test.tsx`; manually aborted after ~2m without failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb4ea8da0832cb2655229e9d2b3ba