### PR TITLE
Update Pages deploy workflow to follow default branch

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     branches:
-      - main
+      - ${{ github.event.repository.default_branch }}
     paths-ignore:
       - 'docs/**'
       - '**/*.md'


### PR DESCRIPTION
## Summary
- ensure the Deploy Pages workflow listens to the repository default branch for push events

## Files touched
- .github/workflows/deploy-pages.yml

## Tokens mapped/added
- n/a

## Tests (unit/e2e + a11y)
- ✅ `pnpm run verify-prompts`
- ❌ `pnpm run check` (fails in current main due to generated gallery manifest type errors unrelated to this change)

## Visual QA (screens/preview routes; themes)
- n/a (workflow-only change)

## CLS/LCP notes (if page)
- n/a

## Risks
- Low: workflow now triggers off whichever branch GitHub marks as default

## Rollback
- Revert the workflow change in `.github/workflows/deploy-pages.yml` to restore the previous `main` branch filter

------
https://chatgpt.com/codex/tasks/task_e_68dfc78f03c0832c9b6d5ecffdc1408f