### PR TITLE
fix: configure deploy base path

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -29,6 +29,8 @@ jobs:
       actions: write
     env:
       NEXT_TELEMETRY_DISABLED: '1'
+      BASE_PATH: Planner
+      NEXT_PUBLIC_BASE_PATH: /Planner
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
## Summary
- set BASE_PATH and NEXT_PUBLIC_BASE_PATH for the deploy workflow so environment validation passes

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e5761d9430832c87bcd7461b6901b9