### PR TITLE
Add CI tool version verification

### DIFF
--- a/.github/actions/verify-tool-versions/action.yml
+++ b/.github/actions/verify-tool-versions/action.yml
@@ -1,0 +1,65 @@
+name: "Verify tool versions"
+description: "Ensure Node.js and pnpm versions match repository expectations."
+
+inputs:
+  node-version-file:
+    description: "Path to the Node.js version file"
+    default: ".nvmrc"
+  pnpm-version:
+    description: "Expected pnpm version"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check Node.js and pnpm versions
+      shell: bash
+      env:
+        NODE_VERSION_FILE: "${{ inputs['node-version-file'] }}"
+        EXPECTED_PNPM: "${{ inputs['pnpm-version'] }}"
+      run: |
+        set -euo pipefail
+
+        if [ -z "$EXPECTED_PNPM" ]; then
+          echo "Expected pnpm version must be provided." >&2
+          exit 1
+        fi
+
+        if [ ! -f "$NODE_VERSION_FILE" ]; then
+          echo "Node.js version file '$NODE_VERSION_FILE' not found." >&2
+          exit 1
+        fi
+
+        EXPECTED_NODE_RAW="$(cat "$NODE_VERSION_FILE")"
+        EXPECTED_NODE="$(echo "$EXPECTED_NODE_RAW" | tr -d '\n\r[:space:]')"
+        EXPECTED_NODE="${EXPECTED_NODE#v}"
+
+        if [ -z "$EXPECTED_NODE" ]; then
+          echo "Node.js version file '$NODE_VERSION_FILE' did not contain a version." >&2
+          exit 1
+        fi
+
+        ACTUAL_NODE_RAW="$(node --version)"
+        ACTUAL_NODE="${ACTUAL_NODE_RAW#v}"
+
+        if [[ "$EXPECTED_NODE" == *.* || "$EXPECTED_NODE" == *-* ]]; then
+          if [ "$ACTUAL_NODE" != "$EXPECTED_NODE" ]; then
+            echo "Node.js version mismatch. Expected $EXPECTED_NODE but found $ACTUAL_NODE." >&2
+            exit 1
+          fi
+        else
+          ACTUAL_NODE_MAJOR="${ACTUAL_NODE%%.*}"
+          if [ "$ACTUAL_NODE_MAJOR" != "$EXPECTED_NODE" ]; then
+            echo "Node.js major version mismatch. Expected $EXPECTED_NODE.x but found $ACTUAL_NODE." >&2
+            exit 1
+          fi
+        fi
+
+        ACTUAL_PNPM="$(pnpm --version)"
+
+        if [ "$ACTUAL_PNPM" != "$EXPECTED_PNPM" ]; then
+          echo "pnpm version mismatch. Expected $EXPECTED_PNPM but found $ACTUAL_PNPM." >&2
+          exit 1
+        fi
+
+        echo "Using Node.js $ACTUAL_NODE_RAW and pnpm $ACTUAL_PNPM."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
           checkout-ref: ${{ github.event.pull_request.head.sha || github.sha }}
           cache-prefix: ci
 
+      - name: Verify tool versions
+        uses: ./.github/actions/verify-tool-versions
+        with:
+          pnpm-version: ${{ env.PNPM_VERSION }}
+
       - name: Refresh gallery usage manifest
         env:
           TSX_TEMPDIR: node_modules/.cache/tsx
@@ -87,6 +92,11 @@ jobs:
         with:
           checkout-ref: ${{ github.event.pull_request.head.sha || github.sha }}
           cache-prefix: ci
+
+      - name: Verify tool versions
+        uses: ./.github/actions/verify-tool-versions
+        with:
+          pnpm-version: ${{ env.PNPM_VERSION }}
 
       - name: Refresh gallery usage manifest
         env:
@@ -133,6 +143,11 @@ jobs:
           checkout-ref: ${{ github.event.pull_request.head.sha || github.sha }}
           cache-prefix: ci
 
+      - name: Verify tool versions
+        uses: ./.github/actions/verify-tool-versions
+        with:
+          pnpm-version: ${{ env.PNPM_VERSION }}
+
       - name: Refresh gallery usage manifest
         env:
           TSX_TEMPDIR: node_modules/.cache/tsx
@@ -167,6 +182,11 @@ jobs:
         with:
           checkout-ref: ${{ github.event.pull_request.head.sha || github.sha }}
           cache-prefix: ci
+
+      - name: Verify tool versions
+        uses: ./.github/actions/verify-tool-versions
+        with:
+          pnpm-version: ${{ env.PNPM_VERSION }}
 
       - name: Refresh gallery usage manifest
         env:
@@ -204,6 +224,11 @@ jobs:
         with:
           checkout-ref: ${{ github.event.pull_request.head.sha || github.sha }}
           cache-prefix: ci
+
+      - name: Verify tool versions
+        uses: ./.github/actions/verify-tool-versions
+        with:
+          pnpm-version: ${{ env.PNPM_VERSION }}
 
       - name: Refresh gallery usage manifest
         env:
@@ -260,6 +285,11 @@ jobs:
         with:
           checkout-ref: ${{ github.event.pull_request.head.sha || github.sha }}
           cache-prefix: ci
+
+      - name: Verify tool versions
+        uses: ./.github/actions/verify-tool-versions
+        with:
+          pnpm-version: ${{ env.PNPM_VERSION }}
 
       - name: Refresh gallery usage manifest
         env:
@@ -368,6 +398,11 @@ jobs:
         with:
           checkout-ref: ${{ github.event.pull_request.head.sha || github.sha }}
           cache-prefix: ci
+
+      - name: Verify tool versions
+        uses: ./.github/actions/verify-tool-versions
+        with:
+          pnpm-version: ${{ env.PNPM_VERSION }}
 
       - name: Refresh gallery usage manifest
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Requires [Node.js](https://nodejs.org) 22 or newer.
+Requires [Node.js](https://nodejs.org) 22.x and [pnpm](https://pnpm.io) 10.13.1. The CI pipeline reads `.nvmrc` and checks `node --version` and `pnpm --version` to ensure they match these values, so align your local environment accordingly.
 
 ## Scripts
 


### PR DESCRIPTION
## Summary
- add a composite action that reads `.nvmrc`, checks `node --version`/`pnpm --version`, and fails on mismatches
- invoke the verification step after `setup-node-project` in every CI job
- document the enforced Node.js 22.x and pnpm 10.13.1 requirements for contributors

## Testing
- pnpm run check *(fails: TypeScript sees a temporarily raw `generated-manifest.ts` while vitest is mutating it)*

------
https://chatgpt.com/codex/tasks/task_e_68e44caf1738832cbbc673e4d44f6611