### PR TITLE
Fix gallery regen messaging to reference build-gallery-usage

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -31,7 +31,7 @@ For governance and enforcement workflows, read [Design System Governance](./desi
 
 ## Gallery previews
 
-- Run `pnpm run build-gallery-usage` after touching gallery files. `pnpm install` runs a postinstall check that regenerates the manifest automatically when it detects gallery changes, but running the command yourself keeps `src/components/gallery/generated-manifest.ts` and the cached preview slugs current while you iterate and ensures Playwright coverage stays in sync.
+- Run the canonical `pnpm run build-gallery-usage` command after touching gallery files. `pnpm install` runs a postinstall check that regenerates the manifest automatically when it detects gallery changes, but running the command yourself keeps `src/components/gallery/generated-manifest.ts` and the cached preview slugs current while you iterate and ensures Playwright coverage stays in sync.
 - Visit `/preview/[slug]` to render a single component or state in isolation. Slugs combine the gallery entry, optional state, and the theme variant (currently Glitch and Aurora). Axis metadata surfaces as `axis-…` query parameters so automation can label captured variants.
 - Trigger the **Visual Regression** workflow to record screenshots. It installs the production build, walks every generated preview route through the `@visual` Playwright suite, and uploads diffs when comparisons fail.
 - Visit `/preview/theme-matrix` to audit every gallery entry and state across Glitch, Aurora, Kitten, Oceanic, Citrus, Noir, and Hardstuck. The matrix reuses the in-gallery previews, ensuring Playwright screenshots and axe coverage span every theme without triggering layout shift.

--- a/scripts/regen-if-needed.ts
+++ b/scripts/regen-if-needed.ts
@@ -27,6 +27,8 @@ const galleryManifestFile = path.join(
   "src/components/gallery/generated-manifest.ts",
 );
 
+const galleryUsageCommand = "pnpm run build-gallery-usage";
+
 const usageInputPatterns = [
   "src/app/**/*.{ts,tsx}",
   "src/components/**/*.gallery.{ts,tsx}",
@@ -197,7 +199,7 @@ export const generatorValidations: GeneratorValidation[] = [
   },
   {
     name: "Gallery manifest",
-    command: "pnpm run build-gallery-usage",
+    command: galleryUsageCommand,
   },
   {
     name: "Theme CSS",
@@ -256,14 +258,14 @@ async function validateGalleryManifest(): Promise<void> {
     contents = await fs.readFile(galleryManifestFile, "utf8");
   } catch {
     throw new Error(
-      "Missing gallery manifest. Run `pnpm run build-gallery-usage` to regenerate src/components/gallery/generated-manifest.ts.",
+      `Missing gallery manifest. Run \`${galleryUsageCommand}\` to regenerate src/components/gallery/generated-manifest.ts.`,
     );
   }
 
   const trimmed = contents.trimStart();
   if (trimmed.startsWith("{")) {
     throw new Error(
-      "Gallery manifest appears to contain raw JSON. Run `pnpm run build-gallery-usage` to regenerate src/components/gallery/generated-manifest.ts.",
+      `Gallery manifest appears to contain raw JSON. Run \`${galleryUsageCommand}\` to regenerate src/components/gallery/generated-manifest.ts.`,
     );
   }
 
@@ -281,13 +283,13 @@ async function validateGalleryManifest(): Promise<void> {
       .map((signature) => signature.replace("export const ", ""))
       .join(", ");
     throw new Error(
-      `Gallery manifest is missing required exports: ${exportNames}. Run \`pnpm run build-gallery-usage\` to regenerate src/components/gallery/generated-manifest.ts.`,
+      `Gallery manifest is missing required exports: ${exportNames}. Run \`${galleryUsageCommand}\` to regenerate src/components/gallery/generated-manifest.ts.`,
     );
   }
 }
 
 async function regenerateGalleryUsage(): Promise<void> {
-  run("pnpm run build-gallery-usage");
+  run(galleryUsageCommand);
   await validateGalleryManifest();
   const files = await getUsageInputFiles();
   await updateManifest(
@@ -308,7 +310,7 @@ export async function ensureGalleryManifestIntegrity(): Promise<boolean> {
 
     const message = error instanceof Error ? error.message : String(error);
     console.warn(
-      `${message}\nRegenerating gallery manifest with \`pnpm run build-gallery-usage\`.`,
+      `${message}\nRegenerating gallery manifest with \`${galleryUsageCommand}\`.`,
     );
     await regenerateGalleryUsage();
     return true;

--- a/tests/scripts/regen-if-needed.test.ts
+++ b/tests/scripts/regen-if-needed.test.ts
@@ -19,10 +19,12 @@ vi.mock("url", async () => {
   };
 });
 
+const GALLERY_USAGE_COMMAND = "pnpm run build-gallery-usage";
+
 const REQUIRED_GENERATOR_COMMANDS = [
   "pnpm run regen-ui",
   "pnpm run regen-feature",
-  "pnpm run build-gallery-usage",
+  GALLERY_USAGE_COMMAND,
   "pnpm run generate-themes",
   "pnpm run generate-tokens",
 ];
@@ -249,6 +251,17 @@ describe("gallery manifest validation", () => {
     ).resolves.toBe(false);
   });
 
+  it("throws in CI when the manifest is missing and references the gallery usage command", async () => {
+    fs.rmSync(manifestPath, { force: true });
+
+    const regenModule = await importRegenModule("1");
+    await expect(
+      regenModule.ensureGalleryManifestIntegrity(),
+    ).rejects.toThrow(
+      `Missing gallery manifest. Run \`${GALLERY_USAGE_COMMAND}\` to regenerate src/components/gallery/generated-manifest.ts.`,
+    );
+  });
+
   it("requests regeneration locally when the manifest is malformed", async () => {
     const regenModule = await importRegenModule();
     const warnSpy = vi
@@ -307,7 +320,7 @@ describe("gallery manifest validation", () => {
       await expect(
         regenModule.ensureGalleryManifestIntegrity(),
       ).rejects.toThrow(
-        "Gallery manifest appears to contain raw JSON. Run `pnpm run build-gallery-usage` to regenerate src/components/gallery/generated-manifest.ts.",
+        `Gallery manifest appears to contain raw JSON. Run \`${GALLERY_USAGE_COMMAND}\` to regenerate src/components/gallery/generated-manifest.ts.`,
       );
 
       const manifestAfterAttempt = fs.readFileSync(manifestPath, "utf8");
@@ -331,7 +344,7 @@ describe("gallery manifest validation", () => {
     await expect(
       regenModule.ensureGalleryManifestIntegrity(),
     ).rejects.toThrow(
-      "Gallery manifest appears to contain raw JSON. Run `pnpm run build-gallery-usage` to regenerate src/components/gallery/generated-manifest.ts.",
+      `Gallery manifest appears to contain raw JSON. Run \`${GALLERY_USAGE_COMMAND}\` to regenerate src/components/gallery/generated-manifest.ts.`,
     );
   });
 
@@ -430,7 +443,7 @@ describe("gallery manifest validation", () => {
       await new Promise((resolve) => setImmediate(resolve));
 
       expect(execSyncMock).toHaveBeenCalledWith(
-        "pnpm run build-gallery-usage",
+        GALLERY_USAGE_COMMAND,
         expect.objectContaining({ stdio: "inherit" }),
       );
       expect(manifestReads).toBeGreaterThanOrEqual(2);


### PR DESCRIPTION
## Summary
- factor the gallery manifest validation script to share a single `pnpm run build-gallery-usage` command constant across validations, regeneration, and logging
- refresh the design system guide to call out the canonical `pnpm run build-gallery-usage` command
- extend the regen script tests to cover the missing-manifest path and assert the updated error guidance

## Files Touched
- docs/design-system.md
- scripts/regen-if-needed.ts
- tests/scripts/regen-if-needed.test.ts

## Design Tokens
- None

## Tests
- `pnpm exec vitest run tests/scripts/regen-if-needed.test.ts`

## Risks
- Low; changes are limited to CLI messaging, documentation, and related unit tests

## Rollback Plan
- Revert this commit

------
https://chatgpt.com/codex/tasks/task_e_68e0bfbe29f8832ca0a144424744a072