### PR TITLE
setup-node: align heredoc terminator

### DIFF
--- a/.github/actions/setup-node-project/action.yml
+++ b/.github/actions/setup-node-project/action.yml
@@ -69,7 +69,11 @@ runs:
         if [ -n "${{ inputs['package-manager'] }}" ]; then
           RAW_PM="${{ inputs['package-manager'] }}"
         else
-          RAW_PM="$(node --input-type=module <<<"$NODE_DETECTION_SCRIPT")"
+          RAW_PM="$(
+            node --input-type=module <<EOF
+$NODE_DETECTION_SCRIPT
+EOF
+          )"
         fi
 
         if [ -z "$RAW_PM" ]; then


### PR DESCRIPTION
## Summary
- align the heredoc terminator for the package manager detection script so bash recognizes it correctly

## Files Touched
- .github/actions/setup-node-project/action.yml

## Tokens
- None

## Tests
- `bash -c 'set -euo pipefail; NODE_DETECTION_SCRIPT=...; RAW_PM="$(node --input-type=module <<EOF ...)"'`

## Visual QA
- N/A

## Performance
- None

## Risks & Flags
- None

## Rollback
- Revert commit 5100cca with `git revert 5100cca`

------
https://chatgpt.com/codex/tasks/task_e_68e11e071664832cacba7e4583a9db66