### PR TITLE
fix: align heredoc terminator

### DIFF
--- a/.github/actions/setup-node-project/action.yml
+++ b/.github/actions/setup-node-project/action.yml
@@ -72,7 +72,7 @@ runs:
           RAW_PM="$(
             node --input-type=module <<EOF
             $NODE_DETECTION_SCRIPT
-            EOF
+EOF
           )"
         fi
 


### PR DESCRIPTION
## Summary
- align the EOF terminator in the setup-node-project composite action so the heredoc closes correctly

## Testing
- pnpm run verify-prompts

------
https://chatgpt.com/codex/tasks/task_e_68e155bfb690832cb121f88d0f41345b