### PR TITLE
Fix pnpm audit step for pnpm 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Audit dependencies
         run: |
           set +e
-          pnpm audit --severity-threshold=moderate --json > audit-report.json
+          pnpm audit --audit-level=moderate --json > audit-report.json
           AUDIT_STATUS=$?
           node scripts/audit-ci-report.mjs audit-report.json
           REPORT_STATUS=$?

--- a/scripts/audit-ci-report.mjs
+++ b/scripts/audit-ci-report.mjs
@@ -3,8 +3,18 @@ import fs from "node:fs";
 const [reportPath = "audit-report.json"] = process.argv.slice(2);
 
 function readReport(path) {
+  if (!fs.existsSync(path)) {
+    throw new Error(`Audit report not found at ${path}`);
+  }
+
   const data = fs.readFileSync(path, "utf8");
-  return JSON.parse(data);
+  const trimmed = data.trim();
+
+  if (trimmed.length === 0) {
+    throw new Error(`Audit report at ${path} was empty`);
+  }
+
+  return JSON.parse(trimmed);
 }
 
 function formatSeverityTable(counts) {


### PR DESCRIPTION
## Summary
- switch the CI audit command to pnpm 10's `--audit-level` flag so JSON reports are produced again
- harden the audit report parser with missing/empty file guards for clearer CI failures

## Files Touched
- .github/workflows/ci.yml
- scripts/audit-ci-report.mjs

## Tokens Mapped / Added
- none

## Tests
- `pnpm run verify-prompts`
- `pnpm run check` *(fails: Db > usePersistentState > uses the latest initial value provided after a key swap; pre-existing?)*

## Visual QA
- not applicable (no visual changes)

## CLS/LCP Notes
- not applicable

## Risks
- low; CI-only changes to audit command and parser guards

## Rollback
- revert this commit

------
https://chatgpt.com/codex/tasks/task_e_68dee86bc55c832cadd6b34016edcf15