### PR TITLE
ci: fix setup action heredoc parsing

### DIFF
--- a/.github/actions/setup-node-project/action.yml
+++ b/.github/actions/setup-node-project/action.yml
@@ -70,9 +70,7 @@ runs:
           RAW_PM="${{ inputs['package-manager'] }}"
         else
           RAW_PM="$(
-            node --input-type=module <<EOF
-            $NODE_DETECTION_SCRIPT
-EOF
+            node --input-type=module <<<"$NODE_DETECTION_SCRIPT"
           )"
         fi
 
@@ -161,10 +159,7 @@ EOF
       shell: bash
       env:
         LOCKFILE: ${{ steps.detect.outputs.lockfile }}
-      run: |
-        set -euo pipefail
-        HASH="$(
-          node --input-type=module <<'EOF'
+        LOCKFILE_HASH_SCRIPT: |
           import { createHash } from "node:crypto";
           import { readFileSync } from "node:fs";
           import { resolve } from "node:path";
@@ -179,7 +174,10 @@ EOF
           const contents = readFileSync(absolute);
           const hash = createHash("sha256").update(contents).digest("hex");
           console.log(hash);
-EOF
+      run: |
+        set -euo pipefail
+        HASH="$(
+          node --input-type=module <<<"$LOCKFILE_HASH_SCRIPT"
         )"
         echo "value=$HASH" >>"$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- replace heredoc usage in the setup-node-project composite action with here-string evaluation
- move the lockfile hashing script into an environment value to keep the YAML manifest valid

## Files Touched
- .github/actions/setup-node-project/action.yml

## Tokens
- none

## Tests
- `pnpm run lint`
- `pnpm run lint:design`
- `pnpm run typecheck`
- `pnpm run guard:artifacts`
- `pnpm test -- --run` *(times out on `tests/planner/useTodayHeroTasks.test.tsx` in this environment)*

## Visual QA
- not applicable

## Performance
- none

## Risks & Flags
- minimal risk; action now relies on here-strings instead of heredocs

## Rollback
- revert the commit

------
https://chatgpt.com/codex/tasks/task_e_68e1882da828832c9dd50d1576bf3287