### PR TITLE
chore: allow node 22 semver range

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "pnpm@10.13.1",
   "engines": {
-    "node": "22.x",
+    "node": ">=22",
     "pnpm": "10.13.1"
   },
   "name": "noxis-planner",


### PR DESCRIPTION
## Summary
- update the Node.js engine requirement in `package.json` to accept any Node 22 release or newer so the config matches the documented support window

## Testing
- `pnpm run verify-prompts`
- `pnpm run lint`
- `pnpm run lint:design`
- `pnpm test tests/scripts/regen-if-needed.test.ts -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68e0d909b7f0832c96063b7461cd81e5