### PR TITLE
Pin pnpm action setup to commit hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4.2.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false
@@ -112,7 +112,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4.2.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false
@@ -205,7 +205,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4.2.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -55,7 +55,7 @@ jobs:
           fi
       - name: Setup pnpm
         if: steps.detect-package-manager.outputs.manager == 'pnpm'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
         with:
           version: 9
       - name: Setup Node


### PR DESCRIPTION
Title: Pin pnpm action setup to commit hash

Summary:
- Pin pnpm/action-setup to commit a7487c7e89a18df4991f7f222e4898a00d66ddda across CI and Next.js workflows
- Document the pinned version with inline comments for each usage

Files touched:
- .github/workflows/ci.yml
- .github/workflows/nextjs.yml

Tokens mapped/added:
- None

Tests (unit/e2e + a11y):
- Not run (workflow-only change)

Visual QA (screens/preview routes; themes):
- Not applicable

CLS/LCP notes (if page):
- Not applicable

Risks:
- Low: workflow configuration change only

Rollback:
- Revert this commit

------
https://chatgpt.com/codex/tasks/task_e_68dee809d500832c8345fbd15c7cbb98