### PR TITLE
chore: format package manager detection script

### DIFF
--- a/.github/actions/setup-node-project/action.yml
+++ b/.github/actions/setup-node-project/action.yml
@@ -56,7 +56,20 @@ runs:
         if [ -n "${{ inputs['package-manager'] }}" ]; then
           RAW_PM="${{ inputs['package-manager'] }}"
         else
-          RAW_PM="$(node --input-type=module -e "import { readFileSync } from 'node:fs'; import { resolve } from 'node:path'; import { cwd } from 'node:process'; try { const packageJsonPath = resolve(cwd(), 'package.json'); const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')); console.log(packageJson?.packageManager ?? ''); } catch { console.log(''); }")"
+          RAW_PM="$(node --input-type=module <<'EOF'
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { cwd } from 'node:process';
+
+try {
+  const packageJsonPath = resolve(cwd(), 'package.json');
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  console.log(packageJson?.packageManager ?? '');
+} catch {
+  console.log('');
+}
+EOF
+)"
         fi
 
         if [ -z "$RAW_PM" ]; then


### PR DESCRIPTION
## Summary
- replace the inline Node.js snippet in the setup-node-project action with a heredoc script so each YAML line stays under the lint limit

## Testing
- pnpm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0ecace2c4832c95b541d9c5cbacfa