### PR TITLE
Add granular env loader regression coverage

### DIFF
--- a/tests/env/client.test.ts
+++ b/tests/env/client.test.ts
@@ -26,11 +26,32 @@ describe("loadClientEnv", () => {
     `);
   });
 
-  it("throws when client Sentry toggles are provided without a DSN", () => {
+  it("throws when NEXT_PUBLIC_SENTRY_ENVIRONMENT is provided without a DSN", () => {
     const attempt = () =>
       loadClientEnv({
         NEXT_PUBLIC_SAFE_MODE: "false",
         NEXT_PUBLIC_SENTRY_ENVIRONMENT: "preview",
+      } as unknown as NodeJS.ProcessEnv);
+
+    expect(attempt).toThrowError(ZodError);
+    expect(attempt).toThrowErrorMatchingInlineSnapshot(`
+      [ZodError: [
+        {
+          "path": [
+            "NEXT_PUBLIC_SENTRY_DSN"
+          ],
+          "code": "custom",
+          "message": "NEXT_PUBLIC_SENTRY_DSN is required when configuring browser Sentry options."
+        }
+      ]]
+    `);
+  });
+
+  it("throws when NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE is provided without a DSN", () => {
+    const attempt = () =>
+      loadClientEnv({
+        NEXT_PUBLIC_SAFE_MODE: "false",
+        NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE: "0.1",
       } as unknown as NodeJS.ProcessEnv);
 
     expect(attempt).toThrowError(ZodError);

--- a/tests/env/server.test.ts
+++ b/tests/env/server.test.ts
@@ -28,12 +28,34 @@ describe("loadServerEnv", () => {
     `);
   });
 
-  it("throws when Sentry toggles are provided without a DSN", () => {
+  it("throws when SENTRY_ENVIRONMENT is provided without a DSN", () => {
     const attempt = () =>
       loadServerEnv({
         NODE_ENV: "production",
         SAFE_MODE: "false",
         SENTRY_ENVIRONMENT: "production",
+      } as unknown as NodeJS.ProcessEnv);
+
+    expect(attempt).toThrowError(ZodError);
+    expect(attempt).toThrowErrorMatchingInlineSnapshot(`
+      [ZodError: [
+        {
+          "path": [
+            "SENTRY_DSN"
+          ],
+          "code": "custom",
+          "message": "SENTRY_DSN is required when configuring server Sentry options."
+        }
+      ]]
+    `);
+  });
+
+  it("throws when SENTRY_TRACES_SAMPLE_RATE is provided without a DSN", () => {
+    const attempt = () =>
+      loadServerEnv({
+        NODE_ENV: "production",
+        SAFE_MODE: "false",
+        SENTRY_TRACES_SAMPLE_RATE: "0.5",
       } as unknown as NodeJS.ProcessEnv);
 
     expect(attempt).toThrowError(ZodError);


### PR DESCRIPTION
## Summary
- add explicit `loadServerEnv` coverage for missing safe-mode flag, Sentry environment, and traces sample rate inputs to confirm error messaging and healthy snapshots. 【F:tests/env/server.test.ts†L1-L78】
- extend `loadClientEnv` tests to exercise missing public safe mode along with Sentry environment and trace sample rate toggles, and capture the happy path snapshot. 【F:tests/env/client.test.ts†L1-L78】

## Files Touched
- tests/env/server.test.ts
- tests/env/client.test.ts

## Tokens Mapped / Added
- n/a

## Tests
- `node ./node_modules/vitest/vitest.mjs run tests/env/server.test.ts tests/env/client.test.ts` 【08cec6†L1-L36】
- `pnpm run lint` 【1ac8f1†L1-L4】
- `pnpm run lint:design` 【772afe†L1-L4】
- `pnpm run typecheck` 【479024†L1-L4】【1042e2†L1-L3】

## Visual QA
- not applicable (no visual changes)

## CLS / LCP Impact
- not applicable

## Risks
- Low; changes are additive tests only.

## Rollback
- `git revert 56adafd8f3ac5fba8f09f382bc7e9e4c48e5252e`


------
https://chatgpt.com/codex/tasks/task_e_68de5e1f584c832c9d880f4710ccd69e