### PR TITLE
Ensure pnpm is available before cached Node setup

### DIFF
--- a/.github/actions/setup-node-project/action.yml
+++ b/.github/actions/setup-node-project/action.yml
@@ -106,6 +106,13 @@ runs:
           echo "lockfile=$LOCKFILE"
         } >>"$GITHUB_OUTPUT"
 
+    - name: Setup pnpm
+      if: ${{ steps.detect.outputs.manager == 'pnpm' }}
+      uses: pnpm/action-setup@v4
+      with:
+        version: ${{ steps.detect.outputs['manager-version'] != '' && steps.detect.outputs['manager-version'] || 'latest' }}
+        run_install: false
+
     - name: Setup Node.js
       uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4.1.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  PNPM_VERSION: 10.13.1
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -28,6 +31,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4.2.1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
@@ -101,6 +110,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4.2.1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
@@ -188,6 +203,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4.2.1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444


### PR DESCRIPTION
## Summary
- install pnpm via pnpm/action-setup before invoking actions/setup-node so cache detection succeeds
- share pnpm setup in the reusable setup-node-project composite action to cover other workflows

## Files Touched
- .github/workflows/ci.yml
- .github/actions/setup-node-project/action.yml

## Tokens Mapped/Added
- n/a

## Tests (Unit/E2E + A11y)
- not run (CI configuration change only)

## Visual QA (Screens/Preview Routes; Themes)
- n/a

## CLS/LCP Notes (if page)
- n/a

## Risks
- minimal: GitHub-hosted runners execute an additional setup step before Node install

## Rollback
- revert this commit

------
https://chatgpt.com/codex/tasks/task_e_68dee3894224832cbdf8c64c31632f4a