### PR TITLE
chore: forbid styled-components imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,6 +29,19 @@ const eslintConfig = [
       design: designPlugin,
     },
     rules: {
+      // Styled-components bypasses our tokenized primitives and theming, so block it globally.
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "styled-components",
+              message:
+                "Use the shared design system primitives and Tailwind utilities instead of styled-components.",
+            },
+          ],
+        },
+      ],
       "design/no-raw-design-values": "error",
     },
   },


### PR DESCRIPTION
Title: chore: forbid styled-components imports

Summary:
- Add a global ESLint restricted-import rule that blocks styled-components and explains the design-system rationale alongside existing guidance.
- Extend the design lint script to flag styled-components usage inside src/components/ui so CI scripts catch violations even without ESLint.

Files touched:
- eslint.config.mjs
- scripts/design-lint.ts

Tokens mapped/added:
- None.

Tests (unit/e2e + a11y):
- pnpm run lint
- pnpm run lint:design

Visual QA (screens/preview routes; themes):
- Not applicable (no visual changes).

CLS/LCP notes:
- Not applicable.

Risks:
- Possible false positives if third-party comments mention styled-components; adjust lint rule if needed.

Rollback:
- Revert this commit.

------
https://chatgpt.com/codex/tasks/task_e_68deedd00fe0832ca2232ddcd683cc64