### PR TITLE
Normalize GitHub Pages slug comparisons

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -67,8 +67,11 @@ const githubPagesSlug = isGitHubPages ? resolveGitHubPagesSlug() : "";
 const expectedUserOrOrgSlug =
   repositoryOwnerSlug !== undefined ? `${repositoryOwnerSlug}.github.io` : undefined;
 const resolvedRepositorySlug = repositorySlug ?? githubPagesSlug;
+const expectedUserOrOrgSlugLower = expectedUserOrOrgSlug?.toLowerCase();
+const resolvedRepositorySlugLower = resolvedRepositorySlug?.toLowerCase();
 const isUserOrOrgGitHubPage =
-  expectedUserOrOrgSlug !== undefined && resolvedRepositorySlug === expectedUserOrOrgSlug;
+  expectedUserOrOrgSlugLower !== undefined &&
+  resolvedRepositorySlugLower === expectedUserOrOrgSlugLower;
 
 const normalizedBasePathValue = isGitHubPages
   ? githubPagesSlug && !isUserOrOrgGitHubPage

--- a/scripts/deploy-gh-pages.ts
+++ b/scripts/deploy-gh-pages.ts
@@ -157,7 +157,11 @@ export function isUserOrOrgGitHubPagesRepository({
 
   const expectedSlug = `${repositoryOwnerSlug}.github.io`;
   const candidateSlug = repositoryNameSlug ?? fallbackSlug;
-  return candidateSlug === expectedSlug;
+  if (!candidateSlug) {
+    return false;
+  }
+
+  return candidateSlug.toLowerCase() === expectedSlug.toLowerCase();
 }
 
 function parseRemoteSlug(remoteUrl: string): GitHubRepositoryParts {

--- a/tests/scripts/deploy-gh-pages.test.ts
+++ b/tests/scripts/deploy-gh-pages.test.ts
@@ -151,6 +151,15 @@ describe("isUserOrOrgGitHubPagesRepository", () => {
       }),
     ).toBe(true);
   });
+
+  it("matches owner.github.io repositories when the owner slug includes uppercase characters", () => {
+    expect(
+      isUserOrOrgGitHubPagesRepository({
+        repositoryOwnerSlug: "EnollaTomazic",
+        repositoryNameSlug: "enollatomazic.github.io",
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("detectRepositorySlug", () => {


### PR DESCRIPTION
## Summary
- treat GitHub Pages slug comparisons as case-insensitive in the deploy script
- mirror the case-insensitive comparison in the Next.js config so basePath logic is accurate
- add a regression test covering an uppercase repository owner slug

## Testing
- pnpm test tests/scripts/deploy-gh-pages.test.ts --run
- pnpm run check *(fails: TypeScript errors in src/components/gallery/generated-manifest.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e33f826794832c9e09a95c2f963695