### PR TITLE
docs: document gallery manifest automation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,10 @@ Requires [Node.js](https://nodejs.org) 22 or newer.
 
 Use [`tsx`](https://github.com/esbuild-kit/tsx) for running TypeScript-powered scripts. All pnpm tasks already invoke `tsx` (or `node --import tsx`) so aligning local commands with it keeps runtime behavior consistent with CI.
 
+### Automatic regeneration during install
+
+Running `pnpm install` invokes `scripts/postinstall.mjs`, which executes `scripts/regen-if-needed.ts`. The script validates that `src/components/gallery/generated-manifest.ts` exists and exports the gallery payload modules before the install completes. When the manifest is stale (for example, after checking out a branch that touched gallery entries) the postinstall step automatically runs `pnpm run build-gallery-usage` and other required generators. Expect a short CLI progress bar while the tasks run. If the manifest is missing or malformed the install will fail with instructions to run `pnpm run build-gallery` manually and commit the regenerated output.
+
 ## UI components
 
 When adding a new UI component or style under `src/components/ui`, run:

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -31,7 +31,7 @@ For governance and enforcement workflows, read [Design System Governance](./desi
 
 ## Gallery previews
 
-- Run `pnpm run build-gallery-usage` after touching gallery files. It refreshes `src/components/gallery/generated-manifest.ts` with preview slugs and keeps Playwright coverage in sync.
+- Run `pnpm run build-gallery-usage` after touching gallery files. `pnpm install` runs a postinstall check that regenerates the manifest automatically when it detects gallery changes, but running the command yourself keeps `src/components/gallery/generated-manifest.ts` and the cached preview slugs current while you iterate and ensures Playwright coverage stays in sync.
 - Visit `/preview/[slug]` to render a single component or state in isolation. Slugs combine the gallery entry, optional state, and the theme variant (currently Glitch and Aurora). Axis metadata surfaces as `axis-…` query parameters so automation can label captured variants.
 - Trigger the **Visual Regression** workflow to record screenshots. It installs the production build, walks every generated preview route through the `@visual` Playwright suite, and uploads diffs when comparisons fail.
 - Visit `/preview/theme-matrix` to audit every gallery entry and state across Glitch, Aurora, Kitten, Oceanic, Citrus, Noir, and Hardstuck. The matrix reuses the in-gallery previews, ensuring Playwright screenshots and axe coverage span every theme without triggering layout shift.


### PR DESCRIPTION
## Summary
- document the postinstall gallery manifest validation/regeneration flow so contributors know why installs may rerun generators
- note in the design system gallery docs that postinstall already refreshes the manifest while encouraging manual runs during iteration

## Testing
- [x] `pnpm run verify-prompts`
- [ ] `pnpm run check` *(fails locally: `Db > usePersistentState > uses the latest initial value provided after a key swap` when run via the combined script; reran `pnpm run lint`, `pnpm run lint:design`, `NEXT_PUBLIC_SAFE_MODE=0 pnpm run typecheck`, `pnpm run guard:artifacts`, and `NEXT_PUBLIC_SAFE_MODE=0 pnpm exec vitest run tests/lib/Db.test.ts` individually)*

## Rollback Plan
- [ ] Toggle `NEXT_PUBLIC_DEPTH_THEME` to `off`/`0` and redeploy to restore the legacy depth tokens and components.
- [ ] Capture any residual depth-theme metrics to confirm the flag has returned to the legacy path.

## Monitoring
- [ ] Depth-theme analytics flag is visible in dashboards and alerting remains green.

------
https://chatgpt.com/codex/tasks/task_e_68e0174880a4832c88aa10f7a71868ee