### PR TITLE
postinstall: preflight gallery manifest

### DIFF
--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,10 +1,16 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
 if (process.env.npm_config_package_lock_only === "true") {
   console.log("Skipping postinstall: package-lock-only install detected.");
+  process.exit(0);
+}
+
+if (process.env.SKIP_GALLERY_CHECK === "true") {
+  console.log("Skipping postinstall: gallery check explicitly disabled.");
   process.exit(0);
 }
 
@@ -17,7 +23,24 @@ try {
   process.exit(0);
 }
 
-const scriptPath = resolve(dirname(fileURLToPath(import.meta.url)), "regen-if-needed.ts");
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const manifestPath = resolve(scriptDir, "../src/components/gallery/generated-manifest.ts");
+
+if (existsSync(manifestPath)) {
+  const manifestContents = readFileSync(manifestPath, "utf8").trim();
+  if (manifestContents.startsWith("{")) {
+    const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+    const { status } = spawnSync(pnpmCommand, ["run", "build-gallery-usage"], {
+      stdio: "inherit",
+    });
+
+    if (status !== 0) {
+      process.exit(status ?? 1);
+    }
+  }
+}
+
+const scriptPath = resolve(scriptDir, "regen-if-needed.ts");
 const child = spawn(process.execPath, ["--import", tsxModulePath, scriptPath], {
   stdio: "inherit",
 });


### PR DESCRIPTION
**Summary:**
- add an opt-out for the gallery validation during postinstall via `SKIP_GALLERY_CHECK`.
- regenerate the gallery manifest locally when the cached file looks like raw JSON before running validation.

**Files Touched:**
- scripts/postinstall.mjs

**Tokens:**
- none

**Tests:**
- `pnpm run lint`
- `pnpm run lint:design`
- `pnpm run typecheck`
- `pnpm run guard:artifacts`
- `pnpm run verify-prompts`
- `pnpm test -- --run` *(fails/aborted: vitest run exceeds runtime in this environment)*
- `pnpm run check` *(fails/aborted: vitest run exceeds runtime in this environment)*

**Visual QA:**
- not applicable

**Performance:**
- none

**Risks & Flags:**
- Vitest suite and `pnpm run check` could not complete in this container; re-run in CI/local environment.

**Rollback:**
- `git revert <commit>`

------
https://chatgpt.com/codex/tasks/task_e_68e2ce8cd59c832c9de98fbd6e38f74e