### PR TITLE
ci: isolate tsx cache directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,8 @@ jobs:
           cache-prefix: ci
 
       - name: Verify prompts registry
+        env:
+          TSX_TEMPDIR: node_modules/.cache/tsx
         run: pnpm run verify-prompts
 
       - name: Lint
@@ -120,6 +122,8 @@ jobs:
           pnpm run design-lint
 
       - name: Guard generated artifacts
+        env:
+          TSX_TEMPDIR: node_modules/.cache/tsx
         run: pnpm run guard:artifacts
 
       - name: Summarize lint
@@ -145,6 +149,8 @@ jobs:
           cache-prefix: ci
 
       - name: Type check
+        env:
+          TSX_TEMPDIR: node_modules/.cache/tsx
         run: |
           echo "::add-matcher::.github/matchers/typescript.json"
           pnpm run typecheck:ci


### PR DESCRIPTION
## Summary
- set TSX_TEMPDIR for TSX-based CI steps so caches stay in node_modules/.cache/tsx
- avoid polluting the repository with node-compile-cache or tsx-* directories during lint/typecheck jobs

## Files Touched
- .github/workflows/ci.yml

## Tokens
- none

## Tests
- TSX_TEMPDIR=node_modules/.cache/tsx pnpm run verify-prompts
- TSX_TEMPDIR=node_modules/.cache/tsx pnpm run guard:artifacts

## Visual QA
- not applicable

## Performance
- none

## Risks & Flags
- low risk: workflow-only change isolating TSX temp output

## Rollback
- revert this commit

------
https://chatgpt.com/codex/tasks/task_e_68e12d91e580832c91c718ed1c33c6d1