### PR TITLE
Fix package manager detection to use ESM reader

### DIFF
--- a/.github/actions/setup-node-project/action.yml
+++ b/.github/actions/setup-node-project/action.yml
@@ -56,7 +56,7 @@ runs:
         if [ -n "${{ inputs['package-manager'] }}" ]; then
           RAW_PM="${{ inputs['package-manager'] }}"
         else
-          RAW_PM="$(node -p "(() => { try { return require('./package.json').packageManager || ''; } catch { return ''; } })()")"
+          RAW_PM="$(node --input-type=module -e "import { readFileSync } from 'node:fs'; import { resolve } from 'node:path'; import { cwd } from 'node:process'; try { const packageJsonPath = resolve(cwd(), 'package.json'); const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')); console.log(packageJson?.packageManager ?? ''); } catch { console.log(''); }")"
         fi
 
         if [ -z "$RAW_PM" ]; then


### PR DESCRIPTION
## Summary
- replace the composite action's CommonJS require call with an ESM `node --input-type=module` command so package.json is parsed without relying on require
- keep the existing fallback to npm while ensuring packageManager entries such as `pnpm@<version>` resolve to the correct lockfile and install command

## Testing
- [x] `pnpm run verify-prompts`
- [ ] `pnpm run check`
  - Fails in the current repository because `src/components/gallery/generated-manifest.ts` is regenerated without object delimiters, leading to persistent TypeScript syntax errors during `pnpm run typecheck`

## Rollback Plan
- [ ] Toggle `NEXT_PUBLIC_DEPTH_THEME` to `off`/`0` and redeploy to restore the legacy depth tokens and components.
- [ ] Capture any residual depth-theme metrics to confirm the flag has returned to the legacy path.

## Monitoring
- [ ] Depth-theme analytics flag is visible in dashboards and alerting remains green.

------
https://chatgpt.com/codex/tasks/task_e_68e0054eb05c832ca068b78022857b6a