### PR TITLE
Fix Sentry sample values in env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,9 +21,9 @@ SAFE_MODE="false"
 NEXT_PUBLIC_SAFE_MODE="false"
 
 # Browser Sentry configuration. Provide DSN + environment to enable monitoring in production.
-NEXT_PUBLIC_SENTRY_DSN=""
-NEXT_PUBLIC_SENTRY_ENVIRONMENT=""
-NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=""
+NEXT_PUBLIC_SENTRY_DSN="https://examplePublicKey.ingest.sentry.io/1234567"
+NEXT_PUBLIC_SENTRY_ENVIRONMENT="development"
+NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE="0.25"
 
 # Toggle GitHub Pages behavior in Next.js builds.
 # Set to "true" when exporting for GitHub Pages so asset URLs include the base path.
@@ -39,9 +39,9 @@ GITHUB_PAGES="false"
 SKIP_PREVIEW_STATIC="false"
 
 # Server-side Sentry configuration. Provide DSN + environment to enable monitoring in production.
-SENTRY_DSN=""
-SENTRY_ENVIRONMENT=""
-SENTRY_TRACES_SAMPLE_RATE=""
+SENTRY_DSN="https://examplePublicKey.ingest.sentry.io/1234567"
+SENTRY_ENVIRONMENT="development"
+SENTRY_TRACES_SAMPLE_RATE="0.25"
 
 # Personal access token with "public_repo" scope for CI deployments.
 # Leave empty for local builds that rely on your configured git remote.


### PR DESCRIPTION
## Summary
- replace empty Sentry placeholders in `.env.example` with realistic sample values so copying the file no longer triggers optionalNonEmptyString validation errors

## Files Touched
- .env.example

## Tokens Mapped/Added
- n/a

## Tests (unit/e2e + a11y)
- `pnpm run verify-prompts`
- `pnpm run check` *(hangs: vitest suite stalled around `tests/planner/useTodayHeroTasks.test.tsx` even after several minutes; manually interrupted)*
- `pnpm exec vitest tests/lib/Db.test.ts --run`

## Visual QA (screens/preview routes; themes)
- n/a – no visual changes

## CLS/LCP notes
- n/a

## Risks
- minimal: sample environment defaults only

## Rollback
- revert this commit

------
https://chatgpt.com/codex/tasks/task_e_68de8db72a48832ca7f22144d36a122c