### PR TITLE
Avoid resetting persisted state when only initial changes

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -406,7 +406,9 @@ export function usePersistentState<T>(
   React.useEffect(() => {
     if (!Object.is(initialRef.current, initial)) {
       initialRef.current = initial;
-      pendingInitialResetKeyRef.current = key;
+      if (!loadedRef.current) {
+        pendingInitialResetKeyRef.current = key;
+      }
     }
 
     if (


### PR DESCRIPTION
## Summary
- stop scheduling a reset of the persisted state when the key already has hydrated data by checking `loadedRef` before updating `pendingInitialResetKeyRef`

## Testing
- `pnpm run verify-prompts`
- `pnpm run check` *(hangs after running for ~13 minutes; aborted to continue work)*

------
https://chatgpt.com/codex/tasks/task_e_68e358a0c780832cba28f49fbacdaa86