### PR TITLE
scripts: unify deploy entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "postinstall": "node scripts/postinstall.mjs",
     "prepare": "node scripts/prepare.mjs",
     "launch": "tsx scripts/launcher.ts",
-    "deploy": "tsx scripts/deploy-gh-pages.ts",
+    "deploy:pnpm": "tsx scripts/deploy-gh-pages.ts",
+    "deploy": "pnpm run deploy:pnpm",
     "report:summary": "node scripts/report-summary.mjs"
   },
   "dependencies": {


### PR DESCRIPTION
**Summary:**
- add a helper script entry that runs the existing GitHub Pages deploy implementation via pnpm.
- point the public deploy script to the helper so both pnpm and npm use the same command.

**Files Touched:**
- package.json

**Tokens:**
- None.

**Tests:**
- `DEPLOY_ARTIFACT_ONLY=true pnpm run deploy`
- `DEPLOY_ARTIFACT_ONLY=true npm run deploy`

**Visual QA:**
- Not applicable (no UI changes).

**Performance:**
- None.

**Risks & Flags:**
- None.

**Rollback:**
- Revert commit 271499dfcab084bcd48a7c332c82c1ddfa6bc823.


------
https://chatgpt.com/codex/tasks/task_e_68e297952000832c90ad602763df2ee7