### PR TITLE
fix: compute lockfile hash with Node

### DIFF
--- a/.github/actions/setup-node-project/action.yml
+++ b/.github/actions/setup-node-project/action.yml
@@ -159,9 +159,28 @@ EOF
     - name: Compute lockfile hash
       id: lockfile
       shell: bash
+      env:
+        LOCKFILE: ${{ steps.detect.outputs.lockfile }}
       run: |
         set -euo pipefail
-        HASH=$(sha256sum "${{ steps.detect.outputs.lockfile }}" | cut -d' ' -f1)
+        HASH="$(
+          node --input-type=module <<'EOF'
+          import { createHash } from "node:crypto";
+          import { readFileSync } from "node:fs";
+          import { resolve } from "node:path";
+
+          const lockfile = process.env.LOCKFILE;
+          if (!lockfile) {
+            console.error("LOCKFILE environment variable is required to compute the cache key.");
+            process.exit(1);
+          }
+
+          const absolute = resolve(lockfile);
+          const contents = readFileSync(absolute);
+          const hash = createHash("sha256").update(contents).digest("hex");
+          console.log(hash);
+EOF
+        )"
         echo "value=$HASH" >>"$GITHUB_OUTPUT"
 
     - name: Derive node_modules cache key


### PR DESCRIPTION
**Title:** fix: compute lockfile hash with Node

**Summary:**
- replace the `sha256sum` shell call in the setup-node-project composite action with a Node-based SHA-256 hash so macOS runners without GNU coreutils can resolve the lockfile hash reliably.
- validate the required environment variable before hashing to surface actionable errors when the lockfile path is missing.

**Files Touched:**
- .github/actions/setup-node-project/action.yml

**Tokens:**
- None.

**Tests:**
- pnpm run verify-prompts
- pnpm run lint
- pnpm run lint:design
- pnpm run guard:artifacts
- pnpm run typecheck
- pnpm exec vitest run tests/lib/Db.test.ts tests/components/PageHeader.test.tsx tests/scripts/regen-if-needed.test.ts tests/planner/WeekPicker.test.tsx

**Visual QA:**
- Not applicable (build tooling only).

**Performance:**
- None.

**Risks & Flags:**
- Low risk; change only affects the composite GitHub Action hashing logic.

**Rollback:**
- Revert the commit `fix: use node to hash lockfile in setup action`.

------
https://chatgpt.com/codex/tasks/task_e_68e16e6b17c0832cbd8067d59bc909d6