### PR TITLE
build: harden postinstall gallery fallback

### DIFF
--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { existsSync, readFileSync } from "node:fs";
@@ -14,6 +14,17 @@ if (process.env.SKIP_GALLERY_CHECK === "true") {
   process.exit(0);
 }
 
+const isCiEnvironment = (() => {
+  const value = process.env.CI;
+  if (!value) {
+    return false;
+  }
+
+  const normalized = value.toLowerCase();
+  return normalized !== "false" && normalized !== "0";
+})();
+
+const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 const require = createRequire(import.meta.url);
 let tsxModulePath;
 try {
@@ -25,31 +36,128 @@ try {
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const manifestPath = resolve(scriptDir, "../src/components/gallery/generated-manifest.ts");
+const scriptPath = resolve(scriptDir, "regen-if-needed.ts");
+
+const runGalleryManifestGeneration = () => {
+  const result = spawnSync(pnpmCommand, ["run", "build-gallery-usage"], {
+    stdio: "inherit",
+  });
+
+  if (result.status === 0) {
+    return 0;
+  }
+
+  const exitCode = result.status ?? 1;
+  const reason = result.error?.message;
+  if (reason) {
+    console.warn(`Failed to regenerate gallery manifest: ${reason}`);
+  } else {
+    console.warn(
+      `Failed to regenerate gallery manifest: command exited with code ${exitCode}.`,
+    );
+  }
+
+  return exitCode;
+};
+
+const runRegenIfNeeded = () => {
+  const result = spawnSync(process.execPath, ["--import", tsxModulePath, scriptPath], {
+    stdio: "inherit",
+  });
+
+  if (result.status === 0) {
+    return 0;
+  }
+
+  if (result.error) {
+    console.error(result.error);
+  }
+
+  return result.status ?? 1;
+};
+
+const shouldSkipForCi = (exitCode, attempted) => {
+  if (!isCiEnvironment) {
+    return false;
+  }
+
+  if (exitCode === 0) {
+    return false;
+  }
+
+  if (!attempted) {
+    return false;
+  }
+
+  console.warn(
+    "Gallery manifest regeneration failed during postinstall; continuing because CI will run validation separately.",
+  );
+  return true;
+};
+
+let attemptedGalleryRegeneration = false;
+let galleryRegenerationExitCode = 0;
 
 if (existsSync(manifestPath)) {
-  const manifestContents = readFileSync(manifestPath, "utf8").trim();
+  const manifestContents = readFileSync(manifestPath, "utf8").trimStart();
   if (manifestContents.startsWith("{")) {
-    const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
-    const { status } = spawnSync(pnpmCommand, ["run", "build-gallery-usage"], {
-      stdio: "inherit",
-    });
+    attemptedGalleryRegeneration = true;
+    galleryRegenerationExitCode = runGalleryManifestGeneration();
 
-    if (status !== 0) {
-      process.exit(status ?? 1);
+    if (
+      shouldSkipForCi(
+        galleryRegenerationExitCode,
+        attemptedGalleryRegeneration && galleryRegenerationExitCode !== 0,
+      )
+    ) {
+      process.exit(0);
+    }
+
+    if (galleryRegenerationExitCode !== 0) {
+      process.exit(galleryRegenerationExitCode);
     }
   }
 }
 
-const scriptPath = resolve(scriptDir, "regen-if-needed.ts");
-const child = spawn(process.execPath, ["--import", tsxModulePath, scriptPath], {
-  stdio: "inherit",
-});
+const runRegenWithFallback = () => {
+  let exitCode = runRegenIfNeeded();
 
-child.on("exit", (code) => {
-  process.exit(code ?? 0);
-});
+  if (exitCode === 0) {
+    return 0;
+  }
 
-child.on("error", (error) => {
-  console.error(error);
-  process.exit(1);
-});
+  if (!attemptedGalleryRegeneration) {
+    attemptedGalleryRegeneration = true;
+    galleryRegenerationExitCode = runGalleryManifestGeneration();
+
+    if (
+      shouldSkipForCi(
+        galleryRegenerationExitCode,
+        attemptedGalleryRegeneration && galleryRegenerationExitCode !== 0,
+      )
+    ) {
+      return 0;
+    }
+
+    if (galleryRegenerationExitCode === 0) {
+      exitCode = runRegenIfNeeded();
+      return exitCode;
+    }
+
+    return galleryRegenerationExitCode;
+  }
+
+  return exitCode;
+};
+
+const finalExitCode = runRegenWithFallback();
+if (
+  shouldSkipForCi(
+    finalExitCode,
+    attemptedGalleryRegeneration && galleryRegenerationExitCode !== 0,
+  )
+) {
+  process.exit(0);
+}
+
+process.exit(finalExitCode);


### PR DESCRIPTION
Summary:
- add CI-aware fallback handling in scripts/postinstall.mjs so raw gallery manifests trigger regeneration without failing installs
- capture non-zero exits from regen-if-needed and re-run gallery generation before optionally skipping in CI scenarios

Files Touched:
- scripts/postinstall.mjs

Tokens:
- none

Tests:
- pnpm run lint
- pnpm run lint:design
- pnpm run typecheck
- pnpm run guard:artifacts
- pnpm test -- --run (hangs on useTodayHeroTasks locally)

Visual QA:
- not applicable

Performance:
- none

Risks & Flags:
- pnpm test -- --run still stalls on useTodayHeroTasks in this environment; upstream CI should confirm full suite

Rollback:
- revert commit 690882b and re-run postinstall


------
https://chatgpt.com/codex/tasks/task_e_68e2fc21b104832ca6bbd4b6840a7b70