### PR TITLE
Ensure gallery manifest writes are atomic

### DIFF
--- a/scripts/build-gallery-usage.ts
+++ b/scripts/build-gallery-usage.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import fg from "fast-glob";
 import ts from "typescript";
+import { writeFileAtomically } from "./utils/write-file-atomically";
 import type {
   GalleryRegistryPayload,
   GallerySection,
@@ -133,7 +134,7 @@ async function writeManifest(files: readonly string[]): Promise<void> {
     entries[rel] = { mtimeMs: stat.mtimeMs } satisfies ManifestEntry;
   }
   await ensureCacheDir();
-  await fs.writeFile(manifestFile, JSON.stringify(entries, null, 2));
+  await writeFileAtomically(manifestFile, JSON.stringify(entries, null, 2));
 }
 
 function getScriptKind(file: string): ts.ScriptKind {
@@ -583,7 +584,7 @@ async function buildGalleryManifest(
   validateManifestSource(source);
 
   await fs.mkdir(path.dirname(manifestOutput), { recursive: true });
-  await fs.writeFile(manifestOutput, source);
+  await writeFileAtomically(manifestOutput, source);
 }
 
 async function main(): Promise<void> {
@@ -597,7 +598,7 @@ async function main(): Promise<void> {
   const usage = await buildUsage(registry.payload.sections);
   const previewRoutes = buildPreviewRoutes(registry.payload.sections);
   await fs.mkdir(path.dirname(usageFile), { recursive: true });
-  await fs.writeFile(usageFile, `${JSON.stringify(usage, null, 2)}\n`);
+  await writeFileAtomically(usageFile, `${JSON.stringify(usage, null, 2)}\n`);
   await buildGalleryManifest(modules, registry.payload, previewRoutes);
   await writeManifest([...new Set(trackedFiles)]);
 }

--- a/scripts/utils/write-file-atomically.ts
+++ b/scripts/utils/write-file-atomically.ts
@@ -1,0 +1,49 @@
+import { randomBytes } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const DEFAULT_MAX_RENAME_RETRIES = 3;
+
+export interface WriteFileAtomicallyOptions {
+  readonly encoding?: BufferEncoding | null;
+  readonly mode?: number;
+  readonly flag?: string | number;
+  readonly signal?: AbortSignal;
+  readonly maxRetries?: number;
+}
+
+type WriteData = Parameters<typeof fs.writeFile>[1];
+type WriteOptions = Omit<WriteFileAtomicallyOptions, "maxRetries">;
+
+export const writeFileAtomically = async (
+  filePath: string,
+  data: WriteData,
+  options: WriteFileAtomicallyOptions = {},
+): Promise<void> => {
+  const { maxRetries = DEFAULT_MAX_RENAME_RETRIES, ...writeOptions } = options;
+  const directory = path.dirname(filePath);
+  await fs.mkdir(directory, { recursive: true });
+
+  const tempBase = `.tmp-${path.basename(filePath)}-${process.pid}-${Date.now()}-${randomBytes(6).toString("hex")}`;
+  const tempPath = path.join(directory, tempBase);
+
+  await fs.writeFile(tempPath, data, writeOptions as WriteOptions);
+
+  let attempt = 0;
+  while (true) {
+    try {
+      await fs.rename(tempPath, filePath);
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException | undefined)?.code;
+      if (code === "EEXIST" && attempt < maxRetries) {
+        attempt += 1;
+        await fs.rm(filePath, { force: true });
+        continue;
+      }
+
+      await fs.rm(tempPath, { force: true });
+      throw error;
+    }
+  }
+};

--- a/tests/scripts/write-file-atomically.test.ts
+++ b/tests/scripts/write-file-atomically.test.ts
@@ -1,0 +1,50 @@
+import os from "node:os";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { writeFileAtomically } from "../../scripts/utils/write-file-atomically";
+
+describe("writeFileAtomically", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "write-file-atomically-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("writes the requested content", async () => {
+    const target = path.join(tempDir, "example.txt");
+
+    await writeFileAtomically(target, "hello world", { encoding: "utf8" });
+
+    const result = await fs.readFile(target, "utf8");
+    expect(result).toBe("hello world");
+  });
+
+  it("retries when rename reports EEXIST", async () => {
+    const target = path.join(tempDir, "retry.txt");
+    await fs.writeFile(target, "original", "utf8");
+
+    const originalRename = fs.rename.bind(fs);
+    const renameSpy = vi
+      .spyOn(fs, "rename")
+      .mockImplementationOnce(async (oldPath, newPath) => {
+        const error = new Error("exists") as NodeJS.ErrnoException;
+        error.code = "EEXIST";
+        throw error;
+      })
+      .mockImplementation((oldPath, newPath) => originalRename(oldPath, newPath));
+
+    await writeFileAtomically(target, "updated", { encoding: "utf8", maxRetries: 3 });
+
+    const result = await fs.readFile(target, "utf8");
+    expect(result).toBe("updated");
+    expect(renameSpy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable `writeFileAtomically` helper to guarantee atomic writes when generating artifacts
- switch the gallery usage build script to use the atomic writer for the cache manifest, usage map, and manifest bundle
- cover the new helper with Vitest to validate success cases and `EEXIST` retry behavior

## Files Touched
- scripts/build-gallery-usage.ts
- scripts/utils/write-file-atomically.ts
- tests/scripts/write-file-atomically.test.ts

## Design Tokens
- None

## Tests
- `pnpm exec vitest run write-file-atomically`
- `pnpm run typecheck`
- `pnpm run verify-prompts`
- `pnpm run guard:artifacts`

## Visual QA
- Not applicable (no UI changes)

## Performance
- No impact expected

## Risks
- Low; changes isolated to build tooling with automated coverage

## Rollback Plan
- Revert the commit to restore the prior build pipeline

------
https://chatgpt.com/codex/tasks/task_e_68e0d686ab74832c82cdf3fca810be2f