### PR TITLE
Fix workflow lint warnings in CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,9 @@ jobs:
           - suite: theme-previews
             title: Theme previews + axe
             command: >-
-              npx playwright test tests/e2e/accessibility.spec.ts tests/e2e/gallery-preview.spec.ts tests/e2e/hero-images-preview.spec.ts tests/e2e/home-planner-previews.spec.ts --config playwright.config.ts --project=chromium-w1440 --reporter=github --pass-with-no-tests
+              npx playwright test tests/e2e/accessibility.spec.ts tests/e2e/gallery-preview.spec.ts
+              tests/e2e/hero-images-preview.spec.ts tests/e2e/home-planner-previews.spec.ts
+              --config playwright.config.ts --project=chromium-w1440 --reporter=github --pass-with-no-tests
             previews: " /preview/theme-matrix, /preview/hero-images, /preview/gallery"
 
     steps:
@@ -241,13 +243,14 @@ jobs:
 
       - name: Start Next.js server
         run: |
-          pnpm run start -- --hostname $PLAYWRIGHT_HOST --port $PLAYWRIGHT_PORT &
-          echo $! > next.pid
+          pnpm run start -- --hostname "$PLAYWRIGHT_HOST" --port "$PLAYWRIGHT_PORT" &
+          echo "$!" > next.pid
 
       - name: Wait for Next.js to boot
         run: |
           for attempt in {1..30}; do
-            if curl -sSf "http://$PLAYWRIGHT_HOST:$PLAYWRIGHT_PORT/" > /dev/null; then
+            echo "Attempt ${attempt}/30: checking http://${PLAYWRIGHT_HOST}:${PLAYWRIGHT_PORT}/"
+            if curl -sSf "http://${PLAYWRIGHT_HOST}:${PLAYWRIGHT_PORT}/" > /dev/null; then
               exit 0
             fi
             sleep 2

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -37,7 +37,7 @@ jobs:
         uses: reviewdog/action-actionlint@0b71b30a47a15c4d849868cca394fb656f1cf657 # v1.67.0
         with:
           github_token: ${{ github.token }}
-          fail_on_error: true
+          fail_level: error
 
       - name: Install yamllint
         run: sudo apt-get update && sudo apt-get install -y yamllint


### PR DESCRIPTION
Title: Fix workflow lint warnings in CI configuration

Summary:
- Wrap the theme preview Playwright command to meet actionlint line-length limits.
- Quote Playwright server environment variables and add retry logging to satisfy shellcheck guidance.
- Update workflow-lint to use reviewdog's `fail_level` input now that `fail_on_error` is deprecated.

Files touched:
- .github/workflows/ci.yml
- .github/workflows/workflow-lint.yml

Tokens mapped/added:
- None.

Tests (unit/e2e + a11y):
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test -- --run` *(cancelled after ~50s; Vitest was still queuing 140+ remaining specs in serial)*

Visual QA (screens/preview routes; themes):
- Not applicable (no UI changes).

CLS/LCP notes (if page):
- Not applicable.

Risks:
- Minimal; CI workflow behavior unchanged aside from safer variable quoting and logging.

Rollback:
- Revert this commit.


------
https://chatgpt.com/codex/tasks/task_e_68dee83e98bc832c9e0a22502811e343