### PR TITLE
routing: prefix global home links with base path

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { Button, PageShell } from "@/components/ui";
 import { createLogger } from "@/lib/logging";
 import { captureException } from "@/lib/observability/sentry";
+import { withBasePath } from "@/lib/utils";
 
 export type RouteError = Error & { digest?: string };
 
@@ -30,7 +31,7 @@ export function RouteErrorContent({
   description,
   retryLabel = "Try again",
   homeLabel = "Go to dashboard",
-  homeHref = "/",
+  homeHref = withBasePath("/"),
 }: RouteErrorContentProps) {
   useEffect(() => {
     routeErrorLog.error("Route error boundary captured an exception", error);

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -6,6 +6,7 @@ import {
   PageHeader,
   PageShell,
 } from "@/components/ui";
+import { withBasePath } from "@/lib/utils";
 
 export const metadata: Metadata = {
   title: "Page Not Found",
@@ -32,7 +33,7 @@ export default function NotFound() {
           heading: "This page does not exist",
           actions: (
             <Button asChild>
-              <Link href="/">Go home</Link>
+              <Link href={withBasePath("/")}>Go home</Link>
             </Button>
           ),
           children: (

--- a/src/app/preview/pages-check/page.tsx
+++ b/src/app/preview/pages-check/page.tsx
@@ -37,7 +37,7 @@ export default function PagesCheckPage() {
             className="shadow-outline-subtle"
           />
           <Button asChild variant="neo">
-            <Link href="/">Return home</Link>
+            <Link href={withBasePath("/")}>Return home</Link>
           </Button>
         </div>
       </SectionCard>

--- a/src/components/chrome/SiteChrome.tsx
+++ b/src/components/chrome/SiteChrome.tsx
@@ -8,6 +8,7 @@ import BrandWordmark from "@/components/chrome/BrandWordmark";
 import ThemeToggle from "@/components/ui/theme/ThemeToggle";
 import AnimationToggle from "@/components/ui/AnimationToggle";
 import { PageShell } from "@/components/ui";
+import { withBasePath } from "@/lib/utils";
 import Link from "next/link";
 import IconButton from "@/components/ui/primitives/IconButton";
 import { Menu } from "lucide-react";
@@ -51,7 +52,7 @@ export default function SiteChrome({ children }: SiteChromeProps) {
           />
 
           <Link
-            href="/"
+            href={withBasePath("/")}
             aria-label="Home"
             className="col-span-full flex items-center gap-[var(--space-2)] md:col-span-3"
           >


### PR DESCRIPTION
**Summary:**
- wrap the SiteChrome brand link with `withBasePath` so the global header home link respects the deployment base path
- update the route error boundary, not-found page, and preview CTA home links to resolve via `withBasePath` for consistent navigation under a base path

**Files Touched:**
- src/components/chrome/SiteChrome.tsx
- src/app/error.tsx
- src/app/not-found.tsx
- src/app/preview/pages-check/page.tsx

**Tokens:** none.

**Tests:**
- ✅ `pnpm run verify-prompts`
- ❌ `pnpm run check` *(fails in the current baseline because `src/components/gallery/generated-manifest.ts` still contains raw JSON; the TypeScript checker aborts after `guard:artifacts` removes `tsx` caches)*

**Visual QA:** not applicable (link target updates only).

**Performance:** none.

**Risks & Flags:** Low risk; affects only base-path resolution for existing home links.

**Rollback:** `git revert <commit>`.

------
https://chatgpt.com/codex/tasks/task_e_68e104344a34832c8c240565b75386e2