### PR TITLE
ci: inline setup per job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,40 +27,8 @@ on:
       - 'CHANGELOG.md'
 
 jobs:
-  setup:
-    name: Setup dependencies
-    runs-on: ubuntu-latest
-    outputs:
-      package-manager: ${{ steps.setup.outputs['package-manager'] }}
-      install-command: ${{ steps.setup.outputs['install-command'] }}
-      lockfile: ${{ steps.setup.outputs.lockfile }}
-      node-version: ${{ steps.setup.outputs['node-version'] }}
-      node-modules-cache-hit: ${{ steps.setup.outputs['node-modules-cache-hit'] }}
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - name: Setup Node project
-        id: setup
-        uses: ./.github/actions/setup-node-project
-        with:
-          cache-prefix: ci
-
-      - name: Summarize setup
-        if: always()
-        run: |
-          {
-            echo "## Setup";
-            echo "- Status: ${{ job.status }}";
-            echo "- Package manager: ${{ steps.setup.outputs['package-manager'] }}";
-            echo "- Node.js version: ${{ steps.setup.outputs['node-version'] }}";
-            echo "- node_modules cache hit: ${{ steps.setup.outputs['node-modules-cache-hit'] }}";
-          } >> "$GITHUB_STEP_SUMMARY"
-
   audit:
     name: Audit
-    needs: setup
     runs-on: ubuntu-latest
 
     steps:
@@ -96,7 +64,6 @@ jobs:
 
   lint:
     name: Lint
-    needs: setup
     runs-on: ubuntu-latest
 
     steps:
@@ -138,7 +105,6 @@ jobs:
 
   typecheck:
     name: Type check
-    needs: setup
     runs-on: ubuntu-latest
 
     steps:
@@ -167,7 +133,6 @@ jobs:
 
   unit-tests:
     name: Unit tests
-    needs: setup
     runs-on: ubuntu-latest
 
     steps:
@@ -210,7 +175,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: setup
 
     steps:
       - uses: actions/checkout@v4
@@ -261,7 +225,6 @@ jobs:
 
   playwright:
     runs-on: ubuntu-latest
-    needs: setup
     env:
       PLAYWRIGHT_HOST: 127.0.0.1
       PLAYWRIGHT_PORT: 3100


### PR DESCRIPTION
**Summary:**
- remove the dedicated `setup` job from the CI workflow
- drop `needs: setup` dependencies while retaining the setup action in each job

**Files Touched:**
- .github/workflows/ci.yml

**Tokens:**
- none

**Tests:**
- not run (workflow-only change)

**Visual QA:**
- not applicable

**Performance:**
- none

**Risks & Flags:**
- workflow update; each job still initializes the node project before running

**Rollback:**
- revert the commit

------
https://chatgpt.com/codex/tasks/task_e_68e24b459f84832c843d926a1f54d571