### PR TITLE
fix: restore merge commit checkout in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.sha || github.event.pull_request.head.sha }}
       - name: Setup Node project
         id: setup
         uses: ./.github/actions/setup-node-project
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.sha || github.event.pull_request.head.sha }}
       - name: Setup Node project
         uses: ./.github/actions/setup-node-project
         with:
@@ -100,7 +100,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.sha || github.event.pull_request.head.sha }}
       - name: Setup Node project
         uses: ./.github/actions/setup-node-project
         with:
@@ -135,7 +135,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.sha || github.event.pull_request.head.sha }}
       - name: Setup Node project
         uses: ./.github/actions/setup-node-project
         with:
@@ -162,7 +162,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.sha || github.event.pull_request.head.sha }}
       - name: Setup Node project
         uses: ./.github/actions/setup-node-project
         with:
@@ -204,7 +204,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.sha || github.event.pull_request.head.sha }}
       - name: Setup Node project
         uses: ./.github/actions/setup-node-project
         with:
@@ -283,7 +283,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.sha || github.event.pull_request.head.sha }}
       - name: Setup Node project
         uses: ./.github/actions/setup-node-project
         with:


### PR DESCRIPTION
## Summary
- ensure all CI jobs prioritize `github.sha` when checking out so PRs run against the merge commit

## Testing
- [ ] `npm run verify-prompts`
- [ ] `npm run check`

## Rollback Plan
- [ ] Toggle `NEXT_PUBLIC_DEPTH_THEME` to `off`/`0` and redeploy to restore the legacy depth tokens and components.
- [ ] Capture any residual depth-theme metrics to confirm the flag has returned to the legacy path.

## Monitoring
- [ ] Depth-theme analytics flag is visible in dashboards and alerting remains green.


------
https://chatgpt.com/codex/tasks/task_e_68e0db7355d0832cbefa2f4ca01bf78e