### PR TITLE
fix: align CheckCircle radii with tokens

### DIFF
--- a/src/components/ui/toggles/CheckCircle.module.css
+++ b/src/components/ui/toggles/CheckCircle.module.css
@@ -1,12 +1,13 @@
 .button {
   --cc-color: hsl(var(--success));
   --cc-glow: hsl(var(--success-glow));
+  --cc-radius: var(--radius-full);
 }
 
 .rim {
   position: absolute;
   inset: 0;
-  border-radius: 9999px;
+  border-radius: var(--cc-radius);
   padding: var(--space-1);
   pointer-events: none;
   opacity: 0;
@@ -36,7 +37,7 @@
 .scanlines {
   position: absolute;
   inset: calc(var(--space-1) / 2);
-  border-radius: 9999px;
+  border-radius: var(--cc-radius);
   pointer-events: none;
   opacity: 0;
   background: repeating-linear-gradient(
@@ -59,7 +60,7 @@
 .bloom {
   position: absolute;
   inset: calc(var(--space-2) * -1);
-  border-radius: 9999px;
+  border-radius: var(--cc-radius);
   pointer-events: none;
   opacity: 0;
   filter: blur(calc(var(--space-3) - var(--hairline-w) * 2));
@@ -77,7 +78,7 @@
   pointer-events: none;
   position: absolute;
   inset: 0;
-  border-radius: 9999px;
+  border-radius: var(--cc-radius);
   mix-blend-mode: screen;
   opacity: 0;
 }


### PR DESCRIPTION
## Summary
- introduce a shared `--cc-radius` custom property in the CheckCircle toggle styles
- replace hard-coded circular radii with the shared token-driven value to keep glow layers circular

## Testing
- npm run verify-prompts
- npm run check *(fails: vitest workers hit Node heap OOM in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb4ebf8d4832c86c479189d814142