### PR TITLE
ci: let deploy script derive base path

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -48,12 +48,8 @@ jobs:
         run: |
           set -euo pipefail
           export DEPLOY_ARTIFACT_ONLY=true
-          REPO_NAME="${GITHUB_REPOSITORY##*/}"
-          if [[ "${REPO_NAME}" == *.github.io ]]; then
-            export NEXT_PUBLIC_BASE_PATH=""
-          else
-            export NEXT_PUBLIC_BASE_PATH="/${REPO_NAME}"
-          fi
+          # The deploy script derives the correct base path for project pages and
+          # clears it for user/org pages, so no extra env wiring is required here.
           pnpm run deploy
 
       - name: Upload static artifact


### PR DESCRIPTION
**Summary:**
- remove redundant NEXT_PUBLIC_BASE_PATH export from the Pages workflow and defer base path detection to the existing deploy script.
- document the behavior in-line so future adjustments happen in one place.

**Files Touched:**
- .github/workflows/deploy-pages.yml

**Tokens:**
- none

**Tests:**
- `pnpm run verify-prompts`
- `TSX_DISABLE_CACHE=1 pnpm run check` *(fails: TypeScript still reads partially-regenerated gallery manifest during concurrent run)*
- `pnpm run analyze`

**Visual QA:**
- not applicable (no UI changes)

**Performance:**
- `pnpm run analyze`

**Risks & Flags:**
- Low; deployment now relies solely on the deploy script’s slug detection, matching local runs. Highlighted the behavior in comments to keep workflow and script aligned.

**Rollback:**
- `git revert dd31cca`

------
https://chatgpt.com/codex/tasks/task_e_68e25ea5cddc832c8b938d2795309638