### PR TITLE
Add AI assistant UI primitives with previews and tests

### DIFF
--- a/src/app/preview/ai/AIPreviewClient.tsx
+++ b/src/app/preview/ai/AIPreviewClient.tsx
@@ -3,24 +3,92 @@
 import * as React from "react";
 
 import { Button } from "@/components/ui";
-import { AIAbortButton, AIErrorCard, AILoadingShimmer } from "@/components/ui/ai";
+import {
+  AIAbortButton,
+  AIConfidenceHint,
+  type AIConfidenceLevel,
+  AIErrorCard,
+  AIExplainTooltip,
+  AILoadingShimmer,
+  AIRetryErrorBubble,
+  AITypingIndicator,
+} from "@/components/ui/ai";
 
 export default function AIPreviewClient() {
   const [busy, setBusy] = React.useState(true);
   const [showError, setShowError] = React.useState(false);
+  const [isTyping, setIsTyping] = React.useState(true);
+  const [showTypingAvatar, setShowTypingAvatar] = React.useState(true);
+  const [inlineError, setInlineError] = React.useState(true);
+  const [confidenceLevel, setConfidenceLevel] = React.useState<AIConfidenceLevel>("medium");
+  const [confidenceScore, setConfidenceScore] = React.useState(0.62);
 
   const handleAbort = React.useCallback(() => {
     setBusy(false);
     setShowError(true);
+    setIsTyping(false);
+    setInlineError(true);
   }, []);
 
   const handleRetry = React.useCallback(() => {
     setBusy(true);
     setShowError(false);
+    setInlineError(false);
+    setIsTyping(true);
+  }, []);
+
+  const cycleConfidence = React.useCallback(() => {
+    setConfidenceLevel((previous) => {
+      const levels: AIConfidenceLevel[] = ["low", "medium", "high"];
+      const currentIndex = levels.indexOf(previous);
+      const nextLevel = levels[(currentIndex + 1) % levels.length];
+      const scoreByLevel: Record<AIConfidenceLevel, number> = {
+        low: 0.28,
+        medium: 0.62,
+        high: 0.92,
+      };
+      setConfidenceScore(scoreByLevel[nextLevel]);
+      return nextLevel;
+    });
+  }, []);
+
+  const toggleInlineError = React.useCallback(() => {
+    setInlineError((previous) => !previous);
   }, []);
 
   return (
     <div className="space-y-[var(--space-4)]">
+      <section className="space-y-[var(--space-3)]">
+        <AITypingIndicator
+          isTyping={isTyping}
+          showAvatar={showTypingAvatar}
+          hint={isTyping ? "Streaming contextual response" : "Paused"}
+          className="border border-[hsl(var(--accent)/0.3)] bg-[hsl(var(--surface)/0.75)]"
+        >
+          {isTyping ? "Drafting follow-up" : "Tap resume to continue"}
+        </AITypingIndicator>
+        <div className="flex flex-wrap gap-[var(--space-2)]">
+          <Button
+            type="button"
+            size="sm"
+            variant="quiet"
+            onClick={() => setIsTyping((previous) => !previous)}
+            className="px-[var(--space-3)]"
+          >
+            {isTyping ? "Pause typing" : "Resume typing"}
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="quiet"
+            onClick={() => setShowTypingAvatar((previous) => !previous)}
+            className="px-[var(--space-3)]"
+          >
+            {showTypingAvatar ? "Hide avatar" : "Show avatar"}
+          </Button>
+        </div>
+      </section>
+
       <AILoadingShimmer
         lines={4}
         label={busy ? "Generating response…" : "Stream paused"}
@@ -40,6 +108,81 @@ export default function AIPreviewClient() {
         </div>
       </AILoadingShimmer>
 
+      <section className="space-y-[var(--space-3)]">
+        <AIConfidenceHint
+          level={confidenceLevel}
+          score={confidenceScore}
+          description={confidenceDescriptions[confidenceLevel]}
+        >
+          <AIExplainTooltip
+            triggerLabel="Why this rating?"
+            explanation="Confidence blends retrieval coverage, grounding matches, and the assistant's self-check heuristics."
+            shortcutHint="Use ⌘· to open the trace inspector."
+            tone="neutral"
+            triggerProps={{ size: "sm", variant: "quiet" }}
+          />
+        </AIConfidenceHint>
+        <div className="flex flex-wrap gap-[var(--space-2)]">
+          <Button
+            type="button"
+            size="sm"
+            variant="quiet"
+            onClick={cycleConfidence}
+            className="px-[var(--space-3)]"
+          >
+            Cycle confidence
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="quiet"
+            onClick={() => setConfidenceScore((value) => Math.min(1, Math.max(0, Number((value + 0.08).toFixed(2)))))}
+            className="px-[var(--space-3)]"
+          >
+            Boost score
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="quiet"
+            onClick={() => setConfidenceScore((value) => Math.max(0, Number((value - 0.12).toFixed(2))))}
+            className="px-[var(--space-3)]"
+          >
+            Reduce score
+          </Button>
+        </div>
+      </section>
+
+      <section className="space-y-[var(--space-3)]">
+        {inlineError ? (
+          <AIRetryErrorBubble
+            message="The assistant lost connection mid-thought."
+            hint="Retry to request a clean draft."
+            onRetry={() => {
+              setInlineError(false);
+              setBusy(true);
+            }}
+          >
+            <AIExplainTooltip
+              triggerLabel="See diagnostics"
+              explanation="Connection dropped between streaming chunks. We recommend retrying so the assistant can rehydrate context."
+              triggerProps={{ size: "sm", variant: "quiet" }}
+            />
+          </AIRetryErrorBubble>
+        ) : null}
+        <div className="flex flex-wrap gap-[var(--space-2)]">
+          <Button
+            type="button"
+            size="sm"
+            variant="quiet"
+            onClick={toggleInlineError}
+            className="px-[var(--space-3)]"
+          >
+            {inlineError ? "Dismiss inline error" : "Show inline error"}
+          </Button>
+        </div>
+      </section>
+
       {showError ? (
         <AIErrorCard
           description="The assistant stopped before completing the draft."
@@ -50,3 +193,9 @@ export default function AIPreviewClient() {
     </div>
   );
 }
+
+const confidenceDescriptions: Record<AIConfidenceLevel, string> = {
+  low: "Grounding is limited, so double-check the assistant before sharing.",
+  medium: "Signals look solid with a couple of open questions to verify.",
+  high: "The answer matched trusted sources and passed self-checks.",
+};

--- a/src/components/prompts/prompts.gallery.tsx
+++ b/src/components/prompts/prompts.gallery.tsx
@@ -52,7 +52,15 @@ import {
   SectionCard as UiSectionCard,
   Spinner,
 } from "@/components/ui";
-import { AIAbortButton, AIErrorCard, AILoadingShimmer } from "@/components/ui/ai";
+import {
+  AIAbortButton,
+  AIConfidenceHint,
+  AIErrorCard,
+  AIExplainTooltip,
+  AILoadingShimmer,
+  AIRetryErrorBubble,
+  AITypingIndicator,
+} from "@/components/ui/ai";
 import { Check as CheckIcon } from "lucide-react";
 import DemoHeader from "./DemoHeader";
 import GoalListDemo from "./GoalListDemo";
@@ -3870,10 +3878,213 @@ React.useEffect(() => {
       code: `<Spinner size="xl" />`,
     },
     {
+      id: "ai-typing-indicator",
+      name: "AITypingIndicator",
+      description: "Live status bubble that animates while the assistant is drafting a reply.",
+      element: (
+        <AITypingIndicator hint="Streaming contextual response">Drafting follow-up</AITypingIndicator>
+      ),
+      tags: ["ai", "typing", "status"],
+      code: `<AITypingIndicator hint="Streaming contextual response">
+  Drafting follow-up
+</AITypingIndicator>`,
+      states: [
+        {
+          id: "paused",
+          name: "Paused",
+          description: "Muted activity state for when the stream halts but the shell remains visible.",
+          element: (
+            <AITypingIndicator isTyping={false} hint="Paused">
+              Tap resume to continue
+            </AITypingIndicator>
+          ),
+          code: `<AITypingIndicator isTyping={false} hint="Paused">
+  Tap resume to continue
+</AITypingIndicator>`,
+        },
+        {
+          id: "minimal",
+          name: "Minimal",
+          description: "Avatar-free mode keeps the footprint tight for dense chat layouts.",
+          element: (
+            <AITypingIndicator showAvatar={false} hint="Gathering teammates" />
+          ),
+          code: `<AITypingIndicator showAvatar={false} hint="Gathering teammates" />`,
+        },
+      ],
+    },
+    {
+      id: "ai-confidence-hint",
+      name: "AIConfidenceHint",
+      description: "Confidence badge summarizing grounding quality and risk cues.",
+      element: (
+        <AIConfidenceHint
+          level="medium"
+          score={0.62}
+          description="Signals look solid with a couple of open questions to verify."
+        >
+          <AIExplainTooltip
+            triggerLabel="Why this rating?"
+            explanation="Confidence blends retrieval coverage, grounding matches, and the assistant's self-check heuristics."
+            shortcutHint="Use ⌘· to open the trace inspector."
+            tone="neutral"
+            triggerProps={{ size: "sm", variant: "quiet" }}
+          />
+        </AIConfidenceHint>
+      ),
+      tags: ["ai", "confidence", "status"],
+      code: `<AIConfidenceHint
+  level="medium"
+  score={0.62}
+  description="Signals look solid with a couple of open questions to verify."
+>
+  <AIExplainTooltip
+    triggerLabel="Why this rating?"
+    explanation="Confidence blends retrieval coverage, grounding matches, and the assistant's self-check heuristics."
+    shortcutHint="Use ⌘· to open the trace inspector."
+    tone="neutral"
+    triggerProps={{ size: "sm", variant: "quiet" }}
+  />
+</AIConfidenceHint>`,
+      states: [
+        {
+          id: "low",
+          name: "Low",
+          element: (
+            <AIConfidenceHint
+              level="low"
+              score={0.22}
+              description="Grounding is limited, so double-check the assistant before sharing."
+            />
+          ),
+          code: `<AIConfidenceHint
+  level="low"
+  score={0.22}
+  description="Grounding is limited, so double-check the assistant before sharing."
+/>`,
+        },
+        {
+          id: "high",
+          name: "High",
+          element: (
+            <AIConfidenceHint
+              level="high"
+              score={0.92}
+              description="The answer matched trusted sources and passed self-checks."
+            />
+          ),
+          code: `<AIConfidenceHint
+  level="high"
+  score={0.92}
+  description="The answer matched trusted sources and passed self-checks."
+/>`,
+        },
+      ],
+    },
+    {
+      id: "ai-retry-error-bubble",
+      name: "AIRetryErrorBubble",
+      description: "Inline error bubble for transient streaming interruptions.",
+      element: (
+        <AIRetryErrorBubble
+          message="The assistant lost connection mid-thought."
+          hint="Retry to request a clean draft."
+          onRetry={() => {}}
+        >
+          <AIExplainTooltip
+            triggerLabel="See diagnostics"
+            explanation="Connection dropped between streaming chunks. We recommend retrying so the assistant can rehydrate context."
+            triggerProps={{ size: "sm", variant: "quiet" }}
+          />
+        </AIRetryErrorBubble>
+      ),
+      tags: ["ai", "error", "inline"],
+      code: `<AIRetryErrorBubble
+  message="The assistant lost connection mid-thought."
+  hint="Retry to request a clean draft."
+  onRetry={() => {}}
+>
+  <AIExplainTooltip
+    triggerLabel="See diagnostics"
+    explanation="Connection dropped between streaming chunks. We recommend retrying so the assistant can rehydrate context."
+    triggerProps={{ size: "sm", variant: "quiet" }}
+  />
+</AIRetryErrorBubble>`,
+      states: [
+        {
+          id: "acknowledged",
+          name: "Acknowledged",
+          description: "Remove the retry affordance once the issue clears but keep the transcript context.",
+          element: (
+            <AIRetryErrorBubble
+              message="Assistant recovered after a brief network hiccup."
+              hint="You can continue the conversation."
+            />
+          ),
+          code: `<AIRetryErrorBubble
+  message="Assistant recovered after a brief network hiccup."
+  hint="You can continue the conversation."
+/>`,
+        },
+      ],
+    },
+    {
+      id: "ai-explain-tooltip",
+      name: "AIExplainTooltip",
+      description: "Contextual helper trigger that surfaces why the assistant chose a path.",
+      element: (
+        <AIExplainTooltip
+          triggerLabel="How grounding works"
+          explanation="We cross-check the draft with curated playbook snippets and logged scrim outcomes before surfacing it here."
+          shortcutHint="Press ? to open help"
+        />
+      ),
+      tags: ["ai", "tooltip", "helper"],
+      code: `<AIExplainTooltip
+  triggerLabel="How grounding works"
+  explanation="We cross-check the draft with curated playbook snippets and logged scrim outcomes before surfacing it here."
+  shortcutHint="Press ? to open help"
+/>`,
+      states: [
+        {
+          id: "neutral",
+          name: "Neutral surface",
+          element: (
+            <AIExplainTooltip
+              triggerLabel="Why am I seeing this?"
+              explanation="Neutral tone keeps the helper grounded when accent colors would clash with nearby status surfaces."
+              tone="neutral"
+            />
+          ),
+          code: `<AIExplainTooltip
+  triggerLabel="Why am I seeing this?"
+  explanation="Neutral tone keeps the helper grounded when accent colors would clash with nearby status surfaces."
+  tone="neutral"
+/>`,
+        },
+        {
+          id: "open",
+          name: "Default open",
+          element: (
+            <AIExplainTooltip
+              triggerLabel="Trace summary"
+              explanation="Opens by default for first-run experiences where guidance is critical."
+              defaultOpen
+            />
+          ),
+          code: `<AIExplainTooltip
+  triggerLabel="Trace summary"
+  explanation="Opens by default for first-run experiences where guidance is critical."
+  defaultOpen
+/>`,
+        },
+      ],
+    },
+    {
       id: "ai-loading-shimmer",
       name: "AILoadingShimmer",
       description: "Skeleton shell paired with helper text for streaming responses.",
-      element: <AILoadingShimmer lines={4} />, 
+      element: <AILoadingShimmer lines={4} />,
       tags: ["ai", "loading", "skeleton"],
       code: `<AILoadingShimmer lines={4} />`,
     },

--- a/src/components/ui/ai/AIConfidenceHint.tsx
+++ b/src/components/ui/ai/AIConfidenceHint.tsx
@@ -1,0 +1,134 @@
+import * as React from "react";
+import { ShieldCheck, ShieldQuestion, ShieldAlert } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export type AIConfidenceLevel = "low" | "medium" | "high";
+
+export interface AIConfidenceHintProps extends React.ComponentPropsWithoutRef<"div"> {
+  readonly level: AIConfidenceLevel;
+  readonly label?: string;
+  readonly score?: number;
+  readonly description?: string;
+  readonly formatScore?: (score: number) => string;
+}
+
+const LEVEL_CONFIG: Record<AIConfidenceLevel, { label: string; tone: string; foreground: string; icon: React.ReactNode }> = {
+  low: {
+    label: "Low",
+    tone: "danger",
+    foreground: "danger-foreground",
+    icon: <ShieldAlert aria-hidden className="size-[var(--space-4)]" />,
+  },
+  medium: {
+    label: "Medium",
+    tone: "warning",
+    foreground: "warning-foreground",
+    icon: <ShieldQuestion aria-hidden className="size-[var(--space-4)]" />,
+  },
+  high: {
+    label: "High",
+    tone: "success",
+    foreground: "success-foreground",
+    icon: <ShieldCheck aria-hidden className="size-[var(--space-4)]" />,
+  },
+};
+
+const toneBackground: Record<string, string> = {
+  danger: "bg-[hsl(var(--danger)/0.14)] border-[hsl(var(--danger)/0.35)]",
+  warning: "bg-[hsl(var(--warning-soft-strong))] border-[hsl(var(--warning)/0.45)]",
+  success: "bg-[hsl(var(--success-soft))] border-[hsl(var(--success)/0.35)]",
+};
+
+const toneForeground: Record<string, string> = {
+  danger: "text-[hsl(var(--danger-foreground))]",
+  warning: "text-[hsl(var(--warning-foreground))]",
+  success: "text-[hsl(var(--success-foreground))]",
+};
+
+const barTone: Record<string, string> = {
+  danger: "bg-[hsl(var(--danger))]",
+  warning: "bg-[hsl(var(--warning))]",
+  success: "bg-[hsl(var(--success))]",
+};
+
+const AIConfidenceHint = React.forwardRef<HTMLDivElement, AIConfidenceHintProps>(
+  (
+    { level, label = "Confidence", score, description, formatScore = defaultFormat, className, children, ...props },
+    ref,
+  ) => {
+    const config = LEVEL_CONFIG[level];
+    const scoreLabel = typeof score === "number" ? formatScore(score) : undefined;
+    const normalizedScore = React.useMemo(() => {
+      if (typeof score !== "number") return undefined;
+      if (Number.isNaN(score)) return undefined;
+      return Math.min(1, Math.max(0, score));
+    }, [score]);
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "flex flex-col gap-[var(--space-2)] rounded-card border p-[var(--space-3)] shadow-[var(--shadow-outline-faint)]",
+          toneBackground[config.tone],
+          toneForeground[config.tone],
+          className,
+        )}
+        {...props}
+      >
+        <div className="flex items-start gap-[var(--space-2)]">
+          <span
+            aria-hidden
+            className={cn(
+              "grid size-[var(--space-8)] shrink-0 place-items-center rounded-full bg-[hsl(var(--panel)/0.85)] text-[inherit] shadow-[var(--shadow-inset-hairline)]",
+              toneForeground[config.tone],
+            )}
+          >
+            {config.icon}
+          </span>
+          <div className="flex flex-1 flex-col gap-[var(--space-1-5)]">
+            <div className="flex flex-wrap items-baseline gap-x-[var(--space-2)] gap-y-[var(--space-1)]">
+              <p className="text-label font-medium tracking-[-0.01em]">{label}</p>
+              <span className="text-caption font-semibold uppercase tracking-[0.08em] opacity-85">
+                {config.label}
+              </span>
+              {scoreLabel ? <span className="text-caption opacity-85">{scoreLabel}</span> : null}
+            </div>
+            {description ? <p className="text-caption opacity-80">{description}</p> : null}
+            {children}
+          </div>
+        </div>
+        <div className="flex h-[var(--space-2)] items-center gap-[var(--space-1)]">
+          {Array.from({ length: 5 }).map((_, index) => {
+            const isActive = (() => {
+              if (normalizedScore === undefined) {
+                return index < (level === "low" ? 2 : level === "medium" ? 3 : 5);
+              }
+              const step = (index + 1) / 5;
+              return normalizedScore >= step - 0.0001;
+            })();
+
+            return (
+              <span
+                key={index}
+                aria-hidden
+                className={cn(
+                  "flex-1 rounded-full bg-[hsl(var(--muted)/0.6)]",
+                  isActive ? barTone[config.tone] : "opacity-60",
+                )}
+              />
+            );
+          })}
+        </div>
+      </div>
+    );
+  },
+);
+
+AIConfidenceHint.displayName = "AIConfidenceHint";
+
+export default AIConfidenceHint;
+
+function defaultFormat(score: number) {
+  return `${Math.round(score * 100)}%`;
+}

--- a/src/components/ui/ai/AIErrorCard.tsx
+++ b/src/components/ui/ai/AIErrorCard.tsx
@@ -41,8 +41,8 @@ const AIErrorCard = React.forwardRef<HTMLDivElement, AIErrorCardProps>(
     ref,
   ) => {
     const retryAction = React.useMemo(() => {
-      if (!onRetry) return null;
       if (actions) return actions;
+      if (!onRetry) return null;
       return (
         <Button
           type="button"

--- a/src/components/ui/ai/AIExplainTooltip.tsx
+++ b/src/components/ui/ai/AIExplainTooltip.tsx
@@ -1,0 +1,213 @@
+import * as React from "react";
+import { Info } from "lucide-react";
+
+import { Button } from "@/components/ui";
+import { cn } from "@/lib/utils";
+
+export type AIExplainTooltipAlignment = "start" | "center" | "end";
+export type AIExplainTooltipTone = "accent" | "neutral";
+type TriggerElement = HTMLButtonElement | HTMLAnchorElement;
+
+export interface AIExplainTooltipProps extends React.ComponentPropsWithoutRef<"div"> {
+  readonly triggerLabel: string;
+  readonly explanation: React.ReactNode;
+  readonly shortcutHint?: string;
+  readonly icon?: React.ReactNode;
+  readonly alignment?: AIExplainTooltipAlignment;
+  readonly tone?: AIExplainTooltipTone;
+  readonly open?: boolean;
+  readonly defaultOpen?: boolean;
+  readonly onOpenChange?: (open: boolean) => void;
+  readonly triggerProps?: React.ComponentPropsWithoutRef<typeof Button>;
+}
+
+const toneBackground: Record<AIExplainTooltipTone, string> = {
+  accent: "bg-[hsl(var(--accent-soft))] border-[hsl(var(--accent)/0.4)] text-[hsl(var(--accent-foreground))]",
+  neutral: "bg-[hsl(var(--surface)/0.9)] border-[hsl(var(--border)/0.6)] text-foreground",
+};
+
+const AIExplainTooltip = React.forwardRef<HTMLDivElement, AIExplainTooltipProps>(
+  (
+    {
+      triggerLabel,
+      explanation,
+      shortcutHint,
+      icon,
+      alignment = "start",
+      tone = "accent",
+      open,
+      defaultOpen,
+      onOpenChange,
+      triggerProps,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const id = React.useId();
+    const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen ?? false);
+    const isControlled = open !== undefined;
+    const isOpen = isControlled ? open : uncontrolledOpen;
+
+    const setOpen = React.useCallback(
+      (value: boolean) => {
+        if (!isControlled) {
+          setUncontrolledOpen(value);
+        }
+        onOpenChange?.(value);
+      },
+      [isControlled, onOpenChange],
+    );
+
+    const handleToggle = React.useCallback(() => {
+      setOpen(!isOpen);
+    }, [isOpen, setOpen]);
+
+    const close = React.useCallback(() => {
+      setOpen(false);
+    }, [setOpen]);
+
+    const handleKeyDown = React.useCallback(
+      (event: React.KeyboardEvent<TriggerElement>) => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          close();
+        }
+      },
+      [close],
+    );
+
+    const handleFocus = React.useCallback(() => {
+      setOpen(true);
+    }, [setOpen]);
+
+    const handleBlur = React.useCallback(
+      (event: React.FocusEvent<TriggerElement>) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          close();
+        }
+      },
+      [close],
+    );
+
+    const handlePointerEnter = React.useCallback(() => {
+      setOpen(true);
+    }, [setOpen]);
+
+    const handlePointerLeave = React.useCallback(() => {
+      close();
+    }, [close]);
+
+    const {
+      className: triggerClassName,
+      onClick: onTriggerClick,
+      onFocus: onTriggerFocus,
+      onBlur: onTriggerBlur,
+      onPointerEnter: onTriggerPointerEnter,
+      onPointerLeave: onTriggerPointerLeave,
+      onKeyDown: onTriggerKeyDown,
+      tone: triggerTone,
+      ...restTriggerProps
+    } = triggerProps ?? {};
+
+    const resolvedTone = triggerTone ?? (tone === "accent" ? "accent" : "primary");
+
+    return (
+      <div
+        ref={ref}
+        className={cn("relative inline-flex flex-col items-start", className)}
+        {...props}
+      >
+        <Button
+          type="button"
+          size="sm"
+          variant="quiet"
+          tone={resolvedTone}
+          aria-expanded={isOpen}
+          aria-controls={id}
+          aria-describedby={isOpen ? id : undefined}
+          onClick={(event: React.MouseEvent<TriggerElement>) => {
+            const clickHandler =
+              onTriggerClick as ((event: React.MouseEvent<TriggerElement>) => void) | undefined;
+            clickHandler?.(event);
+            if (!event.defaultPrevented) {
+              handleToggle();
+            }
+          }}
+          onKeyDown={(event: React.KeyboardEvent<TriggerElement>) => {
+            const keyHandler =
+              onTriggerKeyDown as ((event: React.KeyboardEvent<TriggerElement>) => void) | undefined;
+            keyHandler?.(event);
+            if (!event.defaultPrevented) {
+              handleKeyDown(event);
+            }
+          }}
+          onFocus={(event: React.FocusEvent<TriggerElement>) => {
+            const focusHandler =
+              onTriggerFocus as ((event: React.FocusEvent<TriggerElement>) => void) | undefined;
+            focusHandler?.(event);
+            if (!event.defaultPrevented) {
+              handleFocus();
+            }
+          }}
+          onBlur={(event: React.FocusEvent<TriggerElement>) => {
+            const blurHandler =
+              onTriggerBlur as ((event: React.FocusEvent<TriggerElement>) => void) | undefined;
+            blurHandler?.(event);
+            if (!event.defaultPrevented) {
+              handleBlur(event);
+            }
+          }}
+          onPointerEnter={(event: React.PointerEvent<TriggerElement>) => {
+            const pointerEnterHandler =
+              onTriggerPointerEnter as ((event: React.PointerEvent<TriggerElement>) => void) | undefined;
+            pointerEnterHandler?.(event);
+            if (!event.defaultPrevented) {
+              handlePointerEnter();
+            }
+          }}
+          onPointerLeave={(event: React.PointerEvent<TriggerElement>) => {
+            const pointerLeaveHandler =
+              onTriggerPointerLeave as ((event: React.PointerEvent<TriggerElement>) => void) | undefined;
+            pointerLeaveHandler?.(event);
+            if (!event.defaultPrevented) {
+              handlePointerLeave();
+            }
+          }}
+          className={cn("gap-[var(--space-1-5)] px-[var(--space-3)]", triggerClassName)}
+          {...restTriggerProps}
+        >
+          {icon ?? <Info className="size-[var(--space-4)]" aria-hidden />}
+          <span>{triggerLabel}</span>
+        </Button>
+        <div
+          id={id}
+          role="tooltip"
+          data-state={isOpen ? "open" : "closed"}
+          aria-hidden={isOpen ? undefined : "true"}
+          className={cn(
+            "pointer-events-none absolute z-10 mt-[var(--space-2)] min-w-[min(22rem,calc(100vw-2rem))] rounded-card border p-[var(--space-3)] text-left shadow-[var(--shadow-outline-subtle)] transition-opacity duration-200 ease-out",
+            toneBackground[tone],
+            alignClassNames[alignment],
+            isOpen ? "opacity-100" : "opacity-0",
+          )}
+        >
+          <p className="text-label font-medium leading-snug">{explanation}</p>
+          {shortcutHint ? (
+            <p className="pt-[var(--space-1-5)] text-caption opacity-80">{shortcutHint}</p>
+          ) : null}
+        </div>
+      </div>
+    );
+  },
+);
+
+AIExplainTooltip.displayName = "AIExplainTooltip";
+
+export default AIExplainTooltip;
+
+const alignClassNames: Record<AIExplainTooltipAlignment, string> = {
+  start: "left-0",
+  center: "left-1/2 -translate-x-1/2 transform",
+  end: "right-0",
+};

--- a/src/components/ui/ai/AIRetryErrorBubble.tsx
+++ b/src/components/ui/ai/AIRetryErrorBubble.tsx
@@ -1,0 +1,72 @@
+import * as React from "react";
+import { AlertTriangle, RotateCcw } from "lucide-react";
+
+import { Button } from "@/components/ui";
+import { cn } from "@/lib/utils";
+
+export interface AIRetryErrorBubbleProps extends React.ComponentPropsWithoutRef<"div"> {
+  readonly message: string;
+  readonly hint?: string;
+  readonly onRetry?: () => void;
+  readonly retryLabel?: string;
+  readonly icon?: React.ReactNode;
+  readonly actions?: React.ReactNode;
+}
+
+const DEFAULT_RETRY_LABEL = "Retry";
+
+const AIRetryErrorBubble = React.forwardRef<HTMLDivElement, AIRetryErrorBubbleProps>(
+  (
+    { message, hint, onRetry, retryLabel = DEFAULT_RETRY_LABEL, icon, actions, className, children, ...props },
+    ref,
+  ) => {
+    const retryAction = React.useMemo(() => {
+      if (!onRetry) return actions;
+      if (actions) return actions;
+      return (
+        <Button
+          type="button"
+          size="sm"
+          tone="danger"
+          variant="quiet"
+          onClick={onRetry}
+          className="gap-[var(--space-2)] px-[var(--space-3)]"
+        >
+          <RotateCcw aria-hidden className="size-[var(--space-4)]" />
+          {retryLabel}
+        </Button>
+      );
+    }, [actions, onRetry, retryLabel]);
+
+    return (
+      <div
+        ref={ref}
+        role="alert"
+        aria-live="assertive"
+        className={cn(
+          "flex items-start gap-[var(--space-3)] rounded-card border border-[hsl(var(--danger)/0.4)]",
+          "bg-[hsl(var(--danger)/0.16)] p-[var(--space-3)] text-[hsl(var(--danger-foreground))] shadow-[var(--shadow-outline-subtle)]",
+          className,
+        )}
+        {...props}
+      >
+        <span
+          aria-hidden
+          className="grid size-[var(--space-8)] shrink-0 place-items-center rounded-full bg-[hsl(var(--danger)/0.2)] text-[hsl(var(--danger))] shadow-[var(--shadow-inset-hairline)]"
+        >
+          {icon ?? <AlertTriangle className="size-[var(--space-4)]" aria-hidden />}
+        </span>
+        <div className="flex flex-1 flex-col gap-[var(--space-2)]">
+          <p className="text-label font-medium">{message}</p>
+          {hint ? <p className="text-caption text-[hsl(var(--danger-foreground)/0.78)]">{hint}</p> : null}
+          {children}
+          {retryAction ? <div className="pt-[var(--space-1-5)]">{retryAction}</div> : null}
+        </div>
+      </div>
+    );
+  },
+);
+
+AIRetryErrorBubble.displayName = "AIRetryErrorBubble";
+
+export default AIRetryErrorBubble;

--- a/src/components/ui/ai/AITypingIndicator.tsx
+++ b/src/components/ui/ai/AITypingIndicator.tsx
@@ -1,0 +1,94 @@
+import * as React from "react";
+import { Sparkles } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export interface AITypingIndicatorProps extends React.ComponentPropsWithoutRef<"div"> {
+  readonly label?: string;
+  readonly hint?: string;
+  readonly isTyping?: boolean;
+  readonly dotCount?: number;
+  readonly showAvatar?: boolean;
+  readonly avatar?: React.ReactNode;
+}
+
+const MIN_DOTS = 2;
+const DEFAULT_DOTS = 3;
+const MAX_DOTS = 5;
+const DEFAULT_LABEL = "Assistant is typing";
+
+const AITypingIndicator = React.forwardRef<HTMLDivElement, AITypingIndicatorProps>(
+  (
+    {
+      label = DEFAULT_LABEL,
+      hint,
+      isTyping = true,
+      dotCount = DEFAULT_DOTS,
+      showAvatar = true,
+      avatar,
+      className,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const dots = React.useMemo(() => {
+      const constrained = Math.max(MIN_DOTS, Math.min(MAX_DOTS, dotCount));
+      return Array.from({ length: constrained });
+    }, [dotCount]);
+
+    return (
+      <div
+        ref={ref}
+        role="status"
+        aria-live="polite"
+        aria-busy={isTyping ? "true" : undefined}
+        className={cn(
+          "flex items-center gap-[var(--space-3)] rounded-card border border-[hsl(var(--accent)/0.35)]",
+          "bg-[hsl(var(--surface)/0.72)] p-[var(--space-3)] text-left shadow-[var(--shadow-outline-faint)] backdrop-blur-sm",
+          className,
+        )}
+        {...props}
+      >
+        {showAvatar ? (
+          <span
+            aria-hidden
+            className="grid size-[var(--space-9)] place-items-center rounded-full border border-[hsl(var(--accent)/0.35)] bg-[hsl(var(--accent-soft))] text-[hsl(var(--accent-foreground))] shadow-[var(--shadow-inset-hairline)]"
+          >
+            {avatar ?? <Sparkles className="size-[var(--space-5)]" aria-hidden />}
+          </span>
+        ) : null}
+        <div className="flex flex-1 flex-col gap-[var(--space-1-5)]">
+          <div className="flex flex-wrap items-baseline gap-x-[var(--space-2)] gap-y-[var(--space-1)]">
+            <p className="text-label font-medium text-foreground" aria-live="polite">
+              {label}
+            </p>
+            {hint ? (
+              <span className="text-caption text-muted-foreground">{hint}</span>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-[var(--space-1)]">
+            {dots.map((_, index) => (
+              <span
+                key={index}
+                aria-hidden
+                className={cn(
+                  "size-[var(--space-1-5)] rounded-full bg-[hsl(var(--accent))] opacity-70",
+                  isTyping ? "motion-safe:animate-pulse" : undefined,
+                )}
+                style={isTyping ? { animationDelay: `${index * 120}ms`, animationDuration: "1200ms" } : undefined}
+              />
+            ))}
+            {children ? (
+              <span className="text-caption text-muted-foreground">{children}</span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    );
+  },
+);
+
+AITypingIndicator.displayName = "AITypingIndicator";
+
+export default AITypingIndicator;

--- a/src/components/ui/ai/index.ts
+++ b/src/components/ui/ai/index.ts
@@ -4,3 +4,15 @@ export { default as AIErrorCard } from "./AIErrorCard";
 export type { AIErrorCardProps } from "./AIErrorCard";
 export { default as AILoadingShimmer } from "./AILoadingShimmer";
 export type { AILoadingShimmerProps } from "./AILoadingShimmer";
+export { default as AITypingIndicator } from "./AITypingIndicator";
+export type { AITypingIndicatorProps } from "./AITypingIndicator";
+export { default as AIRetryErrorBubble } from "./AIRetryErrorBubble";
+export type { AIRetryErrorBubbleProps } from "./AIRetryErrorBubble";
+export { default as AIConfidenceHint } from "./AIConfidenceHint";
+export type { AIConfidenceHintProps, AIConfidenceLevel } from "./AIConfidenceHint";
+export { default as AIExplainTooltip } from "./AIExplainTooltip";
+export type {
+  AIExplainTooltipProps,
+  AIExplainTooltipAlignment,
+  AIExplainTooltipTone,
+} from "./AIExplainTooltip";

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -2,10 +2,18 @@
 // Do not edit directly.
 export { default as AIAbortButton } from "./ai/AIAbortButton";
 export * from "./ai/AIAbortButton";
+export { default as AIConfidenceHint } from "./ai/AIConfidenceHint";
+export * from "./ai/AIConfidenceHint";
 export { default as AIErrorCard } from "./ai/AIErrorCard";
 export * from "./ai/AIErrorCard";
+export { default as AIExplainTooltip } from "./ai/AIExplainTooltip";
+export * from "./ai/AIExplainTooltip";
 export { default as AILoadingShimmer } from "./ai/AILoadingShimmer";
 export * from "./ai/AILoadingShimmer";
+export { default as AIRetryErrorBubble } from "./ai/AIRetryErrorBubble";
+export * from "./ai/AIRetryErrorBubble";
+export { default as AITypingIndicator } from "./ai/AITypingIndicator";
+export * from "./ai/AITypingIndicator";
 export { default as AnimationToggle } from "./AnimationToggle";
 export { default as CatCompanion } from "./CatCompanion";
 export { default as Cluster } from "./Cluster";

--- a/storybook/src/components/ui/AIConfidenceHint.stories.tsx
+++ b/storybook/src/components/ui/AIConfidenceHint.stories.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { AIConfidenceHint, AIExplainTooltip } from "@/components/ui/ai";
+
+const meta: Meta<typeof AIConfidenceHint> = {
+  title: "AI/AIConfidenceHint",
+  component: AIConfidenceHint,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Confidence hints communicate how well the assistant grounded its response so players know when to verify details.",
+      },
+    },
+  },
+  args: {
+    level: "medium",
+    score: 0.62,
+    description: "Signals look solid with a couple of open questions to verify.",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AIConfidenceHint>;
+
+export const Medium: Story = {};
+
+export const Low: Story = {
+  args: {
+    level: "low",
+    score: 0.22,
+    description: "Grounding is limited, so double-check the assistant before sharing.",
+  },
+};
+
+export const High: Story = {
+  args: {
+    level: "high",
+    score: 0.92,
+    description: "The answer matched trusted sources and passed self-checks.",
+  },
+};
+
+export const WithTooltip: Story = {
+  render: (args) => (
+    <AIConfidenceHint {...args}>
+      <AIExplainTooltip
+        triggerLabel="Why this rating?"
+        explanation="Confidence blends retrieval coverage, grounding matches, and the assistant's self-check heuristics."
+        tone="neutral"
+        triggerProps={{ size: "sm", variant: "quiet" }}
+      />
+    </AIConfidenceHint>
+  ),
+};

--- a/storybook/src/components/ui/AIExplainTooltip.stories.tsx
+++ b/storybook/src/components/ui/AIExplainTooltip.stories.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { AIExplainTooltip } from "@/components/ui/ai";
+
+const meta: Meta<typeof AIExplainTooltip> = {
+  title: "AI/AIExplainTooltip",
+  component: AIExplainTooltip,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Explain tooltips provide contextual guidance without pulling focus away from the transcript or action buttons.",
+      },
+    },
+  },
+  args: {
+    triggerLabel: "How grounding works",
+    explanation:
+      "We cross-check the draft with curated playbook snippets and logged scrim outcomes before surfacing it here.",
+    shortcutHint: "Press ? to open help",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AIExplainTooltip>;
+
+export const Accent: Story = {};
+
+export const Neutral: Story = {
+  args: {
+    tone: "neutral",
+    triggerLabel: "Why am I seeing this?",
+    explanation: "Neutral tone keeps the helper grounded when accent colors would clash with nearby status surfaces.",
+  },
+};
+
+export const DefaultOpen: Story = {
+  args: {
+    defaultOpen: true,
+    triggerLabel: "Trace summary",
+    explanation: "Opens by default for first-run experiences where guidance is critical.",
+  },
+};

--- a/storybook/src/components/ui/AIRetryErrorBubble.stories.tsx
+++ b/storybook/src/components/ui/AIRetryErrorBubble.stories.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { AIRetryErrorBubble, AIExplainTooltip } from "@/components/ui/ai";
+
+const meta: Meta<typeof AIRetryErrorBubble> = {
+  title: "AI/AIRetryErrorBubble",
+  component: AIRetryErrorBubble,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Retry bubbles acknowledge transient issues in the stream and keep the transcript readable while offering recovery.",
+      },
+    },
+  },
+  args: {
+    onRetry: () => {},
+  },
+  argTypes: {
+    onRetry: { action: "retry" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AIRetryErrorBubble>;
+
+export const Default: Story = {
+  args: {
+    message: "The assistant lost connection mid-thought.",
+    hint: "Retry to request a clean draft.",
+  },
+};
+
+export const WithDiagnostics: Story = {
+  args: {
+    message: "The assistant lost connection mid-thought.",
+    hint: "Retry to request a clean draft.",
+  },
+  render: (args) => (
+    <AIRetryErrorBubble {...args}>
+      <AIExplainTooltip
+        triggerLabel="See diagnostics"
+        explanation="Connection dropped between streaming chunks. We recommend retrying so the assistant can rehydrate context."
+        triggerProps={{ size: "sm", variant: "quiet" }}
+      />
+    </AIRetryErrorBubble>
+  ),
+};
+
+export const Acknowledged: Story = {
+  args: {
+    message: "Assistant recovered after a brief network hiccup.",
+    hint: "You can continue the conversation.",
+    onRetry: undefined,
+  },
+};

--- a/storybook/src/components/ui/AITypingIndicator.stories.tsx
+++ b/storybook/src/components/ui/AITypingIndicator.stories.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { AITypingIndicator } from "@/components/ui/ai";
+
+const meta: Meta<typeof AITypingIndicator> = {
+  title: "AI/AITypingIndicator",
+  component: AITypingIndicator,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Typing indicator bubbles show that the assistant is still streaming context while keeping the transcript readable.",
+      },
+    },
+  },
+  args: {
+    hint: "Streaming contextual response",
+    children: "Drafting follow-up",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AITypingIndicator>;
+
+export const Typing: Story = {
+  args: {
+    isTyping: true,
+  },
+};
+
+export const Paused: Story = {
+  args: {
+    isTyping: false,
+    hint: "Paused",
+    children: "Tap resume to continue",
+  },
+};
+
+export const Minimal: Story = {
+  args: {
+    showAvatar: false,
+    hint: "Gathering teammates",
+    children: undefined,
+  },
+};

--- a/tests/ui/AIComponents.test.tsx
+++ b/tests/ui/AIComponents.test.tsx
@@ -2,7 +2,15 @@ import * as React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-import { AIAbortButton, AIErrorCard, AILoadingShimmer } from "@/components/ui/ai";
+import {
+  AIAbortButton,
+  AIConfidenceHint,
+  AIErrorCard,
+  AIExplainTooltip,
+  AILoadingShimmer,
+  AIRetryErrorBubble,
+  AITypingIndicator,
+} from "@/components/ui/ai";
 
 describe("AIErrorCard", () => {
   it("renders alert semantics and retry action", () => {
@@ -62,5 +70,74 @@ describe("AIAbortButton", () => {
     expect(button).not.toBeDisabled();
     fireEvent.click(button);
     expect(onAbort).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("AITypingIndicator", () => {
+  it("renders typing dots and snapshot", () => {
+    const { container } = render(
+      <AITypingIndicator hint="Streaming contextual response">Drafting follow-up</AITypingIndicator>,
+    );
+
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-busy", "true");
+    expect(status.querySelectorAll("span[aria-hidden='true']").length).toBeGreaterThan(0);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("disables aria-busy when paused", () => {
+    render(<AITypingIndicator isTyping={false} showAvatar={false} />);
+    const status = screen.getByRole("status");
+    expect(status).not.toHaveAttribute("aria-busy");
+  });
+});
+
+describe("AIRetryErrorBubble", () => {
+  it("invokes retry handler and snapshots the layout", () => {
+    const onRetry = vi.fn();
+    const { container } = render(
+      <AIRetryErrorBubble message="The assistant lost connection" onRetry={onRetry} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe("AIConfidenceHint", () => {
+  it("formats scores and level metadata", () => {
+    const { container } = render(
+      <AIConfidenceHint
+        level="high"
+        score={0.9}
+        description="Grounding verified"
+        formatScore={(value) => `${(value * 100).toFixed(1)} pts`}
+      />,
+    );
+
+    expect(screen.getByText(/High/i)).toBeInTheDocument();
+    expect(screen.getByText(/90.0 pts/)).toBeInTheDocument();
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe("AIExplainTooltip", () => {
+  it("toggles open state via click", () => {
+    render(
+      <AIExplainTooltip
+        triggerLabel="Why this rating?"
+        explanation="Confidence blends retrieval coverage, grounding matches, and the assistant's self-check heuristics."
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: /why this rating/i });
+    fireEvent.click(trigger);
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).toHaveAttribute("data-state", "open");
+    expect(tooltip).toHaveTextContent(/Confidence blends/);
+    expect(tooltip).toMatchSnapshot();
+    fireEvent.keyDown(trigger, { key: "Escape" });
+    expect(tooltip).toHaveAttribute("data-state", "closed");
   });
 });

--- a/tests/ui/__snapshots__/AIComponents.test.tsx.snap
+++ b/tests/ui/__snapshots__/AIComponents.test.tsx.snap
@@ -1,0 +1,273 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AIConfidenceHint > formats scores and level metadata 1`] = `
+<div
+  class="flex flex-col gap-[var(--space-2)] rounded-card border p-[var(--space-3)] shadow-[var(--shadow-outline-faint)] bg-[hsl(var(--success-soft))] border-[hsl(var(--success)/0.35)] text-[hsl(var(--success-foreground))]"
+>
+  <div
+    class="flex items-start gap-[var(--space-2)]"
+  >
+    <span
+      aria-hidden="true"
+      class="grid size-[var(--space-8)] shrink-0 place-items-center rounded-full bg-[hsl(var(--panel)/0.85)] shadow-[var(--shadow-inset-hairline)] text-[hsl(var(--success-foreground))]"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-shield-check size-[var(--space-4)]"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+        />
+        <path
+          d="m9 12 2 2 4-4"
+        />
+      </svg>
+    </span>
+    <div
+      class="flex flex-1 flex-col gap-[var(--space-1-5)]"
+    >
+      <div
+        class="flex flex-wrap items-baseline gap-x-[var(--space-2)] gap-y-[var(--space-1)]"
+      >
+        <p
+          class="text-label font-medium tracking-[-0.01em]"
+        >
+          Confidence
+        </p>
+        <span
+          class="text-caption font-semibold uppercase tracking-[0.08em] opacity-85"
+        >
+          High
+        </span>
+        <span
+          class="text-caption opacity-85"
+        >
+          90.0 pts
+        </span>
+      </div>
+      <p
+        class="text-caption opacity-80"
+      >
+        Grounding verified
+      </p>
+    </div>
+  </div>
+  <div
+    class="flex h-[var(--space-2)] items-center gap-[var(--space-1)]"
+  >
+    <span
+      aria-hidden="true"
+      class="flex-1 rounded-full bg-[hsl(var(--success))]"
+    />
+    <span
+      aria-hidden="true"
+      class="flex-1 rounded-full bg-[hsl(var(--success))]"
+    />
+    <span
+      aria-hidden="true"
+      class="flex-1 rounded-full bg-[hsl(var(--success))]"
+    />
+    <span
+      aria-hidden="true"
+      class="flex-1 rounded-full bg-[hsl(var(--success))]"
+    />
+    <span
+      aria-hidden="true"
+      class="flex-1 rounded-full bg-[hsl(var(--muted)/0.6)] opacity-60"
+    />
+  </div>
+</div>
+`;
+
+exports[`AIExplainTooltip > toggles open state via click 1`] = `
+<div
+  class="pointer-events-none absolute z-10 mt-[var(--space-2)] min-w-[min(22rem,calc(100vw-2rem))] rounded-card border p-[var(--space-3)] text-left shadow-[var(--shadow-outline-subtle)] transition-opacity duration-200 ease-out bg-[hsl(var(--accent-soft))] border-[hsl(var(--accent)/0.4)] text-[hsl(var(--accent-foreground))] left-0 opacity-100"
+  data-state="open"
+  id=":r0:"
+  role="tooltip"
+>
+  <p
+    class="text-label font-medium leading-snug"
+  >
+    Confidence blends retrieval coverage, grounding matches, and the assistant's self-check heuristics.
+  </p>
+</div>
+`;
+
+exports[`AIRetryErrorBubble > invokes retry handler and snapshots the layout 1`] = `
+<div
+  aria-live="assertive"
+  class="flex items-start gap-[var(--space-3)] rounded-card border border-[hsl(var(--danger)/0.4)] bg-[hsl(var(--danger)/0.16)] p-[var(--space-3)] text-[hsl(var(--danger-foreground))] shadow-[var(--shadow-outline-subtle)]"
+  role="alert"
+>
+  <span
+    aria-hidden="true"
+    class="grid size-[var(--space-8)] shrink-0 place-items-center rounded-full bg-[hsl(var(--danger)/0.2)] text-[hsl(var(--danger))] shadow-[var(--shadow-inset-hairline)]"
+  >
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-triangle-alert size-[var(--space-4)]"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+      />
+      <path
+        d="M12 9v4"
+      />
+      <path
+        d="M12 17h.01"
+      />
+    </svg>
+  </span>
+  <div
+    class="flex flex-1 flex-col gap-[var(--space-2)]"
+  >
+    <p
+      class="text-label font-medium"
+    >
+      The assistant lost connection
+    </p>
+    <div
+      class="pt-[var(--space-1-5)]"
+    >
+      <button
+        class="_neu_0e7b1b _root_2452a7 relative inline-flex items-center justify-center rounded-card r-card-md border font-medium tracking-[0.02em] transition-all duration-motion-sm ease-out motion-reduce:transition-none hover:bg-[--hover] active:bg-[--active] focus-visible:ring-2 focus-visible:ring-[var(--ring-contrast)] focus-visible:shadow-[var(--shadow-glow-md)] focus-visible:[outline:var(--spacing-0-5)_solid_var(--ring-contrast)] focus-visible:[outline-offset:var(--spacing-0-5)] disabled:opacity-disabled disabled:pointer-events-none data-[loading=true]:opacity-loading data-[reduce-motion=true]:focus-visible:shadow-none data-[reduce-motion=true]:focus-visible:[box-shadow:none] data-[disabled=true]:opacity-disabled data-[disabled=true]:pointer-events-none [--neu-radius:var(--radius-card)] h-[var(--control-h-sm)] text-label [&_svg]:size-[var(--space-4)] gap-[var(--space-2)] px-[var(--space-3)] [--hover:hsl(var(--danger)/0.1)] [--active:hsl(var(--danger)/0.2)] text-danger [--neu-surface:hsl(var(--danger)/0.12)] border-danger/35"
+        data-tone="danger"
+        data-variant="quiet"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="relative z-10 inline-flex items-center gap-[var(--space-1)]"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-rotate-ccw size-[var(--space-4)]"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"
+            />
+            <path
+              d="M3 3v5h5"
+            />
+          </svg>
+          Retry
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AITypingIndicator > renders typing dots and snapshot 1`] = `
+<div
+  aria-busy="true"
+  aria-live="polite"
+  class="flex items-center gap-[var(--space-3)] rounded-card border border-[hsl(var(--accent)/0.35)] bg-[hsl(var(--surface)/0.72)] p-[var(--space-3)] text-left shadow-[var(--shadow-outline-faint)] backdrop-blur-sm"
+  role="status"
+>
+  <span
+    aria-hidden="true"
+    class="grid size-[var(--space-9)] place-items-center rounded-full border border-[hsl(var(--accent)/0.35)] bg-[hsl(var(--accent-soft))] text-[hsl(var(--accent-foreground))] shadow-[var(--shadow-inset-hairline)]"
+  >
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-sparkles size-[var(--space-5)]"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
+      />
+      <path
+        d="M20 2v4"
+      />
+      <path
+        d="M22 4h-4"
+      />
+      <circle
+        cx="4"
+        cy="20"
+        r="2"
+      />
+    </svg>
+  </span>
+  <div
+    class="flex flex-1 flex-col gap-[var(--space-1-5)]"
+  >
+    <div
+      class="flex flex-wrap items-baseline gap-x-[var(--space-2)] gap-y-[var(--space-1)]"
+    >
+      <p
+        aria-live="polite"
+        class="text-label font-medium text-foreground"
+      >
+        Assistant is typing
+      </p>
+      <span
+        class="text-caption text-muted-foreground"
+      >
+        Streaming contextual response
+      </span>
+    </div>
+    <div
+      class="flex items-center gap-[var(--space-1)]"
+    >
+      <span
+        aria-hidden="true"
+        class="size-[var(--space-1-5)] rounded-full bg-[hsl(var(--accent))] opacity-70 motion-safe:animate-pulse"
+        style="animation-delay: 0ms; animation-duration: 1200ms;"
+      />
+      <span
+        aria-hidden="true"
+        class="size-[var(--space-1-5)] rounded-full bg-[hsl(var(--accent))] opacity-70 motion-safe:animate-pulse"
+        style="animation-delay: 120ms; animation-duration: 1200ms;"
+      />
+      <span
+        aria-hidden="true"
+        class="size-[var(--space-1-5)] rounded-full bg-[hsl(var(--accent))] opacity-70 motion-safe:animate-pulse"
+        style="animation-delay: 240ms; animation-duration: 1200ms;"
+      />
+      <span
+        class="text-caption text-muted-foreground"
+      >
+        Drafting follow-up
+      </span>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Title: Add AI assistant UI primitives with previews and tests

Summary:
- add token-driven AI primitives for typing indicator, retry bubble, confidence hint, and explain tooltip plus AIErrorCard action flex
- wire AIPreviewClient and prompts gallery demos to showcase every interactive state of the new components
- cover the new surfaces with Storybook stories, Vitest snapshots, and regenerated UI exports

Files touched:
- src/components/ui/ai/*
- src/app/preview/ai/AIPreviewClient.tsx
- src/components/prompts/prompts.gallery.tsx
- storybook/src/components/ui/*
- tests/ui/AIComponents.test.tsx and snapshots
- src/components/ui/index.ts

Tokens mapped/added:
- reused existing accent/danger/success/warning token variables for surfaces, borders, typography, and spacing; no new tokens introduced

Tests (unit/e2e + a11y):
- pnpm run lint
- pnpm run lint:design
- pnpm run typecheck
- pnpm vitest run tests/ui/AIComponents.test.tsx

Visual QA (screens/preview routes; themes):
- previewed via /preview/ai with interactive toggles covering typing, confidence, retry, and explain tooltip states across themes

CLS/LCP notes (if page):
- preview components retain stable layout; no new layout shifts introduced

Risks:
- minimal; new components isolated and backwards-compatible, but monitor AI explain tooltip interactions inside dense layouts

Rollback:
- revert this commit

------
https://chatgpt.com/codex/tasks/task_e_68dede5c09e4832c9a59044238767c05