### PR TITLE
Add profiling workflow for Next.js profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ pnpm run generate-tokens
 
 The script shows a progress bar and runs automatically before `pnpm run build`.
 
+## Profiling React performance
+
+Use the dedicated profiler workflow when you need detailed commit timing data. The `pnpm run profile` command runs the standard prebuild checks, enables the React profiler flags, and launches the dev server with Turbo for faster iteration. Profiling is blocked automatically when `SAFE_MODE` is active so CI and production builds cannot leak profiling bundles. See [docs/profiling.md](docs/profiling.md) for the full workflow.
+
 ## Contributing
 
 - Before committing, run `pnpm run verify-prompts` to confirm gallery coverage and `pnpm run check` to execute tests, lint, and type checks.

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,36 @@
+# React Profiler Workflow
+
+The planner ships with a dedicated development workflow for capturing React profiler traces without accidentally enabling profiling in production builds.
+
+## Prerequisites
+
+- Ensure `SAFE_MODE` (and `NEXT_PUBLIC_SAFE_MODE`) are set to `false` in your local `.env.local`. Profiling is intentionally blocked when safe mode is active so CI and production environments cannot ship profiling bundles by mistake.
+- Install dependencies with `pnpm install` so the local Next.js binary is available.
+
+## Start the profiler
+
+Run the dedicated profile script:
+
+```bash
+pnpm run profile
+```
+
+The script performs the standard prebuild checks, sets `REACT_PROFILER=1`, and launches `next dev` through `scripts/run-next.ts` with the required `--profiling` flag. While the profiler is enabled, the runner also forces the Turbo dev server (`--turbo`) for faster refresh cycles.
+
+If `SAFE_MODE` is still enabled, the script exits early with a clear error so that production environments never launch the profiler.
+
+## Capture traces
+
+1. Open [http://localhost:3000](http://localhost:3000) in Chrome.
+2. Open the React Developer Tools Profiler tab.
+3. Start a profiling session, interact with the app, then stop recording to analyze the commit timings.
+
+## Return to the standard dev server
+
+Stop the profiler session (`Ctrl+C`) and restart the dev server with the usual command:
+
+```bash
+pnpm run dev
+```
+
+This restores the default configuration without the profiling flags or Turbo override.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "type": "module",
   "scripts": {
     "dev": "pnpm run prebuild && tsx scripts/run-next.ts dev -p 3000",
+    "profile": "pnpm run prebuild && cross-env REACT_PROFILER=1 tsx scripts/run-next.ts dev -p 3000 --profiling",
     "prebuild": "tsx scripts/regen-if-needed.ts",
     "regen-ui": "tsx scripts/generate-ui-index.ts",
     "build-gallery-usage": "node --import tsx --import ./scripts/register-loaders.mjs scripts/build-gallery-usage.ts",


### PR DESCRIPTION
Title: Add profiling workflow for Next.js profiling

Summary:
- add a dedicated `pnpm run profile` flow that sets `REACT_PROFILER` and launches Next with the profiling flag
- enhance `scripts/run-next.ts` to inject profiling/turbo flags when the env variable is enabled and guard against SAFE_MODE deployments
- document how to run the profiler and link it from the README for quick discovery

Files touched:
- README.md
- docs/profiling.md
- package.json
- scripts/run-next.ts

Tokens mapped/added:
- None

Tests (unit/e2e + a11y):
- pnpm run lint
- pnpm run typecheck
- pnpm test -- --run *(fails locally: vitest watcher cancels before completion; see notes)*

Visual QA (screens/preview routes; themes):
- Not applicable (no UI changes).

CLS/LCP notes (if page):
- Not applicable.

Risks:
- Profiling flow exits early when SAFE_MODE is active; ensure SAFE_MODE stays `false` locally when profiling.

Rollback:
- Revert this commit.

------
https://chatgpt.com/codex/tasks/task_e_68de77447aac832c9b98291de749ae84