### PR TITLE
Add test to verify gallery manifest exports

### DIFF
--- a/tests/gallery-manifest.test.ts
+++ b/tests/gallery-manifest.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const manifestPath = path.resolve(
+  process.cwd(),
+  "src/components/gallery/generated-manifest.ts",
+);
+
+const requiredExports = [
+  "export const galleryPayload",
+  "export const galleryPreviewRoutes",
+  "export const galleryPreviewModules",
+] as const;
+
+describe("gallery manifest source", () => {
+  it("contains the expected exports", () => {
+    const manifestSource = readFileSync(manifestPath, "utf8");
+
+    for (const requiredExport of requiredExports) {
+      expect(manifestSource).toContain(requiredExport);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a Vitest to ensure the generated gallery manifest source contains the required exports

## Testing
- pnpm vitest run tests/gallery-manifest.test.ts *(fails: manifest currently lacks the expected export declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd6f383f4832c9884a7c3b21f6c88