### PR TITLE
ci: guard artifact directories in lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,9 @@ jobs:
           echo "::add-matcher::.github/matchers/eslint-stylish.json"
           pnpm run design-lint
 
+      - name: Guard generated artifacts
+        run: pnpm run guard:artifacts
+
       - name: Summarize lint
         if: always()
         run: |


### PR DESCRIPTION
## Summary
- add the artifact guard script to the CI lint job so forbidden directories fail the workflow

## Testing
- [ ] `npm run verify-prompts`
- [ ] `npm run check`
- `pnpm run guard:artifacts`

## Rollback Plan
- [ ] Toggle `NEXT_PUBLIC_DEPTH_THEME` to `off`/`0` and redeploy to restore the legacy depth tokens and components.
- [ ] Capture any residual depth-theme metrics to confirm the flag has returned to the legacy path.

## Monitoring
- [ ] Depth-theme analytics flag is visible in dashboards and alerting remains green.

------
https://chatgpt.com/codex/tasks/task_e_68e0e01e1e50832ca345a93d7643ca08