### PR TITLE
github-pages: restore runtime base path

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ import tokens from "../../tokens/tokens.js";
 import { resolveTokenColor } from "@/lib/color";
 import SiteChrome from "@/components/chrome/SiteChrome";
 import { CatCompanion, DecorLayer, PageShell, SkipLink } from "@/components/ui";
-import { withBasePath } from "@/lib/utils";
+import { getBasePath, withBasePath } from "@/lib/utils";
 import Script from "next/script";
 import ThemeProvider from "@/lib/theme-context";
 import { THEME_BOOTSTRAP_SCRIPT_PATH } from "@/lib/theme";
@@ -77,6 +77,7 @@ export default async function RootLayout({
   const organicDepthDataAttribute = organicDepthState ? "organic" : "legacy";
   const glitchLandingDataAttribute = glitchLandingState ? "enabled" : "legacy";
   const year = new Date().getFullYear();
+  const basePath = getBasePath();
   const assetUrlCss = [
     ":root {",
     `  --asset-noise-url: url("${withBasePath("/noise.svg")}");`,
@@ -92,6 +93,7 @@ export default async function RootLayout({
       data-depth-theme={depthThemeDataAttribute}
       data-organic-depth={organicDepthDataAttribute}
       data-glitch-landing={glitchLandingDataAttribute}
+      data-base-path={basePath || undefined}
       suppressHydrationWarning
     >
       <head>


### PR DESCRIPTION
**Summary**
* Teach `withBasePath`/`withoutBasePath` to prefer the runtime router base path (or HTML data attribute) when available so GitHub Pages builds fetch local assets correctly.
* Surface the resolved base path on the root `<html>` element for deterministic client-side lookups.
* Extend the base path utility tests to cover the new runtime detection behaviour.

**Files Touched**
* src/lib/utils.ts
* src/app/layout.tsx
* tests/lib/WithBasePath.test.ts

**Tokens**
* none

**Tests**
* `pnpm vitest run tests/lib/WithBasePath.test.ts`
* `pnpm run lint`
* `pnpm run lint:design`
* `pnpm run typecheck`
* `pnpm run guard:artifacts`
* `pnpm run verify-prompts`

**Visual QA**
* not applicable (no visual changes)

**Performance**
* none

**Risks & Flags**
* Low – affects base path helpers; covered by new unit tests.

**Rollback**
* `git revert <commit>`

------
https://chatgpt.com/codex/tasks/task_e_68e15cd31f94832c95a7a22b4a27d772