### PR TITLE
fix: align select scanlines with tokens

### DIFF
--- a/src/components/ui/select/Select.module.css
+++ b/src/components/ui/select/Select.module.css
@@ -202,8 +202,8 @@
   mask-composite: exclude;
   background: repeating-linear-gradient(
     0deg,
-    hsl(var(--foreground) / 0.1) 0 1px,
-    transparent 2px 4px
+    hsl(var(--foreground) / 0.1) 0 var(--hairline-w),
+    transparent calc(var(--space-1) / 2) var(--space-1)
   );
   mix-blend-mode: soft-light;
   opacity: 0.2;


### PR DESCRIPTION
## Summary
- replace the select scanline gradient pixel stops with token-based values so the effect respects hairline and spacing scales

## Testing
- npm run verify-prompts
- npx vitest run tests/components/PageHeader.test.tsx
- npm run lint
- npm run lint:design
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ddb4f5ebc8832cadc23116f66fd6f2