### PR TITLE
Add reusable skip link component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,7 @@ import {
 import tokens from "../../tokens/tokens.js";
 import { resolveTokenColor } from "@/lib/color";
 import SiteChrome from "@/components/chrome/SiteChrome";
-import { CatCompanion, DecorLayer, PageShell } from "@/components/ui";
+import { CatCompanion, DecorLayer, PageShell, SkipLink } from "@/components/ui";
 import { withBasePath } from "@/lib/utils";
 import Script from "next/script";
 import ThemeProvider from "@/lib/theme-context";
@@ -191,12 +191,7 @@ export default async function RootLayout({
           data-organic-depth={organicDepthDataAttribute}
           data-glitch-landing={glitchLandingDataAttribute}
         >
-          <a
-            className="fixed left-[var(--space-4)] top-[var(--space-4)] z-50 inline-flex items-center rounded-[var(--radius-lg)] bg-background px-[var(--space-4)] py-[var(--space-2)] text-ui font-medium text-foreground shadow-outline-subtle outline-none transition-all duration-motion-sm ease-out opacity-0 -translate-y-full pointer-events-none focus-visible:translate-y-0 focus-visible:opacity-100 focus-visible:pointer-events-auto focus-visible:shadow-ring focus-visible:no-underline focus-visible:outline-none hover:shadow-ring focus-visible:active:translate-y-[var(--space-1)]"
-            href="#main-content"
-          >
-            Skip to main content
-          </a>
+          <SkipLink targetId="main-content" />
           <noscript>
             <div
               role="status"
@@ -226,7 +221,7 @@ export default async function RootLayout({
                 <SiteChrome>
                   <CatCompanion />
                   <div className="relative z-10">
-                    <main id="main-content" tabIndex={-1}>
+                    <main id="main-content" role="main" tabIndex={-1}>
                       {children}
                     </main>
                     <footer

--- a/src/app/preview/a11y/A11yPreviewClient.tsx
+++ b/src/app/preview/a11y/A11yPreviewClient.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { Focus, Keyboard } from "lucide-react";
 
-import { Badge, Button, useDialogTrap } from "@/components/ui";
+import { Badge, Button, SkipLink, useDialogTrap } from "@/components/ui";
 import { cn } from "@/lib/utils";
 
 const FLOW_STEPS = [
@@ -32,9 +32,56 @@ const FLOW_STEPS = [
 export default function A11yPreviewClient() {
   return (
     <div className="space-y-[var(--space-6)]">
+      <SkipLinkDemo />
       <FocusTrapDemo />
       <KeyboardFlowDemo />
     </div>
+  );
+}
+
+function SkipLinkDemo() {
+  const targetId = "skip-link-demo-target";
+
+  return (
+    <section
+      aria-labelledby="a11y-skip-link-heading"
+      className="space-y-[var(--space-4)]"
+      data-a11y-panel="skip-link"
+    >
+      <header className="space-y-[var(--space-1)]">
+        <h2
+          id="a11y-skip-link-heading"
+          className="text-heading-sm font-semibold tracking-[-0.01em]"
+        >
+          Skip link navigation
+        </h2>
+        <p className="max-w-3xl text-label text-muted-foreground">
+          Use the skip link to bypass repetitive chrome and land directly on the
+          primary landmark. Focus the control and press Enter to jump to the
+          labeled region.
+        </p>
+      </header>
+      <div className="space-y-[var(--space-3)]">
+        <SkipLink targetId={targetId} className="left-auto right-[var(--space-4)]">
+          Skip to demo content
+        </SkipLink>
+        <p className="text-label text-muted-foreground">
+          Press Tab until the skip link appears in the top corner, then
+          activate it to focus the content below.
+        </p>
+        <div
+          id={targetId}
+          tabIndex={-1}
+          className="space-y-[var(--space-2)] rounded-card border border-border bg-surface p-[var(--space-4)] text-body text-foreground shadow-outline-subtle"
+        >
+          <p className="font-medium">Demo content</p>
+          <p className="text-label text-muted-foreground">
+            When the skip link is activated, focus moves here. Auditors can
+            verify the focus-visible ring and announceable heading.
+          </p>
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/src/components/prompts/PromptsDemos.tsx
+++ b/src/components/prompts/PromptsDemos.tsx
@@ -26,6 +26,7 @@ import {
   BlobContainer,
   DripEdge,
   IssueBadge,
+  SkipLink,
 } from "@/components/ui";
 import Badge from "@/components/ui/primitives/Badge";
 import IconButton from "@/components/ui/primitives/IconButton";
@@ -58,6 +59,7 @@ export default function PromptsDemos() {
   const issueDemoPanelId = React.useId();
   const issueDemoBadgeId = `${issueDemoPanelId}-badge`;
   const [issueDemoExpanded, setIssueDemoExpanded] = React.useState(false);
+  const skipLinkDemoTargetId = React.useId();
 
   return (
     <>
@@ -88,6 +90,36 @@ export default function PromptsDemos() {
               <CheckIcon aria-hidden />
             </IconButton>
           </Input>
+        </div>
+      </Card>
+      <Card className="mt-[var(--space-8)] space-y-[var(--space-4)]">
+        <h3 className="type-title">Skip link</h3>
+        <p className="text-ui text-muted-foreground">
+          Global skip links let keyboard users bypass chrome and land on the
+          main region without tabbing through every control.
+        </p>
+        <div className="space-y-[var(--space-3)]">
+          <SkipLink
+            targetId={skipLinkDemoTargetId}
+            className="left-auto right-[var(--space-4)]"
+          >
+            Skip to prompts content
+          </SkipLink>
+          <p className="text-label text-muted-foreground">
+            Tab forward until the skip link appears, then activate it to move
+            focus into the demo panel.
+          </p>
+          <div
+            id={skipLinkDemoTargetId}
+            tabIndex={-1}
+            className="space-y-[var(--space-2)] rounded-card border border-border bg-surface p-[var(--space-4)] text-body text-foreground shadow-outline-subtle"
+          >
+            <p className="font-medium">Prompts skip target</p>
+            <p className="text-label text-muted-foreground">
+              The focus-visible treatment and tokenized spacing match the
+              production layout for parity across previews.
+            </p>
+          </div>
         </div>
       </Card>
       <Card className="mt-[var(--space-8)] space-y-[var(--space-4)]">

--- a/src/components/ui/SkipLink.tsx
+++ b/src/components/ui/SkipLink.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface SkipLinkProps
+  extends Omit<React.ComponentPropsWithoutRef<"a">, "href"> {
+  /**
+   * ID of the landmark to focus when activated. A leading `#` is optional.
+   */
+  targetId: string;
+  /**
+   * Accessible label for the skip action. Defaults to "Skip to main content".
+   */
+  children?: React.ReactNode;
+  /**
+   * Optional href override when linking outside of the current page.
+   */
+  href?: string;
+}
+
+const BASE_CLASSES =
+  "fixed left-[var(--space-4)] top-[var(--space-4)] z-50 inline-flex items-center rounded-[var(--radius-lg)] bg-background px-[var(--space-4)] py-[var(--space-2)] text-ui font-medium text-foreground shadow-outline-subtle outline-none transition-all duration-motion-sm ease-out opacity-0 -translate-y-full pointer-events-none focus-visible:translate-y-0 focus-visible:opacity-100 focus-visible:pointer-events-auto focus-visible:shadow-ring focus-visible:no-underline focus-visible:outline-none hover:shadow-ring focus-visible:active:translate-y-[var(--space-1)]";
+
+const SkipLink = React.forwardRef<HTMLAnchorElement, SkipLinkProps>(
+  (
+    {
+      targetId,
+      children = "Skip to main content",
+      className,
+      href,
+      ...props
+    },
+    ref,
+  ) => {
+    const normalizedTarget = targetId.startsWith("#")
+      ? targetId
+      : `#${targetId}`;
+    const resolvedHref = href ?? normalizedTarget;
+
+    return (
+      <a
+        {...props}
+        ref={ref}
+        className={cn(BASE_CLASSES, className)}
+        href={resolvedHref}
+      >
+        {children}
+      </a>
+    );
+  },
+);
+
+SkipLink.displayName = "SkipLink";
+
+export default SkipLink;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -98,6 +98,8 @@ export { default as Sheet } from "./Sheet";
 export * from "./Sheet";
 export { default as Sidebar } from "./Sidebar";
 export * from "./Sidebar";
+export { default as SkipLink } from "./SkipLink";
+export * from "./SkipLink";
 export { default as Stack } from "./Stack";
 export * from "./Stack";
 export { default as Switcher } from "./Switcher";


### PR DESCRIPTION
## Summary
- add a reusable `<SkipLink />` primitive that wraps the focus-visible skip navigation styling and exports it through the UI barrel
- swap the inline anchor in the root layout for `<SkipLink targetId="main-content" />`, add `role="main"`, and surface the component in accessibility and prompts previews

## Files touched
- src/app/layout.tsx
- src/app/preview/a11y/A11yPreviewClient.tsx
- src/components/prompts/PromptsDemos.tsx
- src/components/ui/SkipLink.tsx
- src/components/ui/index.ts

## Tokens mapped/added
- Reused existing spacing, radius, background, and focus tokens; no new tokens introduced.

## Tests (unit/e2e + a11y)
- npm run verify-prompts
- npm run lint
- npm run lint:design
- npm run typecheck
- NODE_OPTIONS=--max-old-space-size=8192 VITEST_MAX_THREADS=2 npx vitest run tests/lib/Db.test.ts tests/components/PageHeader.test.tsx tests/planner/WeekPicker.test.tsx tests/home/useHomePlannerOverview.test.tsx tests/primitives/IconButton.test.tsx tests/planner/UsePlannerStore.test.tsx tests/lib/clipboard.test.ts tests/components/ComponentsGalleryState.test.tsx

## Visual QA (screens/preview routes; themes)
- Updated `/preview/a11y` and prompts gallery to document the skip link; verified theme tokens reused.

## CLS/LCP notes (if page)
- Skip link remains visually hidden until focused; no layout shifts introduced.

## Risks
- Low risk: skip link target IDs must remain in sync with main landmarks across layouts.

## Rollback
- Revert commit 78c5e52 if regressions surface.


------
https://chatgpt.com/codex/tasks/task_e_68ddfd8abe40832ca712dc29fb1fe6cd