### PR TITLE
Fix shell quoting in Next.js Pages workflow

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -35,19 +35,25 @@ jobs:
         id: detect-package-manager
         run: |
           if [ -f "${{ github.workspace }}/pnpm-lock.yaml" ]; then
-            echo "manager=pnpm" >> $GITHUB_OUTPUT
-            echo "command=install --frozen-lockfile --prefer-offline" >> $GITHUB_OUTPUT
-            echo "runner=pnpm" >> $GITHUB_OUTPUT
+            {
+              echo "manager=pnpm"
+              echo "command=install --frozen-lockfile --prefer-offline"
+              echo "runner=pnpm"
+            } >>"$GITHUB_OUTPUT"
             exit 0
           elif [ -f "${{ github.workspace }}/yarn.lock" ]; then
-            echo "manager=yarn" >> $GITHUB_OUTPUT
-            echo "command=install" >> $GITHUB_OUTPUT
-            echo "runner=yarn" >> $GITHUB_OUTPUT
+            {
+              echo "manager=yarn"
+              echo "command=install"
+              echo "runner=yarn"
+            } >>"$GITHUB_OUTPUT"
             exit 0
           elif [ -f "${{ github.workspace }}/package-lock.json" ]; then
-            echo "manager=npm" >> $GITHUB_OUTPUT
-            echo "command=ci" >> $GITHUB_OUTPUT
-            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
+            {
+              echo "manager=npm"
+              echo "command=ci"
+              echo "runner=npx --no-install"
+            } >>"$GITHUB_OUTPUT"
             exit 0
           else
             echo "Unable to determine package manager"


### PR DESCRIPTION
## Summary
- wrap GitHub Actions output writes in grouped blocks to satisfy shellcheck SC2129
- quote GITHUB_OUTPUT redirections to avoid word-splitting per shellcheck SC2086

## Files touched
- .github/workflows/nextjs.yml

## Tokens mapped/added
- n/a

## Tests (unit/e2e + a11y)
- ⚠️ `pnpm run verify-prompts` (passes)【c453e9†L1-L5】【309bd2†L1-L3】
- ⚠️ `pnpm run check` (aborted after lengthy vitest run; lint/format portions completed, test suite encountered prior flaky failure)【028941†L1-L4】【aec2be†L1-L18】
- ⚠️ `pnpm test -- --run` (aborted due to hanging test suite; no regressions introduced by workflow-only change)【727f02†L1-L12】【c906a4†L1-L12】

## Visual QA (screens/preview routes; themes)
- not applicable

## CLS/LCP notes (if page)
- not applicable

## Risks
- Low: workflow-only change guarded by existing detection logic

## Rollback
- Revert commit 2c97345 or restore previous .github/workflows/nextjs.yml

------
https://chatgpt.com/codex/tasks/task_e_68deea285480832c8fc042cc98d3f1a9