### PR TITLE
chore: restrict styled-components usage

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,27 @@ const designPlugin = {
   },
 };
 
+const styledComponentsMessage =
+  "Use the shared design system primitives and Tailwind utilities instead of styled-components.";
+
+const restrictedDesignImports = [
+  {
+    name: "styled-components",
+    message: styledComponentsMessage,
+  },
+  {
+    name: "styled-components/macro",
+    message: styledComponentsMessage,
+  },
+];
+
+const restrictedDesignImportPatterns = [
+  {
+    group: ["styled-components/*"],
+    message: styledComponentsMessage,
+  },
+];
+
 const eslintConfig = [
   {
     ignores: ["src/components/gallery/generated-manifest.ts"],
@@ -30,16 +51,12 @@ const eslintConfig = [
     },
     rules: {
       // Styled-components bypasses our tokenized primitives and theming, so block it globally.
+      // Keep this in sync with scripts/design-lint.ts so CI catches violations even when ESLint is skipped.
       "no-restricted-imports": [
         "error",
         {
-          paths: [
-            {
-              name: "styled-components",
-              message:
-                "Use the shared design system primitives and Tailwind utilities instead of styled-components.",
-            },
-          ],
+          paths: restrictedDesignImports,
+          patterns: restrictedDesignImportPatterns,
         },
       ],
       "design/no-raw-design-values": "error",

--- a/scripts/design-lint.ts
+++ b/scripts/design-lint.ts
@@ -33,7 +33,11 @@ const TOKEN_SOURCE_FILES = [
 
 const CLASS_UTILITY_IDENTIFIERS = new Set(["cn", "clsx"]);
 const IGNORED_TOKEN_PREFIXES = ["tw-", "radix-", "sb-", "swiper-", "geist-"];
-const STYLED_COMPONENTS_TARGET = "styled-components";
+const STYLED_COMPONENTS_IDENTIFIER = "styled-components";
+const STYLED_COMPONENTS_REGEX = /styled-components(?:\/macro)?/g;
+// Keep this message aligned with the ESLint restriction in eslint.config.mjs.
+const STYLED_COMPONENTS_MESSAGE =
+  "styled-components (including styled-components/macro) is not allowed in src/components/ui. Use tokenized primitives instead.";
 
 const HEX_COLOR_PATTERN = /#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})\b/gi;
 const COLOR_FUNCTION_PATTERN = /\b(?:rgb|rgba|hsl|hsla)\((?!\s*var\()/gi;
@@ -465,7 +469,7 @@ async function checkForStyledComponents(violations: Violation[]): Promise<void> 
       continue;
     }
 
-    if (!contents.includes(STYLED_COMPONENTS_TARGET)) {
+    if (!contents.includes(STYLED_COMPONENTS_IDENTIFIER)) {
       continue;
     }
 
@@ -478,16 +482,15 @@ async function checkForStyledComponents(violations: Violation[]): Promise<void> 
     );
 
     const relative = path.relative(rootDir, filePath).replace(/\\/g, "/");
-    const regex = /styled-components/g;
+    STYLED_COMPONENTS_REGEX.lastIndex = 0;
     let match: RegExpExecArray | null;
-    while ((match = regex.exec(contents))) {
+    while ((match = STYLED_COMPONENTS_REGEX.exec(contents))) {
       const { line, character } = sourceFile.getLineAndCharacterOfPosition(match.index);
       violations.push({
         file: relative,
         line: line + 1,
         column: character + 1,
-        message:
-          "styled-components is not allowed in src/components/ui. Use tokenized primitives instead.",
+        message: STYLED_COMPONENTS_MESSAGE,
       });
     }
   }


### PR DESCRIPTION
Summary:
- add a centralized ESLint restriction (including macro/deep imports) to prevent styled-components usage across the codebase.
- extend the custom design lint script to flag styled-components references under src/components/ui and align messaging with the ESLint rule.

Files touched:
- eslint.config.mjs
- scripts/design-lint.ts

Tokens mapped/added:
- None.

Tests (unit/e2e + a11y):
- pnpm run lint
- pnpm run design-lint

Visual QA (screens/preview routes; themes):
- Not applicable (no visual changes).

CLS/LCP notes (if page):
- Not applicable.

Risks:
- Low risk: new lint rule blocks styled-components usage; ensure contributors avoid the library going forward.

Rollback:
- Revert commit cdcaddfa12b6c3a9856a7b1459d9a0a86aaf2d1e.


------
https://chatgpt.com/codex/tasks/task_e_68deef2f570c832c99c740ea020e8273