### PR TITLE
Fix pnpm version detection quoting in Pages workflow

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -63,7 +63,8 @@ jobs:
         if: steps.detect-package-manager.outputs.manager == 'pnpm'
         id: pnpm-version
         run: |
-          echo "version=$(node -p \"require('./package.json').packageManager.split('@')[1]\")" >> "$GITHUB_OUTPUT"
+          VERSION=$(node -p "require('./package.json').packageManager.split('@')[1]")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Setup pnpm
         if: steps.detect-package-manager.outputs.manager == 'pnpm'
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4


### PR DESCRIPTION
## Summary
- prevent shell quoting errors when resolving the pnpm version in the Pages workflow by capturing the Node output before echoing

## Files Touched
- .github/workflows/nextjs.yml

## Tokens Mapped / Added
- n/a

## Tests (Unit / E2E / a11y)
- `pnpm run verify-prompts`
- `pnpm run check` *(fails: vitest OOM in this environment)*

## Visual QA (Screens / Preview Routes / Themes)
- n/a (workflow-only change)

## CLS / LCP Notes
- n/a

## Risks
- Low: workflow change only affects pnpm users in GitHub Pages deploy job

## Rollback
- Revert commit `Fix pnpm version detection quoting in Pages workflow`


------
https://chatgpt.com/codex/tasks/task_e_68deef7839ac832cb7e05755a790596b