### PR TITLE
fix: restore YAML indentation for setup-node-project action

### DIFF
--- a/.github/actions/setup-node-project/action.yml
+++ b/.github/actions/setup-node-project/action.yml
@@ -56,20 +56,8 @@ runs:
         if [ -n "${{ inputs['package-manager'] }}" ]; then
           RAW_PM="${{ inputs['package-manager'] }}"
         else
-          RAW_PM="$(node --input-type=module <<'EOF'
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { cwd } from 'node:process';
-
-try {
-  const packageJsonPath = resolve(cwd(), 'package.json');
-  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
-  console.log(packageJson?.packageManager ?? '');
-} catch {
-  console.log('');
-}
-EOF
-)"
+          NODE_DETECTION_SCRIPT=$'import { readFileSync } from "node:fs";\nimport { resolve } from "node:path";\nimport { cwd } from "node:process";\n\ntry {\n  const packageJsonPath = resolve(cwd(), "package.json");\n  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));\n  console.log(packageJson?.packageManager ?? "");\n} catch {\n  console.log("");\n}'
+          RAW_PM="$(node --input-type=module -e "$NODE_DETECTION_SCRIPT")"
         fi
 
         if [ -z "$RAW_PM" ]; then


### PR DESCRIPTION
## Summary
- replace the heredoc-based Node detection script with an inline module script string so the YAML block remains properly indented
- ensure the composite action can be parsed by YAML tooling and GitHub Actions consumers

## Testing
- `ruby -ryaml -e "YAML.load_file('.github/actions/setup-node-project/action.yml')"`

## Files Touched
- `.github/actions/setup-node-project/action.yml`

## Design Tokens
- None

## Visual QA
- Not applicable

## Performance Impact
- None

## Risks
- Low; the detection logic still executes the same Node script using an inline string.

## Rollback Plan
- Revert this commit.


------
https://chatgpt.com/codex/tasks/task_e_68e0eeb6299c832ca04ad83e0497b700