### PR TITLE
Improve streaming abort cleanup for AI safety helpers

### DIFF
--- a/tests/ai/safety.test.ts
+++ b/tests/ai/safety.test.ts
@@ -151,6 +151,15 @@ describe("streaming abort helpers", () => {
     expect(target.signal.aborted).toBe(true);
     expect(target.signal.reason).toBe("parent");
   });
+
+  it("returns cleanup to unlink sources", () => {
+    const parent = new AbortController();
+    const target = new AbortController();
+    const unlink = linkAbortSignals(target, parent.signal);
+    unlink();
+    parent.abort("ignored");
+    expect(target.signal.aborted).toBe(false);
+  });
 });
 
 describe("applyModelSafety", () => {


### PR DESCRIPTION
## Summary
- ensure jittered retry helpers detach linked abort signals after completion to avoid leaking parent listeners
- update streaming abort link helper to return an explicit cleanup callback
- cover abort unlink behaviour with an additional safety unit test

## Files Touched
- src/ai/safety.ts
- tests/ai/safety.test.ts

## Tokens Mapped / Added
- none

## Tests
- npm test -- --run tests/ai/safety.test.ts
- npm run lint
- npm run lint:design

## Visual QA
- not applicable (no UI changes)

## CLS / LCP Notes
- not applicable

## Risks
- low; retry loop and abort propagation code paths now clean up listeners but maintain existing behaviour

## Rollback
- revert commit 204cc5ec3976a3a7bdb9c0d985669355c34f80c3

------
https://chatgpt.com/codex/tasks/task_e_68de32b1ae10832ca6e6488616333adc