### PR TITLE
Refactor safe mode feature flag env handling

### DIFF
--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -49,8 +49,7 @@ const svgNumericFilters = parseBooleanFlag(rawSvgNumericFilters, true);
 const depthThemeEnabled = parseBooleanFlag(rawDepthTheme, false);
 const organicDepthEnabled = parseBooleanFlag(rawOrganicDepth, false);
 const glitchLandingEnabled = parseBooleanFlag(rawGlitchLanding, true);
-const safeModeSource = rawSafeMode ?? (typeof process !== "undefined" ? process.env.SAFE_MODE : undefined);
-const safeModeEnabled = parseBooleanFlag(safeModeSource, false);
+const safeModeEnabled = parseBooleanFlag(rawSafeMode, false);
 
 export function isSafeModeEnabled(): boolean {
   return safeModeEnabled;

--- a/tests/lib/features.test.ts
+++ b/tests/lib/features.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+type MockedClientEnv = {
+  NEXT_PUBLIC_BASE_PATH?: string;
+  NEXT_PUBLIC_DEPTH_THEME?: string;
+  NEXT_PUBLIC_ENABLE_METRICS?: string;
+  NEXT_PUBLIC_FEATURE_SVG_NUMERIC_FILTERS?: string;
+  NEXT_PUBLIC_ORGANIC_DEPTH?: string;
+  NEXT_PUBLIC_SAFE_MODE: string;
+  NEXT_PUBLIC_SENTRY_DSN?: string;
+  NEXT_PUBLIC_SENTRY_ENVIRONMENT?: string;
+  NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE?: string;
+  NEXT_PUBLIC_UI_GLITCH_LANDING?: string;
+};
+
+const baseEnv: MockedClientEnv = {
+  NEXT_PUBLIC_SAFE_MODE: "false",
+};
+
+function mockClientEnv(overrides: Partial<MockedClientEnv>): void {
+  const mockedEnv: MockedClientEnv = { ...baseEnv, ...overrides } as MockedClientEnv;
+
+  vi.doMock("../../env/client", () => ({
+    __esModule: true,
+    default: vi.fn(() => mockedEnv),
+  }));
+}
+
+describe("features.safeModeEnabled", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete process.env.SAFE_MODE;
+  });
+
+  it("returns true when the typed client env enables the flag", async () => {
+    mockClientEnv({ NEXT_PUBLIC_SAFE_MODE: "true" });
+
+    const features = await import("../../src/lib/features");
+
+    expect(features.safeModeEnabled).toBe(true);
+    expect(features.isSafeModeEnabled()).toBe(true);
+  });
+
+  it("returns false when the typed client env disables the flag", async () => {
+    mockClientEnv({ NEXT_PUBLIC_SAFE_MODE: "off" });
+
+    const features = await import("../../src/lib/features");
+
+    expect(features.safeModeEnabled).toBe(false);
+  });
+
+  it("ignores process.env overrides in favor of the typed env", async () => {
+    process.env.SAFE_MODE = "1";
+    mockClientEnv({ NEXT_PUBLIC_SAFE_MODE: "0" });
+
+    const features = await import("../../src/lib/features");
+
+    expect(features.safeModeEnabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- remove the `process.env` fallback so `safeModeEnabled` is derived exclusively from the typed client env loader
- add targeted unit coverage that mocks the typed env to verify safe mode toggling and ignore bare `process.env`

## Files touched
- src/lib/features.ts
- tests/lib/features.test.ts

## Tokens mapped/added
- none

## Tests (unit/e2e + a11y)
- `pnpm vitest run tests/lib/features.test.ts`
- `pnpm run lint`
- `pnpm run lint:design`
- `pnpm run typecheck`

## Visual QA (screens/preview routes; themes)
- not applicable

## CLS/LCP notes (if page)
- not applicable

## Risks
- minimal: safe mode flag resolution now relies solely on typed env loaders

## Rollback
- revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68deb896f064832ca1b6ef9f3e8f4c79