### PR TITLE
Document glitch landing feature flag rename

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,9 @@ NEXT_PUBLIC_ENABLE_METRICS="auto"
 NEXT_PUBLIC_FEATURE_SVG_NUMERIC_FILTERS="true"
 NEXT_PUBLIC_DEPTH_THEME="false"
 NEXT_PUBLIC_ORGANIC_DEPTH="false"
-# Preferred flag name; NEXT_PUBLIC_UI_GLITCH_LANDING remains supported for backward compatibility.
+# Preferred flag name (documented in README). NEXT_PUBLIC_UI_GLITCH_LANDING remains supported for backward compatibility.
 NEXT_PUBLIC_FEATURE_GLITCH_LANDING="true"
+# Legacy alias for older deployments. Keep in sync with NEXT_PUBLIC_FEATURE_GLITCH_LANDING until they migrate.
 NEXT_PUBLIC_UI_GLITCH_LANDING="true"
 
 # Safe mode gates experimental AI-assisted tooling on both the server and client.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ The app reads configuration from your shell environment at build time. Use `.env
 | `GH_PAGES_BRANCH` | `gh-pages` | Target branch for the GitHub Pages deploy script. Override if your site publishes from a different branch. |
 | `GITHUB_PAGES_BRANCH` | `""` | Optional alias the deploy script reads when `GH_PAGES_BRANCH` is unset. Useful when reusing existing CI variables. |
 | `NEXT_PUBLIC_API_*` | _unset_ | Placeholder namespace for future API endpoints (for example, `NEXT_PUBLIC_API_BASE_URL`). Prefix additional public URLs with `NEXT_PUBLIC_` so Next.js exposes them to the client. |
-| `NEXT_PUBLIC_UI_GLITCH_LANDING` | `true` | Gates the glitch landing experience. Set to `false` to render the legacy landing layout without glitch overlays while retaining the standard planner preview. |
+| `NEXT_PUBLIC_FEATURE_GLITCH_LANDING` | `true` | Preferred flag for the glitch landing experience. Set to `false` to render the legacy landing layout without glitch overlays. Supersedes `NEXT_PUBLIC_UI_GLITCH_LANDING`. |
+| `NEXT_PUBLIC_UI_GLITCH_LANDING` | `true` | Legacy alias for `NEXT_PUBLIC_FEATURE_GLITCH_LANDING`. Leave enabled for backward compatibility with older builds until they can migrate to the new flag. |
 | `NEXT_PHASE` | _unset_ | Optional Next.js phase override for debugging phase-specific logic. The build sets this automatically in most workflows. |
 | `NODE_ENV` | `development` | Runtime environment hint used by Next.js. The build pipeline sets this automatically; override only for advanced debugging. |
 


### PR DESCRIPTION
## Summary
- document the NEXT_PUBLIC_FEATURE_GLITCH_LANDING flag in the README env table and describe the legacy alias
- align .env.example comments with the README guidance while clarifying that the legacy flag is only for backward compatibility

## Testing
- pnpm run verify-prompts
- pnpm run check *(fails: typecheck detects temporary raw JSON in src/components/gallery/generated-manifest.ts during concurrent runs)*

------
https://chatgpt.com/codex/tasks/task_e_68e3226dfaf8832cb3b7b54b13fceede