### PR TITLE
Fix usePersistentState initial reset on key reuse

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -416,7 +416,7 @@ export function usePersistentState<T>(
         Object.is(stateRef.current, previousAppliedInitial);
       if (
         pendingInitialResetKeyRef.current !== null ||
-        (hasHydratedRef.current && stateMatchesAppliedInitial)
+        stateMatchesAppliedInitial
       ) {
         pendingInitialResetKeyRef.current = key;
       }


### PR DESCRIPTION
## Summary
- ensure `usePersistentState` resets to the latest initial value when a key is reused
- simplify the initial reset guard so fresh renders honor new defaults before hydration completes

## Testing
- `pnpm vitest run tests/lib/Db.test.ts --run --reporter=dot`


------
https://chatgpt.com/codex/tasks/task_e_68e53ba0c0b0832c9a6e0493cd9cb7c6