### PR TITLE
chore: align heredoc indentation

### DIFF
--- a/.github/actions/setup-node-project/action.yml
+++ b/.github/actions/setup-node-project/action.yml
@@ -71,8 +71,8 @@ runs:
         else
           RAW_PM="$(
             node --input-type=module <<EOF
-$NODE_DETECTION_SCRIPT
-EOF
+            $NODE_DETECTION_SCRIPT
+            EOF
           )"
         fi
 


### PR DESCRIPTION
## Summary
- align the here-doc invocation in the setup-node-project composite action so the embedded script and terminator follow the surrounding shell indentation

## Testing
- actionlint

------
https://chatgpt.com/codex/tasks/task_e_68e14a357964832c85c9683b94e8d8a0