### PR TITLE
env: restore server validation bootstrap

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@
 import "./globals.css";
 // Load tokens + per-theme backdrops AFTER globals so overrides win.
 import "./themes.css";
+import "@/env/validate-server-env";
 
 import type { Metadata, Viewport } from "next";
 import {

--- a/src/env/validate-server-env.ts
+++ b/src/env/validate-server-env.ts
@@ -1,0 +1,6 @@
+import loadServerEnv from "../../env/server";
+
+// Validate the server environment variables at module import time. This keeps the
+// runtime enforcement that previously happened in the root layout while avoiding
+// the need for every caller to manually invoke the loader.
+loadServerEnv();


### PR DESCRIPTION
Summary:
- ensure the root layout eagerly validates server-side environment variables by importing a small helper
- add a dedicated module that invokes loadServerEnv at import time so schema enforcement continues to run in production

Files Touched:
- src/app/layout.tsx
- src/env/validate-server-env.ts

Tokens:
- none

Tests:
- pnpm exec vitest run tests/env/server.test.ts
- pnpm run lint
- pnpm run lint:design
- pnpm run typecheck
- pnpm run guard:artifacts
- pnpm run verify-prompts

Visual QA:
- not applicable (no visual changes)

Performance:
- none

Risks & Flags:
- minimal; new helper import is synchronous and memoizes on module load

Rollback:
- git revert b7c3d8220c73699b3097b73476391c8daf3ac154


------
https://chatgpt.com/codex/tasks/task_e_68e14a442ab0832c8ee4ffecd79234c0