### PR TITLE
Add deploy env validation before static export

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -43,6 +43,12 @@ jobs:
       - name: Verify prompts registry
         run: pnpm run verify-prompts
 
+      - name: Validate env for deploy
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm exec tsx scripts/validate-deploy-env.ts
+
       - name: Export static site
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Run `pnpm run deploy` (or `npm run deploy`) from the project root whenever you'r
 
 Before building, the script verifies that a Git push target is configured. If `git remote get-url origin` fails and both `GITHUB_REPOSITORY` and `GITHUB_TOKEN` are missing, the deploy exits early and asks you to add an `origin` remote or supply those environment variables before re-running `pnpm run deploy` or `npm run deploy`.
 
+The CI workflow runs `scripts/validate-deploy-env.ts` before exporting to confirm the environment matches the detected repository slug. When the repository publishes to `https://<username>.github.io/<repo>/`, the check expects `BASE_PATH=<repo>` and `NEXT_PUBLIC_BASE_PATH=/<repo>`. User/organization GitHub Pages sites (slugs that already end in `.github.io`) should leave both variables empty. If the validation fails, update the variables in your shell, `.env.local`, or CI secrets until the logged "actual" values match the "expected" ones.
+
 When the static files are published to `https://<username>.github.io/<repo>/`, the home page is served from `https://<username>.github.io/<repo>/` rather than the domain root. Use that base path whenever you link to or bookmark the deployed site. Only repositories that exactly match `https://<username>.github.io` (user/organization GitHub Pages) skip the base path; similarly named repositories such as `docs.github.io` owned by another organization continue to publish under `/<repo>/`.
 
 For CI (or any environment that should push automatically), export `GITHUB_TOKEN`, `GITHUB_REPOSITORY`, and (optionally) `CI=true` before running the deploy script. When those values are present, the script adds an authenticated remote URL so the push succeeds without additional setup.

--- a/scripts/validate-deploy-env.ts
+++ b/scripts/validate-deploy-env.ts
@@ -1,0 +1,71 @@
+import fs from "node:fs";
+import process from "node:process";
+
+import {
+  detectRepositorySlug,
+  isUserOrOrgGitHubPagesRepository,
+  parseGitHubRepository,
+} from "./deploy-gh-pages";
+
+function formatValue(value: string): string {
+  return value.length > 0 ? value : "<empty>";
+}
+
+function main(): void {
+  const nvmrcPath = new URL("../.nvmrc", import.meta.url);
+  const nvmrcVersion = fs.readFileSync(nvmrcPath, "utf8").trim();
+  console.log(`[deploy-env] .nvmrc Node version: ${nvmrcVersion}`);
+
+  const { slug, ownerSlug: fallbackOwnerSlug } = detectRepositorySlug();
+  const repositoryParts = parseGitHubRepository(process.env.GITHUB_REPOSITORY);
+  const isUserOrOrgGitHubPage = isUserOrOrgGitHubPagesRepository({
+    repositoryOwnerSlug: repositoryParts.owner ?? fallbackOwnerSlug,
+    repositoryNameSlug: repositoryParts.name,
+    fallbackSlug: slug,
+  });
+
+  const expectedBasePath = slug.length > 0 && !isUserOrOrgGitHubPage ? slug : "";
+  const expectedNextPublicBasePath = expectedBasePath ? `/${expectedBasePath}` : "";
+
+  const actualBasePath = (process.env.BASE_PATH ?? "").trim();
+  const actualNextPublicBasePath = (process.env.NEXT_PUBLIC_BASE_PATH ?? "").trim();
+
+  console.log(`[deploy-env] Expected BASE_PATH: ${formatValue(expectedBasePath)}`);
+  console.log(`[deploy-env] Actual BASE_PATH:   ${formatValue(actualBasePath)}`);
+  console.log(
+    `[deploy-env] Expected NEXT_PUBLIC_BASE_PATH: ${formatValue(expectedNextPublicBasePath)}`,
+  );
+  console.log(
+    `[deploy-env] Actual NEXT_PUBLIC_BASE_PATH:   ${formatValue(actualNextPublicBasePath)}`,
+  );
+
+  const mismatches: string[] = [];
+  if (actualBasePath !== expectedBasePath) {
+    mismatches.push(
+      `BASE_PATH should be "${expectedBasePath}" but was "${actualBasePath}"`,
+    );
+  }
+  if (actualNextPublicBasePath !== expectedNextPublicBasePath) {
+    mismatches.push(
+      `NEXT_PUBLIC_BASE_PATH should be "${expectedNextPublicBasePath}" but was "${actualNextPublicBasePath}"`,
+    );
+  }
+
+  if (mismatches.length > 0) {
+    mismatches.push(
+      "Update BASE_PATH and NEXT_PUBLIC_BASE_PATH to match the repository slug before deploying.",
+    );
+    throw new Error(`Deploy environment mismatch:\n - ${mismatches.join("\n - ")}`);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  if (error instanceof Error) {
+    console.error(error.message);
+  } else {
+    console.error(error);
+  }
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a GitHub Actions step to validate the deploy environment before exporting static assets
- implement a reusable `scripts/validate-deploy-env.ts` script that logs expected vs actual base paths and fails on mismatches
- document the new validation requirement and remediation steps in the GitHub Pages section of the README

## Testing
- pnpm run verify-prompts
- pnpm run check *(fails: long-running vitest/typecheck sequence; aborted after manifest regeneration errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e452277500832cabfb1131e50e6984