### PR TITLE
fix: normalize gh-pages alias restoration

### DIFF
--- a/tests/lib/GitHubPagesBootstrap.test.ts
+++ b/tests/lib/GitHubPagesBootstrap.test.ts
@@ -80,6 +80,31 @@ describe("github-pages bootstrap helpers", () => {
         storedLocation: "/planner/tasks",
       }),
     ).toBeNull();
+
+    expect(
+      planGitHubPagesRestoration({
+        basePath: "/planner",
+        currentPath: "/planner/index.html",
+        storedLocation: "/planner/current",
+      }),
+    ).toBe("/planner");
+
+    expect(
+      planGitHubPagesRestoration({
+        basePath: "/planner",
+        currentPath: "/planner/index.html",
+        storedLocation:
+          "/planner/0123456789abcdef0123456789abcdef01234567/index.html",
+      }),
+    ).toBe("/planner");
+
+    expect(
+      planGitHubPagesRestoration({
+        basePath: "",
+        currentPath: "/index.html",
+        storedLocation: "/current",
+      }),
+    ).toBe("/");
   });
 
   it("exposes the storage key literal", () => {

--- a/tests/public/github-pages-bootstrap-alias.test.ts
+++ b/tests/public/github-pages-bootstrap-alias.test.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GITHUB_PAGES_REDIRECT_STORAGE_KEY } from "@/lib/github-pages";
+
+function loadBootstrapSource(basePath: string): string {
+  const scriptPath = path.join(
+    process.cwd(),
+    "public",
+    "scripts",
+    "github-pages-bootstrap.js",
+  );
+  const originalSource = fs.readFileSync(scriptPath, "utf8");
+  return originalSource
+    .replace(
+      /"__GITHUB_PAGES_REDIRECT_STORAGE_KEY__"/gu,
+      `"${GITHUB_PAGES_REDIRECT_STORAGE_KEY}"`,
+    )
+    .replace(/"__BASE_PATH__"/gu, `"${basePath}"`);
+}
+
+describe("github pages bootstrap alias handling", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("normalizes deploy aliases to the base path root", () => {
+    const source = loadBootstrapSource("/planner");
+    const historyReplaceState = vi.fn();
+    const locationReplace = vi.fn();
+    const getItem = vi.fn(() => "current");
+    const removeItem = vi.fn();
+
+    const history = {
+      replaceState: (...args: unknown[]) => {
+        historyReplaceState(...args);
+      },
+    };
+
+    const location = {
+      pathname: "/index.html",
+      search: "",
+      hash: "",
+      replace: (...args: unknown[]) => {
+        locationReplace(...args);
+      },
+    };
+
+    const windowObject = {
+      location,
+      history,
+      sessionStorage: {
+        getItem,
+        removeItem,
+      },
+    };
+
+    (windowObject as typeof windowObject & { window?: unknown }).window =
+      windowObject;
+
+    const execute = new Function("window", source);
+    execute(windowObject);
+
+    expect(getItem).toHaveBeenCalledWith(GITHUB_PAGES_REDIRECT_STORAGE_KEY);
+    expect(removeItem).toHaveBeenCalledWith(GITHUB_PAGES_REDIRECT_STORAGE_KEY);
+    const historyCall = historyReplaceState.mock.calls[0]?.[2];
+    const locationCall = locationReplace.mock.calls[0]?.[0];
+
+    expect(historyCall ?? locationCall).toBe("/");
+  });
+});


### PR DESCRIPTION
## Summary
- normalize GitHub Pages restoration planning to strip `current` and commit alias folders back to the base path root
- mirror the alias guard in the bootstrap script so static exports and the helper stay in sync
- add regression tests covering alias normalization both in helper logic and the shipped bootstrap script

## Files Touched
- public/scripts/github-pages-bootstrap.js
- src/lib/github-pages.ts
- tests/lib/GitHubPagesBootstrap.test.ts
- tests/public/github-pages-bootstrap-alias.test.ts

## Tokens
- None

## Tests
- `pnpm vitest run tests/lib/GitHubPagesBootstrap.test.ts tests/public/github-pages-bootstrap-alias.test.ts`
- `pnpm run lint`
- `pnpm run lint:design`
- `pnpm run typecheck` *(fails: gallery manifest in repo requires regeneration outside this change)*
- `pnpm run guard:artifacts`

## Visual QA
- Not applicable (no UI changes)

## Performance
- No impact expected

## Risks & Flags
- Alias detection currently treats 7-40 char hex segments as commits; adjust if GitHub Pages introduces other alias formats.

## Rollback
- `git revert 466f4f66a0f9ef3ac5b8c77a1f0b0fd06f587e74`


------
https://chatgpt.com/codex/tasks/task_e_68e1282c74e0832c941863580926195e