### PR TITLE
Fix gallery generator safe mode defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ The app reads configuration from your shell environment at build time. Use `.env
 
 > **Tip:** Keep `.env.local` out of version control. Only `.env.example` belongs in the repository so collaborators and CI pipelines can discover the supported configuration.
 
+> **Note:** The gallery usage generator (`pnpm run build-gallery-usage`) defaults both `SAFE_MODE` and `NEXT_PUBLIC_SAFE_MODE` to `"false"` when they are missing so CI and local automation stay aligned with `.env.example` without extra setup.
+
 ## Metrics reporting on static hosts
 
 Static exports (including GitHub Pages) no longer bundle a `/api/metrics` Route Handler. To keep the browser reporting hook lightweight and optional:

--- a/scripts/build-gallery-usage.ts
+++ b/scripts/build-gallery-usage.ts
@@ -4,16 +4,48 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import fg from "fast-glob";
 import ts from "typescript";
-import {
-  createGalleryRegistry,
-  type GalleryRegistryPayload,
-  type GallerySection,
-  type GallerySerializableEntry,
-  type GallerySerializableSection,
-  type GalleryPreviewRoute,
+import type {
+  GalleryRegistryPayload,
+  GallerySection,
+  GallerySerializableEntry,
+  GallerySerializableSection,
+  GalleryPreviewRoute,
 } from "../src/components/gallery/registry";
-import { BG_CLASSES, VARIANTS } from "../src/lib/theme";
 import type { Background, Variant } from "../src/lib/theme";
+
+const SAFE_MODE_DEFAULT = "false";
+
+function ensureSafeModeEnv(): void {
+  const nextPublicSafeMode = process.env.NEXT_PUBLIC_SAFE_MODE;
+  const safeMode = process.env.SAFE_MODE;
+
+  if (nextPublicSafeMode === undefined && safeMode === undefined) {
+    process.env.NEXT_PUBLIC_SAFE_MODE = SAFE_MODE_DEFAULT;
+    process.env.SAFE_MODE = SAFE_MODE_DEFAULT;
+    return;
+  }
+
+  if (nextPublicSafeMode === undefined && safeMode !== undefined) {
+    process.env.NEXT_PUBLIC_SAFE_MODE = safeMode;
+  }
+
+  if (safeMode === undefined && nextPublicSafeMode !== undefined) {
+    process.env.SAFE_MODE = nextPublicSafeMode;
+  }
+}
+
+ensureSafeModeEnv();
+
+const [galleryModule, themeModule] = (await Promise.all([
+  import("../src/components/gallery/registry"),
+  import("../src/lib/theme"),
+])) as [
+  typeof import("../src/components/gallery/registry"),
+  typeof import("../src/lib/theme"),
+];
+
+const { createGalleryRegistry } = galleryModule;
+const { BG_CLASSES, VARIANTS } = themeModule;
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/tests/scripts/build-gallery-usage.test.ts
+++ b/tests/scripts/build-gallery-usage.test.ts
@@ -1,0 +1,41 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const scriptPath = path.join(repoRoot, "scripts", "build-gallery-usage.ts");
+const registerLoadersPath = path.join(
+  repoRoot,
+  "scripts",
+  "register-loaders.mjs",
+);
+
+const nodeArgs = [
+  "--import",
+  "tsx",
+  "--import",
+  registerLoadersPath,
+  scriptPath,
+];
+
+describe("build-gallery-usage safe mode fallback", () => {
+  it("completes when SAFE_MODE variables are unset", () => {
+    const env = { ...process.env };
+    delete env.NEXT_PUBLIC_SAFE_MODE;
+    delete env.SAFE_MODE;
+
+    const result = spawnSync(process.execPath, nodeArgs, {
+      cwd: repoRoot,
+      env,
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+
+    if (result.error) {
+      throw result.error;
+    }
+
+    expect(result.status).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the gallery usage generator seeds SAFE_MODE and NEXT_PUBLIC_SAFE_MODE defaults before loading gallery modules
- avoid overriding existing SAFE_MODE settings while keeping mirrored values in sync when only one side is provided
- add an integration-style Vitest that runs the generator with both variables unset and document the implicit fallback in the README

## Testing
- `pnpm test --run tests/scripts/build-gallery-usage.test.ts`
- `env -u NEXT_PUBLIC_SAFE_MODE -u SAFE_MODE node --import tsx --import ./scripts/register-loaders.mjs scripts/build-gallery-usage.ts`

## Files Touched
- README.md
- scripts/build-gallery-usage.ts
- tests/scripts/build-gallery-usage.test.ts

## Design Tokens
- None.

## Visual QA
- Not applicable (no UI changes).

## Performance
- No impact on CLS/LCP or bundle sizes.

## Risks
- Low: generator fallback touches environment variables only when they are missing; existing CI overrides remain respected.

## Rollback Plan
- Revert this commit.


------
https://chatgpt.com/codex/tasks/task_e_68e0bf5b4d8c832c94602d10a6802e27