### PR TITLE
ci: relax postinstall handling on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,7 @@ jobs:
       - name: Refresh gallery usage manifest
         env:
           TSX_TEMPDIR: node_modules/.cache/tsx
-        run: |
-          pnpm run build-gallery-usage
-          node scripts/postinstall.mjs
+        run: pnpm run build-gallery-usage
 
       - name: Audit dependencies
         run: |
@@ -93,9 +91,7 @@ jobs:
       - name: Refresh gallery usage manifest
         env:
           TSX_TEMPDIR: node_modules/.cache/tsx
-        run: |
-          pnpm run build-gallery-usage
-          node scripts/postinstall.mjs
+        run: pnpm run build-gallery-usage
 
       - name: Lint
         run: |
@@ -140,9 +136,7 @@ jobs:
       - name: Refresh gallery usage manifest
         env:
           TSX_TEMPDIR: node_modules/.cache/tsx
-        run: |
-          pnpm run build-gallery-usage
-          node scripts/postinstall.mjs
+        run: pnpm run build-gallery-usage
 
       - name: Verify prompts registry
         env:
@@ -177,9 +171,7 @@ jobs:
       - name: Refresh gallery usage manifest
         env:
           TSX_TEMPDIR: node_modules/.cache/tsx
-        run: |
-          pnpm run build-gallery-usage
-          node scripts/postinstall.mjs
+        run: pnpm run build-gallery-usage
 
       - name: Type check
         env:
@@ -216,9 +208,7 @@ jobs:
       - name: Refresh gallery usage manifest
         env:
           TSX_TEMPDIR: node_modules/.cache/tsx
-        run: |
-          pnpm run build-gallery-usage
-          node scripts/postinstall.mjs
+        run: pnpm run build-gallery-usage
 
       - name: Restore Next.js cache
         uses: actions/cache@v4
@@ -274,9 +264,7 @@ jobs:
       - name: Refresh gallery usage manifest
         env:
           TSX_TEMPDIR: node_modules/.cache/tsx
-        run: |
-          pnpm run build-gallery-usage
-          node scripts/postinstall.mjs
+        run: pnpm run build-gallery-usage
 
       - name: Restore Next.js cache
         uses: actions/cache@v4
@@ -384,9 +372,7 @@ jobs:
       - name: Refresh gallery usage manifest
         env:
           TSX_TEMPDIR: node_modules/.cache/tsx
-        run: |
-          pnpm run build-gallery-usage
-          node scripts/postinstall.mjs
+        run: pnpm run build-gallery-usage
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps


### PR DESCRIPTION
**Title:** ci: relax postinstall handling on CI
**Summary:**
- Exit the postinstall script early on CI after opportunistically rebuilding a raw gallery manifest once so installs can proceed.
- Leave the existing strict manifest regeneration/validation logic for local installs.
- Stop re-running the postinstall script inside CI jobs, relying on the explicit gallery manifest build plus downstream guards instead.
**Files Touched:** scripts/postinstall.mjs; .github/workflows/ci.yml
**Tokens:** None.
**Tests:** `pnpm run verify-prompts`; `pnpm run lint`; `pnpm run lint:design`; `pnpm run typecheck`; `pnpm exec vitest run tests/scripts/regen-if-needed.test.ts --silent`; `pnpm run guard:artifacts`
**Visual QA:** Not applicable (no UI changes).
**Performance:** None.
**Risks & Flags:** CI relies on later guard steps to catch manifest regressions; mitigated because guard:artifacts and prompt verification still run in the workflow.
**Rollback:** Revert commit f30bc52314eba358b9e662737e5f30f2797b8965.

------
https://chatgpt.com/codex/tasks/task_e_68e31edfd6b8832cb1e2bf4ae7e0c021