### PR TITLE
chore: use heredoc for node detection script

### DIFF
--- a/.github/actions/setup-node-project/action.yml
+++ b/.github/actions/setup-node-project/action.yml
@@ -56,7 +56,20 @@ runs:
         if [ -n "${{ inputs['package-manager'] }}" ]; then
           RAW_PM="${{ inputs['package-manager'] }}"
         else
-          NODE_DETECTION_SCRIPT=$'import { readFileSync } from "node:fs";\nimport { resolve } from "node:path";\nimport { cwd } from "node:process";\n\ntry {\n  const packageJsonPath = resolve(cwd(), "package.json");\n  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));\n  console.log(packageJson?.packageManager ?? "");\n} catch {\n  console.log("");\n}'
+          NODE_DETECTION_SCRIPT=$(cat <<'EOF'
+            import { readFileSync } from "node:fs";
+            import { resolve } from "node:path";
+            import { cwd } from "node:process";
+
+            try {
+              const packageJsonPath = resolve(cwd(), "package.json");
+              const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+              console.log(packageJson?.packageManager ?? "");
+            } catch {
+              console.log("");
+            }
+            EOF
+          )
           RAW_PM="$(node --input-type=module -e "$NODE_DETECTION_SCRIPT")"
         fi
 


### PR DESCRIPTION
## Summary
- update the setup-node-project action to assign the Node detection script via a heredoc so long lines are wrapped
- keep the script contents unchanged while satisfying the workflow lint line-length rule

## Testing
- yamllint -d "{extends: default, rules: {line-length: {max: 200}, comments: disable, document-start: disable, truthy: disable}}" .github

------
https://chatgpt.com/codex/tasks/task_e_68e0f6456720832cb43d511c67704476