### PR TITLE
fix: align aurora preview spacing with tokens

### DIFF
--- a/src/components/prompts/ColorGallery.tsx
+++ b/src/components/prompts/ColorGallery.tsx
@@ -72,7 +72,7 @@ export default function ColorGallery() {
                   <AuroraSwatch key={token} token={token} />
                 ))}
               </div>
-              <p className="mt-2 text-center text-label text-muted-foreground">
+              <p className="mt-[var(--space-2)] text-center text-label text-muted-foreground">
                 Use <code>aurora-g</code>, <code>aurora-g-light</code>,{" "}
                 <code>aurora-p</code>, and <code>aurora-p-light</code> Tailwind
                 classes for aurora effects.


### PR DESCRIPTION
## Summary
- replace the aurora description margin utility with a token-backed spacing class in the color gallery preview
- verified no other raw spacing utilities remain in the aurora section

## Testing
- pnpm run lint:design

------
https://chatgpt.com/codex/tasks/task_e_68e0d276147c832c89556766556f93ba