### PR TITLE
feat: allow configuring AI safety defaults via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@ NEXT_PUBLIC_UI_GLITCH_LANDING="true"
 SAFE_MODE="false"
 NEXT_PUBLIC_SAFE_MODE="false"
 
+# Override AI prompt defaults when integrating providers with different limits.
+AI_MAX_INPUT_LENGTH="16000"
+AI_TOKENS_PER_CHAR="4"
+
 # Browser Sentry configuration. Provide DSN + environment to enable monitoring in production.
 NEXT_PUBLIC_SENTRY_DSN="https://examplePublicKey.ingest.sentry.io/1234567"
 NEXT_PUBLIC_SENTRY_ENVIRONMENT="development"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ The app reads configuration from your shell environment at build time. Use `.env
 | `NEXT_PUBLIC_ENABLE_METRICS` | `"auto"` | Controls the browser web vitals hook. `auto` only ships metrics in production when a metrics endpoint is configured; set to `true`/`false` to force enable or disable respectively. |
 | `NEXT_PUBLIC_METRICS_ENDPOINT` | `""` | Absolute or relative URL the browser uses for web vitals submissions. Leave empty to disable metrics when hosting static exports without a backend. |
 | `SAFE_MODE` | `false` | Server-side safe mode for AI-assisted tooling. Enable in CI or production when external AI providers should remain isolated from unreleased flows. |
+| `AI_MAX_INPUT_LENGTH` | `"16000"` | Default grapheme cap applied when sanitizing prompts. Increase when your provider accepts longer inputs; decrease to enforce tighter limits. |
+| `AI_TOKENS_PER_CHAR` | `"4"` | Heuristic tokens-per-character ratio used when estimating budgets without provider-specific metadata. Tweak to better reflect your model's tokenization. |
 | `NEXT_PUBLIC_SAFE_MODE` | `false` | Client-side mirror of `SAFE_MODE`. Keep the values in sync so browser logic agrees with server enforcement. |
 | `NEXT_PUBLIC_FEATURE_SVG_NUMERIC_FILTERS` | `true` | Feature flag for SVG numeric filters in the planner UI. Disable if custom deployments hit rendering issues. |
 | `NEXT_PUBLIC_DEPTH_THEME` | `false` | Feature flag enabling additional depth theming. Disable to render the legacy flat palette. |


### PR DESCRIPTION
## Summary
- load AI prompt length and token estimation defaults from validated environment overrides with fallbacks
- document the new AI environment variables in the README configuration table and `.env.example`
- add tests that reload the safety module to verify the overrides are applied when environment variables are set

## Testing
- pnpm test tests/ai/safety.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e3c7380b70832cb5c396419d2815c9