### PR TITLE
Add gallery manifest generator validation

### DIFF
--- a/scripts/regen-if-needed.ts
+++ b/scripts/regen-if-needed.ts
@@ -190,6 +190,10 @@ export const generatorValidations: GeneratorValidation[] = [
     command: "pnpm run regen-feature",
   },
   {
+    name: "Gallery manifest",
+    command: "pnpm run build-gallery-usage",
+  },
+  {
     name: "Theme CSS",
     command: "pnpm run generate-themes",
   },

--- a/tests/scripts/regen-if-needed.test.ts
+++ b/tests/scripts/regen-if-needed.test.ts
@@ -24,6 +24,7 @@ let regenModule: typeof import("../../scripts/regen-if-needed");
 const REQUIRED_GENERATOR_COMMANDS = [
   "pnpm run regen-ui",
   "pnpm run regen-feature",
+  "pnpm run build-gallery-usage",
   "pnpm run generate-themes",
   "pnpm run generate-tokens",
 ];


### PR DESCRIPTION
## Summary
- add the gallery manifest generator to the regen validation list so CI enforces `pnpm run build-gallery-usage`
- update the regen-if-needed unit test expectations to include the new generator command

## Testing
- `pnpm test tests/scripts/regen-if-needed.test.ts`

## Files Touched
- scripts/regen-if-needed.ts
- tests/scripts/regen-if-needed.test.ts

## Design Tokens
- n/a

## Visual QA
- n/a (non-UI change)

## Performance
- none

## Risks
- low; validation now runs one additional generator command

## Rollback Plan
- revert this commit

------
https://chatgpt.com/codex/tasks/task_e_68e0151b89ac832c97383fccc94ea638