### PR TITLE
pages: tighten user pages detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Run `pnpm run deploy` from the project root whenever you're ready to publish. Th
 
 Before building, the script verifies that a Git push target is configured. If `git remote get-url origin` fails and both `GITHUB_REPOSITORY` and `GITHUB_TOKEN` are missing, the deploy exits early and asks you to add an `origin` remote or supply those environment variables before re-running `pnpm run deploy`.
 
-When the static files are published to `https://<username>.github.io/<repo>/`, the home page is served from `https://<username>.github.io/<repo>/` rather than the domain root. Use that base path whenever you link to or bookmark the deployed site.
+When the static files are published to `https://<username>.github.io/<repo>/`, the home page is served from `https://<username>.github.io/<repo>/` rather than the domain root. Use that base path whenever you link to or bookmark the deployed site. Only repositories that exactly match `https://<username>.github.io` (user/organization GitHub Pages) skip the base path; similarly named repositories such as `docs.github.io` owned by another organization continue to publish under `/<repo>/`.
 
 For CI (or any environment that should push automatically), export `GITHUB_TOKEN`, `GITHUB_REPOSITORY`, and (optionally) `CI=true` before running the deploy script. When those values are present, the script adds an authenticated remote URL so the push succeeds without additional setup.
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -33,6 +33,7 @@ const normalizeSlug = (value) => {
 
 const isGitHubPages = process.env.GITHUB_PAGES === "true";
 const repositorySlug = normalizeSlug(process.env.GITHUB_REPOSITORY?.split("/").pop());
+const repositoryOwnerSlug = normalizeSlug(process.env.GITHUB_REPOSITORY?.split("/")?.[0]);
 
 const resolveGitHubPagesSlug = () => {
   const explicitSlugSources = [process.env.NEXT_PUBLIC_BASE_PATH, process.env.BASE_PATH];
@@ -63,7 +64,11 @@ const resolveGitHubPagesSlug = () => {
 };
 
 const githubPagesSlug = isGitHubPages ? resolveGitHubPagesSlug() : "";
-const isUserOrOrgGitHubPage = (repositorySlug ?? githubPagesSlug)?.endsWith(".github.io") ?? false;
+const expectedUserOrOrgSlug =
+  repositoryOwnerSlug !== undefined ? `${repositoryOwnerSlug}.github.io` : undefined;
+const resolvedRepositorySlug = repositorySlug ?? githubPagesSlug;
+const isUserOrOrgGitHubPage =
+  expectedUserOrOrgSlug !== undefined && resolvedRepositorySlug === expectedUserOrOrgSlug;
 
 const normalizedBasePathValue = isGitHubPages
   ? githubPagesSlug && !isUserOrOrgGitHubPage

--- a/tests/scripts/deploy-gh-pages.test.ts
+++ b/tests/scripts/deploy-gh-pages.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   flattenBasePathDirectory,
   injectGitHubPagesPlaceholders,
+  isUserOrOrgGitHubPagesRepository,
 } from "../../scripts/deploy-gh-pages";
 import { GITHUB_PAGES_REDIRECT_STORAGE_KEY } from "@/lib/github-pages";
 
@@ -100,5 +101,26 @@ describe("injectGitHubPagesPlaceholders", () => {
     ).toBe(
       `const key = "${GITHUB_PAGES_REDIRECT_STORAGE_KEY}"; const base = "/planner";`,
     );
+  });
+});
+
+describe("isUserOrOrgGitHubPagesRepository", () => {
+  it("treats docs.github.io as a project page when owned by another organization", () => {
+    expect(
+      isUserOrOrgGitHubPagesRepository({
+        repositoryOwnerSlug: "acme",
+        repositoryNameSlug: "docs.github.io",
+        fallbackSlug: "docs.github.io",
+      }),
+    ).toBe(false);
+  });
+
+  it("detects owner.github.io repositories as user or organization pages", () => {
+    expect(
+      isUserOrOrgGitHubPagesRepository({
+        repositoryOwnerSlug: "acme",
+        repositoryNameSlug: "acme.github.io",
+      }),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
**Summary:**
- require GitHub Pages user/org detection to match the owner slug plus `.github.io` in both Next config and the deploy script
- add reusable helpers and unit coverage for distinguishing user pages from similarly named project repos
- document the clarified behaviour for mixed `.github.io` repository ownerships in the README

**Files Touched:**
- README.md
- next.config.mjs
- scripts/deploy-gh-pages.ts
- tests/scripts/deploy-gh-pages.test.ts

**Tokens:**
- None

**Tests:**
- `pnpm exec vitest run tests/scripts/deploy-gh-pages.test.ts`
- `pnpm run lint`
- `pnpm run lint:design`
- `pnpm run typecheck`
- `pnpm run guard:artifacts`
- `pnpm run verify-prompts`

**Visual QA:**
- n/a – no UI changes

**Performance:**
- none

**Risks & Flags:**
- Behaviour now depends on repository owner slug being available via `GITHUB_REPOSITORY`

**Rollback:**
- `git revert f4c50ff`

------
https://chatgpt.com/codex/tasks/task_e_68e242d19d50832caafe70d43789d810