### PR TITLE
Include work branch in deployment workflows

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - work
     paths-ignore:
       - 'docs/**'
       - '**/*.md'

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -7,7 +7,7 @@ name: Deploy Next.js site to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
+    branches: ["main", "work"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Summary:
- ensure the GitHub Pages deployment workflow also triggers on pushes to the `work` branch
- update the Next.js deployment workflow to run for the `work` branch as well as `main`

Files touched:
- .github/workflows/deploy-pages.yml
- .github/workflows/nextjs.yml

Tokens mapped/added:
- n/a (workflow-only change)

Tests (unit/e2e + a11y):
- not run (workflow-only change)

Visual QA (screens/preview routes; themes):
- n/a (no UI changes)

CLS/LCP notes (if page):
- n/a

Risks:
- Low: workflows now run on an additional branch.

Rollback:
- revert commit 4365c82

------
https://chatgpt.com/codex/tasks/task_e_68dfca85bc90832c86f3fe6655c28598