### PR TITLE
Guard workflow-lint artifacts

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -31,9 +31,8 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4.2.1
-        with:
-          fetch-depth: 2
+      - name: Setup Node project
+        uses: ./.github/actions/setup-node-project
 
       - name: actionlint
         uses: reviewdog/action-actionlint@0b71b30a47a15c4d849868cca394fb656f1cf657 # v1.67.0
@@ -47,3 +46,6 @@ jobs:
       - name: Run yamllint
         run: |
           yamllint -d "{extends: default, rules: {line-length: {max: 200}, comments: disable, document-start: disable, truthy: disable}}" .github
+
+      - name: Guard transient artifacts
+        run: pnpm run guard:artifacts

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -27,7 +27,7 @@ The `ci.yml` workflow defines first-class jobs for audits, linting, type-checkin
 - The `theme-previews` entry in the Playwright matrix downloads the `next-build` artefact, verifies it before starting the server, and then exercises any tests tagged `@axe` (or the full suite when none are tagged).
 - Visual E2E coverage now captures per-theme snapshots for the depth-aware button and card previews while rerunning axe against those preview routes from the same matrix entry. Keep `npx playwright test` wired into CI so this job remains the source of truth for depth and theme regressions.
 - The `Deploy Pages` workflow builds the static export on pushes to `main`, verifying prompts before the export, uploading the artefact for traceability, and executing the [`actions/deploy-pages`](https://github.com/actions/deploy-pages) step to publish the site.
-- `workflow-lint.yml` runs `actionlint` and `yamllint` whenever workflow files change (or on demand) so breaking changes surface before they land in `ci.yml` or `deploy-pages.yml`.
+- `workflow-lint.yml` runs `actionlint`, `yamllint`, and `pnpm run guard:artifacts` whenever workflow files change (or on demand) so breaking changes surface before they land in `ci.yml` or `deploy-pages.yml`.
 
 ## Bundle analysis and performance budgets
 


### PR DESCRIPTION
## Summary
- bootstrap the workflow-lint job with the shared setup-node-project composite action
- run `pnpm run guard:artifacts` after actionlint and yamllint complete
- document the additional guard requirement in the CI workflow guide

## Testing
- pnpm run verify-prompts
- pnpm run check *(fails: repository ships with a raw gallery manifest and a failing `Db > usePersistentState` test)*

------
https://chatgpt.com/codex/tasks/task_e_68e40ea279a0832c9c89bdba85e69de3