### PR TITLE
ci: gate build on fast checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,11 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   build:
+    needs:
+      - lint
+      - typecheck
+      - unit-tests
+      - audit
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
**Title:** ci: gate build on fast checks
**Summary:** Ensure the CI build job waits for linting, type checking, unit tests, and dependency audits before running so bundle analysis only executes after fast checks succeed.
**Files Touched:** .github/workflows/ci.yml
**Tokens:** None.
**Tests:** `pnpm run check` *(fails: gallery manifest in repo is raw JSON; see scripts/regen-if-needed guidance).* 
**Visual QA:** Not applicable (CI configuration change only).
**Performance:** None.
**Risks & Flags:** Minimal; workflow ordering change only.
**Rollback:** Revert commit 6fc7dd0cd3cbba72a2b010d7176a1c504c6aff40.


------
https://chatgpt.com/codex/tasks/task_e_68e250f32a50832cb3c7a6dfe5310f01