### PR TITLE
ci: split prompt verification job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,6 @@ jobs:
           checkout-ref: ${{ github.event.pull_request.head.sha || github.sha }}
           cache-prefix: ci
 
-      - name: Verify prompts registry
-        env:
-          TSX_TEMPDIR: node_modules/.cache/tsx
-        run: pnpm run verify-prompts
-
       - name: Lint
         run: |
           echo "::add-matcher::.github/matchers/eslint-stylish.json"
@@ -108,6 +103,36 @@ jobs:
         run: |
           {
             echo "## Lint";
+            echo "- Status: ${{ job.status }}";
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  prompt-verify:
+    name: Verify prompts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Node project
+        uses: ./.github/actions/setup-node-project
+        with:
+          checkout-ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          cache-prefix: ci
+
+      - name: Verify prompts registry
+        env:
+          TSX_TEMPDIR: node_modules/.cache/tsx
+        run: pnpm run verify-prompts
+
+      - name: Summarize prompt verification
+        if: always()
+        run: |
+          {
+            echo "## Verify prompts";
             echo "- Status: ${{ job.status }}";
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -195,6 +220,7 @@ jobs:
       - typecheck
       - unit-tests
       - audit
+      - prompt-verify
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
**Summary:**
- move prompt verification from the lint job into a dedicated workflow job
- gate the build job on prompt verification so artifacts wait for prompt validation

**Files Touched:**
- .github/workflows/ci.yml

**Tokens:**
- none

**Tests:**
- not run (CI configuration change only)

**Visual QA:**
- not applicable (CI configuration change)

**Performance:**
- none

**Risks & Flags:**
- CI-only change; monitor first pipeline run after merge

**Rollback:**
- revert commit `ci: run prompt verification in dedicated job`


------
https://chatgpt.com/codex/tasks/task_e_68e29dd926c0832ca03f911342536bae