### PR TITLE
Align Next.js Pages workflow with shared setup

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -31,58 +31,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-      - name: Detect package manager
-        id: detect-package-manager
-        run: |
-          if [ -f "${{ github.workspace }}/pnpm-lock.yaml" ]; then
-            {
-              echo "manager=pnpm"
-              echo "command=install --frozen-lockfile --prefer-offline"
-              echo "runner=pnpm"
-            } >>"$GITHUB_OUTPUT"
-            exit 0
-          elif [ -f "${{ github.workspace }}/yarn.lock" ]; then
-            {
-              echo "manager=yarn"
-              echo "command=install"
-              echo "runner=yarn"
-            } >>"$GITHUB_OUTPUT"
-            exit 0
-          elif [ -f "${{ github.workspace }}/package-lock.json" ]; then
-            {
-              echo "manager=npm"
-              echo "command=ci"
-              echo "runner=npx --no-install"
-            } >>"$GITHUB_OUTPUT"
-            exit 0
-          else
-            echo "Unable to determine package manager"
-            exit 1
-          fi
-      - name: Resolve pnpm version
-        if: steps.detect-package-manager.outputs.manager == 'pnpm'
-        id: pnpm-version
-        run: |
-          VERSION=$(node -p "require('./package.json').packageManager.split('@')[1]")
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-      - name: Setup pnpm
-        if: steps.detect-package-manager.outputs.manager == 'pnpm'
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
-        with:
-          version: ${{ steps.pnpm-version.outputs.version }}
-      - name: Setup Node
-        uses: actions/setup-node@v5
-        with:
-          node-version: "20"
-          cache: ${{ steps.detect-package-manager.outputs.manager }}
+      - uses: ./.github/actions/setup-node-project
       - name: Setup Pages
         uses: actions/configure-pages@v5
-        with:
-          # Automatically inject basePath in your Next.js configuration file and disable
-          # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
-          #
-          # You may remove this line if you want to manage the configuration yourself.
-          static_site_generator: next
       - name: Restore cache
         uses: actions/cache@v4
         with:
@@ -94,9 +45,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml', '**/package-lock.json', '**/yarn.lock') }}-
       - name: Install dependencies
-        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
-      - name: Build with Next.js
-        run: ${{ steps.detect-package-manager.outputs.runner }} next build
+        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Verify prompts registry
+        run: pnpm run verify-prompts
+      - name: Export static site
+        run: DEPLOY_ARTIFACT_ONLY=true pnpm run deploy
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- replace the bespoke Node and pnpm setup with the shared setup-node-project action so CI respects .nvmrc and the repo's pnpm version
- mirror the deploy-pages build steps by running prompt verification and the deploy script that prepares the Pages artifact, removing the redundant static_site_generator override

## Files touched
- .github/workflows/nextjs.yml

## Tokens mapped/added
- N/A (CI-only change)

## Tests (unit/e2e + a11y)
- ✅ `pnpm run verify-prompts`
- ❌ `pnpm run check` *(fails during typecheck: generated gallery manifest is parsed as TS and already errors on main)*

## Visual QA (screens/preview routes; themes)
- N/A (workflow-only change)

## CLS/LCP notes (if page)
- N/A

## Risks
- Low: workflow uses the same shared setup and deploy script as the existing deploy-pages pipeline.

## Rollback
- Revert this PR.


------
https://chatgpt.com/codex/tasks/task_e_68defb2d39a8832c96a3b99a9543a2c8