### PR TITLE
features: accept glitch landing alias

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,8 @@ NEXT_PUBLIC_ENABLE_METRICS="auto"
 NEXT_PUBLIC_FEATURE_SVG_NUMERIC_FILTERS="true"
 NEXT_PUBLIC_DEPTH_THEME="false"
 NEXT_PUBLIC_ORGANIC_DEPTH="false"
+# Preferred flag name; NEXT_PUBLIC_UI_GLITCH_LANDING remains supported for backward compatibility.
+NEXT_PUBLIC_FEATURE_GLITCH_LANDING="true"
 NEXT_PUBLIC_UI_GLITCH_LANDING="true"
 
 # Safe mode gates experimental AI-assisted tooling on both the server and client.

--- a/env/client.ts
+++ b/env/client.ts
@@ -25,6 +25,7 @@ const clientEnvSchema = z
     NEXT_PUBLIC_SENTRY_DSN: optionalNonEmptyString,
     NEXT_PUBLIC_SENTRY_ENVIRONMENT: optionalNonEmptyString,
     NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE: optionalNonEmptyString,
+    NEXT_PUBLIC_FEATURE_GLITCH_LANDING: z.string().optional(),
     NEXT_PUBLIC_UI_GLITCH_LANDING: z.string().optional(),
   })
   .superRefine((value, ctx) => {
@@ -55,6 +56,7 @@ export function loadClientEnv(source: NodeJS.ProcessEnv = process.env): ClientEn
     NEXT_PUBLIC_SENTRY_DSN: source.NEXT_PUBLIC_SENTRY_DSN,
     NEXT_PUBLIC_SENTRY_ENVIRONMENT: source.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
     NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE: source.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE,
+    NEXT_PUBLIC_FEATURE_GLITCH_LANDING: source.NEXT_PUBLIC_FEATURE_GLITCH_LANDING,
     NEXT_PUBLIC_UI_GLITCH_LANDING: source.NEXT_PUBLIC_UI_GLITCH_LANDING,
   });
 }

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -20,7 +20,8 @@ const {
   NEXT_PUBLIC_FEATURE_SVG_NUMERIC_FILTERS: rawSvgNumericFilters,
   NEXT_PUBLIC_DEPTH_THEME: rawDepthTheme,
   NEXT_PUBLIC_ORGANIC_DEPTH: rawOrganicDepth,
-  NEXT_PUBLIC_UI_GLITCH_LANDING: rawGlitchLanding,
+  NEXT_PUBLIC_FEATURE_GLITCH_LANDING: rawFeatureGlitchLanding,
+  NEXT_PUBLIC_UI_GLITCH_LANDING: rawLegacyGlitchLanding,
   NEXT_PUBLIC_SAFE_MODE: rawSafeMode,
 } = readClientEnv();
 
@@ -48,7 +49,11 @@ function parseBooleanFlag(raw: string | undefined, fallback: boolean): boolean {
 const svgNumericFilters = parseBooleanFlag(rawSvgNumericFilters, true);
 const depthThemeEnabled = parseBooleanFlag(rawDepthTheme, false);
 const organicDepthEnabled = parseBooleanFlag(rawOrganicDepth, false);
-const glitchLandingEnabled = parseBooleanFlag(rawGlitchLanding, true);
+const glitchLandingRaw =
+  rawFeatureGlitchLanding !== undefined
+    ? rawFeatureGlitchLanding
+    : rawLegacyGlitchLanding;
+const glitchLandingEnabled = parseBooleanFlag(glitchLandingRaw, true);
 const safeModeEnabled = parseBooleanFlag(rawSafeMode, false);
 
 export function isSafeModeEnabled(): boolean {

--- a/tests/lib/features.test.ts
+++ b/tests/lib/features.test.ts
@@ -4,6 +4,7 @@ type MockedClientEnv = {
   NEXT_PUBLIC_BASE_PATH?: string;
   NEXT_PUBLIC_DEPTH_THEME?: string;
   NEXT_PUBLIC_ENABLE_METRICS?: string;
+  NEXT_PUBLIC_FEATURE_GLITCH_LANDING?: string;
   NEXT_PUBLIC_FEATURE_SVG_NUMERIC_FILTERS?: string;
   NEXT_PUBLIC_ORGANIC_DEPTH?: string;
   NEXT_PUBLIC_SAFE_MODE: string;
@@ -60,5 +61,42 @@ describe("features.safeModeEnabled", () => {
     const features = await import("../../src/lib/features");
 
     expect(features.safeModeEnabled).toBe(false);
+  });
+});
+
+describe("features.glitchLandingEnabled", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the legacy flag when the new alias is not provided", async () => {
+    mockClientEnv({ NEXT_PUBLIC_UI_GLITCH_LANDING: "false" });
+
+    const features = await import("../../src/lib/features");
+
+    expect(features.glitchLandingEnabled).toBe(false);
+  });
+
+  it("prefers the new alias when both flags are provided", async () => {
+    mockClientEnv({
+      NEXT_PUBLIC_FEATURE_GLITCH_LANDING: "false",
+      NEXT_PUBLIC_UI_GLITCH_LANDING: "true",
+    });
+
+    const features = await import("../../src/lib/features");
+
+    expect(features.glitchLandingEnabled).toBe(false);
+  });
+
+  it("enables the flag when only the new alias is provided", async () => {
+    mockClientEnv({ NEXT_PUBLIC_FEATURE_GLITCH_LANDING: "yes" });
+
+    const features = await import("../../src/lib/features");
+
+    expect(features.glitchLandingEnabled).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- allow the client env loader to read NEXT_PUBLIC_FEATURE_GLITCH_LANDING alongside the legacy flag
- have the features module prefer the new alias and add regression tests for both names
- document the alias in the example env file for discoverability

## Files Touched
- .env.example
- env/client.ts
- src/lib/features.ts
- tests/lib/features.test.ts

## Tokens
- None

## Tests
- pnpm vitest run tests/lib/features.test.ts --run
- pnpm run lint
- pnpm run lint:design
- pnpm run typecheck
- pnpm run guard:artifacts
- pnpm run verify-prompts

## Visual QA
- Not applicable (no UI changes)

## Performance
- None

## Risks & Flags
- Dual-read of glitch landing flag to keep backward compatibility

## Rollback
- Revert the commit

------
https://chatgpt.com/codex/tasks/task_e_68e2b4282ce8832cabef4310e5a6988e