### PR TITLE
typecheck: ignore manifest union diagnostics

### DIFF
--- a/scripts/typecheck.ts
+++ b/scripts/typecheck.ts
@@ -81,7 +81,7 @@ async function main(): Promise<void> {
   const diagnostics = ts
     .getPreEmitDiagnostics(program.getProgram())
     .filter((diagnostic) => {
-      if (diagnostic.code !== 2590) {
+      if (diagnostic.code !== 2589 && diagnostic.code !== 2590) {
         return true;
       }
       const fileName = diagnostic.file?.fileName;
@@ -89,9 +89,15 @@ async function main(): Promise<void> {
         return true;
       }
       const normalized = path.normalize(fileName);
-      return !normalized.endsWith(
-        path.normalize("src/components/gallery/generated-manifest.ts"),
-      );
+      if (
+        normalized.endsWith(
+          path.normalize("src/components/gallery/generated-manifest.ts"),
+        )
+      ) {
+        // Ignore union size explosions from the large auto-generated manifest file.
+        return false;
+      }
+      return true;
     });
   bars.stop();
 


### PR DESCRIPTION
Summary:
- Update the typecheck diagnostic filter to suppress TS2589/TS2590 warnings emitted by the auto-generated gallery manifest while leaving other files untouched.
- Add documentation explaining that the suppression targets the large manifest file.

Files Touched:
- scripts/typecheck.ts

Tokens:
- None.

Tests:
- Not run (not requested).

Visual QA:
- Not applicable.

Performance:
- None.

Risks & Flags:
- None.

Rollback:
- Revert commit e2591c52349c95087209e5164ab927d9ec1a9185.


------
https://chatgpt.com/codex/tasks/task_e_68e156c2e468832cbae77075a818aaa2