### PR TITLE
planner: prevent post-unmount state updates

### DIFF
--- a/src/components/planner/createDayTextFieldHook.ts
+++ b/src/components/planner/createDayTextFieldHook.ts
@@ -42,6 +42,9 @@ export function createDayTextFieldHook({
 
     const [value, setValue] = React.useState<string>(() => persistedValue);
     const [saving, setSaving] = React.useState(false);
+    const mountedRef = React.useRef(true);
+    const scheduleSavingResetRef = React.useRef(scheduleSavingReset);
+    scheduleSavingResetRef.current = scheduleSavingReset;
     const lastSavedRef = React.useRef(persistedValue.trim());
 
     const trimmed = React.useMemo(() => value.trim(), [value]);
@@ -54,8 +57,10 @@ export function createDayTextFieldHook({
         applyForIso(trimmed);
         lastSavedRef.current = trimmed;
       } finally {
-        scheduleSavingReset(() => {
-          setSaving(false);
+        scheduleSavingResetRef.current(() => {
+          if (mountedRef.current) {
+            setSaving(false);
+          }
         });
       }
     }, [applyForIso, isDirty, trimmed]);
@@ -64,6 +69,12 @@ export function createDayTextFieldHook({
       setValue(persistedValue);
       lastSavedRef.current = persistedValue.trim();
     }, [iso, persistedValue]);
+
+    React.useEffect(() => {
+      return () => {
+        mountedRef.current = false;
+      };
+    }, []);
 
     return { value, setValue, saving, isDirty, lastSavedRef, commit } as const;
   };


### PR DESCRIPTION
**Summary**
- guard the planner text field hook with a mounted ref so post-unmount callbacks do not update state
- reuse a ref to invoke the latest `scheduleSavingReset` handler during commit cleanup
- extend the day text field hook tests to cover the unmount flow and ensure no late state updates occur

**Files Touched**
- src/components/planner/createDayTextFieldHook.ts
- tests/planner/createDayTextFieldHook.test.tsx

**Tokens**
- none

**Tests**
- `pnpm exec vitest run tests/planner/createDayTextFieldHook.test.tsx`
- `pnpm run lint`
- `pnpm run lint:design`
- `pnpm run guard:artifacts`

**Visual QA**
- not applicable (no UI changes)

**Performance**
- none

**Risks & Flags**
- Full `pnpm run typecheck` still fails locally because the generated gallery manifest resolves to raw JSON; this change does not touch that area.

**Rollback**
- Revert commit `Prevent unmounted state updates in day text hook`

------
https://chatgpt.com/codex/tasks/task_e_68e181ab0ec4832cbdc6394980ae4c4b