### PR TITLE
prompts: clarify verifier behavior

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ pnpm run check-prompts
 
 `regen-ui` regenerates `src/components/ui/index.ts` so pages can import the component from `@/components/ui`.
 
-`check-prompts` verifies that every component in `src/components/ui` and `src/components/prompts` has a corresponding entry in `src/app/prompts/page.tsx` or `src/components/prompts/PromptsDemos.tsx`.
+`check-prompts` scans every prompt source file to confirm that components in `src/components/ui` and `src/components/prompts` are referenced somewhere in the gallery demos.
 
 After running the scripts, add a demo of the new component to `src/app/prompts/page.tsx` so it appears in the prompts gallery.
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -45,7 +45,7 @@ This project standardises Node-based automation through the reusable workflow de
 
 ## Prompt verification behaviour
 
-Prompt checks always run through the consolidated matcher that scans every prompt file for references. The legacy mode that only inspected `src/app/prompts/page.tsx` and `src/components/prompts/PromptsDemos.tsx` has been removed. Setting `PROMPT_CHECK_MODE` no longer changes execution—it simply emits a console warning so existing pipelines can drop the flag without breaking.
+Prompt checks always run through the consolidated matcher that scans every prompt file for references. The legacy mode that only inspected a subset of prompt sources has been removed, and `pnpm run verify-prompts` / `pnpm run check-prompts` now share the same behaviour in every environment. The `PROMPT_CHECK_MODE` environment flag is no longer supported—remove it from any automation since it is ignored by the scripts.
 
 ## Manual visual regression workflow
 

--- a/scripts/verify-prompts.ts
+++ b/scripts/verify-prompts.ts
@@ -173,7 +173,7 @@ export async function runPromptVerification(
   const argv = options.argv ?? process.argv.slice(2);
   if (typeof process.env.PROMPT_CHECK_MODE === "string") {
     console.warn(
-      "PROMPT_CHECK_MODE is deprecated; the modern prompt verification always runs.",
+      "PROMPT_CHECK_MODE is no longer supported; remove the flag because the consolidated prompt verification always runs.",
     );
   }
   const args = new Set(argv);

--- a/tests/scripts/verify-prompts.test.ts
+++ b/tests/scripts/verify-prompts.test.ts
@@ -25,7 +25,7 @@ describe("verify-prompts", () => {
 
     await expect(runPromptVerification({ argv: [] })).resolves.toBeUndefined();
     expect(warnSpy).toHaveBeenCalledWith(
-      "PROMPT_CHECK_MODE is deprecated; the modern prompt verification always runs.",
+      "PROMPT_CHECK_MODE is no longer supported; remove the flag because the consolidated prompt verification always runs.",
     );
   });
 });


### PR DESCRIPTION
**Summary:**
- clarify that the prompt verification scripts always run the consolidated matcher and no longer honour legacy modes.
- update contributing guidance to describe the modern prompt scanning behaviour.
- align the verify-prompts script and test warning with the unsupported PROMPT_CHECK_MODE flag.

**Files Touched:**
- CONTRIBUTING.md
- docs/ci.md
- scripts/verify-prompts.ts
- tests/scripts/verify-prompts.test.ts

**Tokens:**
- none

**Tests:**
- `pnpm vitest tests/scripts/verify-prompts.test.ts`

**Visual QA:**
- not applicable (documentation and script changes only)

**Performance:**
- none

**Risks & Flags:**
- none

**Rollback:**
- revert commit `bcf9abd`

------
https://chatgpt.com/codex/tasks/task_e_68e237a1e760832c9ef0e2016858a83e